### PR TITLE
allow numpy array in with_columns

### DIFF
--- a/narwhals/dependencies.py
+++ b/narwhals/dependencies.py
@@ -29,3 +29,8 @@ def get_cudf() -> Any:
 
 def get_pyarrow() -> Any:
     return sys.modules.get("pyarrow", None)
+
+
+def get_numpy() -> Any:
+    """Import numpy (if available - else return None)."""
+    return sys.modules.get("numpy", None)

--- a/tests/frame/with_columns_sequence_test.py
+++ b/tests/frame/with_columns_sequence_test.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+
+import narwhals as nw
+from tests.utils import compare_dicts
+
+data = {
+    "a": ["foo", "bars"],
+    "ab": ["foo", "bars"],
+}
+
+
+@pytest.mark.parametrize("constructor", [pd.DataFrame, pl.DataFrame])
+def test_with_columns(constructor: Any) -> None:
+    result = nw.from_native(constructor(data)).with_columns(d=np.array([4, 5]))
+    expected = {"a": ["foo", "bars"], "ab": ["foo", "bars"], "d": [4, 5]}
+    compare_dicts(result, expected)


### PR DESCRIPTION
partial fix for #141 

For passing lists / tuples, I _think_ what we need is a Series constructor. Something like
```python
df.with_columns(
    g_1=nw.Series(
        ["A"] * (n_samples // 2) + ["B"] * (n_samples // 2),
        implementation=nw.get_implementation(X),
    )
)
```
?

We need to pass something to `nw.Series`, otherwise it doesn't know which library's Series to create

An alternative API could be
```python
plx = nw.get_namespace(X)
df.with_columns(
    g_1=plx.Series(["A"] * (n_samples // 2) + ["B"] * (n_samples // 2))
)
```
which...might be a bit cleaner?