### PR TITLE
feat: `Expr.name` namespace

### DIFF
--- a/docs/api-reference/expressions_name.md
+++ b/docs/api-reference/expressions_name.md
@@ -1,0 +1,13 @@
+# `narwhals.Expr.name`
+
+::: narwhals.expression.ExprNameNamespace
+    handler: python
+    options:
+      members:
+        - map
+        - prefix
+        - suffix
+        - to_lowercase
+        - to_uppercase
+      show_source: false
+      show_bases: false

--- a/docs/api-reference/expressions_str.md
+++ b/docs/api-reference/expressions_str.md
@@ -4,6 +4,7 @@
     handler: python
     options:
       members:
+        - starts_with
         - ends_with
         - head
         - to_datetime

--- a/docs/api-reference/series_str.md
+++ b/docs/api-reference/series_str.md
@@ -4,6 +4,7 @@
     handler: python
     options:
       members:
+        - starts_with
         - ends_with
         - head
       show_source: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - api-reference/series_str.md
     - api-reference/expressions.md
     - api-reference/expressions_dt.md
+    - api-reference/expressions_name.md
     - api-reference/expressions_str.md
     - api-reference/dtypes.md
     - api-reference/dependencies.md

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -350,7 +350,6 @@ class PandasExprNameNamespace:
 
     def map(self, function: Callable[[str], str]) -> PandasExpr:
         root_names = self._expr._root_names
-        implementation = self._expr._implementation
 
         if root_names is None:
             msg = (
@@ -360,28 +359,19 @@ class PandasExprNameNamespace:
             )
             raise ValueError(msg)
 
-        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
-            tmp = df.select(root_names)
-            return [
-                PandasSeries(
-                    tmp[n]._series.rename(function(n)), implementation=implementation
-                )
-                for n in root_names
-            ]
-
         return self._expr.__class__(
-            mapper,
-            depth=self._expr._depth + 1,
+            lambda df: [
+                series.alias(function(series.name)) for series in self._expr._call(df)
+            ],
+            depth=self._expr._depth,
             function_name=self._expr._function_name,
             root_names=root_names,
             output_names=[function(name) for name in root_names],
-            implementation=implementation,
+            implementation=self._expr._implementation,
         )
 
     def prefix(self, prefix: str) -> PandasExpr:
         root_names = self._expr._root_names
-        implementation = self._expr._implementation
-
         if root_names is None:
             msg = (
                 "Anonymous expressions are not supported in `.name.prefix`.\n"
@@ -390,29 +380,19 @@ class PandasExprNameNamespace:
             )
             raise ValueError(msg)
 
-        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
-            tmp = df.select(root_names)
-
-            return [
-                PandasSeries(
-                    tmp[n]._series.rename(prefix + tmp[n]._series.name),
-                    implementation=implementation,
-                )
-                for n in root_names
-            ]
-
         return self._expr.__class__(
-            mapper,
-            depth=self._expr._depth + 1,
+            lambda df: [
+                series.alias(prefix + series.name) for series in self._expr._call(df)
+            ],
+            depth=self._expr._depth,
             function_name=self._expr._function_name,
             root_names=root_names,
             output_names=[prefix + name for name in root_names],
-            implementation=implementation,
+            implementation=self._expr._implementation,
         )
 
     def suffix(self, suffix: str) -> PandasExpr:
         root_names = self._expr._root_names
-        implementation = self._expr._implementation
 
         if root_names is None:
             msg = (
@@ -422,29 +402,19 @@ class PandasExprNameNamespace:
             )
             raise ValueError(msg)
 
-        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
-            tmp = df.select(root_names)
-
-            return [
-                PandasSeries(
-                    tmp[n]._series.rename(tmp[n]._series.name + suffix),
-                    implementation=implementation,
-                )
-                for n in root_names
-            ]
-
         return self._expr.__class__(
-            mapper,
-            depth=self._expr._depth + 1,
+            lambda df: [
+                series.alias(series.name + suffix) for series in self._expr._call(df)
+            ],
+            depth=self._expr._depth,
             function_name=self._expr._function_name,
             root_names=root_names,
             output_names=[name + suffix for name in root_names],
-            implementation=implementation,
+            implementation=self._expr._implementation,
         )
 
     def to_lowercase(self) -> PandasExpr:
         root_names = self._expr._root_names
-        implementation = self._expr._implementation
 
         if root_names is None:
             msg = (
@@ -454,29 +424,19 @@ class PandasExprNameNamespace:
             )
             raise ValueError(msg)
 
-        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
-            tmp = df.select(root_names)
-
-            return [
-                PandasSeries(
-                    tmp[n]._series.rename(tmp[n]._series.name.lower()),
-                    implementation=implementation,
-                )
-                for n in root_names
-            ]
-
         return self._expr.__class__(
-            mapper,
-            depth=self._expr._depth + 1,
+            lambda df: [
+                series.alias(series.name.lower()) for series in self._expr._call(df)
+            ],
+            depth=self._expr._depth,
             function_name=self._expr._function_name,
             root_names=root_names,
             output_names=[name.lower() for name in root_names],
-            implementation=implementation,
+            implementation=self._expr._implementation,
         )
 
     def to_uppercase(self) -> PandasExpr:
         root_names = self._expr._root_names
-        implementation = self._expr._implementation
 
         if root_names is None:
             msg = (
@@ -486,22 +446,13 @@ class PandasExprNameNamespace:
             )
             raise ValueError(msg)
 
-        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
-            tmp = df.select(root_names)
-
-            return [
-                PandasSeries(
-                    tmp[n]._series.rename(tmp[n]._series.name.upper()),
-                    implementation=implementation,
-                )
-                for n in root_names
-            ]
-
         return self._expr.__class__(
-            mapper,
-            depth=self._expr._depth + 1,
+            lambda df: [
+                series.alias(series.name.upper()) for series in self._expr._call(df)
+            ],
+            depth=self._expr._depth,
             function_name=self._expr._function_name,
             root_names=root_names,
             output_names=[name.upper() for name in root_names],
-            implementation=implementation,
+            implementation=self._expr._implementation,
         )

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -352,15 +352,15 @@ class PandasExprNameNamespace:
         root_names = self._expr._root_names
         implementation = self._expr._implementation
 
-        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
-            if root_names is None:
-                msg = (
-                    "Anonymous expressions are not supported in `.name.map`.\n"
-                    "Instead of `nw.all()`, try using a named expression, such as "
-                    "`nw.col('a', 'b')`\n"
-                )
-                raise ValueError(msg)
+        if root_names is None:
+            msg = (
+                "Anonymous expressions are not supported in `.name.map`.\n"
+                "Instead of `nw.all()`, try using a named expression, such as "
+                "`nw.col('a', 'b')`\n"
+            )
+            raise ValueError(msg)
 
+        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
             tmp = df.select(root_names)
             return [
                 PandasSeries(
@@ -382,15 +382,15 @@ class PandasExprNameNamespace:
         root_names = self._expr._root_names
         implementation = self._expr._implementation
 
-        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
-            if root_names is None:
-                msg = (
-                    "Anonymous expressions are not supported in `.name.prefix`.\n"
-                    "Instead of `nw.all()`, try using a named expression, such as "
-                    "`nw.col('a', 'b')`\n"
-                )
-                raise ValueError(msg)
+        if root_names is None:
+            msg = (
+                "Anonymous expressions are not supported in `.name.prefix`.\n"
+                "Instead of `nw.all()`, try using a named expression, such as "
+                "`nw.col('a', 'b')`\n"
+            )
+            raise ValueError(msg)
 
+        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
             tmp = df.select(root_names)
 
             return [
@@ -414,15 +414,15 @@ class PandasExprNameNamespace:
         root_names = self._expr._root_names
         implementation = self._expr._implementation
 
-        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
-            if root_names is None:
-                msg = (
-                    "Anonymous expressions are not supported in `.name.suffix`.\n"
-                    "Instead of `nw.all()`, try using a named expression, such as "
-                    "`nw.col('a', 'b')`\n"
-                )
-                raise ValueError(msg)
+        if root_names is None:
+            msg = (
+                "Anonymous expressions are not supported in `.name.suffix`.\n"
+                "Instead of `nw.all()`, try using a named expression, such as "
+                "`nw.col('a', 'b')`\n"
+            )
+            raise ValueError(msg)
 
+        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
             tmp = df.select(root_names)
 
             return [
@@ -446,15 +446,15 @@ class PandasExprNameNamespace:
         root_names = self._expr._root_names
         implementation = self._expr._implementation
 
-        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
-            if root_names is None:
-                msg = (
-                    "Anonymous expressions are not supported in `.name.to_lowercase`.\n"
-                    "Instead of `nw.all()`, try using a named expression, such as "
-                    "`nw.col('a', 'b')`\n"
-                )
-                raise ValueError(msg)
+        if root_names is None:
+            msg = (
+                "Anonymous expressions are not supported in `.name.to_lowercase`.\n"
+                "Instead of `nw.all()`, try using a named expression, such as "
+                "`nw.col('a', 'b')`\n"
+            )
+            raise ValueError(msg)
 
+        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
             tmp = df.select(root_names)
 
             return [
@@ -478,15 +478,15 @@ class PandasExprNameNamespace:
         root_names = self._expr._root_names
         implementation = self._expr._implementation
 
-        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
-            if root_names is None:
-                msg = (
-                    "Anonymous expressions are not supported in `.name.to_uppercase`.\n"
-                    "Instead of `nw.all()`, try using a named expression, such as "
-                    "`nw.col('a', 'b')`\n"
-                )
-                raise ValueError(msg)
+        if root_names is None:
+            msg = (
+                "Anonymous expressions are not supported in `.name.to_uppercase`.\n"
+                "Instead of `nw.all()`, try using a named expression, such as "
+                "`nw.col('a', 'b')`\n"
+            )
+            raise ValueError(msg)
 
+        def mapper(df: PandasDataFrame) -> list[PandasSeries]:
             tmp = df.select(root_names)
 
             return [

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -457,6 +457,11 @@ class PandasSeriesStringNamespace:
             self._series._series.str.endswith(suffix),
         )
 
+    def starts_with(self, prefix: str) -> PandasSeries:
+        return self._series._from_series(
+            self._series._series.str.startswith(prefix),
+        )
+
     def head(self, n: int = 5) -> PandasSeries:
         return self._series._from_series(
             self._series._series.str[:n],

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -919,6 +919,9 @@ class SeriesStringNamespace:
     def ends_with(self, suffix: str) -> Series:
         return self._series.__class__(self._series._series.str.ends_with(suffix))
 
+    def starts_with(self, suffix: str) -> Series:
+        return self._series.__class__(self._series._series.str.starts_with(suffix))
+
     def head(self, n: int = 5) -> Series:
         """
         Take the first n elements of each string.

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -36,7 +36,8 @@ base_err_msg = "Anonymous expressions are not supported in "
     [df_pandas, df_polars, df_mpd],
 )
 def test_map(df_raw: Any) -> None:
-    func = lambda s: s[::-1].lower()  # noqa: E731
+    def func(s: str) -> str:
+        return s[::-1].lower()
 
     df = nw.LazyFrame(df_raw)
     result = df.select((nw.col("foo", "BAR") * 2).name.map(func))

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import os
+import warnings
+from typing import Any
+
+import pandas as pd
+import polars as pl
+import pytest
+
+import narwhals as nw
+
+data = {"foo": [1, 2, 3], "BAR": [4, 5, 6]}
+df_pandas = pd.DataFrame(data)
+df_polars = pl.LazyFrame(data)
+
+if os.environ.get("CI", None):
+    try:
+        import modin.pandas as mpd
+    except ImportError:  # pragma: no cover
+        df_mpd = df_pandas.copy()
+    else:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=UserWarning)
+            df_mpd = mpd.DataFrame(data)
+else:  # pragma: no cover
+    df_mpd = df_pandas.copy()
+
+
+@pytest.mark.parametrize(
+    "df_raw",
+    [df_pandas, df_polars, df_mpd],
+)
+def test_prefix(df_raw: Any) -> None:
+    prefix = "pre_"
+    df = nw.LazyFrame(df_raw)
+    result = df.select(nw.col("foo", "BAR").name.prefix(prefix))
+    result_native = nw.to_native(result)
+    expected = [prefix + k for k in data]
+
+    assert result.columns == expected
+    assert list(result_native.columns) == expected
+
+
+@pytest.mark.parametrize(
+    "df_raw",
+    [df_pandas, df_polars, df_mpd],
+)
+def test_suffix(df_raw: Any) -> None:
+    suffix = "_post"
+    df = nw.LazyFrame(df_raw)
+    result = df.select(nw.col("foo", "BAR").name.suffix(suffix))
+    result_native = nw.to_native(result)
+    expected = [k + suffix for k in data]
+
+    assert result.columns == expected
+    assert list(result_native.columns) == expected
+
+
+@pytest.mark.parametrize(
+    "df_raw",
+    [df_pandas, df_polars, df_mpd],
+)
+def test_to_lowercase(df_raw: Any) -> None:
+    df = nw.LazyFrame(df_raw)
+    result = df.select(nw.col("foo", "BAR").name.to_lowercase())
+    result_native = nw.to_native(result)
+    expected = [k.lower() for k in data]
+
+    assert result.columns == expected
+    assert list(result_native.columns) == expected
+
+
+@pytest.mark.parametrize(
+    "df_raw",
+    [df_pandas, df_polars, df_mpd],
+)
+def test_to_uppercase(df_raw: Any) -> None:
+    df = nw.LazyFrame(df_raw)
+    result = df.select(nw.col("foo", "BAR").name.to_uppercase())
+    result_native = nw.to_native(result)
+    expected = [k.upper() for k in data]
+
+    assert result.columns == expected
+    assert list(result_native.columns) == expected
+
+
+@pytest.mark.parametrize(
+    "df_raw",
+    [df_pandas, df_polars, df_mpd],
+)
+def test_map(df_raw: Any) -> None:
+    func = lambda s: s[:2].lower()  # noqa: E731
+
+    df = nw.LazyFrame(df_raw)
+    result = df.select(nw.col("foo", "BAR").name.map(func))
+    result_native = nw.to_native(result)
+    expected = [func(k) for k in data]
+
+    assert result.columns == expected
+    assert list(result_native.columns) == expected

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -27,6 +27,8 @@ else:  # pragma: no cover
     df_mpd = df_pandas.copy()
 
 
+base_err_msg = "Anonymous expressions are not supported in "
+
 @pytest.mark.parametrize(
     "df_raw",
     [df_pandas, df_polars, df_mpd],
@@ -37,9 +39,12 @@ def test_prefix(df_raw: Any) -> None:
     result = df.select(nw.col("foo", "BAR").name.prefix(prefix))
     result_native = nw.to_native(result)
     expected = [prefix + k for k in data]
-
     assert result.columns == expected
     assert list(result_native.columns) == expected
+
+    if not isinstance(df_raw, (pl.LazyFrame, pl.DataFrame)):
+        with pytest.raises(ValueError, match=base_err_msg + "`.name.prefix`."):
+            df.select(nw.all().name.prefix(prefix))
 
 
 @pytest.mark.parametrize(
@@ -56,6 +61,11 @@ def test_suffix(df_raw: Any) -> None:
     assert result.columns == expected
     assert list(result_native.columns) == expected
 
+    if not isinstance(df_raw, (pl.LazyFrame, pl.DataFrame)):
+        with pytest.raises(ValueError, match=base_err_msg + "`.name.suffix`."):
+            df.select(nw.all().name.suffix(suffix))
+
+
 
 @pytest.mark.parametrize(
     "df_raw",
@@ -69,6 +79,11 @@ def test_to_lowercase(df_raw: Any) -> None:
 
     assert result.columns == expected
     assert list(result_native.columns) == expected
+
+    if not isinstance(df_raw, (pl.LazyFrame, pl.DataFrame)):
+        with pytest.raises(ValueError, match=base_err_msg + "`.name.to_lowercase`."):
+            df.select(nw.all().name.to_lowercase())
+
 
 
 @pytest.mark.parametrize(
@@ -84,6 +99,9 @@ def test_to_uppercase(df_raw: Any) -> None:
     assert result.columns == expected
     assert list(result_native.columns) == expected
 
+    if not isinstance(df_raw, (pl.LazyFrame, pl.DataFrame)):
+        with pytest.raises(ValueError, match=base_err_msg + "`.name.to_uppercase`."):
+            df.select(nw.all().name.to_uppercase())
 
 @pytest.mark.parametrize(
     "df_raw",
@@ -99,3 +117,7 @@ def test_map(df_raw: Any) -> None:
 
     assert result.columns == expected
     assert list(result_native.columns) == expected
+
+    if not isinstance(df_raw, (pl.LazyFrame, pl.DataFrame)):
+        with pytest.raises(ValueError, match=base_err_msg + "`.name.map`."):
+            df.select(nw.all().name.map(func))

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -29,6 +29,7 @@ else:  # pragma: no cover
 
 base_err_msg = "Anonymous expressions are not supported in "
 
+
 @pytest.mark.parametrize(
     "df_raw",
     [df_pandas, df_polars, df_mpd],
@@ -66,7 +67,6 @@ def test_suffix(df_raw: Any) -> None:
             df.select(nw.all().name.suffix(suffix))
 
 
-
 @pytest.mark.parametrize(
     "df_raw",
     [df_pandas, df_polars, df_mpd],
@@ -85,7 +85,6 @@ def test_to_lowercase(df_raw: Any) -> None:
             df.select(nw.all().name.to_lowercase())
 
 
-
 @pytest.mark.parametrize(
     "df_raw",
     [df_pandas, df_polars, df_mpd],
@@ -102,6 +101,7 @@ def test_to_uppercase(df_raw: Any) -> None:
     if not isinstance(df_raw, (pl.LazyFrame, pl.DataFrame)):
         with pytest.raises(ValueError, match=base_err_msg + "`.name.to_uppercase`."):
             df.select(nw.all().name.to_uppercase())
+
 
 @pytest.mark.parametrize(
     "df_raw",

--- a/tests/test_str.py
+++ b/tests/test_str.py
@@ -45,3 +45,23 @@ def test_ends_with(df_raw: Any) -> None:
         "a": [True, False],
     }
     compare_dicts(result_native, expected)
+
+
+@pytest.mark.parametrize(
+    "df_raw",
+    [df_pandas, df_polars, df_mpd],
+)
+def test_starts_with(df_raw: Any) -> None:
+    df = nw.LazyFrame(df_raw)
+    result = df.select(nw.col("a").str.starts_with("fda"))
+    result_native = nw.to_native(result)
+    expected = {
+        "a": [True, False],
+    }
+    compare_dicts(result_native, expected)
+    result = df.select(df.collect()["a"].str.starts_with("fda"))
+    result_native = nw.to_native(result)
+    expected = {
+        "a": [True, False],
+    }
+    compare_dicts(result_native, expected)

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -87,7 +87,11 @@ documented = [
     for i in content.splitlines()
     if i.startswith("        - ")
 ]
-if missing := set(top_level_functions).difference(documented).difference({"dt", "str"}):
+if (
+    missing := set(top_level_functions)
+    .difference(documented)
+    .difference({"dt", "str", "name"})
+):
     print("Series: not documented")  # noqa: T201
     print(missing)  # noqa: T201
     ret = 1
@@ -106,7 +110,11 @@ documented = [
     for i in content.splitlines()
     if i.startswith("        - ")
 ]
-if missing := set(top_level_functions).difference(documented).difference({"str", "dt"}):
+if (
+    missing := set(top_level_functions)
+    .difference(documented)
+    .difference({"str", "dt", "name"})
+):
     print("Expr: not documented")  # noqa: T201
     print(missing)  # noqa: T201
     ret = 1


### PR DESCRIPTION
# Description

Introduces `Expr.name` namespace and 5 methods within it (`.map`, `.suffix`, `.prefix`, `.to_lowercase`, and `to_uppercase` (Fix #130).
Adds `starts_with` withing the `Expr.str` namespace.

## Current issues

If I am understanding correctly from polars, name namespace should address the _root_ name. 
As I was to implement these from scratch as an Expr, I am unsure if there are uncovered edge cases with the current implementation. ~~Once this is clarified I will add checks for the `Anonymous expressions` case.~~
