### PR TITLE
Docs/attribute docstrings

### DIFF
--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -29,14 +29,17 @@ if TYPE_CHECKING:
         def join(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
-# Anything which can be converted to an expression.
 IntoExpr: TypeAlias = Union["Expr", str, "Series"]
-# Anything which can be converted to a Narwhals DataFrame.
+"""Anything which can be converted to an expression."""
+
 IntoDataFrame: TypeAlias = Union["NativeFrame", "DataFrame[Any]"]
-# Anything which can be converted to a Narwhals DataFrame or LazyFrame.
+"""Anything which can be converted to a Narwhals DataFrame."""
+
 IntoFrame: TypeAlias = Union["NativeFrame", "DataFrame[Any]", "LazyFrame[Any]"]
-# DataFrame or LazyFrame
+"""Anything which can be converted to a Narwhals DataFrame or LazyFrame."""
+
 Frame: TypeAlias = Union["DataFrame[Any]", "LazyFrame[Any]"]
+"""DataFrame or LazyFrame"""
 
 # TypeVars for some of the above
 IntoFrameT = TypeVar("IntoFrameT", bound="IntoFrame")


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Another small one here ! I promise I will get back to more Pyarrow implementations after this one! 😂

While annotating functions with Narwhals' custom types, I wanted to double check the "definition" of those.

The explanation for each type was previously given as as comment in the source code itself, which is usually fine. But this additional information does not propagate in the "definition" view of some (most?) text editors. 

By adding a string litteral immediately after the value assignment (from [PEP-258](https://peps.python.org/pep-0258/#attribute-docstrings)), the information is then made available in the "definition/documentation views", see example below:

**Before**
![Screenshot 2024-07-10 113310](https://github.com/narwhals-dev/narwhals/assets/66913960/f3922edc-f742-496f-aa36-43fe8cf7c7a6)

**Code Change**
```python
IntoExpr: TypeAlias = Union["Expr", str, "Series"]
"""Anything which can be converted to an expression."""
```

**After**
![Screenshot 2024-07-10 113350](https://github.com/narwhals-dev/narwhals/assets/66913960/79ac9cfb-e9d8-43f8-b602-17f83e7a06e0)



