### PR TITLE
clean: factor `filter_test` and `filter_test_series` out of `test_common`

### DIFF
--- a/tests/frame/filter_test.py
+++ b/tests/frame/filter_test.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+import narwhals as nw
+from tests.utils import compare_dicts
+
+
+def test_filter(constructor: Any) -> None:
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    df = nw.from_native(constructor(data), eager_only=True)
+    result = df.filter(nw.col("a") > 1)
+    expected = {"a": [3, 2], "b": [4, 6], "z": [8.0, 9.0]}
+    compare_dicts(result, expected)
+
+
+def test_filter_series(constructor: Any) -> None:
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    df = nw.from_native(constructor(data), eager_only=True).with_columns(
+        mask=nw.col("a") > 1
+    )
+    result = df.filter(df["mask"]).drop("mask")
+    expected = {"a": [3, 2], "b": [4, 6], "z": [8.0, 9.0]}
+    compare_dicts(result, expected)

--- a/tests/frame/test_common.py
+++ b/tests/frame/test_common.py
@@ -60,30 +60,6 @@ df_pa_na = pa.table({"a": [None, 3, 2], "b": [4, 4, 6], "z": [7.0, None, 9]})
 
 
 @pytest.mark.parametrize(
-    "df_raw",
-    [df_pandas, df_lazy, df_pandas_nullable, df_pandas_pyarrow],
-)
-def test_filter(df_raw: Any) -> None:
-    df = nw.from_native(df_raw)
-    result = df.filter(nw.col("a") > 1)
-    result_native = nw.to_native(result)
-    expected = {"a": [3, 2], "b": [4, 6], "z": [8.0, 9.0]}
-    compare_dicts(result_native, expected)
-
-
-@pytest.mark.parametrize(
-    "df_raw",
-    [df_pandas, df_polars],
-)
-def test_filter_series(df_raw: Any) -> None:
-    df = nw.from_native(df_raw, eager_only=True).with_columns(mask=nw.col("a") > 1)
-    result = df.filter(df["mask"]).drop("mask")
-    result_native = nw.to_native(result)
-    expected = {"a": [3, 2], "b": [4, 6], "z": [8.0, 9.0]}
-    compare_dicts(result_native, expected)
-
-
-@pytest.mark.parametrize(
     "constructor",
     [pd.DataFrame, pl.DataFrame, pa.table],
 )


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue: https://github.com/narwhals-dev/narwhals/issues/401
- Closes: None

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Before the change, 6 tests were executed when I ran:
```
pytest tests/frame/test_common.py::test_filter tests/frame/test_common.py::test_filter_series
```
Now, 8 are executed with:
```
pytest tests/frame/filter_test.py
```
Is that expected?  

---

Also, I tried using `constructor_with_pyarrow` but two tests failed with errors like:
```
...
E       AttributeError: 'ArrowDataFrame' object has no attribute 'filter'
...
E       AttributeError: 'ArrowDataFrame' object has no attribute 'with_columns'
...
```

Any suggestions? Maybe there's an easy fix, I'm not too familiar with this repo yet.  

---

**One more question**: why aren't factored out tests using `nw.to_native(result)` and comparing `result_native` anymore? (just out of curiosity, I don't know why they were being converted to native to begin with)