### PR TITLE
ci: try improving release flow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,7 +2,6 @@ exclude-labels:
   - skip changelog
   - release
 name-template: 'Narwhals v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
 
 change-template: '- $TITLE (#$NUMBER)' 
     

--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -4,6 +4,9 @@ import re
 import subprocess
 import sys
 
+subprocess.run(["git", "fetch", "upstream"])
+subprocess.run(["git", "reset", "--hard", "upstream/main"])
+
 how = sys.argv[1]
 
 with open("pyproject.toml", encoding="utf-8") as f:


### PR DESCRIPTION
make sure that, for `bump_version`, we're starting off on `upstream/main`

i'm also removing the tag from the release drafter so it doesn't get overwritten