### PR TITLE
bug: don't skip arrow tests on macOS

### DIFF
--- a/tests/expr/test_dt.py
+++ b/tests/expr/test_dt.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from datetime import datetime
 from datetime import timedelta
 from typing import Any
@@ -16,6 +15,7 @@ from hypothesis import given
 import narwhals as nw
 from narwhals.utils import parse_version
 from tests.utils import compare_dicts
+from tests.utils import is_windows
 
 data = {
     "a": [
@@ -174,10 +174,7 @@ def test_total_minutes(timedeltas: timedelta) -> None:
 @pytest.mark.parametrize(
     "fmt", ["%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%Y/%m/%d %H:%M:%S", "%G-W%V-%u", "%G-W%V"]
 )
-@pytest.mark.skipif(
-    sys.platform in ["win32", "cygwin"],
-    reason="pyarrow breaking on windows",
-)
+@pytest.mark.skipif(is_windows(), reason="pyarrow breaking on windows")
 def test_dt_to_string(constructor: Any, fmt: str) -> None:
     input_frame = nw.from_native(constructor(data), eager_only=True)
     input_series = input_frame["a"]
@@ -208,10 +205,7 @@ def test_dt_to_string(constructor: Any, fmt: str) -> None:
         (datetime(2020, 1, 9, 12, 34, 56, 123456), "2020-01-09T12:34:56.123456"),
     ],
 )
-@pytest.mark.skipif(
-    sys.platform in ["win32", "cygwin"],
-    reason="pyarrow breaking on windows",
-)
+@pytest.mark.skipif(is_windows(), reason="pyarrow breaking on windows")
 def test_dt_to_string_iso_local_datetime(
     constructor: Any, data: datetime, expected: str
 ) -> None:
@@ -259,10 +253,7 @@ def test_dt_to_string_iso_local_datetime(
         (datetime(2020, 1, 9), "2020-01-09"),
     ],
 )
-@pytest.mark.skipif(
-    sys.platform in ["win32", "cygwin"],
-    reason="pyarrow breaking on windows",
-)
+@pytest.mark.skipif(is_windows(), reason="pyarrow breaking on windows")
 def test_dt_to_string_iso_local_date(
     constructor: Any, data: datetime, expected: str
 ) -> None:

--- a/tests/expr/test_dt.py
+++ b/tests/expr/test_dt.py
@@ -175,7 +175,7 @@ def test_total_minutes(timedeltas: timedelta) -> None:
     "fmt", ["%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%Y/%m/%d %H:%M:%S", "%G-W%V-%u", "%G-W%V"]
 )
 @pytest.mark.skipif(
-    "win" in sys.platform,
+    sys.platform in ["win32", "cygwin"],
     reason="pyarrow breaking on windows",
 )
 def test_dt_to_string(constructor: Any, fmt: str) -> None:
@@ -209,7 +209,7 @@ def test_dt_to_string(constructor: Any, fmt: str) -> None:
     ],
 )
 @pytest.mark.skipif(
-    "win" in sys.platform,
+    sys.platform in ["win32", "cygwin"],
     reason="pyarrow breaking on windows",
 )
 def test_dt_to_string_iso_local_datetime(
@@ -260,7 +260,7 @@ def test_dt_to_string_iso_local_datetime(
     ],
 )
 @pytest.mark.skipif(
-    "win" in sys.platform,
+    sys.platform in ["win32", "cygwin"],
     reason="pyarrow breaking on windows",
 )
 def test_dt_to_string_iso_local_date(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import os
+import sys
 import warnings
 from typing import TYPE_CHECKING
 from typing import Any
@@ -53,3 +54,8 @@ def maybe_get_modin_df(df_pandas: pd.DataFrame) -> Any:
                 return mpd.DataFrame(df_pandas.to_dict(orient="list"))
     else:  # pragma: no cover
         return df_pandas
+
+
+def is_windows() -> bool:
+    """Check if the current platform is Windows."""
+    return sys.platform in ["win32", "cygwin"]


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Since `sys.platorm` is `darwin` on MacOS, those tests were skipped when testing locally and local coverage results were also misleading. (Should we also test macOS in the CI? 🤔)
