### PR TITLE
clean: factor `test_<lazy|eager>_instantiation` out of `test_common`

### DIFF
--- a/tests/frame/instantiation_test.py
+++ b/tests/frame/instantiation_test.py
@@ -19,7 +19,7 @@ def test_lazy_instantiation_error() -> None:
     with pytest.raises(
         TypeError, match="Can't instantiate DataFrame from Polars LazyFrame."
     ):
-        _ = nw.DataFrame(df_lazy).shape
+        _ = nw.DataFrame(df_lazy, is_polars=True, backend_version=(0,)).shape
 
 
 def test_eager_instantiation(constructor: Any) -> None:

--- a/tests/frame/instantiation_test.py
+++ b/tests/frame/instantiation_test.py
@@ -7,9 +7,9 @@ import narwhals as nw
 from tests.utils import compare_dicts
 
 
-def test_lazy_instantiation(constructor: Any) -> None:
+def test_lazy_instantiation() -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
-    result = nw.from_native(constructor(data))
+    result = nw.from_native(pl.LazyFrame(data))
     expected = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     compare_dicts(result, expected)
 
@@ -22,8 +22,8 @@ def test_lazy_instantiation_error() -> None:
         _ = nw.DataFrame(df_lazy, is_polars=True, backend_version=(0,)).shape
 
 
-def test_eager_instantiation(constructor: Any) -> None:
+def test_eager_instantiation(constructor_with_pyarrow: Any) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
-    result = nw.from_native(constructor(data), eager_only=True)
+    result = nw.from_native(constructor_with_pyarrow(data), eager_only=True)
     expected = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     compare_dicts(result, expected)

--- a/tests/frame/instantiation_test.py
+++ b/tests/frame/instantiation_test.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import polars as pl
 import pytest
 
 import narwhals as nw
@@ -13,12 +14,12 @@ def test_lazy_instantiation(constructor: Any) -> None:
     compare_dicts(result, expected)
 
 
-def test_lazy_instantiation_error(constructor: Any) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+def test_lazy_instantiation_error() -> None:
+    df_lazy = pl.LazyFrame({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]})
     with pytest.raises(
         TypeError, match="Can't instantiate DataFrame from Polars LazyFrame."
     ):
-        _ = nw.DataFrame(constructor(data)).shape
+        _ = nw.DataFrame(df_lazy).shape
 
 
 def test_eager_instantiation(constructor: Any) -> None:

--- a/tests/frame/instantiation_test.py
+++ b/tests/frame/instantiation_test.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+import pytest
+
+import narwhals as nw
+from tests.utils import compare_dicts
+
+
+def test_lazy_instantiation(constructor: Any) -> None:
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    result = nw.from_native(constructor(data))
+    expected = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    compare_dicts(result, expected)
+
+
+def test_lazy_instantiation_error(df_raw: Any) -> None:
+    with pytest.raises(
+        TypeError, match="Can't instantiate DataFrame from Polars LazyFrame."
+    ):
+        _ = nw.DataFrame(df_raw).shape
+
+
+def test_eager_instantiation(constructor: Any) -> None:
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    result = nw.from_native(constructor(data), eager_only=True)
+    expected = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    compare_dicts(result, expected)

--- a/tests/frame/instantiation_test.py
+++ b/tests/frame/instantiation_test.py
@@ -13,11 +13,12 @@ def test_lazy_instantiation(constructor: Any) -> None:
     compare_dicts(result, expected)
 
 
-def test_lazy_instantiation_error(df_raw: Any) -> None:
+def test_lazy_instantiation_error(constructor: Any) -> None:
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     with pytest.raises(
         TypeError, match="Can't instantiate DataFrame from Polars LazyFrame."
     ):
-        _ = nw.DataFrame(df_raw).shape
+        _ = nw.DataFrame(constructor(data)).shape
 
 
 def test_eager_instantiation(constructor: Any) -> None:

--- a/tests/frame/test_common.py
+++ b/tests/frame/test_common.py
@@ -236,30 +236,6 @@ def test_columns(df_raw: Any) -> None:
     assert result == expected
 
 
-@pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_mpd, df_lazy])
-def test_lazy_instantiation(df_raw: Any) -> None:
-    result = nw.from_native(df_raw)
-    result_native = nw.to_native(result)
-    expected = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
-    compare_dicts(result_native, expected)
-
-
-@pytest.mark.parametrize("df_raw", [df_lazy])
-def test_lazy_instantiation_error(df_raw: Any) -> None:
-    with pytest.raises(
-        TypeError, match="Can't instantiate DataFrame from Polars LazyFrame."
-    ):
-        _ = nw.DataFrame(df_raw, is_polars=True, backend_version=(0,)).shape
-
-
-@pytest.mark.parametrize("df_raw", [df_polars, df_pandas, df_mpd])
-def test_eager_instantiation(df_raw: Any) -> None:
-    result = nw.from_native(df_raw, eager_only=True)
-    result_native = nw.to_native(result)
-    expected = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
-    compare_dicts(result_native, expected)
-
-
 def test_accepted_dataframes() -> None:
     array = np.array([[0, 4.0], [2, 5]])
     with pytest.raises(


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue: https://github.com/narwhals-dev/narwhals/issues/401
- Closes: None

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

I'm not sure the small modifications were translated correctly from the original test. Is not passing eager_only=True enough for a lazy instantiation?