### PR TITLE
docs: add dark-mode switch

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,26 @@ theme:
     - content.code.annotate
     - navigation.footer
     - navigation.indexes
+  palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
 plugins:
 - search
 - mkdocstrings:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
Little pet peeve of mine, but I was looking foward to get the docs in dark mode too.
This PR simply adds the dark mode switch, which has 3 modes:
- System preference (Default dark or light mode based on users' system preference)
- Light mode
- Dark mode


![Screenshot 2024-07-10 110130](https://github.com/narwhals-dev/narwhals/assets/66913960/16606d28-2520-47bc-9b53-1d1e77861e07)
![Screenshot 2024-07-10 110135](https://github.com/narwhals-dev/narwhals/assets/66913960/1ed79db3-1539-42b4-be81-5d484bde7840)

