### PR TITLE
Use enums for implementations

### DIFF
--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
     from narwhals._pandas_like.dataframe import PandasDataFrame
     from narwhals._pandas_like.namespace import PandasNamespace
+    from narwhals._pandas_like.utils import Implementation
 
 
 class PandasExpr:
@@ -25,7 +26,7 @@ class PandasExpr:
         function_name: str,
         root_names: list[str] | None,
         output_names: list[str] | None,
-        implementation: str,
+        implementation: Implementation,
         backend_version: tuple[int, ...],
     ) -> None:
         self._call = call
@@ -57,7 +58,7 @@ class PandasExpr:
     def from_column_names(
         cls: type[Self],
         *column_names: str,
-        implementation: str,
+        implementation: Implementation,
         backend_version: tuple[int, ...],
     ) -> Self:
         def func(df: PandasDataFrame) -> list[PandasSeries]:

--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -9,6 +9,7 @@ from typing import Callable
 from typing import Iterator
 
 from narwhals._expression_parsing import parse_into_exprs
+from narwhals._pandas_like.utils import Implementation
 from narwhals._pandas_like.utils import is_simple_aggregation
 from narwhals._pandas_like.utils import native_series_from_iterable
 from narwhals.utils import remove_prefix
@@ -43,7 +44,7 @@ class PandasGroupBy:
             namespace=self._df.__narwhals_namespace__(),
             **named_aggs,
         )
-        implementation: str = self._df._implementation
+        implementation: Implementation = self._df._implementation
         output_names: list[str] = copy(self._keys)
         for expr in exprs:
             if expr._output_names is None:
@@ -189,7 +190,7 @@ def agg_pandas(  # noqa: PLR0913
             implementation=implementation,
         )
 
-    if implementation == "pandas" and backend_version >= (2, 2):
+    if implementation is Implementation.PANDAS and backend_version >= (2, 2):
         result_complex = grouped.apply(func, include_groups=False)
     else:  # pragma: no cover
         result_complex = grouped.apply(func)

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -19,6 +19,7 @@ from narwhals.utils import flatten
 
 if TYPE_CHECKING:
     from narwhals._pandas_like.typing import IntoPandasExpr
+    from narwhals._pandas_like.utils import Implementation
 
 
 class PandasNamespace:
@@ -49,7 +50,9 @@ class PandasNamespace:
         )
 
     # --- not in spec ---
-    def __init__(self, implementation: str, backend_version: tuple[int, ...]) -> None:
+    def __init__(
+        self, implementation: Implementation, backend_version: tuple[int, ...]
+    ) -> None:
         self._implementation = implementation
         self._backend_version = backend_version
 

--- a/narwhals/_pandas_like/selectors.py
+++ b/narwhals/_pandas_like/selectors.py
@@ -10,11 +10,14 @@ from narwhals._pandas_like.expr import PandasExpr
 if TYPE_CHECKING:
     from narwhals._pandas_like.dataframe import PandasDataFrame
     from narwhals._pandas_like.series import PandasSeries
+    from narwhals._pandas_like.utils import Implementation
     from narwhals.dtypes import DType
 
 
 class PandasSelectorNamespace:
-    def __init__(self, *, implementation: str, backend_version: tuple[int, ...]) -> None:
+    def __init__(
+        self, *, implementation: Implementation, backend_version: tuple[int, ...]
+    ) -> None:
         self._implementation = implementation
         self._backend_version = backend_version
 

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -243,6 +243,7 @@ def from_native(  # noqa: PLR0915
     from narwhals._arrow.series import ArrowSeries
     from narwhals._pandas_like.dataframe import PandasDataFrame
     from narwhals._pandas_like.series import PandasSeries
+    from narwhals._pandas_like.utils import Implementation
     from narwhals.dataframe import DataFrame
     from narwhals.dataframe import LazyFrame
     from narwhals.series import Series
@@ -277,7 +278,7 @@ def from_native(  # noqa: PLR0915
             PandasDataFrame(
                 native_dataframe,
                 backend_version=parse_version(pd.__version__),
-                implementation="pandas",
+                implementation=Implementation.PANDAS,
             ),
             is_polars=False,
             backend_version=parse_version(pd.__version__),
@@ -290,7 +291,7 @@ def from_native(  # noqa: PLR0915
         return DataFrame(
             PandasDataFrame(
                 native_dataframe,
-                implementation="modin",
+                implementation=Implementation.MODIN,
                 backend_version=parse_version(mpd.__version__),
             ),
             is_polars=False,
@@ -304,7 +305,7 @@ def from_native(  # noqa: PLR0915
         return DataFrame(
             PandasDataFrame(
                 native_dataframe,
-                implementation="cudf",
+                implementation=Implementation.CUDF,
                 backend_version=parse_version(cudf.__version__),
             ),
             is_polars=False,
@@ -354,7 +355,7 @@ def from_native(  # noqa: PLR0915
         return Series(
             PandasSeries(
                 native_dataframe,
-                implementation="pandas",
+                implementation=Implementation.PANDAS,
                 backend_version=parse_version(pd.__version__),
             ),
             is_polars=False,
@@ -368,7 +369,7 @@ def from_native(  # noqa: PLR0915
         return Series(
             PandasSeries(
                 native_dataframe,
-                implementation="modin",
+                implementation=Implementation.MODIN,
                 backend_version=parse_version(mpd.__version__),
             ),
             is_polars=False,
@@ -382,7 +383,7 @@ def from_native(  # noqa: PLR0915
         return Series(
             PandasSeries(
                 native_dataframe,
-                implementation="cudf",
+                implementation=Implementation.CUDF,
                 backend_version=parse_version(cudf.__version__),
             ),
             is_polars=False,

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,12 +30,10 @@ def pytest_coverage(session: Session) -> None:
     run_common(session, coverage_threshold)
 
 
-
-
 @nox.session(python=PYTHON_VERSIONS[0])  # type: ignore[misc]
 def minimum_versions(session: Session) -> None:
     session.install(
-        "pandas==0.25.3",
+        "pandas==1.1.5",
         "polars==0.20.3",
         "numpy==1.17.5",
         "pyarrow==11.0.0",

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,7 @@ def pytest_coverage(session: Session) -> None:
 @nox.session(python=PYTHON_VERSIONS[0])  # type: ignore[misc]
 def minimum_versions(session: Session) -> None:
     session.install(
-        "pandas==1.1.5",
+        "pandas==0.25.3",
         "polars==0.20.3",
         "numpy==1.17.5",
         "pyarrow==11.0.0",

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,6 +30,8 @@ def pytest_coverage(session: Session) -> None:
     run_common(session, coverage_threshold)
 
 
+
+
 @nox.session(python=PYTHON_VERSIONS[0])  # type: ignore[misc]
 def minimum_versions(session: Session) -> None:
     session.install(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,8 +102,8 @@ omit = ['narwhals/typing.py']
 exclude_also = [
   "> POLARS_VERSION",
   "if sys.version_info() <",
-  "if implementation == \"modin\"",
-  "if implementation == \"cudf\"",
+  "if implementation is Implementation.MODIN",
+  "if implementation is Implementation.CUDF",
   'request.applymarker\(pytest.mark.xfail\)'
 ]
 

--- a/tests/frame/test_common.py
+++ b/tests/frame/test_common.py
@@ -13,6 +13,7 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
+from narwhals._pandas_like.utils import Implementation
 from narwhals.functions import _get_deps_info
 from narwhals.functions import _get_sys_info
 from narwhals.functions import show_versions
@@ -172,7 +173,7 @@ def test_cross_join(df_raw: Any) -> None:
 def test_cross_join_non_pandas() -> None:
     df = nw.from_native(df_pandas).select("a")
     # HACK to force testing for a non-pandas codepath
-    df._dataframe._implementation = "modin"
+    df._dataframe._implementation = Implementation.MODIN
     result = df.join(df, how="cross")  # type: ignore[arg-type]
     expected = {"a": [1, 1, 1, 3, 3, 3, 2, 2, 2], "a_right": [1, 3, 2, 1, 3, 2, 1, 3, 2]}
     compare_dicts(result, expected)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [X] Code follows style guide (ruff)
- [N/A] Tests added 
- [N/A] Documented the changes

## Rationale

By using enums instead of strings we achieve:

1. Single source of truth: now to add a new backend, one only needs to modify the `narwhals/dependencies.py` file
2. Simplify contribution: by having enums in a single location and using `assert_never`, once a new value is added to the Enum, MyPy will flag all the places where modifications are needed, this is much easier to navigate than finding failed tests
3. For multi-backend implementations (such as pandas), a file called `implementations.py` is added showing the subset of implementations supported for that specific platform
4. Reduce boilerplate: with Enums and a couple of mappings, there is no longer a need for many if/elif/else logic, thus making the code easier to extend. There are several cases not yet addressed in this PR but now the only function used from `dependencies` is the `get_backend` rather than the individual `get_pandas`, etc.
5. Less error prone: by using enums, MyPy becomes much more helpful by actually detecting missing cases in the logic when new backends are added.

## Open questions:

This PR assumes `typing_extensions` is installed, this should be a relatively common case as most projects use this library, however, to keep narwhals dependency free, we would need to add `assert_never` to the utils. 

```python
import enum
from typing_extensions import NoReturn

def assert_never(arg: NoReturn) -> NoReturn:
    raise AssertionError("Expected code to be unreachable")
```
[Source](https://typing.readthedocs.io/en/latest/source/unreachable.html#assert-never-and-exhaustiveness-checking)

The `assert_never` and the `Never` type are included in Python 3.11 so this functionality should be explicitly made available to keep the library compatible with 3.8+

An interesting read on this topic is the following article by [Adam Johnson](https://adamj.eu/tech/2022/10/14/python-type-hints-exhuastiveness-checking/)

---

Would like to hear your thoughts on these changes @MarcoGorelli / @EdAbati 

