### PR TITLE
feat: `strftime` for datetime namespace

### DIFF
--- a/docs/api-reference/expressions_dt.md
+++ b/docs/api-reference/expressions_dt.md
@@ -14,11 +14,11 @@
         - millisecond
         - microsecond
         - nanosecond
-        - strftime
         - total_minutes
         - total_seconds
         - total_milliseconds
         - total_microseconds
         - total_nanoseconds
+        - to_string
       show_source: false
       show_bases: false

--- a/docs/api-reference/expressions_dt.md
+++ b/docs/api-reference/expressions_dt.md
@@ -14,6 +14,7 @@
         - millisecond
         - microsecond
         - nanosecond
+        - strftime
         - total_minutes
         - total_seconds
         - total_milliseconds

--- a/docs/api-reference/series_dt.md
+++ b/docs/api-reference/series_dt.md
@@ -14,11 +14,11 @@
         - millisecond
         - microsecond
         - nanosecond
-        - strftime
         - total_minutes
         - total_seconds
         - total_milliseconds
         - total_microseconds
         - total_nanoseconds
+        - to_string
       show_source: false
       show_bases: false

--- a/docs/api-reference/series_dt.md
+++ b/docs/api-reference/series_dt.md
@@ -14,6 +14,7 @@
         - millisecond
         - microsecond
         - nanosecond
+        - strftime
         - total_minutes
         - total_seconds
         - total_milliseconds

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -380,3 +380,6 @@ class PandasExprDateTimeNamespace:
         return reuse_series_namespace_implementation(
             self._expr, "dt", "total_nanoseconds"
         )
+
+    def strftime(self, format: str) -> PandasExpr:  # noqa: A002
+        return reuse_series_namespace_implementation(self._expr, "dt", "strftime", format)

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -381,5 +381,7 @@ class PandasExprDateTimeNamespace:
             self._expr, "dt", "total_nanoseconds"
         )
 
-    def strftime(self, format: str) -> PandasExpr:  # noqa: A002
-        return reuse_series_namespace_implementation(self._expr, "dt", "strftime", format)
+    def to_string(self, format: str) -> PandasExpr:  # noqa: A002
+        return reuse_series_namespace_implementation(
+            self._expr, "dt", "to_string", format
+        )

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -627,5 +627,5 @@ class PandasSeriesDateTimeNamespace:
             s_abs = s_abs.astype(int)
         return self._series._from_series(s_abs * s_sign)
 
-    def strftime(self, format: str) -> PandasSeries:  # noqa: A002
+    def to_string(self, format: str) -> PandasSeries:  # noqa: A002
         return self._series._from_series(self._series._series.dt.strftime(format))

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -626,3 +626,6 @@ class PandasSeriesDateTimeNamespace:
         if ~s.isna().any():
             s_abs = s_abs.astype(int)
         return self._series._from_series(s_abs * s_sign)
+
+    def strftime(self, format: str) -> PandasSeries:  # noqa: A002
+        return self._series._from_series(self._series._series.dt.strftime(format))

--- a/narwhals/expression.py
+++ b/narwhals/expression.py
@@ -2297,7 +2297,7 @@ class ExprDateTimeNamespace:
             lambda plx: self._expr._call(plx).dt.total_nanoseconds()
         )
 
-    def strftime(self, format: str) -> Expr:  # noqa: A002
+    def to_string(self, format: str) -> Expr:  # noqa: A002
         """
         Convert a Date/Time/Datetime column into a String column with the given format.
 
@@ -2318,7 +2318,7 @@ class ExprDateTimeNamespace:
 
             >>> @nw.narwhalify
             ... def func(df):
-            ...     return df.select(nw.col('a').dt.strftime("%Y/%m/%d %H:%M:%S"))
+            ...     return df.select(nw.col('a').dt.to_string("%Y/%m/%d %H:%M:%S"))
 
             We can then pass either pandas or Polars to `func`:
 
@@ -2340,7 +2340,9 @@ class ExprDateTimeNamespace:
             │ 2020/05/01 00:00:00 │
             └─────────────────────┘
         """
-        return self._expr.__class__(lambda plx: self._expr._call(plx).dt.strftime(format))
+        return self._expr.__class__(
+            lambda plx: self._expr._call(plx).dt.to_string(format)
+        )
 
 
 def col(*names: str | Iterable[str]) -> Expr:

--- a/narwhals/expression.py
+++ b/narwhals/expression.py
@@ -2297,6 +2297,51 @@ class ExprDateTimeNamespace:
             lambda plx: self._expr._call(plx).dt.total_nanoseconds()
         )
 
+    def strftime(self, format: str) -> Expr:  # noqa: A002
+        """
+        Convert a Date/Time/Datetime column into a String column with the given format.
+
+        Examples:
+            >>> from datetime import datetime
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> data = [
+            ...     datetime(2020, 3, 1),
+            ...     datetime(2020, 4, 1),
+            ...     datetime(2020, 5, 1),
+            ... ]
+            >>> df_pd = pd.DataFrame({'a': data})
+            >>> df_pl = pl.DataFrame({'a': data})
+
+            We define a dataframe-agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     return df.select(nw.col('a').dt.strftime("%Y/%m/%d %H:%M:%S"))
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(df_pd)
+                                 a
+            0  2020/03/01 00:00:00
+            1  2020/04/01 00:00:00
+            2  2020/05/01 00:00:00
+
+            >>> func(df_pl)
+            shape: (3, 1)
+            ┌─────────────────────┐
+            │ a                   │
+            │ ---                 │
+            │ str                 │
+            ╞═════════════════════╡
+            │ 2020/03/01 00:00:00 │
+            │ 2020/04/01 00:00:00 │
+            │ 2020/05/01 00:00:00 │
+            └─────────────────────┘
+        """
+        return self._expr.__class__(lambda plx: self._expr._call(plx).dt.strftime(format))
+
 
 def col(*names: str | Iterable[str]) -> Expr:
     """

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2254,7 +2254,7 @@ class SeriesDateTimeNamespace:
         """
         return self._series.__class__(self._series._series.dt.total_nanoseconds())
 
-    def strftime(self, format: str) -> Series:  # noqa: A002
+    def to_string(self, format: str) -> Series:  # noqa: A002
         """
         Convert a Date/Time/Datetime series into a String series with the given format.
 
@@ -2275,7 +2275,7 @@ class SeriesDateTimeNamespace:
 
             >>> @nw.narwhalify(allow_series=True)
             ... def func(s):
-            ...     return s.dt.strftime("%Y/%m/%d")
+            ...     return s.dt.to_string("%Y/%m/%d")
 
             We can then pass either pandas or Polars to `func`:
 
@@ -2294,4 +2294,4 @@ class SeriesDateTimeNamespace:
                "2020/05/01"
             ]
         """
-        return self._series.__class__(self._series._series.dt.strftime(format))
+        return self._series.__class__(self._series._series.dt.to_string(format))

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2253,3 +2253,45 @@ class SeriesDateTimeNamespace:
             ]
         """
         return self._series.__class__(self._series._series.dt.total_nanoseconds())
+
+    def strftime(self, format: str) -> Series:  # noqa: A002
+        """
+        Convert a Date/Time/Datetime series into a String series with the given format.
+
+        Examples:
+            >>> from datetime import datetime
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> data = [
+            ...     datetime(2020, 3, 1),
+            ...     datetime(2020, 4, 1),
+            ...     datetime(2020, 5, 1),
+            ... ]
+            >>> s_pd = pd.Series(data)
+            >>> s_pl = pl.Series(data)
+
+            We define a dataframe-agnostic function:
+
+            >>> @nw.narwhalify(allow_series=True)
+            ... def func(s):
+            ...     return s.dt.strftime("%Y/%m/%d %H:%M:%S")
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(s_pd)
+            0    2020/03/01 00:00:00
+            1    2020/04/01 00:00:00
+            2    2020/05/01 00:00:00
+            dtype: object
+
+            >>> func(s_pl)  # doctest: +NORMALIZE_WHITESPACE
+            shape: (3,)
+            Series: '' [str]
+            [
+               "2020/03/01 00:00:00"
+               "2020/04/01 00:00:00"
+               "2020/05/01 00:00:00"
+            ]
+        """
+        return self._series.__class__(self._series._series.dt.strftime(format))

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2275,23 +2275,23 @@ class SeriesDateTimeNamespace:
 
             >>> @nw.narwhalify(allow_series=True)
             ... def func(s):
-            ...     return s.dt.strftime("%Y/%m/%d %H:%M:%S")
+            ...     return s.dt.strftime("%Y/%m/%d")
 
             We can then pass either pandas or Polars to `func`:
 
             >>> func(s_pd)
-            0    2020/03/01 00:00:00
-            1    2020/04/01 00:00:00
-            2    2020/05/01 00:00:00
+            0    2020/03/01
+            1    2020/04/01
+            2    2020/05/01
             dtype: object
 
             >>> func(s_pl)  # doctest: +NORMALIZE_WHITESPACE
             shape: (3,)
             Series: '' [str]
             [
-               "2020/03/01 00:00:00"
-               "2020/04/01 00:00:00"
-               "2020/05/01 00:00:00"
+               "2020/03/01"
+               "2020/04/01"
+               "2020/05/01"
             ]
         """
         return self._series.__class__(self._series._series.dt.strftime(format))

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -173,8 +173,8 @@ def test_total_minutes(timedeltas: timedelta) -> None:
     "fmt", ["%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%Y/%m/%d %H:%M:%S", "%G-W%V-%u", "%G-W%V"]
 )
 def test_dt_to_string(constructor: Any, fmt: str) -> None:
-    input_frame = nw.from_native(constructor(data))
-    input_series: nw.Series = input_frame["a"]  # type: ignore[assignment]
+    input_frame = nw.from_native(constructor(data), eager_only=True)
+    input_series = input_frame["a"]
 
     expected_col = [datetime.strftime(d, fmt) for d in data["a"]]
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -172,14 +172,14 @@ def test_total_minutes(timedeltas: timedelta) -> None:
 @pytest.mark.parametrize(
     "fmt", ["%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%Y/%m/%d %H:%M:%S", "%G-W%V-%u", "%G-W%V"]
 )
-def test_dt_strftime(constructor: Any, fmt: str) -> None:
+def test_dt_to_string(constructor: Any, fmt: str) -> None:
     input_frame = nw.from_native(constructor(data))
     input_series: nw.Series = input_frame["a"]  # type: ignore[assignment]
 
     expected_col = [datetime.strftime(d, fmt) for d in data["a"]]
 
-    assert nw.to_native(input_series.dt.strftime(fmt)).to_list() == expected_col
+    assert nw.to_native(input_series.dt.to_string(fmt)).to_list() == expected_col
     assert (
-        nw.to_native(input_frame.select(nw.col("a").dt.strftime(fmt))["a"]).to_list()
+        nw.to_native(input_frame.select(nw.col("a").dt.to_string(fmt))["a"]).to_list()
         == expected_col
     )

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -166,3 +166,20 @@ def test_total_minutes(timedeltas: timedelta) -> None:
     assert result_pda == result_pl
     assert result_pdn == result_pl
     assert result_pdns == result_pl
+
+
+@pytest.mark.parametrize("constructor", [pd.DataFrame, pl.DataFrame])
+@pytest.mark.parametrize(
+    "fmt", ["%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%Y/%m/%d %H:%M:%S", "%G-W%V-%u", "%G-W%V"]
+)
+def test_dt_strftime(constructor: Any, fmt: str) -> None:
+    input_frame = nw.from_native(constructor(data))
+    input_series: nw.Series = input_frame["a"]  # type: ignore[assignment]
+
+    expected_col = [datetime.strftime(d, fmt) for d in data["a"]]
+
+    assert nw.to_native(input_series.dt.strftime(fmt)).to_list() == expected_col
+    assert (
+        nw.to_native(input_frame.select(nw.col("a").dt.strftime(fmt))["a"]).to_list()
+        == expected_col
+    )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.

-  `# noqa: A002` is because ruff complain about the "format" naming, but that's what polars uses.
- other comments in the code itself