### PR TITLE
test: Add pylint checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,49 @@
 repos:
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: 'v0.4.8'
-  hooks:
-    # Run the formatter.
-    - id: ruff-format
-    # Run the linter.
-    - id: ruff
-- repo: https://github.com/pycqa/pylint
-  # Cannot be replaced by ruff until https://github.com/astral-sh/ruff/issues/970 is closed
-  rev: "v3.2.5"
-  hooks:
-    - id: pylint
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v1.10.0'
-  hooks:
-    - id: mypy
-      additional_dependencies: ['polars==0.20.10', 'pytest==8.0.1']
-      exclude: utils|tpch
-- repo: https://github.com/codespell-project/codespell
-  rev: 'v2.3.0'
-  hooks:
-    - id: codespell
-      files: \.(py|rst|md)$
-      args: [--ignore-words-list=ser]
-- repo: local
-  hooks:
-    - id: check-api-reference
-      name: check-api-reference
-      pass_filenames: false
-      entry: python -m utils.check_api_reference
-      language: python
-      additional_dependencies: [polars]
-    - id: imports-are-banned
-      name: import are banned (use `get_pandas` instead of `import pandas`)
-      entry: (?<!>>> )import (pandas|polars|modin|cudf)
-      language: pygrep
-      files: ^narwhals/
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.4.8"
+    hooks:
+      # Run the formatter.
+      - id: ruff-format
+      # Run the linter.
+      - id: ruff
+        args:
+          - "--fix"
+
+  - repo: https://github.com/pycqa/pylint
+    # Cannot be replaced by ruff until https://github.com/astral-sh/ruff/issues/970 is closed
+    rev: "v3.2.5"
+    hooks:
+      - id: pylint
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v1.10.0"
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - "polars==0.20.10"
+          - "pytest==8.0.1"
+        exclude: utils|tpch
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: "v2.3.0"
+    hooks:
+      - id: codespell
+        files: \.(py|rst|md)$
+        args:
+          - "--ignore-words-list=ser"
+
+  - repo: local
+    hooks:
+      - id: check-api-reference
+        name: check-api-reference
+        pass_filenames: false
+        entry: python -m utils.check_api_reference
+        language: python
+        additional_dependencies:
+          - "polars"
+
+      - id: imports-are-banned
+        name: import are banned (use `get_pandas` instead of `import pandas`)
+        entry: (?<!>>> )import (pandas|polars|modin|cudf)
+        language: pygrep
+        files: ^narwhals/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,13 @@ repos:
     rev: "v3.2.5"
     hooks:
       - id: pylint
+        additional_dependencies:
+          - "polars"
+          - "pandas"
+          - "pytest"
+          - "scikit-learn"
+          - "hypothesis"
+          - "nox"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,11 @@ repos:
     - id: ruff-format
     # Run the linter.
     - id: ruff
-      args: [--fix]
+- repo: https://github.com/pycqa/pylint
+  # Cannot be replaced by ruff until https://github.com/astral-sh/ruff/issues/970 is closed
+  rev: "v3.2.5"
+  hooks:
+    - id: pylint
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: 'v1.10.0'
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,6 @@ repos:
         additional_dependencies:
           - "polars"
           - "pandas"
-          - "pytest"
-          - "scikit-learn"
-          - "hypothesis"
-          - "nox"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,18 @@ module = [
     "modin.*",
 ]
 ignore_missing_imports = true
+
+
+[tool.pylint.main]
+fail-on = ["I"]
+fail-under = 10
+ignore = ["third_party"]
+ignore-patterns = []
+jobs = 8
+
+
+[tool.pylint."messages control"]
+disable = [
+    "missing-function-docstring",
+    "missing-module-docstring",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,35 @@ fail-under = 10
 ignore = ["third_party"]
 ignore-patterns = []
 jobs = 8
+load-plugins = [
+    "pylint.extensions.bad_builtin",
+    "pylint.extensions.broad_try_clause",
+    "pylint.extensions.code_style",
+    "pylint.extensions.check_elif",
+    "pylint.extensions.code_style",
+    "pylint.extensions.comparison_placement",
+    "pylint.extensions.confusing_elif",
+    "pylint.extensions.consider_ternary_expression",
+    "pylint.extensions.consider_refactoring_into_while_condition",
+    "pylint.extensions.dict_init_mutate",
+    "pylint.extensions.docparams",
+    "pylint.extensions.docstyle",
+    "pylint.extensions.dunder",
+    "pylint.extensions.empty_comment",
+    "pylint.extensions.eq_without_hash",
+    "pylint.extensions.for_any_all",
+    "pylint.extensions.magic_value",
+    "pylint.extensions.mccabe",
+    "pylint.extensions.no_self_use",
+    "pylint.extensions.overlapping_exceptions",
+    "pylint.extensions.private_import",
+    "pylint.extensions.redefined_loop_name",
+    "pylint.extensions.redefined_variable_type",
+    "pylint.extensions.set_membership",
+    "pylint.extensions.typing",
+    "pylint.extensions.while_used",
+]
+py-version = "3.8"
 
 
 [tool.pylint."messages control"]
@@ -118,39 +147,60 @@ disable = [
     "missing-function-docstring",
     "missing-module-docstring",
     "missing-class-docstring",
-    "protected-access",                 # TODO: Enable
-    "line-too-long",                    # TODO: Enable
-    "too-many-arguments",               # TODO: Enable
-    "import-outside-toplevel",          # TODO: Enable
-    "redefined-builtin",                # TODO: Enable
-    "redefined-outer-name",             # TODO: Enable
-    "too-few-public-methods",           # TODO: Enable
-    "too-many-public-methods",          # TODO: Enable
-    "too-many-locals",                  # TODO: Enable
-    "too-many-branches",                # TODO: Enable
-    "too-many-return-statements",       # TODO: Enable
-    "no-member",                        # TODO: Enable
-    "fixme",                            # TODO: Enable
-    "consider-using-dict-items",        # TODO: Enable
-    "no-else-return",                   # TODO: Enable
-    "unsubscriptable-object",           # TODO: Enable
-    "invalid-name",                     # TODO: Enable
-    "wrong-import-order",               # TODO: Enable
-    "unnecessary-dunder-call",          # TODO: Enable
-    "unspecified-encoding",             # TODO: Enable
-    "subprocess-run-check",             # TODO: Enable
-    "too-many-boolean-expressions",     # TODO: Enable
-    "import-self",                      # TODO: Enable
-    "unused-argument",                  # TODO: Enable
-    "possibly-used-before-assignment",  # TODO: Enable
-    "too-many-lines",                   # TODO: Enable
-    "unused-variable",                  # TODO: Enable
-    "comparison-with-itself",           # TODO: Enable
-    "useless-parent-delegation",        # TODO: Enable
-    "ungrouped-imports",                # TODO: Enable
-    "reimported",                       # TODO: Enable
-    "cyclic-import",                    # TODO: Enable
-    "duplicate-code",                   # TODO: Enable
+    "protected-access",                        # TODO: Enable
+    "line-too-long",                           # TODO: Enable
+    "too-many-arguments",                      # TODO: Enable
+    "import-outside-toplevel",                 # TODO: Enable
+    "redefined-builtin",                       # TODO: Enable
+    "redefined-outer-name",                    # TODO: Enable
+    "too-few-public-methods",                  # TODO: Enable
+    "too-many-public-methods",                 # TODO: Enable
+    "too-many-locals",                         # TODO: Enable
+    "too-many-branches",                       # TODO: Enable
+    "too-many-return-statements",              # TODO: Enable
+    "no-member",                               # TODO: Enable
+    "fixme",                                   # TODO: Enable
+    "consider-using-dict-items",               # TODO: Enable
+    "no-else-return",                          # TODO: Enable
+    "unsubscriptable-object",                  # TODO: Enable
+    "invalid-name",                            # TODO: Enable
+    "wrong-import-order",                      # TODO: Enable
+    "unnecessary-dunder-call",                 # TODO: Enable
+    "unspecified-encoding",                    # TODO: Enable
+    "subprocess-run-check",                    # TODO: Enable
+    "too-many-boolean-expressions",            # TODO: Enable
+    "import-self",                             # TODO: Enable
+    "unused-argument",                         # TODO: Enable
+    "possibly-used-before-assignment",         # TODO: Enable
+    "too-many-lines",                          # TODO: Enable
+    "unused-variable",                         # TODO: Enable
+    "comparison-with-itself",                  # TODO: Enable
+    "useless-parent-delegation",               # TODO: Enable
+    "ungrouped-imports",                       # TODO: Enable
+    "reimported",                              # TODO: Enable
+    "cyclic-import",                           # TODO: Enable
+    "duplicate-code",                          # TODO: Enable
+    "magic-value-comparison",                  # TODO: Enable
+    "no-self-use",                             # TODO: Enable
+    "consider-using-namedtuple-or-dataclass",  # TODO: Enable
+    "redefined-variable-type",                 # TODO: Enable
+    "use-set-for-membership",                  # TODO: Enable
+    "eq-without-hash",                         # TODO: Enable
+    "too-complex",                             # TODO: Enable
+    "consider-using-tuple",                    # TODO: Enable
+    "consider-using-assignment-expr",          # TODO: Enable
+    "docstring-first-line-empty",              # TODO: Enable
+    "too-many-try-statements",                 # TODO: Enable
+]
+
+enable = [
+    "bad-inline-option",
+    "file-ignored",
+    "useless-suppression",
+    "deprecated-pragma",
+    "use-symbolic-message-instead",
+    "deprecated-pragma",
+    "file-ignored",
 ]
 
 [tool.pylint.similarities]
@@ -158,3 +208,33 @@ ignore-comments = true
 ignore-docstrings = true
 ignore-signatures = true
 min-similarity-lines = 4
+
+
+[tool.pylint.design]
+max-args = 7
+max-attributes = 7
+max-bool-expr = 5
+max-branches = 12
+max-complexity = 10
+max-locals = 15
+max-parents = 7
+max-public-methods = 20
+max-returns = 6
+max-statements = 50
+
+
+[tool.pylint.dunder]
+good-dunder-names = [
+  "__narwhals_namespace__",
+  "__narwhals_series__",
+  "__narwhals_dataframe__",
+  "__narwhals_lazyframe__",
+  "__native_namespace__",
+  "__array__",
+]
+
+[tool.pylint.format]
+indent-after-paren = 4
+indent-string = "    "
+max-line-length = 120
+max-module-lines = 400

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,4 +117,44 @@ jobs = 8
 disable = [
     "missing-function-docstring",
     "missing-module-docstring",
+    "missing-class-docstring",
+    "protected-access",                 # TODO: Enable
+    "line-too-long",                    # TODO: Enable
+    "too-many-arguments",               # TODO: Enable
+    "import-outside-toplevel",          # TODO: Enable
+    "redefined-builtin",                # TODO: Enable
+    "redefined-outer-name",             # TODO: Enable
+    "too-few-public-methods",           # TODO: Enable
+    "too-many-public-methods",          # TODO: Enable
+    "too-many-locals",                  # TODO: Enable
+    "too-many-branches",                # TODO: Enable
+    "too-many-return-statements",       # TODO: Enable
+    "no-member",                        # TODO: Enable
+    "fixme",                            # TODO: Enable
+    "consider-using-dict-items",        # TODO: Enable
+    "no-else-return",                   # TODO: Enable
+    "unsubscriptable-object",           # TODO: Enable
+    "invalid-name",                     # TODO: Enable
+    "wrong-import-order",               # TODO: Enable
+    "unnecessary-dunder-call",          # TODO: Enable
+    "unspecified-encoding",             # TODO: Enable
+    "subprocess-run-check",             # TODO: Enable
+    "too-many-boolean-expressions",     # TODO: Enable
+    "import-self",                      # TODO: Enable
+    "unused-argument",                  # TODO: Enable
+    "possibly-used-before-assignment",  # TODO: Enable
+    "too-many-lines",                   # TODO: Enable
+    "unused-variable",                  # TODO: Enable
+    "comparison-with-itself",           # TODO: Enable
+    "useless-parent-delegation",        # TODO: Enable
+    "ungrouped-imports",                # TODO: Enable
+    "reimported",                       # TODO: Enable
+    "cyclic-import",                    # TODO: Enable
+    "duplicate-code",                   # TODO: Enable
 ]
+
+[tool.pylint.similarities]
+ignore-comments = true
+ignore-docstrings = true
+ignore-signatures = true
+min-similarity-lines = 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,12 @@ disable = [
     "consider-using-assignment-expr",          # TODO: Enable
     "docstring-first-line-empty",              # TODO: Enable
     "too-many-try-statements",                 # TODO: Enable
+    "import-error",                            # TODO: Enable
+    "wrong-import-position",                   # TODO: Enable
+    "expression-not-assigned",                 # TODO: Enable
+    "implicit-str-concat",                     # TODO: Enable
+    "redefined-loop-name",                     # TODO: Enable
+    "import-private-name",                     # TODO: Enable
 ]
 
 enable = [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

@MarcoGorelli

This PR introduces PyLint checks, ideally ruff should be sufficient but there are several checks that are [only available in pylint](https://github.com/astral-sh/ruff/issues/970). Pylint generates a score based on the failing tests, but that score weights the checks in different ways so I configured it like ruff, either everything passes or it fails (fail-under=10).

There are some sections for the design, format and similarity which provide sensitive defaults that can be customized if need be. The checks contain some optional checkers as well and I believe these will greatly help increasing the code quality and readability.

The rationale is that before doing refactors which could be subjective, trusting unopinionated checks is easier. All the failing checks have been disabled so that new PRs are not affected. The idea is fixing and re-enabling checks one by one, leveraging issues for detail discussion.

If you agree with including pylint as part of the pre-commit checks I would:

1. Open a follow-up PR fixing the most trivial checks
2. Create one issue per non-trivial check to have a separate discussion

I'll be looking forward to hear your thoughts