### PR TITLE
feat: add `to_lowercase` and `to_uppercase` to `Expr.str` namespace 

### DIFF
--- a/docs/api-reference/expressions_str.md
+++ b/docs/api-reference/expressions_str.md
@@ -11,5 +11,7 @@
         - starts_with
         - tail
         - to_datetime
+        - to_uppercase
+        - to_lowercase
       show_source: false
       show_bases: false

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -385,6 +385,20 @@ class PandasExprStringNamespace:
             format,
         )
 
+    def to_uppercase(self) -> PandasExpr:
+        return reuse_series_namespace_implementation(
+            self._expr,
+            "str",
+            "to_uppercase",
+        )
+
+    def to_lowercase(self) -> PandasExpr:
+        return reuse_series_namespace_implementation(
+            self._expr,
+            "str",
+            "to_lowercase",
+        )
+
 
 class PandasExprDateTimeNamespace:
     def __init__(self, expr: PandasExpr) -> None:

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -622,6 +622,16 @@ class PandasSeriesStringNamespace:
             )
         )
 
+    def to_uppercase(self) -> PandasSeries:
+        return self._series._from_native_series(
+            self._series._native_series.str.upper(),
+        )
+
+    def to_lowercase(self) -> PandasSeries:
+        return self._series._from_native_series(
+            self._series._native_series.str.lower(),
+        )
+
 
 class PandasSeriesDateTimeNamespace:
     def __init__(self, series: PandasSeries) -> None:

--- a/narwhals/expression.py
+++ b/narwhals/expression.py
@@ -2081,6 +2081,12 @@ class ExprStringNamespace:
             lambda plx: self._expr._call(plx).str.to_datetime(format=format)
         )
 
+    def to_uppercase(self) -> Expr:
+        return self._expr.__class__(lambda plx: self._expr._call(plx).str.to_uppercase())
+
+    def to_lowercase(self) -> Expr:
+        return self._expr.__class__(lambda plx: self._expr._call(plx).str.to_lowercase())
+
 
 class ExprDateTimeNamespace:
     def __init__(self, expr: Expr) -> None:

--- a/narwhals/expression.py
+++ b/narwhals/expression.py
@@ -2087,7 +2087,7 @@ class ExprStringNamespace:
 
         Notes:
             The PyArrow backend will convert 'ß' to 'ẞ' instead of 'SS'.
-            For more info see: https://github.com/apache/arrow/issues/34599
+            For more info see [the related issue](https://github.com/apache/arrow/issues/34599).
             Other Unicode edge cases may be present and are not tested.
 
         Examples:

--- a/narwhals/expression.py
+++ b/narwhals/expression.py
@@ -2082,9 +2082,88 @@ class ExprStringNamespace:
         )
 
     def to_uppercase(self) -> Expr:
+        r"""
+        Transform string to uppercase variant.
+
+        Notes:
+            The PyArrow backend will convert 'ß' to 'ẞ' instead of 'SS'.
+            For more info see: https://github.com/apache/arrow/issues/34599
+            Other Unicode edge cases may be present and are not tested.
+
+        Examples:
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> data = {"fruits": ["apple", "mango", None]}
+            >>> df_pd = pd.DataFrame(data)
+            >>> df_pl = pl.DataFrame(data)
+
+            We define a dataframe-agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     return df.with_columns(upper_col=nw.col("fruits").str.to_uppercase()))
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(df_pd)
+              fruits  upper_col
+            0  apple      APPLE
+            1  mango      MANGO
+            2   None       None
+
+            >>> func(df_pl)
+            shape: (3, 2)
+            ┌────────┬────────────┐
+            │ fruits ┆ upper_col  │
+            │ ---    ┆ ---        │
+            │ str    ┆ bool       │
+            ╞════════╪════════════╡
+            │ apple  ┆ APPLE      │
+            │ mango  ┆ MANGO      │
+            │ null   ┆ null       │
+            └────────┴────────────┘
+        """
         return self._expr.__class__(lambda plx: self._expr._call(plx).str.to_uppercase())
 
     def to_lowercase(self) -> Expr:
+        r"""
+        Transform string to lowercase variant.
+
+        Examples:
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> data = {"fruits": ["APPLE", "MANGO", None]}
+            >>> df_pd = pd.DataFrame(data)
+            >>> df_pl = pl.DataFrame(data)
+
+            We define a dataframe-agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     return df.with_columns(lower_col=nw.col("fruits").str.to_lowercase()))
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(df_pd)
+              fruits  lower_col
+            0  APPLE      apple
+            1  MANGO      mango
+            2   None       None
+
+            >>> func(df_pl)
+            shape: (3, 2)
+            ┌────────┬────────────┐
+            │ fruits ┆ lower_col  │
+            │ ---    ┆ ---        │
+            │ str    ┆ bool       │
+            ╞════════╪════════════╡
+            │ APPLE  ┆ apple      │
+            │ MANGO  ┆ mango      │
+            │ null   ┆ null       │
+            └────────┴────────────┘
+        """
         return self._expr.__class__(lambda plx: self._expr._call(plx).str.to_lowercase())
 
 

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2191,9 +2191,88 @@ class SeriesStringNamespace:
         return self._series._from_series(self._series._series.str.slice(-n))
 
     def to_uppercase(self) -> Series:
+        r"""
+        Transform string to uppercase variant.
+
+        Notes:
+            The PyArrow backend will convert 'ß' to 'ẞ' instead of 'SS'.
+            For more info see: https://github.com/apache/arrow/issues/34599
+            Other Unicode edge cases may be present and are not tested.
+
+        Examples:
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> data = {"fruits": ["apple", "mango", None]}
+            >>> df_pd = pd.DataFrame(data)
+            >>> df_pl = pl.DataFrame(data)
+
+            We define a dataframe-agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     return df.with_columns(upper_col=nw.col("fruits").str.to_uppercase()))
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(df_pd)
+              fruits  upper_col
+            0  apple      APPLE
+            1  mango      MANGO
+            2   None       None
+
+            >>> func(df_pl)
+            shape: (3, 2)
+            ┌────────┬────────────┐
+            │ fruits ┆ upper_col  │
+            │ ---    ┆ ---        │
+            │ str    ┆ bool       │
+            ╞════════╪════════════╡
+            │ apple  ┆ APPLE      │
+            │ mango  ┆ MANGO      │
+            │ null   ┆ null       │
+            └────────┴────────────┘
+        """
         return self._series._from_series(self._series._series.str.to_uppercase())
 
     def to_lowercase(self) -> Series:
+        r"""
+        Transform string to lowercase variant.
+
+        Examples:
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> data = {"fruits": ["APPLE", "MANGO", None]}
+            >>> df_pd = pd.DataFrame(data)
+            >>> df_pl = pl.DataFrame(data)
+
+            We define a dataframe-agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     return df.with_columns(lower_col=nw.col("fruits").str.to_lowercase()))
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(df_pd)
+              fruits  lower_col
+            0  APPLE      apple
+            1  MANGO      mango
+            2   None       None
+
+            >>> func(df_pl)
+            shape: (3, 2)
+            ┌────────┬────────────┐
+            │ fruits ┆ lower_col  │
+            │ ---    ┆ ---        │
+            │ str    ┆ bool       │
+            ╞════════╪════════════╡
+            │ APPLE  ┆ apple      │
+            │ MANGO  ┆ mango      │
+            │ null   ┆ null       │
+            └────────┴────────────┘
+        """
         return self._series._from_series(self._series._series.str.to_lowercase())
 
 

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2190,6 +2190,12 @@ class SeriesStringNamespace:
         """
         return self._series._from_series(self._series._series.str.slice(-n))
 
+    def to_uppercase(self) -> Series:
+        return self._series._from_series(self._series._series.str.to_uppercase())
+
+    def to_lowercase(self) -> Series:
+        return self._series._from_series(self._series._series.str.to_lowercase())
+
 
 class SeriesDateTimeNamespace:
     def __init__(self, series: Series) -> None:

--- a/tests/expr/str/to_uppercase_to_lowercase_test.py
+++ b/tests/expr/str/to_uppercase_to_lowercase_test.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import narwhals.stable.v1 as nw
+from tests.utils import compare_dicts
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ({"a": ["foo", "bar"]}, {"a": ["FOO", "BAR"]}),
+        (
+            {
+                "a": [
+                    "special case ß",
+                    "ςpecial caσe",  # noqa: RUF001
+                ]
+            },
+            {"a": ["SPECIAL CASE SS", "ΣPECIAL CAΣE"]},
+        ),
+    ],
+)
+def test_str_to_uppercase(constructor: Any, data: Any | None, expected: Any) -> None:
+    df = nw.from_native(constructor(data), eager_only=True)
+    result_frame = df.select(nw.col("a").str.to_uppercase())
+    if (constructor.__name__ == "pandas_pyarrow_constructor") & df["a"].str.contains(
+        "ß"
+    ).any():
+        pytest.skip(
+            "PyArrow converts 'ß' to 'ẞ', see: https://github.com/apache/arrow/issues/34599"
+        )
+    compare_dicts(result_frame, expected)
+
+    result_series = df["a"].str.to_uppercase()
+    assert result_series.to_numpy().tolist() == expected["a"]
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ({"a": ["FOO", "BAR"]}, {"a": ["foo", "bar"]}),
+        (
+            {"a": ["SPECIAL CASE ß", "ΣPECIAL CAΣE"]},
+            {
+                "a": [
+                    "special case ß",
+                    "σpecial caσe",  # noqa: RUF001
+                ]
+            },
+        ),
+    ],
+)
+def test_str_to_lowercase(constructor: Any, data: Any | None, expected: Any) -> None:
+    df = nw.from_native(constructor(data), eager_only=True)
+    result_frame = df.select(nw.col("a").str.to_lowercase())
+    compare_dicts(result_frame, expected)
+
+    result_series = df["a"].str.to_lowercase()
+    assert result_series.to_numpy().tolist() == expected["a"]


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.
This feature allows to convert strings to upper and lower case variants, similar to what is already possible with polars' [`Expr.str.to_lowercase()`](https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.str.to_lowercase.html#polars.Expr.str.to_lowercase)  and pandas' [`Series.str.lower()`](https://pandas.pydata.org/docs/reference/api/pandas.Series.str.lower.html)
### Unicode caveat
There is a caveat for PyArrow's backend that converts the character 'ß' to uppercase 'ẞ' instead of 'SS'. There are probably few others Unicode edgecases but I think the vast majority of users won't be affected. This has been documented in the `to_uppercase` method and linked the issue: **https://github.com/apache/arrow/issues/34599** 

This was my first contribution here, feedback is always welcomed 🙏
