### PR TITLE
refactor: always recommend `from_native`

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1369,7 +1369,7 @@ class DataFrame(BaseFrame):
             ...         "c": ["a", "c", "b"],
             ...     }
             ... )
-            >>> df = nw.DataFrame(df_pl)
+            >>> df = nw.from_native(df_pl, eager_only=True)
             >>> dframe = df.sort("a")
             >>> dframe
             ┌───────────────────────────────────────────────┐
@@ -1473,8 +1473,8 @@ class DataFrame(BaseFrame):
             ...         "ham": ["a", "b", "d"],
             ...     }
             ... )
-            >>> df = nw.DataFrame(df_pl)
-            >>> other_df = nw.DataFrame(other_df_pl)
+            >>> df = nw.from_native(df_pl, eager_only=True)
+            >>> other_df = nw.from_native(df_pl, eager_only=True)
             >>> dframe = df.join(other_df, left_on="ham", right_on="ham")
             >>> dframe
             ┌───────────────────────────────────────────────┐
@@ -1777,7 +1777,7 @@ class LazyFrame(BaseFrame):
             ...         "c": [6, 5, 4, 3, 2, 1],
             ...     }
             ... )
-            >>> lf = nw.LazyFrame(lf_pl)
+            >>> lf = nw.from_native(lf_pl)
             >>> lf
             ┌───────────────────────────────────────────────┐
             | Narwhals LazyFrame                            |
@@ -1943,7 +1943,7 @@ class LazyFrame(BaseFrame):
             ...         "ham": ["a", "b", "c"],
             ...     }
             ... )
-            >>> lf = nw.LazyFrame(lf_pl)
+            >>> lf = nw.from_native(lf_pl)
             >>> lf.schema  # doctest: +SKIP
             OrderedDict({'foo': Int64, 'bar': Float64, 'ham': String})
         """
@@ -1965,7 +1965,7 @@ class LazyFrame(BaseFrame):
             ...         "ham": ["a", "b", "c"],
             ...     }
             ... ).select("foo", "bar")
-            >>> lf = nw.LazyFrame(lf_pl)
+            >>> lf = nw.from_native(lf_pl)
             >>> lf.columns
             ['foo', 'bar']
         """
@@ -2241,7 +2241,7 @@ class LazyFrame(BaseFrame):
             ...         "ham": ["a", "b", "c"],
             ...     }
             ... )
-            >>> lf = nw.LazyFrame(lf_pl)
+            >>> lf = nw.from_native(lf_pl)
             >>> lframe = lf.rename({"foo": "apple"}).collect()
             >>> lframe
             ┌───────────────────────────────────────────────┐
@@ -2396,7 +2396,7 @@ class LazyFrame(BaseFrame):
             ...         "ham": ["a", "b", "c"],
             ...     }
             ... )
-            >>> lf = nw.LazyFrame(lf_pl)
+            >>> lf = nw.from_native(lf_pl)
             >>> lframe = lf.drop("ham").collect()
             >>> lframe
             ┌───────────────────────────────────────────────┐
@@ -2458,7 +2458,7 @@ class LazyFrame(BaseFrame):
             ...         "ham": ["b", "b", "b", "b"],
             ...     }
             ... )
-            >>> lf = nw.LazyFrame(lf_pl)
+            >>> lf = nw.from_native(lf_pl)
             >>> lframe = lf.unique(None).collect().sort("foo")
             >>> lframe
             ┌───────────────────────────────────────────────┐
@@ -2774,7 +2774,7 @@ class LazyFrame(BaseFrame):
             ...         "c": ["a", "c", "b"],
             ...     }
             ... )
-            >>> lf = nw.LazyFrame(lf_pl)
+            >>> lf = nw.from_native(lf_pl)
             >>> lframe = lf.sort("a").collect()
             >>> lframe
             ┌───────────────────────────────────────────────┐
@@ -2878,8 +2878,8 @@ class LazyFrame(BaseFrame):
             ...         "ham": ["a", "b", "d"],
             ...     }
             ... )
-            >>> lf = nw.LazyFrame(lf_pl)
-            >>> other_lf = nw.LazyFrame(other_lf_pl)
+            >>> lf = nw.from_native(lf_pl)
+            >>> other_lf = nw.from_native(other_lf_pl)
             >>> lframe = lf.join(other_lf, left_on="ham", right_on="ham").collect()
             >>> lframe
             ┌───────────────────────────────────────────────┐

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1474,7 +1474,7 @@ class DataFrame(BaseFrame):
             ...     }
             ... )
             >>> df = nw.from_native(df_pl, eager_only=True)
-            >>> other_df = nw.from_native(df_pl, eager_only=True)
+            >>> other_df = nw.from_native(other_df_pl, eager_only=True)
             >>> dframe = df.join(other_df, left_on="ham", right_on="ham")
             >>> dframe
             ┌───────────────────────────────────────────────┐

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1735,23 +1735,12 @@ class LazyFrame(BaseFrame):
         if hasattr(df, "__narwhals_lazyframe__"):
             self._dataframe: Any = df.__narwhals_lazyframe__()
         elif is_polars or (
-            (pl := get_polars()) is not None
-            and isinstance(df, (pl.DataFrame, pl.LazyFrame))
+            (pl := get_polars()) is not None and isinstance(df, pl.LazyFrame)
         ):
-            self._dataframe = df.lazy()
+            self._dataframe = df
             self._is_polars = True
-        elif (pd := get_pandas()) is not None and isinstance(df, pd.DataFrame):
-            self._dataframe = PandasDataFrame(df, implementation="pandas")
-        elif (mpd := get_modin()) is not None and isinstance(
-            df, mpd.DataFrame
-        ):  # pragma: no cover
-            self._dataframe = PandasDataFrame(df, implementation="modin")
-        elif (cudf := get_cudf()) is not None and isinstance(
-            df, cudf.DataFrame
-        ):  # pragma: no cover
-            self._dataframe = PandasDataFrame(df, implementation="cudf")
         else:
-            msg = f"Expected pandas-like dataframe, Polars dataframe, or Polars lazyframe, got: {type(df)}"
+            msg = f"Expected Polars lazyframe or object that implements `__narwhals_lazyframe__`, got: {type(df)}"
             raise TypeError(msg)
 
     def __repr__(self) -> str:  # pragma: no cover

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -388,7 +388,7 @@ class DataFrame(BaseFrame):
             return Series(self._dataframe[item])
 
         elif isinstance(item, (range, slice)):
-            return DataFrame(self._dataframe[item])
+            return self._from_dataframe(self._dataframe[item])
 
         else:
             msg = f"Expected str, range or slice, got: {type(item)}"
@@ -1680,7 +1680,7 @@ class DataFrame(BaseFrame):
             └─────┴─────┴─────┘
         """
 
-        return DataFrame(self._dataframe.null_count())
+        return self._from_dataframe(self._dataframe.null_count())
 
     def item(self: Self, row: int | None = None, column: int | str | None = None) -> Any:
         r"""

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -19,6 +19,16 @@ if TYPE_CHECKING:
 
 
 class Series:
+    """
+    Narwhals Series, backed by a native series.
+
+    The native dataframe might be pandas.Series, polars.Series, ...
+
+    This class is not meant to be instantiated directly - instead, use
+    `narwhals.from_native`, making sure to pass `allow_series=True` or
+    `series_only=True`.
+    """
+
     def __init__(
         self,
         series: Any,

--- a/tests/expr/str/starts_with_ends_with_test.py
+++ b/tests/expr/str/starts_with_ends_with_test.py
@@ -20,7 +20,7 @@ df_mpd = maybe_get_modin_df(df_pandas)
     [df_pandas, df_polars, df_mpd],
 )
 def test_ends_with(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.select(nw.col("a").str.ends_with("das"))
     result_native = nw.to_native(result)
     expected = {
@@ -40,7 +40,7 @@ def test_ends_with(df_raw: Any) -> None:
     [df_pandas, df_polars, df_mpd],
 )
 def test_starts_with(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.select(nw.col("a").str.starts_with("fda"))
     result_native = nw.to_native(result)
     expected = {

--- a/tests/expr/str/starts_with_ends_with_test.py
+++ b/tests/expr/str/starts_with_ends_with_test.py
@@ -11,13 +11,13 @@ from tests.utils import compare_dicts
 from tests.utils import maybe_get_modin_df
 
 df_pandas = pd.DataFrame({"a": ["fdas", "edfas"]})
-df_polars = pl.LazyFrame({"a": ["fdas", "edfas"]})
+df_lazy = pl.LazyFrame({"a": ["fdas", "edfas"]})
 df_mpd = maybe_get_modin_df(df_pandas)
 
 
 @pytest.mark.parametrize(
     "df_raw",
-    [df_pandas, df_polars, df_mpd],
+    [df_pandas, df_lazy, df_mpd],
 )
 def test_ends_with(df_raw: Any) -> None:
     df = nw.from_native(df_raw).lazy()
@@ -37,7 +37,7 @@ def test_ends_with(df_raw: Any) -> None:
 
 @pytest.mark.parametrize(
     "df_raw",
-    [df_pandas, df_polars, df_mpd],
+    [df_pandas, df_lazy, df_mpd],
 )
 def test_starts_with(df_raw: Any) -> None:
     df = nw.from_native(df_raw).lazy()

--- a/tests/frame/drop_nulls_test.py
+++ b/tests/frame/drop_nulls_test.py
@@ -13,13 +13,11 @@ data = {
 }
 
 
-@pytest.mark.parametrize("constructor", [pd.DataFrame, pl.DataFrame])
+@pytest.mark.parametrize("constructor", [pd.DataFrame, pl.LazyFrame])
 def test_drop_nulls(constructor: Any) -> None:
     result = nw.from_native(constructor(data)).drop_nulls()
     expected = {
         "a": [2.0, 4.0],
         "b": [3.0, 5.0],
     }
-    compare_dicts(result, expected)
-    result = nw.from_native(constructor(data)).lazy().drop_nulls()
     compare_dicts(result, expected)

--- a/tests/frame/pipe_test.py
+++ b/tests/frame/pipe_test.py
@@ -13,13 +13,10 @@ data = {
 }
 
 
-@pytest.mark.parametrize("constructor", [pd.DataFrame, pl.DataFrame])
+@pytest.mark.parametrize("constructor", [pd.DataFrame, pl.LazyFrame])
 def test_pipe(constructor: Any) -> None:
     df = nw.from_native(constructor(data))
     columns = df.columns
     result = df.pipe(lambda _df: _df.select([x for x in columns if len(x) == 2]))
-    expected = {"ab": ["foo", "bars"]}
-    compare_dicts(result, expected)
-    result = df.lazy().pipe(lambda _df: _df.select([x for x in columns if len(x) == 2]))
     expected = {"ab": ["foo", "bars"]}
     compare_dicts(result, expected)

--- a/tests/frame/test_common.py
+++ b/tests/frame/test_common.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
 
@@ -13,13 +14,15 @@ from polars.testing import assert_series_equal as pl_assert_series_equal
 from sklearn.utils._testing import ignore_warnings
 
 import narwhals as nw
-from narwhals import dtypes
 from narwhals.functions import _get_deps_info
 from narwhals.functions import _get_sys_info
 from narwhals.functions import show_versions
 from narwhals.utils import parse_version
 from tests.utils import compare_dicts
 from tests.utils import maybe_get_modin_df
+
+if TYPE_CHECKING:
+    from narwhals.dtypes import DType
 
 df_pandas = pd.DataFrame({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]})
 if parse_version(pd.__version__) >= parse_version("1.5.0"):
@@ -58,7 +61,7 @@ df_mpd = maybe_get_modin_df(df_pandas)
     [df_pandas, df_polars, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_sort(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.sort("a", "b")
     result_native = nw.to_native(result)
     expected = {
@@ -82,7 +85,7 @@ def test_sort(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_filter(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.filter(nw.col("a") > 1)
     result_native = nw.to_native(result)
     expected = {"a": [3, 2], "b": [4, 6], "z": [8.0, 9.0]}
@@ -94,7 +97,7 @@ def test_filter(df_raw: Any) -> None:
     [df_pandas, df_polars],
 )
 def test_filter_series(df_raw: Any) -> None:
-    df = nw.DataFrame(df_raw).with_columns(mask=nw.col("a") > 1)
+    df = nw.from_native(df_raw, eager_only=True).with_columns(mask=nw.col("a") > 1)
     result = df.filter(df["mask"]).drop("mask")
     result_native = nw.to_native(result)
     expected = {"a": [3, 2], "b": [4, 6], "z": [8.0, 9.0]}
@@ -106,7 +109,7 @@ def test_filter_series(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_add(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.with_columns(
         c=nw.col("a") + nw.col("b"),
         d=nw.col("a") - nw.col("a").mean(),
@@ -129,7 +132,7 @@ def test_add(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_std(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.select(
         nw.col("a").std().alias("a_ddof_default"),
         nw.col("a").std(ddof=1).alias("a_ddof_1"),
@@ -153,7 +156,7 @@ def test_std(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_double(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.with_columns(nw.all() * 2)
     result_native = nw.to_native(result)
     expected = {"a": [2, 6, 4], "b": [8, 8, 12], "z": [14.0, 16.0, 18.0]}
@@ -169,7 +172,7 @@ def test_double(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_select(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.select("a")
     result_native = nw.to_native(result)
     expected = {"a": [1, 3, 2]}
@@ -178,7 +181,7 @@ def test_select(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_lazy, df_pandas_nullable])
 def test_sumh(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.with_columns(horizonal_sum=nw.sum_horizontal(nw.col("a"), nw.col("b")))
     result_native = nw.to_native(result)
     expected = {
@@ -194,7 +197,7 @@ def test_sumh(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_sumh_literal(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.with_columns(horizonal_sum=nw.sum_horizontal("a", nw.col("b")))
     result_native = nw.to_native(result)
     expected = {
@@ -210,7 +213,7 @@ def test_sumh_literal(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_sum_all(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.select(nw.all().sum())
     result_native = nw.to_native(result)
     expected = {"a": [6], "b": [14], "z": [24.0]}
@@ -224,8 +227,8 @@ def test_sum_all(df_raw: Any) -> None:
     ("dtype", "expected_lit"),
     [(None, [2, 2, 2]), (nw.String, ["2", "2", "2"]), (nw.Float32, [2.0, 2.0, 2.0])],
 )
-def test_lit(df_raw: Any, dtype: dtypes.DType | None, expected_lit: list[Any]) -> None:
-    df = nw.LazyFrame(df_raw)
+def test_lit(df_raw: Any, dtype: DType | None, expected_lit: list[Any]) -> None:
+    df = nw.from_native(df_raw).lazy()
     result = df.with_columns(nw.lit(2, dtype).alias("lit"))
     result_native = nw.to_native(result)
     expected = {
@@ -241,7 +244,7 @@ def test_lit(df_raw: Any, dtype: dtypes.DType | None, expected_lit: list[Any]) -
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_lit_error(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     with pytest.raises(
         ValueError, match="numpy arrays are not supported as literal values"
     ):
@@ -260,7 +263,7 @@ def test_lit_error(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_double_selected(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.select(nw.col("a", "b") * 2)
     result_native = nw.to_native(result)
     expected = {"a": [2, 6, 4], "b": [8, 8, 12]}
@@ -279,7 +282,7 @@ def test_double_selected(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_rename(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.rename({"a": "x", "b": "y"})
     result_native = nw.to_native(result)
     expected = {"x": [1, 3, 2], "y": [4, 4, 6], "z": [7.0, 8, 9]}
@@ -290,7 +293,7 @@ def test_rename(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_join(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     df_right = df
     result = df.join(df_right, left_on=["a", "b"], right_on=["a", "b"], how="inner")
     result_native = nw.to_native(result)
@@ -318,16 +321,16 @@ def test_join(df_raw: Any) -> None:
 # todo: https://github.com/narwhals-dev/narwhals/issues/313
 @pytest.mark.filterwarnings("ignore:Determining|Resolving.*")
 def test_schema(df_raw: Any) -> None:
-    result = nw.LazyFrame(df_raw).schema
+    result = nw.from_native(df_raw).lazy().schema
     expected = {"a": nw.Int64, "b": nw.Int64, "z": nw.Float64}
     assert result == expected
-    result = nw.LazyFrame(df_raw).collect().schema
+    result = nw.from_native(df_raw).lazy().collect().schema
     expected = {"a": nw.Int64, "b": nw.Int64, "z": nw.Float64}
     assert result == expected
-    result = nw.LazyFrame(df_raw).columns  # type: ignore[assignment]
+    result = nw.from_native(df_raw).lazy().columns  # type: ignore[assignment]
     expected = ["a", "b", "z"]  # type: ignore[assignment]
     assert result == expected
-    result = nw.LazyFrame(df_raw).collect().columns  # type: ignore[assignment]
+    result = nw.from_native(df_raw).lazy().collect().columns  # type: ignore[assignment]
     expected = ["a", "b", "z"]  # type: ignore[assignment]
     assert result == expected
 
@@ -338,7 +341,7 @@ def test_schema(df_raw: Any) -> None:
 # todo: https://github.com/narwhals-dev/narwhals/issues/313
 @pytest.mark.filterwarnings("ignore:Determining|Resolving.*")
 def test_columns(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = df.columns
     expected = ["a", "b", "z"]
     assert result == expected
@@ -346,7 +349,7 @@ def test_columns(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_mpd, df_lazy])
 def test_lazy_instantiation(df_raw: Any) -> None:
-    result = nw.LazyFrame(df_raw)
+    result = nw.from_native(df_raw).lazy()
     result_native = nw.to_native(result)
     expected = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     compare_dicts(result_native, expected)
@@ -362,7 +365,7 @@ def test_lazy_instantiation_error(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_mpd])
 def test_eager_instantiation(df_raw: Any) -> None:
-    result = nw.DataFrame(df_raw)
+    result = nw.from_native(df_raw, eager_only=True)
     result_native = nw.to_native(result)
     expected = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     compare_dicts(result_native, expected)
@@ -377,7 +380,7 @@ def test_accepted_dataframes() -> None:
         nw.DataFrame(array)
     with pytest.raises(
         TypeError,
-        match="Expected pandas-like dataframe, Polars dataframe, or Polars lazyframe, got: <class 'numpy.ndarray'>",
+        match="Expected Polars lazyframe or object that implements `__narwhals_lazyframe__`, got: <class 'numpy.ndarray'>",
     ):
         nw.LazyFrame(array)
 
@@ -397,44 +400,48 @@ def test_convert_pandas(df_raw: Any) -> None:
     r"ignore:np\.find_common_type is deprecated\.:DeprecationWarning"
 )
 def test_convert_numpy(df_raw: Any) -> None:
-    result = nw.DataFrame(df_raw).to_numpy()
+    result = nw.from_native(df_raw, eager_only=True).to_numpy()
     expected = np.array([[1, 3, 2], [4, 4, 6], [7.0, 8, 9]]).T
     np.testing.assert_array_equal(result, expected)
     assert result.dtype == "float64"
-    result = nw.DataFrame(df_raw).__array__()
+    result = nw.from_native(df_raw, eager_only=True).__array__()
     np.testing.assert_array_equal(result, expected)
     assert result.dtype == "float64"
 
 
 @pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_mpd])
 def test_shape(df_raw: Any) -> None:
-    result = nw.DataFrame(df_raw).shape
+    result = nw.from_native(df_raw, eager_only=True).shape
     expected = (3, 3)
     assert result == expected
 
 
 @pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_mpd, df_lazy])
 def test_expr_binary(df_raw: Any) -> None:
-    result = nw.LazyFrame(df_raw).with_columns(
-        a=(1 + 3 * nw.col("a")) * (1 / nw.col("a")),
-        b=nw.col("z") / (2 - nw.col("b")),
-        c=nw.col("a") + nw.col("b") / 2,
-        d=nw.col("a") - nw.col("b"),
-        e=((nw.col("a") > nw.col("b")) & (nw.col("a") >= nw.col("z"))).cast(nw.Int64),
-        f=(
-            (nw.col("a") < nw.col("b"))
-            | (nw.col("a") <= nw.col("z"))
-            | (nw.col("a") == 1)
-        ).cast(nw.Int64),
-        g=nw.col("a") != 1,
-        h=(False & (nw.col("a") != 1)),
-        i=(False | (nw.col("a") != 1)),
-        j=2 ** nw.col("a"),
-        k=2 // nw.col("a"),
-        l=nw.col("a") // 2,
-        m=nw.col("a") ** 2,
-        n=nw.col("a") % 2,
-        o=2 % nw.col("a"),
+    result = (
+        nw.from_native(df_raw)
+        .lazy()
+        .with_columns(
+            a=(1 + 3 * nw.col("a")) * (1 / nw.col("a")),
+            b=nw.col("z") / (2 - nw.col("b")),
+            c=nw.col("a") + nw.col("b") / 2,
+            d=nw.col("a") - nw.col("b"),
+            e=((nw.col("a") > nw.col("b")) & (nw.col("a") >= nw.col("z"))).cast(nw.Int64),
+            f=(
+                (nw.col("a") < nw.col("b"))
+                | (nw.col("a") <= nw.col("z"))
+                | (nw.col("a") == 1)
+            ).cast(nw.Int64),
+            g=nw.col("a") != 1,
+            h=(False & (nw.col("a") != 1)),
+            i=(False | (nw.col("a") != 1)),
+            j=2 ** nw.col("a"),
+            k=2 // nw.col("a"),
+            l=nw.col("a") // 2,
+            m=nw.col("a") ** 2,
+            n=nw.col("a") % 2,
+            o=2 % nw.col("a"),
+        )
     )
     result_native = nw.to_native(result)
     expected = {
@@ -478,8 +485,10 @@ def test_expr_unary(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_mpd, df_lazy])
 def test_expr_transform(df_raw: Any) -> None:
-    result = nw.LazyFrame(df_raw).with_columns(
-        a=nw.col("a").is_between(-1, 1), b=nw.col("b").is_in([4, 5])
+    result = (
+        nw.from_native(df_raw)
+        .lazy()
+        .with_columns(a=nw.col("a").is_between(-1, 1), b=nw.col("b").is_in([4, 5]))
     )
     result_native = nw.to_native(result)
     expected = {"a": [True, False, False], "b": [True, True, False], "z": [7, 8, 9]}
@@ -488,7 +497,7 @@ def test_expr_transform(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_lazy])
 def test_expr_min_max(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result_min = nw.to_native(df.select(nw.min("a", "b", "z")))
     result_max = nw.to_native(df.select(nw.max("a", "b", "z")))
     expected_min = {"a": [1], "b": [4], "z": [7]}
@@ -499,7 +508,7 @@ def test_expr_min_max(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_mpd, df_lazy])
 def test_expr_sample(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result_shape = nw.to_native(df.select(nw.col("a").sample(n=2)).collect()).shape
     expected = (2, 1)
     assert result_shape == expected
@@ -510,7 +519,7 @@ def test_expr_sample(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_pandas_na, df_lazy_na])
 def test_expr_na(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result_nna = nw.to_native(
         df.filter((~nw.col("a").is_null()) & (~df.collect()["z"].is_null()))
     )
@@ -522,7 +531,7 @@ def test_expr_na(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_head(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = nw.to_native(df.head(2))
     expected = {"a": [1, 3], "b": [4, 4], "z": [7.0, 8.0]}
     compare_dicts(result, expected)
@@ -538,7 +547,7 @@ def test_head(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_tail(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = nw.to_native(df.tail(2))
     expected = {"a": [3, 2], "b": [4, 6], "z": [8.0, 9]}
     compare_dicts(result, expected)
@@ -554,7 +563,7 @@ def test_tail(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_unique(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = nw.to_native(df.unique("b").sort("b"))
     expected = {"a": [1, 2], "b": [4, 6], "z": [7.0, 9.0]}
     compare_dicts(result, expected)
@@ -565,7 +574,7 @@ def test_unique(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_pandas_na, df_lazy_na])
 def test_drop_nulls(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = nw.to_native(df.select(nw.col("a").drop_nulls()))
     expected = {"a": [3, 2]}
     compare_dicts(result, expected)
@@ -578,8 +587,8 @@ def test_drop_nulls(df_raw: Any) -> None:
     ("df_raw", "df_raw_right"), [(df_pandas, df_right_pandas), (df_lazy, df_right_lazy)]
 )
 def test_concat_horizontal(df_raw: Any, df_raw_right: Any) -> None:
-    df_left = nw.LazyFrame(df_raw)
-    df_right = nw.LazyFrame(df_raw_right)
+    df_left = nw.from_native(df_raw).lazy()
+    df_right = nw.from_native(df_raw_right).lazy()
     result = nw.concat([df_left, df_right], how="horizontal")
     result_native = nw.to_native(result)
     expected = {
@@ -599,8 +608,15 @@ def test_concat_horizontal(df_raw: Any, df_raw_right: Any) -> None:
     ("df_raw", "df_raw_right"), [(df_pandas, df_right_pandas), (df_lazy, df_right_lazy)]
 )
 def test_concat_vertical(df_raw: Any, df_raw_right: Any) -> None:
-    df_left = nw.LazyFrame(df_raw).collect().rename({"a": "c", "b": "d"}).lazy().drop("z")
-    df_right = nw.LazyFrame(df_raw_right)
+    df_left = (
+        nw.from_native(df_raw)
+        .lazy()
+        .collect()
+        .rename({"a": "c", "b": "d"})
+        .lazy()
+        .drop("z")
+    )
+    df_right = nw.from_native(df_raw_right).lazy()
     result = nw.concat([df_left, df_right], how="vertical")
     result_native = nw.to_native(result)
     expected = {"c": [1, 3, 2, 6, 12, -1], "d": [4, 4, 6, 0, -4, 2]}
@@ -613,13 +629,13 @@ def test_concat_vertical(df_raw: Any, df_raw_right: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 def test_lazy(df_raw: Any) -> None:
-    df = nw.DataFrame(df_raw)
+    df = nw.from_native(df_raw, eager_only=True)
     result = df.lazy()
     assert isinstance(result, nw.LazyFrame)
 
 
 def test_to_dict() -> None:
-    df = nw.DataFrame(df_pandas)
+    df = nw.from_native(df_pandas, eager_only=True)
     result = df.to_dict(as_series=True)
     expected = {
         "a": pd.Series([1, 3, 2], name="a"),
@@ -629,7 +645,7 @@ def test_to_dict() -> None:
     for key in expected:
         pd_assert_series_equal(nw.to_native(result[key]), expected[key])
 
-    df = nw.DataFrame(df_polars)
+    df = nw.from_native(df_polars, eager_only=True)
     result = df.to_dict(as_series=True)
     expected = {
         "a": pl.Series("a", [1, 3, 2]),
@@ -644,7 +660,7 @@ def test_to_dict() -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_any_all(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     result = nw.to_native(df.select((nw.all() > 1).all()))
     expected = {"a": [False], "b": [True], "z": [True]}
     compare_dicts(result, expected)
@@ -654,7 +670,7 @@ def test_any_all(df_raw: Any) -> None:
 
 
 def test_invalid() -> None:
-    df = nw.LazyFrame(df_pandas)
+    df = nw.from_native(df_pandas).lazy()
     with pytest.raises(ValueError, match="Multi-output"):
         df.select(nw.all() + nw.all())
     with pytest.raises(TypeError, match="Perhaps you:"):
@@ -665,7 +681,7 @@ def test_invalid() -> None:
 
 @pytest.mark.parametrize("df_raw", [df_pandas])
 def test_reindex(df_raw: Any) -> None:
-    df = nw.DataFrame(df_raw)
+    df = nw.from_native(df_raw, eager_only=True)
     result = df.select("b", df["a"].sort(descending=True))
     expected = {"b": [4, 4, 6], "a": [3, 2, 1]}
     compare_dicts(result, expected)
@@ -689,8 +705,8 @@ def test_reindex(df_raw: Any) -> None:
     [(df_pandas, df_polars), (df_polars, df_pandas)],
 )
 def test_library(df_raw: Any, df_raw_right: Any) -> None:
-    df_left = nw.LazyFrame(df_raw)
-    df_right = nw.LazyFrame(df_raw_right)
+    df_left = nw.from_native(df_raw).lazy()
+    df_right = nw.from_native(df_raw_right).lazy()
     with pytest.raises(
         NotImplementedError, match="Cross-library comparisons aren't supported"
     ):
@@ -707,7 +723,7 @@ def test_library(df_raw: Any, df_raw_right: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 def test_is_duplicated(df_raw: Any) -> None:
-    df = nw.DataFrame(df_raw)
+    df = nw.from_native(df_raw, eager_only=True)
     result = nw.concat([df, df.head(1)]).is_duplicated()  # type: ignore [union-attr]
     expected = np.array([True, False, False, True])
     assert (result.to_numpy() == expected).all()
@@ -716,14 +732,14 @@ def test_is_duplicated(df_raw: Any) -> None:
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 @pytest.mark.parametrize(("threshold", "expected"), [(0, False), (10, True)])
 def test_is_empty(df_raw: Any, threshold: Any, expected: Any) -> None:
-    df = nw.DataFrame(df_raw)
+    df = nw.from_native(df_raw, eager_only=True)
     result = df.filter(nw.col("a") > threshold).is_empty()
     assert result == expected
 
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 def test_is_unique(df_raw: Any) -> None:
-    df = nw.DataFrame(df_raw)
+    df = nw.from_native(df_raw, eager_only=True)
     result = nw.concat([df, df.head(1)]).is_unique()  # type: ignore [union-attr]
     expected = np.array([False, True, True, False])
     assert (result.to_numpy() == expected).all()
@@ -731,7 +747,7 @@ def test_is_unique(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_pandas_na, df_lazy_na.collect()])
 def test_null_count(df_raw: Any) -> None:
-    df = nw.DataFrame(df_raw)
+    df = nw.from_native(df_raw, eager_only=True)
     result = nw.to_native(df.null_count())
     expected = {"a": [1], "b": [0], "z": [1]}
     compare_dicts(result, expected)

--- a/tests/frame/test_common.py
+++ b/tests/frame/test_common.py
@@ -62,7 +62,7 @@ df_mpd = maybe_get_modin_df(df_pandas)
     [df_pandas, df_polars, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_sort(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.sort("a", "b")
     result_native = nw.to_native(result)
     expected = {
@@ -86,7 +86,7 @@ def test_sort(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_filter(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.filter(nw.col("a") > 1)
     result_native = nw.to_native(result)
     expected = {"a": [3, 2], "b": [4, 6], "z": [8.0, 9.0]}
@@ -119,7 +119,7 @@ def test_empty_select(constructor: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_add(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.with_columns(
         c=nw.col("a") + nw.col("b"),
         d=nw.col("a") - nw.col("a").mean(),
@@ -142,7 +142,7 @@ def test_add(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_std(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.select(
         nw.col("a").std().alias("a_ddof_default"),
         nw.col("a").std(ddof=1).alias("a_ddof_1"),
@@ -166,7 +166,7 @@ def test_std(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_double(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.with_columns(nw.all() * 2)
     result_native = nw.to_native(result)
     expected = {"a": [2, 6, 4], "b": [8, 8, 12], "z": [14.0, 16.0, 18.0]}
@@ -182,7 +182,7 @@ def test_double(df_raw: Any) -> None:
     [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
 )
 def test_select(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.select("a")
     result_native = nw.to_native(result)
     expected = {"a": [1, 3, 2]}
@@ -191,7 +191,7 @@ def test_select(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_lazy, df_pandas_nullable])
 def test_sumh(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.with_columns(horizonal_sum=nw.sum_horizontal(nw.col("a"), nw.col("b")))
     result_native = nw.to_native(result)
     expected = {
@@ -207,7 +207,7 @@ def test_sumh(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_sumh_literal(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.with_columns(horizonal_sum=nw.sum_horizontal("a", nw.col("b")))
     result_native = nw.to_native(result)
     expected = {
@@ -223,7 +223,7 @@ def test_sumh_literal(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_sum_all(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.select(nw.all().sum())
     result_native = nw.to_native(result)
     expected = {"a": [6], "b": [14], "z": [24.0]}
@@ -238,7 +238,7 @@ def test_sum_all(df_raw: Any) -> None:
     [(None, [2, 2, 2]), (nw.String, ["2", "2", "2"]), (nw.Float32, [2.0, 2.0, 2.0])],
 )
 def test_lit(df_raw: Any, dtype: DType | None, expected_lit: list[Any]) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.with_columns(nw.lit(2, dtype).alias("lit"))
     result_native = nw.to_native(result)
     expected = {
@@ -254,7 +254,7 @@ def test_lit(df_raw: Any, dtype: DType | None, expected_lit: list[Any]) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_lit_error(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     with pytest.raises(
         ValueError, match="numpy arrays are not supported as literal values"
     ):
@@ -273,7 +273,7 @@ def test_lit_error(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_double_selected(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.select(nw.col("a", "b") * 2)
     result_native = nw.to_native(result)
     expected = {"a": [2, 6, 4], "b": [8, 8, 12]}
@@ -292,7 +292,7 @@ def test_double_selected(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_rename(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.rename({"a": "x", "b": "y"})
     result_native = nw.to_native(result)
     expected = {"x": [1, 3, 2], "y": [4, 4, 6], "z": [7.0, 8, 9]}
@@ -331,13 +331,13 @@ def test_join(df_raw: Any) -> None:
 # todo: https://github.com/narwhals-dev/narwhals/issues/313
 @pytest.mark.filterwarnings("ignore:Determining|Resolving.*")
 def test_schema(df_raw: Any) -> None:
-    result = nw.from_native(df_raw).lazy().schema
+    result = nw.from_native(df_raw).schema
     expected = {"a": nw.Int64, "b": nw.Int64, "z": nw.Float64}
     assert result == expected
     result = nw.from_native(df_raw).lazy().collect().schema
     expected = {"a": nw.Int64, "b": nw.Int64, "z": nw.Float64}
     assert result == expected
-    result = nw.from_native(df_raw).lazy().columns  # type: ignore[assignment]
+    result = nw.from_native(df_raw).columns  # type: ignore[assignment]
     expected = ["a", "b", "z"]  # type: ignore[assignment]
     assert result == expected
     result = nw.from_native(df_raw).lazy().collect().columns  # type: ignore[assignment]
@@ -351,7 +351,7 @@ def test_schema(df_raw: Any) -> None:
 # todo: https://github.com/narwhals-dev/narwhals/issues/313
 @pytest.mark.filterwarnings("ignore:Determining|Resolving.*")
 def test_columns(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = df.columns
     expected = ["a", "b", "z"]
     assert result == expected
@@ -359,7 +359,7 @@ def test_columns(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_mpd, df_lazy])
 def test_lazy_instantiation(df_raw: Any) -> None:
-    result = nw.from_native(df_raw).lazy()
+    result = nw.from_native(df_raw)
     result_native = nw.to_native(result)
     expected = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     compare_dicts(result_native, expected)
@@ -421,30 +421,26 @@ def test_convert_numpy(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_mpd, df_lazy])
 def test_expr_binary(df_raw: Any) -> None:
-    result = (
-        nw.from_native(df_raw)
-        .lazy()
-        .with_columns(
-            a=(1 + 3 * nw.col("a")) * (1 / nw.col("a")),
-            b=nw.col("z") / (2 - nw.col("b")),
-            c=nw.col("a") + nw.col("b") / 2,
-            d=nw.col("a") - nw.col("b"),
-            e=((nw.col("a") > nw.col("b")) & (nw.col("a") >= nw.col("z"))).cast(nw.Int64),
-            f=(
-                (nw.col("a") < nw.col("b"))
-                | (nw.col("a") <= nw.col("z"))
-                | (nw.col("a") == 1)
-            ).cast(nw.Int64),
-            g=nw.col("a") != 1,
-            h=(False & (nw.col("a") != 1)),
-            i=(False | (nw.col("a") != 1)),
-            j=2 ** nw.col("a"),
-            k=2 // nw.col("a"),
-            l=nw.col("a") // 2,
-            m=nw.col("a") ** 2,
-            n=nw.col("a") % 2,
-            o=2 % nw.col("a"),
-        )
+    result = nw.from_native(df_raw).with_columns(
+        a=(1 + 3 * nw.col("a")) * (1 / nw.col("a")),
+        b=nw.col("z") / (2 - nw.col("b")),
+        c=nw.col("a") + nw.col("b") / 2,
+        d=nw.col("a") - nw.col("b"),
+        e=((nw.col("a") > nw.col("b")) & (nw.col("a") >= nw.col("z"))).cast(nw.Int64),
+        f=(
+            (nw.col("a") < nw.col("b"))
+            | (nw.col("a") <= nw.col("z"))
+            | (nw.col("a") == 1)
+        ).cast(nw.Int64),
+        g=nw.col("a") != 1,
+        h=(False & (nw.col("a") != 1)),
+        i=(False | (nw.col("a") != 1)),
+        j=2 ** nw.col("a"),
+        k=2 // nw.col("a"),
+        l=nw.col("a") // 2,
+        m=nw.col("a") ** 2,
+        n=nw.col("a") % 2,
+        o=2 % nw.col("a"),
     )
     result_native = nw.to_native(result)
     expected = {
@@ -488,10 +484,8 @@ def test_expr_unary(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_mpd, df_lazy])
 def test_expr_transform(df_raw: Any) -> None:
-    result = (
-        nw.from_native(df_raw)
-        .lazy()
-        .with_columns(a=nw.col("a").is_between(-1, 1), b=nw.col("b").is_in([4, 5]))
+    result = nw.from_native(df_raw).with_columns(
+        a=nw.col("a").is_between(-1, 1), b=nw.col("b").is_in([4, 5])
     )
     result_native = nw.to_native(result)
     expected = {"a": [True, False, False], "b": [True, True, False], "z": [7, 8, 9]}
@@ -500,7 +494,7 @@ def test_expr_transform(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_lazy])
 def test_expr_min_max(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result_min = nw.to_native(df.select(nw.min("a", "b", "z")))
     result_max = nw.to_native(df.select(nw.max("a", "b", "z")))
     expected_min = {"a": [1], "b": [4], "z": [7]}
@@ -579,8 +573,8 @@ def test_drop_nulls(df_raw: Any) -> None:
     ("df_raw", "df_raw_right"), [(df_pandas, df_right_pandas), (df_lazy, df_right_lazy)]
 )
 def test_concat_horizontal(df_raw: Any, df_raw_right: Any) -> None:
-    df_left = nw.from_native(df_raw).lazy()
-    df_right = nw.from_native(df_raw_right).lazy()
+    df_left = nw.from_native(df_raw)
+    df_right = nw.from_native(df_raw_right)
     result = nw.concat([df_left, df_right], how="horizontal")
     result_native = nw.to_native(result)
     expected = {
@@ -600,14 +594,7 @@ def test_concat_horizontal(df_raw: Any, df_raw_right: Any) -> None:
     ("df_raw", "df_raw_right"), [(df_pandas, df_right_pandas), (df_lazy, df_right_lazy)]
 )
 def test_concat_vertical(df_raw: Any, df_raw_right: Any) -> None:
-    df_left = (
-        nw.from_native(df_raw)
-        .lazy()
-        .collect()
-        .rename({"a": "c", "b": "d"})
-        .lazy()
-        .drop("z")
-    )
+    df_left = nw.from_native(df_raw).rename({"a": "c", "b": "d"}).drop("z").lazy()
     df_right = nw.from_native(df_raw_right).lazy()
     result = nw.concat([df_left, df_right], how="vertical")
     result_native = nw.to_native(result)
@@ -652,7 +639,7 @@ def test_to_dict() -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_any_all(df_raw: Any) -> None:
-    df = nw.from_native(df_raw).lazy()
+    df = nw.from_native(df_raw)
     result = nw.to_native(df.select((nw.all() > 1).all()))
     expected = {"a": [False], "b": [True], "z": [True]}
     compare_dicts(result, expected)
@@ -662,7 +649,7 @@ def test_any_all(df_raw: Any) -> None:
 
 
 def test_invalid() -> None:
-    df = nw.from_native(df_pandas).lazy()
+    df = nw.from_native(df_pandas)
     with pytest.raises(ValueError, match="Multi-output"):
         df.select(nw.all() + nw.all())
     with pytest.raises(TypeError, match="Perhaps you:"):

--- a/tests/frame/test_invalid.py
+++ b/tests/frame/test_invalid.py
@@ -24,7 +24,7 @@ def test_validate_laziness() -> None:
         NotImplementedError,
         match=("The items to concatenate should either all be eager, or all lazy"),
     ):
-        nw.concat([nw.DataFrame(df), nw.LazyFrame(df)])
+        nw.concat([nw.from_native(df, eager_only=True), nw.from_native(df).lazy()])
 
 
 def test_memmap() -> None:

--- a/tests/frame/with_row_index_test.py
+++ b/tests/frame/with_row_index_test.py
@@ -13,11 +13,8 @@ data = {
 }
 
 
-@pytest.mark.parametrize("constructor", [pd.DataFrame, pl.DataFrame])
+@pytest.mark.parametrize("constructor", [pd.DataFrame, pl.LazyFrame])
 def test_with_row_index(constructor: Any) -> None:
     result = nw.from_native(constructor(data)).with_row_index()
     expected = {"a": ["foo", "bars"], "ab": ["foo", "bars"], "index": [0, 1]}
-    compare_dicts(result, expected)
-    result = nw.from_native(constructor(data)).lazy().with_row_index("foo")
-    expected = {"a": ["foo", "bars"], "ab": ["foo", "bars"], "foo": [0, 1]}
     compare_dicts(result, expected)

--- a/tests/hypothesis/test_concat.py
+++ b/tests/hypothesis/test_concat.py
@@ -44,27 +44,29 @@ def test_concat(  # pragma: no cover
 
     if how == "horizontal":
         df_pl = (
-            nw.LazyFrame(df_polars)
+            nw.from_native(df_polars)
+            .lazy()
             .collect()
             .rename({"a": "d", "b": "e"})
             .lazy()
             .drop("c")
         )
         df_pd = (
-            nw.LazyFrame(df_pandas)
+            nw.from_native(df_pandas)
+            .lazy()
             .collect()
             .rename({"a": "d", "b": "e"})
             .lazy()
             .drop("c")
         )
     else:
-        df_pl = nw.LazyFrame(df_polars)
-        df_pd = nw.LazyFrame(df_pandas)
+        df_pl = nw.from_native(df_polars).lazy()
+        df_pd = nw.from_native(df_pandas).lazy()
 
-    other_pl = nw.LazyFrame(df_polars2)
+    other_pl = nw.from_native(df_polars2).lazy()
     dframe_pl = nw.concat([df_pl, other_pl], how=how)
 
-    other_pd = nw.LazyFrame(df_pandas2)
+    other_pd = nw.from_native(df_pandas2).lazy()
     dframe_pd = nw.concat([df_pd, other_pd], how=how)
 
     dframe_pd1 = nw.to_native(dframe_pl)

--- a/tests/hypothesis/test_concat.py
+++ b/tests/hypothesis/test_concat.py
@@ -43,22 +43,8 @@ def test_concat(  # pragma: no cover
     df_pandas2 = pd.DataFrame(data)
 
     if how == "horizontal":
-        df_pl = (
-            nw.from_native(df_polars)
-            .lazy()
-            .collect()
-            .rename({"a": "d", "b": "e"})
-            .lazy()
-            .drop("c")
-        )
-        df_pd = (
-            nw.from_native(df_pandas)
-            .lazy()
-            .collect()
-            .rename({"a": "d", "b": "e"})
-            .lazy()
-            .drop("c")
-        )
+        df_pl = nw.from_native(df_polars).rename({"a": "d", "b": "e"}).drop("c").lazy()
+        df_pd = nw.from_native(df_pandas).rename({"a": "d", "b": "e"}).drop("c").lazy()
     else:
         df_pl = nw.from_native(df_polars).lazy()
         df_pd = nw.from_native(df_pandas).lazy()

--- a/tests/series/test_common.py
+++ b/tests/series/test_common.py
@@ -46,11 +46,11 @@ df_lazy = pl.LazyFrame({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]})
     "df_raw", [df_pandas, df_polars, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_len(df_raw: Any) -> None:
-    result = len(nw.Series(df_raw["a"]))
+    result = len(nw.from_native(df_raw["a"], series_only=True))
     assert result == 3
-    result = nw.Series(df_raw["a"]).len()
+    result = nw.from_native(df_raw["a"], series_only=True).len()
     assert result == 3
-    result = len(nw.LazyFrame(df_raw).collect()["a"])
+    result = len(nw.from_native(df_raw).lazy().collect()["a"])
     assert result == 3
 
 
@@ -81,14 +81,16 @@ def test_filter(df_raw: Any) -> None:
     result = nw.from_native(df_raw["a"], series_only=True).filter(df_raw["a"] > 1)
     expected = np.array([3, 2])
     assert (result.to_numpy() == expected).all()
-    result = nw.DataFrame(df_raw).select(nw.col("a").filter(nw.col("a") > 1))["a"]
+    result = nw.from_native(df_raw, eager_only=True).select(
+        nw.col("a").filter(nw.col("a") > 1)
+    )["a"]
     expected = np.array([3, 2])
     assert (result.to_numpy() == expected).all()
 
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 def test_gt(df_raw: Any) -> None:
-    s = nw.Series(df_raw["a"])
+    s = nw.from_native(df_raw["a"], series_only=True)
     result = s > s  # noqa: PLR0124
     assert not result[0]
     assert not result[1]
@@ -103,7 +105,7 @@ def test_gt(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_dtype(df_raw: Any) -> None:
-    result = nw.LazyFrame(df_raw).collect()["a"].dtype
+    result = nw.from_native(df_raw).lazy().collect()["a"].dtype
     assert result == nw.Int64
     assert result.is_numeric()
 
@@ -112,7 +114,7 @@ def test_dtype(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_reductions(df_raw: Any) -> None:
-    s = nw.LazyFrame(df_raw).collect()["a"]
+    s = nw.from_native(df_raw).lazy().collect()["a"]
     assert s.mean() == 2.0
     assert s.std() == 1.0
     assert s.min() == 1
@@ -133,16 +135,16 @@ def test_reductions(df_raw: Any) -> None:
     "df_raw", [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow]
 )
 def test_boolean_reductions(df_raw: Any) -> None:
-    df = nw.LazyFrame(df_raw).select(nw.col("a") > 1)
+    df = nw.from_native(df_raw).lazy().select(nw.col("a") > 1)
     assert not df.collect()["a"].all()
     assert df.collect()["a"].any()
 
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_lazy])
 def test_convert(df_raw: Any) -> None:
-    result = nw.LazyFrame(df_raw).collect()["a"].to_numpy()
+    result = nw.from_native(df_raw).lazy().collect()["a"].to_numpy()
     assert_array_equal(result, np.array([1, 3, 2]))
-    result = nw.LazyFrame(df_raw).collect()["a"].to_pandas()
+    result = nw.from_native(df_raw).lazy().collect()["a"].to_pandas()
     assert_series_equal(result, pd.Series([1, 3, 2], name="a"))
 
 
@@ -179,7 +181,7 @@ def test_dtypes() -> None:
             "m": pl.Boolean,
         },
     )
-    result = nw.DataFrame(df).schema
+    result = nw.from_native(df, eager_only=True).schema
     expected = {
         "a": nw.Int64,
         "b": nw.Int32,
@@ -196,7 +198,7 @@ def test_dtypes() -> None:
         "m": nw.Boolean,
     }
     assert result == expected
-    result_pd = nw.DataFrame(df.to_pandas()).schema
+    result_pd = nw.from_native(df.to_pandas(), eager_only=True).schema
     assert result_pd == expected
 
 
@@ -237,7 +239,7 @@ def test_cast() -> None:
             "o": pl.Categorical,
         },
     )
-    df = nw.DataFrame(df_raw).select(
+    df = nw.from_native(df_raw, eager_only=True).select(
         nw.col("a").cast(nw.Int32),
         nw.col("b").cast(nw.Int16),
         nw.col("c").cast(nw.Int8),
@@ -273,7 +275,7 @@ def test_cast() -> None:
         "o": nw.String,
     }
     assert result == expected
-    result_pd = nw.DataFrame(df.to_pandas()).schema
+    result_pd = nw.from_native(df.to_pandas(), eager_only=True).schema
     assert result_pd == expected
     result = df.select(
         df["a"].cast(nw.Int32),
@@ -372,16 +374,15 @@ def test_cast() -> None:
 
 def test_to_numpy() -> None:
     s = pd.Series([1, 2, None], dtype="Int64")
-    result = nw.Series(s).to_numpy()
-    assert result.dtype == "float64"
-    result = nw.Series(s).__array__()
-    assert result.dtype == "float64"
-    assert nw.Series(s).shape == (3,)
+    nw_series = nw.from_native(s, series_only=True)
+    assert nw_series.to_numpy().dtype == "float64"
+    assert nw_series.__array__().dtype == "float64"
+    assert nw_series.shape == (3,)
 
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 def test_is_duplicated(df_raw: Any) -> None:
-    series = nw.Series(df_raw["b"])
+    series = nw.from_native(df_raw["b"], series_only=True)
     result = series.is_duplicated()
     expected = np.array([True, True, False])
     assert (result.to_numpy() == expected).all()
@@ -390,14 +391,14 @@ def test_is_duplicated(df_raw: Any) -> None:
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 @pytest.mark.parametrize(("threshold", "expected"), [(0, False), (10, True)])
 def test_is_empty(df_raw: Any, threshold: Any, expected: Any) -> None:
-    series = nw.Series(df_raw["a"])
+    series = nw.from_native(df_raw["b"], series_only=True)
     result = series.filter(series > threshold).is_empty()
     assert result == expected
 
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 def test_is_unique(df_raw: Any) -> None:
-    series = nw.Series(df_raw["b"])
+    series = nw.from_native(df_raw["b"], series_only=True)
     result = series.is_unique()
     expected = np.array([False, False, True])
     assert (result.to_numpy() == expected).all()
@@ -405,14 +406,14 @@ def test_is_unique(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("s_raw", [pd.Series([1, 2, None]), pl.Series([1, 2, None])])
 def test_null_count(s_raw: Any) -> None:
-    series = nw.Series(s_raw)
+    series = nw.from_native(s_raw, series_only=True)
     result = series.null_count()
     assert result == 1
 
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 def test_is_first_distinct(df_raw: Any) -> None:
-    series = nw.Series(df_raw["b"])
+    series = nw.from_native(df_raw["b"], series_only=True)
     result = series.is_first_distinct()
     expected = np.array([True, False, True])
     assert (result.to_numpy() == expected).all()
@@ -420,7 +421,7 @@ def test_is_first_distinct(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 def test_is_last_distinct(df_raw: Any) -> None:
-    series = nw.Series(df_raw["b"])
+    series = nw.from_native(df_raw["b"], series_only=True)
     result = series.is_last_distinct()
     expected = np.array([False, True, True])
     assert (result.to_numpy() == expected).all()
@@ -428,7 +429,7 @@ def test_is_last_distinct(df_raw: Any) -> None:
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 def test_value_counts(df_raw: Any) -> None:
-    series = nw.Series(df_raw["b"])
+    series = nw.from_native(df_raw["b"], series_only=True)
     sorted_result = series.value_counts(sort=True)
     assert sorted_result.columns == ["b", "count"]
 
@@ -449,14 +450,14 @@ def test_value_counts(df_raw: Any) -> None:
     [("a", False, False), ("z", False, True), ("z", True, False)],
 )
 def test_is_sorted(df_raw: Any, col: str, descending: bool, expected: bool) -> None:  # noqa: FBT001
-    series = nw.Series(df_raw[col])
+    series = nw.from_native(df_raw[col], series_only=True)
     result = series.is_sorted(descending=descending)
     assert result == expected
 
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 def test_is_sorted_invalid(df_raw: Any) -> None:
-    series = nw.Series(df_raw["z"])
+    series = nw.from_native(df_raw["z"], series_only=True)
 
     with pytest.raises(TypeError):
         series.is_sorted(descending="invalid_type")  # type: ignore[arg-type]
@@ -493,11 +494,11 @@ def test_quantile(
     ],
 )
 def test_zip_with(df_raw: Any, mask: Any, expected: Any) -> None:
-    series1 = nw.Series(df_raw["a"])
-    series2 = nw.Series(df_raw["b"])
-    mask = nw.Series(mask)
+    series1 = nw.from_native(df_raw["a"], series_only=True)
+    series2 = nw.from_native(df_raw["b"], series_only=True)
+    mask = nw.from_native(mask, series_only=True)
     result = series1.zip_with(mask, series2)
-    expected = nw.Series(expected)
+    expected = nw.from_native(expected, series_only=True)
     assert result == expected
 
 
@@ -515,10 +516,10 @@ df_pandas = pd.DataFrame({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]})
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
 @pytest.mark.parametrize(("index", "expected"), [(0, 1), (1, 3)])
 def test_item(df_raw: Any, index: int, expected: int) -> None:
-    s = nw.Series(df_raw["a"])
+    s = nw.from_native(df_raw["a"], series_only=True)
     result = s.item(index)
     assert result == expected
-    assert nw.Series(df_raw["a"].head(1)).item() == 1
+    assert nw.from_native(df_raw["a"].head(1), series_only=True).item() == 1
 
     with pytest.raises(
         ValueError,
@@ -533,7 +534,7 @@ def test_head(df_raw: Any, n: int) -> None:
     s_raw = df_raw["z"]
     s = nw.from_native(s_raw, allow_series=True)
 
-    assert s.head(n) == nw.Series(s_raw.head(n))
+    assert s.head(n) == nw.from_native(s_raw.head(n), series_only=True)
 
 
 @pytest.mark.parametrize("df_raw", [df_pandas, df_polars])
@@ -542,4 +543,4 @@ def test_tail(df_raw: Any, n: int) -> None:
     s_raw = df_raw["z"]
     s = nw.from_native(s_raw, allow_series=True)
 
-    assert s.tail(n) == nw.Series(s_raw.tail(n))
+    assert s.tail(n) == nw.from_native(s_raw.tail(n), series_only=True)

--- a/tests/series/test_common.py
+++ b/tests/series/test_common.py
@@ -50,7 +50,7 @@ def test_len(df_raw: Any) -> None:
     assert result == 3
     result = nw.from_native(df_raw["a"], series_only=True).len()
     assert result == 3
-    result = len(nw.from_native(df_raw).lazy().collect()["a"])
+    result = len(nw.from_native(df_raw)["a"])
     assert result == 3
 
 

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -18,7 +18,7 @@ df_lazy = pl.LazyFrame(data)
 def test_group_by_complex() -> None:
     expected = {"a": [1, 3], "b": [-3.5, -3.0]}
 
-    df = nw.from_native(df_pandas).lazy()
+    df = nw.from_native(df_pandas)
     with pytest.warns(UserWarning, match="complex group-by"):
         result = nw.to_native(
             df.group_by("a").agg((nw.col("b") - nw.col("c").mean()).mean()).sort("a")
@@ -33,7 +33,7 @@ def test_group_by_complex() -> None:
 
 
 def test_invalid_group_by() -> None:
-    df = nw.from_native(df_pandas).lazy()
+    df = nw.from_native(df_pandas)
     with pytest.raises(RuntimeError, match="does your"):
         df.group_by("a").agg(nw.col("b"))
     with pytest.raises(

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -18,14 +18,14 @@ df_lazy = pl.LazyFrame(data)
 def test_group_by_complex() -> None:
     expected = {"a": [1, 3], "b": [-3.5, -3.0]}
 
-    df = nw.LazyFrame(df_pandas)
+    df = nw.from_native(df_pandas).lazy()
     with pytest.warns(UserWarning, match="complex group-by"):
         result = nw.to_native(
             df.group_by("a").agg((nw.col("b") - nw.col("c").mean()).mean()).sort("a")
         )
     compare_dicts(result, expected)
 
-    df = nw.LazyFrame(df_lazy)
+    df = nw.from_native(df_lazy).lazy()
     result = nw.to_native(
         df.group_by("a").agg((nw.col("b") - nw.col("c").mean()).mean()).sort("a")
     )
@@ -33,7 +33,7 @@ def test_group_by_complex() -> None:
 
 
 def test_invalid_group_by() -> None:
-    df = nw.LazyFrame(df_pandas)
+    df = nw.from_native(df_pandas).lazy()
     with pytest.raises(RuntimeError, match="does your"):
         df.group_by("a").agg(nw.col("b"))
     with pytest.raises(

--- a/tests/tpch_q1_test.py
+++ b/tests/tpch_q1_test.py
@@ -24,7 +24,7 @@ def test_q1(library: str) -> None:
     else:
         df_raw = pl.scan_parquet("tests/data/lineitem.parquet")
     var_1 = datetime(1998, 9, 2)
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     query_result = (
         df.filter(nw.col("l_shipdate") <= var_1)
         .with_columns(
@@ -91,7 +91,7 @@ def test_q1_w_generic_funcs(library: str) -> None:
     else:
         df_raw = pl.read_parquet("tests/data/lineitem.parquet")
     var_1 = datetime(1998, 9, 2)
-    df = nw.DataFrame(df_raw)
+    df = nw.from_native(df_raw, eager_only=True)
     query_result = (
         df.filter(nw.col("l_shipdate") <= var_1)
         .with_columns(
@@ -148,7 +148,7 @@ def test_q1_w_pandas_agg_generic_path() -> None:
     df_raw = pd.read_parquet("tests/data/lineitem.parquet")
     df_raw["l_shipdate"] = pd.to_datetime(df_raw["l_shipdate"])
     var_1 = datetime(1998, 9, 2)
-    df = nw.LazyFrame(df_raw)
+    df = nw.from_native(df_raw).lazy()
     query_result = (
         df.filter(nw.col("l_shipdate") <= var_1)
         .with_columns(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.

As implemented in #331, I like the idea of recommending to use `nw.from_native` instead of the classes directly. Moving this to a separate PR as @MarcoGorelli asked. 
The recommendation was already mentioned in some docstrings, but not applied everywhere. This also allows to simplify the `LazyFrame.__init__`.