### PR TITLE
ban 3rd party imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,8 @@ repos:
       entry: python -m utils.check_api_reference
       language: python
       additional_dependencies: [polars]
-
+    - id: imports-are-banned
+      name: import are banned (use `get_pandas` instead of `import pandas`)
+      entry: (?<!>>> )import (pandas|polars|modin|cudf)
+      language: pygrep
+      files: ^narwhals/

--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -12,6 +12,8 @@ from typing import Iterator
 from narwhals._pandas_like.utils import is_simple_aggregation
 from narwhals._pandas_like.utils import item
 from narwhals._pandas_like.utils import parse_into_exprs
+from narwhals._pandas_like.utils import series_from_iterable
+from narwhals.dependencies import get_pandas
 from narwhals.utils import parse_version
 from narwhals.utils import remove_prefix
 
@@ -88,9 +90,7 @@ def agg_pandas(  # noqa: PLR0913
     - https://github.com/rapidsai/cudf/issues/15118
     - https://github.com/rapidsai/cudf/issues/15084
     """
-    import pandas as pd
-
-    from narwhals._pandas_like.namespace import PandasNamespace
+    pd = get_pandas()
 
     all_simple_aggs = True
     for expr in exprs:
@@ -140,8 +140,6 @@ def agg_pandas(  # noqa: PLR0913
         stacklevel=2,
     )
 
-    plx = PandasNamespace(implementation=implementation)
-
     def func(df: Any) -> Any:
         out_group = []
         out_names = []
@@ -150,10 +148,12 @@ def agg_pandas(  # noqa: PLR0913
             for result_keys in results_keys:
                 out_group.append(item(result_keys._series))
                 out_names.append(result_keys.name)
-        return plx._make_native_series(name="", data=out_group, index=out_names)
+        return series_from_iterable(
+            out_group, index=out_names, name="", implementation=implementation
+        )
 
     if implementation == "pandas":
-        import pandas as pd
+        pd = get_pandas()
 
         if parse_version(pd.__version__) < parse_version("2.2.0"):  # pragma: no cover
             result_complex = grouped.apply(func)

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -41,21 +41,6 @@ class PandasNamespace:
     def selectors(self) -> PandasSelector:
         return PandasSelector(self._implementation)
 
-    def _make_native_series(self, name: str, data: list[Any], index: Any) -> Any:
-        if self._implementation == "pandas":
-            import pandas as pd
-
-            return pd.Series(name=name, data=data, index=index)
-        if self._implementation == "modin":  # pragma: no cover
-            import modin.pandas as mpd
-
-            return mpd.Series(name=name, data=data, index=index)
-        if self._implementation == "cudf":  # pragma: no cover
-            import cudf
-
-            return cudf.Series(name=name, data=data, index=index)
-        raise NotImplementedError  # pragma: no cover
-
     # --- not in spec ---
     def __init__(self, implementation: str) -> None:
         self._implementation = implementation

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -9,6 +9,7 @@ from narwhals._pandas_like.utils import reverse_translate_dtype
 from narwhals._pandas_like.utils import to_datetime
 from narwhals._pandas_like.utils import translate_dtype
 from narwhals._pandas_like.utils import validate_column_comparand
+from narwhals.dependencies import get_pandas
 from narwhals.utils import parse_version
 
 if TYPE_CHECKING:
@@ -81,7 +82,7 @@ class PandasSeries:
         self._implementation = implementation
         self._use_copy_false = False
         if self._implementation == "pandas":
-            import pandas as pd
+            pd = get_pandas()
 
             if parse_version(pd.__version__) < parse_version("3.0.0"):
                 self._use_copy_false = True
@@ -162,11 +163,8 @@ class PandasSeries:
         return self._from_series(res)
 
     def is_in(self, other: Any) -> PandasSeries:
-        import pandas as pd
-
         ser = self._series
         res = ser.isin(other)
-        res[ser.isna()] = pd.NA
         return self._from_series(res)
 
     # Binary comparisons

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -256,17 +256,17 @@ def horizontal_concat(dfs: list[Any], implementation: str) -> Any:
     Should be in namespace.
     """
     if implementation == "pandas":
-        import pandas as pd
+        pd = get_pandas()
 
         if parse_version(pd.__version__) < parse_version("3.0.0"):
             return pd.concat(dfs, axis=1, copy=False)
         return pd.concat(dfs, axis=1)  # pragma: no cover
     if implementation == "cudf":  # pragma: no cover
-        import cudf
+        cudf = get_cudf()
 
         return cudf.concat(dfs, axis=1)
     if implementation == "modin":  # pragma: no cover
-        import modin.pandas as mpd
+        mpd = get_modin()
 
         return mpd.concat(dfs, axis=1)
     msg = f"Unknown implementation: {implementation}"  # pragma: no cover
@@ -289,17 +289,17 @@ def vertical_concat(dfs: list[Any], implementation: str) -> Any:
             msg = "unable to vstack, column names don't match"
             raise TypeError(msg)
     if implementation == "pandas":
-        import pandas as pd
+        pd = get_pandas()
 
         if parse_version(pd.__version__) < parse_version("3.0.0"):
             return pd.concat(dfs, axis=0, copy=False)
         return pd.concat(dfs, axis=0)  # pragma: no cover
     if implementation == "cudf":  # pragma: no cover
-        import cudf
+        cudf = get_cudf()
 
         return cudf.concat(dfs, axis=0)
     if implementation == "modin":  # pragma: no cover
-        import modin.pandas as mpd
+        mpd = get_modin()
 
         return mpd.concat(dfs, axis=0)
     msg = f"Unknown implementation: {implementation}"  # pragma: no cover
@@ -311,15 +311,15 @@ def series_from_iterable(
 ) -> Any:
     """Return native series."""
     if implementation == "pandas":
-        import pandas as pd
+        pd = get_pandas()
 
         return pd.Series(data, name=name, index=index, copy=False)
     if implementation == "cudf":  # pragma: no cover
-        import cudf
+        cudf = get_cudf()
 
         return cudf.Series(data, name=name, index=index)
     if implementation == "modin":  # pragma: no cover
-        import modin.pandas as mpd
+        mpd = get_modin()
 
         return mpd.Series(data, name=name, index=index)
     msg = f"Unknown implementation: {implementation}"  # pragma: no cover
@@ -390,9 +390,9 @@ def reverse_translate_dtype(dtype: DType | type[DType]) -> Any:
     if isinstance_or_issubclass(dtype, dtypes.UInt8):
         return "uint8"
     if isinstance_or_issubclass(dtype, dtypes.String):
-        import pandas as pd
+        pd = get_pandas()
 
-        if parse_version(pd.__version__) >= parse_version("2.0.0"):
+        if pd is not None and parse_version(pd.__version__) >= parse_version("2.0.0"):
             if get_pyarrow() is not None:
                 return "string[pyarrow]"
             return "string[python]"  # pragma: no cover

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 
+from narwhals.dependencies import get_polars
 from narwhals.utils import isinstance_or_issubclass
 
 if TYPE_CHECKING:
@@ -116,7 +117,7 @@ def translate_dtype(plx: Any, dtype: DType) -> Any:
 def to_narwhals_dtype(dtype: Any, *, is_polars: bool) -> DType:
     if not is_polars:
         return dtype  # type: ignore[no-any-return]
-    import polars as pl
+    pl = get_polars()
 
     if dtype == pl.Float64:
         return Float64()

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -67,9 +67,7 @@ class Series:
 
     def __narwhals_namespace__(self) -> Any:
         if self._is_polars:
-            import polars as pl
-
-            return pl
+            return get_polars()
         return self._series.__narwhals_namespace__()
 
     @property


### PR DESCRIPTION
this helps ensure that we're never importing anything on behalf of the user, we should only ever use what they're already using