### PR TITLE
enh: series and expr round method

### DIFF
--- a/docs/api-reference/expressions.md
+++ b/docs/api-reference/expressions.md
@@ -28,6 +28,7 @@
         - n_unique
         - over
         - quantile
+        - round
         - sample
         - shift
         - sort

--- a/docs/api-reference/series.md
+++ b/docs/api-reference/series.md
@@ -32,6 +32,7 @@
         - null_count
         - n_unique
         - quantile
+        - round
         - sample
         - shape
         - shift

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -294,6 +294,9 @@ class PandasExpr:
     def tail(self, n: int) -> Self:
         return reuse_series_implementation(self, "tail", n)
 
+    def round(self: Self, decimals: int = 0) -> Self:
+        return reuse_series_implementation(self, "round", decimals)
+
     @property
     def str(self) -> PandasExprStringNamespace:
         return PandasExprStringNamespace(self)

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -294,7 +294,7 @@ class PandasExpr:
     def tail(self, n: int) -> Self:
         return reuse_series_implementation(self, "tail", n)
 
-    def round(self: Self, decimals: int = 0) -> Self:
+    def round(self: Self, decimals: int) -> Self:
         return reuse_series_implementation(self, "round", decimals)
 
     @property

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -500,6 +500,9 @@ class PandasSeries:
     def tail(self: Self, n: int) -> Self:
         return self._from_series(self._series.tail(n))
 
+    def round(self: Self, decimals: int = 0) -> Self:
+        return self._from_series(self._series.round(decimals=decimals))
+
     @property
     def str(self) -> PandasSeriesStringNamespace:
         return PandasSeriesStringNamespace(self)

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -500,7 +500,7 @@ class PandasSeries:
     def tail(self: Self, n: int) -> Self:
         return self._from_series(self._series.tail(n))
 
-    def round(self: Self, decimals: int = 0) -> Self:
+    def round(self: Self, decimals: int) -> Self:
         return self._from_series(self._series.round(decimals=decimals))
 
     @property

--- a/narwhals/expression.py
+++ b/narwhals/expression.py
@@ -1519,6 +1519,49 @@ class Expr:
 
         return self.__class__(lambda plx: self._call(plx).tail(n))
 
+    def round(self, decimals: int = 0) -> Expr:
+        r"""
+        Round underlying floating point data by `decimals` digits.
+
+        Arguments
+            decimals: Number of decimals to round by.
+
+        Examples:
+            >>> import narwhals as nw
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> data = {"a": [1.12345, 2.56789, 3.901234]}
+            >>> df_pd = pd.DataFrame(data)
+            >>> df_pl = pl.DataFrame(data)
+
+            Let's define a dataframe-agnostic function that rounds to the first decimal:
+
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     return df.select(nw.col("a").round(1))
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(df_pd)  # doctest: +NORMALIZE_WHITESPACE
+                 a
+            0  1.1
+            1  2.6
+            2  3.9
+            >>> func(df_pl)  # doctest: +NORMALIZE_WHITESPACE
+            shape: (3, 1)
+            ┌─────┐
+            │ a   │
+            │ --- │
+            │ f64 │
+            ╞═════╡
+            │ 1.1 │
+            │ 2.6 │
+            │ 3.9 │
+            └─────┘
+        """
+
+        return self.__class__(lambda plx: self._call(plx).round(decimals))
+
     @property
     def str(self) -> ExprStringNamespace:
         return ExprStringNamespace(self)

--- a/narwhals/expression.py
+++ b/narwhals/expression.py
@@ -1523,8 +1523,17 @@ class Expr:
         r"""
         Round underlying floating point data by `decimals` digits.
 
-        Arguments
+        Arguments:
             decimals: Number of decimals to round by.
+
+        Notes:
+            For values exactly halfway between rounded decimal values pandas and Polars behave differently.
+
+            pandas rounds to the nearest even value (e.g. -0.5 and 0.5 round to 0.0, 1.5 and 2.5 round to 2.0, 3.5 and
+            4.5 to 4.0, etc..).
+
+            Polars rounds towards the larger integer (e.g. -0.5 to -1.0, 0.5 to 1.0, 1.5 to 2.0, 2.5 to 3.0, etc..).
+
 
         Examples:
             >>> import narwhals as nw

--- a/narwhals/expression.py
+++ b/narwhals/expression.py
@@ -1532,7 +1532,7 @@ class Expr:
             pandas rounds to the nearest even value (e.g. -0.5 and 0.5 round to 0.0, 1.5 and 2.5 round to 2.0, 3.5 and
             4.5 to 4.0, etc..).
 
-            Polars rounds towards the larger integer (e.g. -0.5 to -1.0, 0.5 to 1.0, 1.5 to 2.0, 2.5 to 3.0, etc..).
+            Polars rounds away from 0 (e.g. -0.5 to -1.0, 0.5 to 1.0, 1.5 to 2.0, 2.5 to 3.0, etc..).
 
 
         Examples:

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -1720,7 +1720,7 @@ class Series:
             pandas rounds to the nearest even value (e.g. -0.5 and 0.5 round to 0.0, 1.5 and 2.5 round to 2.0, 3.5 and
             4.5 to 4.0, etc..).
 
-            Polars rounds towards the larger integer (e.g. -0.5 to -1.0, 0.5 to 1.0, 1.5 to 2.0, 2.5 to 3.0, etc..).
+            Polars rounds away from 0 (e.g. -0.5 to -1.0, 0.5 to 1.0, 1.5 to 2.0, 2.5 to 3.0, etc..).
 
         Examples:
             >>> import narwhals as nw

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -1714,6 +1714,14 @@ class Series:
         Arguments
             decimals: Number of decimals to round by.
 
+        Notes:
+            For values exactly halfway between rounded decimal values pandas and Polars behave differently.
+
+            pandas rounds to the nearest even value (e.g. -0.5 and 0.5 round to 0.0, 1.5 and 2.5 round to 2.0, 3.5 and
+            4.5 to 4.0, etc..).
+
+            Polars rounds towards the larger integer (e.g. -0.5 to -1.0, 0.5 to 1.0, 1.5 to 2.0, 2.5 to 3.0, etc..).
+
         Examples:
             >>> import narwhals as nw
             >>> import pandas as pd

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -1707,6 +1707,46 @@ class Series:
 
         return self._from_series(self._series.tail(n))
 
+    def round(self: Self, decimals: int = 0) -> Self:
+        r"""
+        Round underlying floating point data by `decimals` digits.
+
+        Arguments
+            decimals: Number of decimals to round by.
+
+        Examples:
+            >>> import narwhals as nw
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> data = [1.12345, 2.56789, 3.901234]
+            >>> s_pd = pd.Series(data)
+            >>> s_pl = pl.Series(data)
+
+            Let's define a dataframe-agnostic function that rounds to the first decimal:
+
+            >>> @nw.narwhalify(allow_series=True)
+            ... def func(s):
+            ...     return s.round(1)
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(s_pd)  # doctest: +NORMALIZE_WHITESPACE
+            0    1.1
+            1    2.6
+            2    3.9
+            dtype: float64
+
+            >>> func(s_pl)  # doctest: +NORMALIZE_WHITESPACE
+            shape: (3,)
+            Series: '' [f64]
+            [
+               1.1
+               2.6
+               3.9
+            ]
+        """
+        return self._from_series(self._series.round(decimals))
+
     @property
     def str(self) -> SeriesStringNamespace:
         return SeriesStringNamespace(self)

--- a/tests/expr/round_test.py
+++ b/tests/expr/round_test.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import polars as pl
+import pytest
+
+import narwhals as nw
+from tests.utils import compare_dicts
+
+
+@pytest.mark.parametrize("constructor", [pd.DataFrame, pl.DataFrame])
+@pytest.mark.parametrize("decimals", [0, 1, 2])
+def test_round(constructor: Any, decimals: int) -> None:
+    data = {"a": [1.12345, 2.56789, 3.901234]}
+    df_raw = constructor(data)
+    df = nw.from_native(df_raw, eager_only=True)
+
+    expected_data = {k: [round(e, decimals) for e in v] for k, v in data.items()}
+    result_frame = df.select(nw.col("a").round(decimals))
+    compare_dicts(result_frame, expected_data)
+
+    result_series = df["a"].round(decimals)
+
+    assert result_series.to_numpy().tolist() == expected_data["a"]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -765,19 +765,3 @@ def test_item_value_error(
 ) -> None:
     with pytest.raises(ValueError, match=err_msg):
         nw.from_native(df_raw, eager_only=True).item(row, column)
-
-
-@pytest.mark.parametrize("constructor", [pd.DataFrame, pl.DataFrame])
-@pytest.mark.parametrize("decimals", [0, 1, 2])
-def test_round(constructor: Any, decimals: int) -> None:
-    data = {"a": [1.12345, 2.56789, 3.901234]}
-    df_raw = constructor(data)
-    df = nw.from_native(df_raw, eager_only=True)
-
-    expected_data = {k: [round(e, decimals) for e in v] for k, v in data.items()}
-    result_frame = df.select(nw.col("a").round(decimals))
-    compare_dicts(result_frame, expected_data)
-
-    result_series = df["a"].round(decimals)
-
-    assert result_series.to_numpy().tolist() == expected_data["a"]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -765,3 +765,19 @@ def test_item_value_error(
 ) -> None:
     with pytest.raises(ValueError, match=err_msg):
         nw.from_native(df_raw, eager_only=True).item(row, column)
+
+
+@pytest.mark.parametrize("constructor", [pd.DataFrame, pl.DataFrame])
+@pytest.mark.parametrize("decimals", [0, 1, 2])
+def test_round(constructor: Any, decimals: int) -> None:
+    data = {"a": [1.12345, 2.56789, 3.901234]}
+    df_raw = constructor(data)
+    df = nw.from_native(df_raw, eager_only=True)
+
+    expected_data = {k: [round(e, decimals) for e in v] for k, v in data.items()}
+    result_frame = df.select(nw.col("a").round(decimals))
+    compare_dicts(result_frame, expected_data)
+
+    result_series = df["a"].round(decimals)
+
+    assert result_series.to_numpy().tolist() == expected_data["a"]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Closes #302 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.

I just realized polars does not have a `DataFrame.round`, I guess `df.select(pl.all().round())` would do the trick :) 