### PR TITLE
docs: fix `typing` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Seamlessly support all, without depending on any!
   either getting in the way
 - ✅ **100% branch coverage**, tested against pandas and Polars nightly builds
 - ✅ **Negligible overhead**, see [overhead](https://narwhals-dev.github.io/narwhals/overhead/)
-- ✅ Let your IDE help you thanks to **full static typing**, see [typing](https://narwhals-dev.github.io/narwhals/typing/)
+- ✅ Let your IDE help you thanks to **full static typing**, see [typing](https://narwhals-dev.github.io/narwhals/api-reference/typing/)
 - ✅ **Perfect backwards compatibility policy**,
   see [stable api](https://narwhals-dev.github.io/narwhals/backcompat/) for how to opt-in
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Seamlessly support both, without depending on either!
   either getting in the way
 - ✅ **100% branch coverage**, tested against pandas and Polars nightly builds
 - ✅ **Negligible overhead**, see [overhead](https://narwhals-dev.github.io/narwhals/overhead/)
-- ✅ Let your IDE help you thanks to **full static typing**, see [typing](https://narwhals-dev.github.io/narwhals/typing/)
+- ✅ Let your IDE help you thanks to **full static typing**, see [typing](https://narwhals-dev.github.io/narwhals/api-reference/typing/)
 - ✅ **Perfect backwards compatibility policy**,
   see [stable api](https://narwhals-dev.github.io/narwhals/backcompat/) for how to opt-in
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## If you have comments or can explain your changes, please do so below.

Link referring wrong doc page
