### PR TITLE
refactor: rename `series_from_iterable`

### DIFF
--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -10,8 +10,8 @@ from typing import Iterable
 from typing import Iterator
 
 from narwhals._pandas_like.utils import is_simple_aggregation
+from narwhals._pandas_like.utils import native_series_from_iterable
 from narwhals._pandas_like.utils import parse_into_exprs
-from narwhals._pandas_like.utils import series_from_iterable
 from narwhals.dependencies import get_pandas
 from narwhals.utils import parse_version
 from narwhals.utils import remove_prefix
@@ -156,7 +156,7 @@ def agg_pandas(  # noqa: PLR0913
             for result_keys in results_keys:
                 out_group.append(result_keys._series.item())
                 out_names.append(result_keys.name)
-        return series_from_iterable(
+        return native_series_from_iterable(
             out_group, index=out_names, name="", implementation=implementation
         )
 

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -12,8 +12,8 @@ from narwhals._pandas_like.expr import PandasExpr
 from narwhals._pandas_like.selectors import PandasSelectorNamespace
 from narwhals._pandas_like.series import PandasSeries
 from narwhals._pandas_like.utils import horizontal_concat
+from narwhals._pandas_like.utils import native_series_from_iterable
 from narwhals._pandas_like.utils import parse_into_exprs
-from narwhals._pandas_like.utils import series_from_iterable
 from narwhals._pandas_like.utils import vertical_concat
 from narwhals.utils import flatten
 
@@ -67,7 +67,7 @@ class PandasNamespace:
         self, value: Any, series: PandasSeries
     ) -> PandasSeries:
         return PandasSeries(
-            series_from_iterable(
+            native_series_from_iterable(
                 [value],
                 name=series._series.name,
                 index=series._series.index[0:1],
@@ -111,7 +111,7 @@ class PandasNamespace:
     def lit(self, value: Any, dtype: dtypes.DType | None) -> PandasExpr:
         def _lit_pandas_series(df: PandasDataFrame) -> PandasSeries:
             pandas_series = PandasSeries(
-                series_from_iterable(
+                native_series_from_iterable(
                     data=[value],
                     name="lit",
                     index=df._dataframe.index[0:1],
@@ -157,7 +157,7 @@ class PandasNamespace:
         return PandasExpr(
             lambda df: [
                 PandasSeries(
-                    series_from_iterable(
+                    native_series_from_iterable(
                         [len(df._dataframe)],
                         name="len",
                         index=[0],

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -12,7 +12,6 @@ from narwhals._pandas_like.expr import PandasExpr
 from narwhals._pandas_like.selectors import PandasSelectorNamespace
 from narwhals._pandas_like.series import PandasSeries
 from narwhals._pandas_like.utils import horizontal_concat
-from narwhals._pandas_like.utils import native_series_from_iterable
 from narwhals._pandas_like.utils import parse_into_exprs
 from narwhals._pandas_like.utils import vertical_concat
 from narwhals.utils import flatten
@@ -66,13 +65,10 @@ class PandasNamespace:
     def _create_series_from_scalar(
         self, value: Any, series: PandasSeries
     ) -> PandasSeries:
-        return PandasSeries(
-            native_series_from_iterable(
-                [value],
-                name=series._series.name,
-                index=series._series.index[0:1],
-                implementation=self._implementation,
-            ),
+        return PandasSeries.from_iterable(
+            [value],
+            name=series._series.name,
+            index=series._series.index[0:1],
             implementation=self._implementation,
         )
 
@@ -110,13 +106,10 @@ class PandasNamespace:
 
     def lit(self, value: Any, dtype: dtypes.DType | None) -> PandasExpr:
         def _lit_pandas_series(df: PandasDataFrame) -> PandasSeries:
-            pandas_series = PandasSeries(
-                native_series_from_iterable(
-                    data=[value],
-                    name="lit",
-                    index=df._dataframe.index[0:1],
-                    implementation=self._implementation,
-                ),
+            pandas_series = PandasSeries.from_iterable(
+                data=[value],
+                name="lit",
+                index=df._dataframe.index[0:1],
                 implementation=self._implementation,
             )
             if dtype:
@@ -156,15 +149,12 @@ class PandasNamespace:
     def len(self) -> PandasExpr:
         return PandasExpr(
             lambda df: [
-                PandasSeries(
-                    native_series_from_iterable(
-                        [len(df._dataframe)],
-                        name="len",
-                        index=[0],
-                        implementation=self._implementation,
-                    ),
+                PandasSeries.from_iterable(
+                    [len(df._dataframe)],
+                    name="len",
+                    index=[0],
                     implementation=self._implementation,
-                ),
+                )
             ],
             depth=0,
             function_name="len",

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Iterable
 from typing import Literal
 from typing import Sequence
 
+from narwhals._pandas_like.utils import native_series_from_iterable
 from narwhals._pandas_like.utils import reverse_translate_dtype
 from narwhals._pandas_like.utils import to_datetime
 from narwhals._pandas_like.utils import translate_dtype
@@ -111,6 +113,17 @@ class PandasSeries:
         return self.__class__(
             series,
             implementation=self._implementation,
+        )
+
+    @classmethod
+    def from_iterable(
+        cls: type[Self], data: Iterable[Any], name: str, index: Any, implementation: str
+    ) -> Self:
+        return cls(
+            native_series_from_iterable(
+                data, name=name, index=index, implementation=implementation
+            ),
+            implementation=implementation,
         )
 
     def __len__(self) -> int:

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -344,7 +344,7 @@ def vertical_concat(dfs: list[Any], implementation: str) -> Any:
     raise TypeError(msg)  # pragma: no cover
 
 
-def series_from_iterable(
+def native_series_from_iterable(
     data: Iterable[Any], name: str, index: Any, implementation: str
 ) -> Any:
     """Return native series."""


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 


## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added : TODO
- [ ] Documented the changes : TODO

## If you have comments or can explain your changes, please do so below.

As mentioned in #321, I am proposing a small tweak to `series_from_iterable` to (hopefully) improve readibility:
- renaming to `native_series_from_iterable` given that it returns a "native" (pandas, modin, etc) series
- adding a `from_iterable` to `PandasSeries` to allow creating directly a `PandasSeries`

As checklist above, I still need to add a test. Happy to close if you think it is not needed :)