### PR TITLE
feat: expose `all_horizontal`

### DIFF
--- a/docs/api-reference/narwhals.md
+++ b/docs/api-reference/narwhals.md
@@ -7,6 +7,7 @@ Here are the top-level functions available in Narwhals.
     options:
       members:
         - all
+        - all_horizontal
         - col
         - concat
         - from_native

--- a/narwhals/__init__.py
+++ b/narwhals/__init__.py
@@ -23,6 +23,7 @@ from narwhals.dtypes import UInt64
 from narwhals.dtypes import Unknown
 from narwhals.expression import Expr
 from narwhals.expression import all
+from narwhals.expression import all_horizontal
 from narwhals.expression import col
 from narwhals.expression import len
 from narwhals.expression import lit
@@ -56,6 +57,7 @@ __all__ = [
     "maybe_set_index",
     "get_native_namespace",
     "all",
+    "all_horizontal",
     "col",
     "len",
     "lit",

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -95,13 +95,13 @@ class ArrowSeries:
         pc = get_pyarrow_compute()
         ser = self._native_series
         other = validate_column_comparand(other)
-        return self._from_native_series(pc.and_(ser, other))
+        return self._from_native_series(pc.and_kleene(ser, other))
 
     def __or__(self, other: Any) -> Self:
         pc = get_pyarrow_compute()
         ser = self._native_series
         other = validate_column_comparand(other)
-        return self._from_native_series(pc.or_(ser, other))
+        return self._from_native_series(pc.or_kleene(ser, other))
 
     def __add__(self, other: Any) -> Self:
         pc = get_pyarrow_compute()

--- a/narwhals/expression.py
+++ b/narwhals/expression.py
@@ -3358,8 +3358,7 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         exprs: Name(s) of the columns to use in the aggregation function. Accepts expression input.
 
     Notes:
-        pandas and Polars handle null values differently. Polars distinguishes
-        between NaN and Null, whereas pandas doesn't.
+        pandas and Polars handle null values differently.
 
     Examples:
         >>> import pandas as pd

--- a/narwhals/expression.py
+++ b/narwhals/expression.py
@@ -3344,10 +3344,68 @@ def sum_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         │ 12  │
         │ 18  │
         └─────┘
-
     """
     return Expr(
         lambda plx: plx.sum_horizontal([extract_native(plx, v) for v in flatten(exprs)])
+    )
+
+
+def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
+    r"""
+    Compute the bitwise AND horizontally across columns.
+
+    Arguments:
+        exprs: Name(s) of the columns to use in the aggregation function. Accepts expression input.
+
+    Notes:
+        pandas and Polars handle null values differently. Polars distinguishes
+        between NaN and Null, whereas pandas doesn't.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import polars as pl
+        >>> import narwhals as nw
+        >>> data = {
+        ...     "a": [False, False, True, True, False, None],
+        ...     "b": [False, True, True, None, None, None],
+        ... }
+        >>> df_pl = pl.DataFrame(data)
+        >>> df_pd = pd.DataFrame(data)
+
+        We define a dataframe-agnostic function:
+
+        >>> @nw.narwhalify
+        ... def func(df):
+        ...     return df.select("a", "b", all=nw.all_horizontal("a", "b"))
+
+        We can then pass either pandas or polars to `func`:
+
+        >>> func(df_pd)
+               a      b    all
+        0  False  False  False
+        1  False   True  False
+        2   True   True   True
+        3   True   None  False
+        4  False   None  False
+        5   None   None  False
+
+        >>> func(df_pl)
+        shape: (6, 3)
+        ┌───────┬───────┬───────┐
+        │ a     ┆ b     ┆ all   │
+        │ ---   ┆ ---   ┆ ---   │
+        │ bool  ┆ bool  ┆ bool  │
+        ╞═══════╪═══════╪═══════╡
+        │ false ┆ false ┆ false │
+        │ false ┆ true  ┆ false │
+        │ true  ┆ true  ┆ true  │
+        │ true  ┆ null  ┆ null  │
+        │ false ┆ null  ┆ false │
+        │ null  ┆ null  ┆ null  │
+        └───────┴───────┴───────┘
+    """
+    return Expr(
+        lambda plx: plx.all_horizontal([extract_native(plx, v) for v in flatten(exprs)])
     )
 
 

--- a/narwhals/stable/v1.py
+++ b/narwhals/stable/v1.py
@@ -1108,9 +1108,65 @@ def sum_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         │ 12  │
         │ 18  │
         └─────┘
-
     """
     return _stableify(nw.sum_horizontal(*exprs))
+
+
+def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
+    r"""
+    Compute the bitwise AND horizontally across columns.
+
+    Arguments:
+        exprs: Name(s) of the columns to use in the aggregation function. Accepts expression input.
+
+    Notes:
+        pandas and Polars handle null values differently. Polars distinguishes
+        between NaN and Null, whereas pandas doesn't.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import polars as pl
+        >>> import narwhals.stable.v1 as nw
+        >>> data = {
+        ...     "a": [False, False, True, True, False, None],
+        ...     "b": [False, True, True, None, None, None],
+        ... }
+        >>> df_pl = pl.DataFrame(data)
+        >>> df_pd = pd.DataFrame(data)
+
+        We define a dataframe-agnostic function:
+
+        >>> @nw.narwhalify
+        ... def func(df):
+        ...     return df.select("a", "b", all=nw.all_horizontal("a", "b"))
+
+        We can then pass either pandas or polars to `func`:
+
+        >>> func(df_pd)
+               a      b    all
+        0  False  False  False
+        1  False   True  False
+        2   True   True   True
+        3   True   None  False
+        4  False   None  False
+        5   None   None  False
+
+        >>> func(df_pl)
+        shape: (6, 3)
+        ┌───────┬───────┬───────┐
+        │ a     ┆ b     ┆ all   │
+        │ ---   ┆ ---   ┆ ---   │
+        │ bool  ┆ bool  ┆ bool  │
+        ╞═══════╪═══════╪═══════╡
+        │ false ┆ false ┆ false │
+        │ false ┆ true  ┆ false │
+        │ true  ┆ true  ┆ true  │
+        │ true  ┆ null  ┆ null  │
+        │ false ┆ null  ┆ false │
+        │ null  ┆ null  ┆ null  │
+        └───────┴───────┴───────┘
+    """
+    return _stableify(nw.all_horizontal(*exprs))
 
 
 def is_ordered_categorical(series: Series) -> bool:
@@ -1264,6 +1320,7 @@ __all__ = [
     "maybe_set_index",
     "get_native_namespace",
     "all",
+    "all_horizontal",
     "col",
     "len",
     "lit",

--- a/narwhals/stable/v1.py
+++ b/narwhals/stable/v1.py
@@ -1120,8 +1120,7 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         exprs: Name(s) of the columns to use in the aggregation function. Accepts expression input.
 
     Notes:
-        pandas and Polars handle null values differently. Polars distinguishes
-        between NaN and Null, whereas pandas doesn't.
+        pandas and Polars handle null values differently.
 
     Examples:
         >>> import pandas as pd

--- a/tests/expr/all_horizontal_test.py
+++ b/tests/expr/all_horizontal_test.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+import pytest
+
+import narwhals.stable.v1 as nw
+from tests.utils import compare_dicts
+
+
+@pytest.mark.parametrize("col_expr", [nw.col("a"), "a"])
+def test_allh(constructor_with_pyarrow: Any, col_expr: Any) -> None:
+    data = {
+        "a": [False, False, True],
+        "b": [False, True, True],
+    }
+    df = nw.from_native(constructor_with_pyarrow(data), eager_only=True)
+    result = df.select(all=nw.all_horizontal(col_expr, nw.col("b")))
+
+    expected = {"all": [False, False, True]}
+    compare_dicts(result, expected)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.

Remark that polars and pandas `__and__` logic is different for None.

I fixed the implementation for pyarrow however!