### PR TITLE
DOC: usage example for is_in added in Expr

### DIFF
--- a/narwhals/expression.py
+++ b/narwhals/expression.py
@@ -636,6 +636,48 @@ class Expr:
         )
 
     def is_in(self, other: Any) -> Expr:
+        """
+        Check if elements of this expression are present in the other list.
+
+        Arguments:
+            other: List-like objects.
+
+        Examples:
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> df_pd = pd.DataFrame({'a': [1, 2, 9, 10]})
+            >>> df_pl = pl.DataFrame({'a': [1, 2, 9, 10]})
+
+            Let's define a dataframe-agnostic function:
+
+            >>> def func(df_any):
+            ...    df = nw.from_native(df_any)
+            ...    df = df.with_columns(b = nw.col('a').is_in([1, 2]))
+            ...    return nw.to_native(df)
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(df_pd)
+                a      b
+            0   1   True
+            1   2   True
+            2   9  False
+            3  10  False
+
+            >>> func(df_pl)
+            shape: (4, 2)
+            ┌─────┬───────┐
+            │ a   ┆ b     │
+            │ --- ┆ ---   │
+            │ i64 ┆ bool  │
+            ╞═════╪═══════╡
+            │ 1   ┆ true  │
+            │ 2   ┆ true  │
+            │ 9   ┆ false │
+            │ 10  ┆ false │
+            └─────┴───────┘
+        """
         return self.__class__(lambda plx: self._call(plx).is_in(other))
 
     def filter(self, other: Any) -> Expr:


### PR DESCRIPTION
I noticed that the narwhals Expr.is_in() works slightly different than polars Expr.is_in() - 
it doesn't accept Series and Expressions as "other" argument.  Therefore I changed the description to "list"and "List-like objects"
because it was what I've found in the error description.

Edit: I see now, that has been addressed in #101 , should I then change "list", "list-like objects"to Iterable in the docstrings?