### PR TITLE
Keep Pandas-like Series original name

### DIFF
--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -78,7 +78,7 @@ class PandasSeries:
             DataFrame this column originates from.
         """
 
-        self._name = str(series.name) if series.name is not None else ""
+        self._name = series.name
         self._series = series
         self._implementation = implementation
         self._use_copy_false = False
@@ -119,7 +119,7 @@ class PandasSeries:
 
     @property
     def name(self) -> str:
-        return self._name
+        return self._name  # type: ignore[no-any-return]
 
     @property
     def shape(self) -> tuple[int]:

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pandas as pd
 import pytest
 
@@ -10,3 +12,10 @@ def test_dupes() -> None:
     df = pd.concat([df, df1, df1], axis=1)
     with pytest.raises(ValueError, match="Expected unique"):
         nw.from_native(df)
+
+
+@pytest.mark.parametrize("name", ["a", 1, None])
+def test_series_name(name: Any) -> None:
+    s = pd.Series([1, 2, 3], name=name)
+    result = nw.from_native(s, series_only=True)
+    assert result.name == name


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

As discussed in #204, @MarcoGorelli is it what you had in mind?

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
   is it the correct place? Or should we create a `pandas_like/test_series.py` file?
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Should we also add a line in the docs that say that certain operations assume `str` column names and may not work (e.g. `DataFrame.__getitem__`) ?
Or maybe we can have a warning that is triggered when the column name is not `str` (both in `Series` and `DataFrame`)
