### PR TITLE
feat: add "interchange"-level support for libraries which implement the interchange protocol

### DIFF
--- a/docs/api-reference/narwhals.md
+++ b/docs/api-reference/narwhals.md
@@ -11,6 +11,7 @@ Here are the top-level functions available in Narwhals.
         - col
         - concat
         - from_native
+        - get_level
         - get_native_namespace
         - is_ordered_categorical
         - len

--- a/narwhals/__init__.py
+++ b/narwhals/__init__.py
@@ -33,6 +33,7 @@ from narwhals.expression import min
 from narwhals.expression import sum
 from narwhals.expression import sum_horizontal
 from narwhals.functions import concat
+from narwhals.functions import get_level
 from narwhals.functions import show_versions
 from narwhals.series import Series
 from narwhals.translate import from_native
@@ -49,6 +50,7 @@ __version__ = "1.0.6"
 __all__ = [
     "selectors",
     "concat",
+    "get_level",
     "to_native",
     "from_native",
     "is_ordered_categorical",

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -67,6 +67,10 @@ class ArrowDataFrame:
     def get_column(self, name: str) -> ArrowSeries:
         from narwhals._arrow.series import ArrowSeries
 
+        if not isinstance(name, str):
+            msg = f"Expected str, got: {type(name)}"
+            raise TypeError(msg)
+
         return ArrowSeries(
             self._native_dataframe[name],
             name=name,

--- a/narwhals/_interchange/dataframe.py
+++ b/narwhals/_interchange/dataframe.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 from typing import Any
-from typing import Never
+from typing import NoReturn
 
 from narwhals import dtypes
 
@@ -76,7 +76,7 @@ class InterchangeFrame:
             for column_name in self._df.column_names()
         }
 
-    def __getattr__(self, attr: str) -> Never:
+    def __getattr__(self, attr: str) -> NoReturn:
         msg = (
             f"Attribute {attr} is not supported for metadata-only dataframes.\n\n"
             "Hint: you probably called `nw.from_native` on an object which isn't fully "

--- a/narwhals/_interchange/dataframe.py
+++ b/narwhals/_interchange/dataframe.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import enum
+from typing import Any
+
+from narwhals import dtypes
+
+
+class DtypeKind(enum.IntEnum):
+    # https://data-apis.org/dataframe-protocol/latest/API.html
+    INT = 0
+    UINT = 1
+    FLOAT = 2
+    BOOL = 20
+    STRING = 21  # UTF-8
+    DATETIME = 22
+    CATEGORICAL = 23
+
+
+def map_interchange_dtype_to_narwhals_dtype(
+    interchange_dtype: tuple[DtypeKind, int, Any, Any],
+) -> dtypes.DType:
+    if interchange_dtype[0] == DtypeKind.INT:
+        if interchange_dtype[1] == 64:
+            return dtypes.Int64()
+        if interchange_dtype[1] == 32:
+            return dtypes.Int32()
+        if interchange_dtype[1] == 16:
+            return dtypes.Int16()
+        if interchange_dtype[1] == 8:
+            return dtypes.Int8()
+        raise AssertionError("Invalid bit width for INT")
+    if interchange_dtype[0] == DtypeKind.UINT:
+        if interchange_dtype[1] == 64:
+            return dtypes.UInt64()
+        if interchange_dtype[1] == 32:
+            return dtypes.UInt32()
+        if interchange_dtype[1] == 16:
+            return dtypes.UInt16()
+        if interchange_dtype[1] == 8:
+            return dtypes.UInt8()
+        raise AssertionError("Invalid bit width for UINT")
+    if interchange_dtype[0] == DtypeKind.FLOAT:
+        if interchange_dtype[1] == 64:
+            return dtypes.Float64()
+        if interchange_dtype[1] == 32:
+            return dtypes.Float32()
+        raise AssertionError("Invalid bit width for FLOAT")
+    if interchange_dtype[0] == DtypeKind.BOOL:
+        return dtypes.Boolean()
+    if interchange_dtype[0] == DtypeKind.STRING:
+        return dtypes.String()
+    if interchange_dtype[0] == DtypeKind.DATETIME:
+        return dtypes.Datetime()
+    if interchange_dtype[0] == DtypeKind.CATEGORICAL:  # pragma: no cover
+        # upstream issue: https://github.com/ibis-project/ibis/issues/9570
+        return dtypes.Categorical()
+    msg = f"Invalid dtype, got: {interchange_dtype}"  # pragma: no cover
+    raise AssertionError(msg)
+
+
+class InterchangeFrame:
+    def __init__(self, df: Any) -> None:
+        self._df = df
+
+    def __narwhals_dataframe__(self) -> Any:
+        return self
+
+    @property
+    def schema(self) -> dict[str, dtypes.DType]:
+        return {
+            column_name: map_interchange_dtype_to_narwhals_dtype(
+                self._df.get_column_by_name(column_name).dtype
+            )
+            for column_name in self._df.column_names()
+        }

--- a/narwhals/_interchange/dataframe.py
+++ b/narwhals/_interchange/dataframe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import enum
 from typing import Any
+from typing import Never
 
 from narwhals import dtypes
 
@@ -74,3 +75,13 @@ class InterchangeFrame:
             )
             for column_name in self._df.column_names()
         }
+
+    def __getattr__(self, attr: str) -> Never:
+        msg = (
+            f"Attribute {attr} is not supported for metadata-only dataframes.\n\n"
+            "Hint: you probably called `nw.from_native` on an object which isn't fully "
+            "supported by Narwhals, yet implements `__dataframe__`. If you would like to "
+            "see this kind of object supported in Narwhals, please open a feature request "
+            "at https://github.com/narwhals-dev/narwhals/issues."
+        )
+        raise NotImplementedError(msg)

--- a/narwhals/_interchange/series.py
+++ b/narwhals/_interchange/series.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import NoReturn
+
+from narwhals._interchange.dataframe import map_interchange_dtype_to_narwhals_dtype
+
+if TYPE_CHECKING:
+    from narwhals import dtypes
+
+
+class InterchangeSeries:
+    def __init__(self, df: Any) -> None:
+        self._native_series = df
+
+    def __narwhals_series__(self) -> Any:
+        return self
+
+    @property
+    def dtype(self) -> dtypes.DType:
+        return map_interchange_dtype_to_narwhals_dtype(self._native_series.dtype)
+
+    def __getattr__(self, attr: str) -> NoReturn:
+        msg = (
+            f"Attribute {attr} is not supported for metadata-only dataframes.\n\n"
+            "Hint: you probably called `nw.from_native` on an object which isn't fully "
+            "supported by Narwhals, yet implements `__dataframe__`. If you would like to "
+            "see this kind of object supported in Narwhals, please open a feature request "
+            "at https://github.com/narwhals-dev/narwhals/issues."
+        )
+        raise NotImplementedError(msg)

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -218,9 +218,11 @@ class DataFrame(BaseFrame[FrameT]):
         *,
         backend_version: tuple[int, ...],
         is_polars: bool,
+        level: Literal["full", "metadata"] = "full",
     ) -> None:
         self._is_polars = is_polars
         self._backend_version = backend_version
+        self._level: Literal["full", "metadata"] = level
         if hasattr(df, "__narwhals_dataframe__"):
             self._compliant_frame: Any = df.__narwhals_dataframe__()
         elif is_polars and isinstance(df, get_polars().DataFrame):
@@ -1927,9 +1929,11 @@ class LazyFrame(BaseFrame[FrameT]):
         *,
         is_polars: bool,
         backend_version: tuple[int, ...],
+        level: Literal["full", "metadata"] = "full",
     ) -> None:
         self._is_polars = is_polars
         self._backend_version = backend_version
+        self._level = level
         if hasattr(df, "__narwhals_lazyframe__"):
             self._compliant_frame: Any = df.__narwhals_lazyframe__()
         elif is_polars and (

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -59,6 +59,7 @@ class BaseFrame(Generic[FrameT]):
             df,
             is_polars=self._is_polars,
             backend_version=self._backend_version,
+            level=self._level,
         )
 
     def _flatten_and_extract(self, *args: Any, **kwargs: Any) -> Any:

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -38,6 +38,7 @@ class BaseFrame(Generic[FrameT]):
     _compliant_frame: Any
     _is_polars: bool
     _backend_version: tuple[int, ...]
+    _level: Literal["full", "metadata"]
 
     def __len__(self) -> Any:
         return self._compliant_frame.__len__()
@@ -119,6 +120,7 @@ class BaseFrame(Generic[FrameT]):
             self._compliant_frame.lazy(),
             is_polars=self._is_polars,
             backend_version=self._backend_version,
+            level=self._level,
         )
 
     def with_columns(
@@ -218,7 +220,7 @@ class DataFrame(BaseFrame[FrameT]):
         *,
         backend_version: tuple[int, ...],
         is_polars: bool,
-        level: Literal["full", "metadata"] = "full",
+        level: Literal["full", "metadata"],
     ) -> None:
         self._is_polars = is_polars
         self._backend_version = backend_version
@@ -1929,7 +1931,7 @@ class LazyFrame(BaseFrame[FrameT]):
         *,
         is_polars: bool,
         backend_version: tuple[int, ...],
-        level: Literal["full", "metadata"] = "full",
+        level: Literal["full", "metadata"],
     ) -> None:
         self._is_polars = is_polars
         self._backend_version = backend_version
@@ -2002,6 +2004,7 @@ class LazyFrame(BaseFrame[FrameT]):
             self._compliant_frame.collect(),
             is_polars=self._is_polars,
             backend_version=self._backend_version,
+            level=self._level,
         )
 
     # inherited

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -38,7 +38,7 @@ class BaseFrame(Generic[FrameT]):
     _compliant_frame: Any
     _is_polars: bool
     _backend_version: tuple[int, ...]
-    _level: Literal["full", "metadata"]
+    _level: Literal["full", "interchange"]
 
     def __len__(self) -> Any:
         return self._compliant_frame.__len__()
@@ -221,11 +221,11 @@ class DataFrame(BaseFrame[FrameT]):
         *,
         backend_version: tuple[int, ...],
         is_polars: bool,
-        level: Literal["full", "metadata"],
+        level: Literal["full", "interchange"],
     ) -> None:
         self._is_polars = is_polars
         self._backend_version = backend_version
-        self._level: Literal["full", "metadata"] = level
+        self._level: Literal["full", "interchange"] = level
         if hasattr(df, "__narwhals_dataframe__"):
             self._compliant_frame: Any = df.__narwhals_dataframe__()
         elif is_polars and isinstance(df, get_polars().DataFrame):
@@ -1937,7 +1937,7 @@ class LazyFrame(BaseFrame[FrameT]):
         *,
         is_polars: bool,
         backend_version: tuple[int, ...],
-        level: Literal["full", "metadata"],
+        level: Literal["full", "interchange"],
     ) -> None:
         self._is_polars = is_polars
         self._backend_version = backend_version

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -458,6 +458,7 @@ class DataFrame(BaseFrame[FrameT]):
             self._compliant_frame.get_column(name),
             backend_version=self._backend_version,
             is_polars=self._is_polars,
+            level=self._level,
         )
 
     @overload
@@ -527,6 +528,7 @@ class DataFrame(BaseFrame[FrameT]):
                 self._compliant_frame[item],
                 backend_version=self._backend_version,
                 is_polars=self._is_polars,
+                level=self._level,
             )
 
         elif isinstance(item, (Sequence, slice)) or (
@@ -592,6 +594,7 @@ class DataFrame(BaseFrame[FrameT]):
                     value,
                     backend_version=self._backend_version,
                     is_polars=self._is_polars,
+                    level=self._level,
                 )
                 for key, value in self._compliant_frame.to_dict(
                     as_series=as_series
@@ -1705,6 +1708,7 @@ class DataFrame(BaseFrame[FrameT]):
             self._compliant_frame.is_duplicated(),
             backend_version=self._backend_version,
             is_polars=self._is_polars,
+            level=self._level,
         )
 
     def is_empty(self: Self) -> bool:
@@ -1791,6 +1795,7 @@ class DataFrame(BaseFrame[FrameT]):
             self._compliant_frame.is_unique(),
             backend_version=self._backend_version,
             is_polars=self._is_polars,
+            level=self._level,
         )
 
     def null_count(self: Self) -> Self:

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import platform
 import sys
+from typing import TYPE_CHECKING
+from typing import Any
 from typing import Iterable
 from typing import Literal
 from typing import TypeVar
@@ -16,6 +18,9 @@ from narwhals.utils import validate_same_library
 # However, trying to provide one results in mypy still complaining...
 # The rest of the annotations seem to work fine with this anyway
 FrameT = TypeVar("FrameT", bound=Union[DataFrame, LazyFrame])  # type: ignore[type-arg]
+
+if TYPE_CHECKING:
+    from narwhals.series import Series
 
 
 def concat(
@@ -116,3 +121,17 @@ def show_versions() -> None:
     print("\nPython dependencies:")  # noqa: T201
     for k, stat in deps_info.items():
         print(f"{k:>13}: {stat}")  # noqa: T201
+
+
+def get_level(
+    obj: DataFrame[Any] | LazyFrame[Any] | Series,
+) -> Literal["full", "metadata"]:
+    """
+    Level of support Narwhals has for current object.
+
+    This can be one of:
+
+    - 'full': full Narwhals API support
+    - 'metadata': only metadata operations are supported (`df.schema`)
+    """
+    return obj._level

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -125,7 +125,7 @@ def show_versions() -> None:
 
 def get_level(
     obj: DataFrame[Any] | LazyFrame[Any] | Series,
-) -> Literal["full", "metadata"]:
+) -> Literal["full", "interchange"]:
     """
     Level of support Narwhals has for current object.
 

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -32,7 +32,7 @@ class Series:
         *,
         backend_version: tuple[int, ...],
         is_polars: bool,
-        level: Literal["full", "metadata"],
+        level: Literal["full", "interchange"],
     ) -> None:
         self._is_polars = is_polars
         self._backend_version = backend_version

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -32,9 +32,11 @@ class Series:
         *,
         backend_version: tuple[int, ...],
         is_polars: bool,
+        level: Literal["full", "metadata"] = "full",
     ) -> None:
         self._is_polars = is_polars
         self._backend_version = backend_version
+        self._level = level
         if hasattr(series, "__narwhals_series__"):
             self._compliant_series = series.__narwhals_series__()
         elif is_polars and (

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -298,6 +298,7 @@ class Series:
             self._compliant_series.to_frame(),
             is_polars=self._is_polars,
             backend_version=self._backend_version,
+            level=self._level,
         )
 
     def to_list(self) -> list[Any]:
@@ -1676,6 +1677,7 @@ class Series:
             self._compliant_series.value_counts(sort=sort, parallel=parallel),
             is_polars=self._is_polars,
             backend_version=self._backend_version,
+            level=self._level,
         )
 
     def quantile(

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -32,7 +32,7 @@ class Series:
         *,
         backend_version: tuple[int, ...],
         is_polars: bool,
-        level: Literal["full", "metadata"] = "full",
+        level: Literal["full", "metadata"],
     ) -> None:
         self._is_polars = is_polars
         self._backend_version = backend_version
@@ -104,7 +104,10 @@ class Series:
 
     def _from_compliant_series(self, series: Any) -> Self:
         return self.__class__(
-            series, is_polars=self._is_polars, backend_version=self._backend_version
+            series,
+            is_polars=self._is_polars,
+            backend_version=self._backend_version,
+            level=self._level,
         )
 
     def __repr__(self) -> str:  # pragma: no cover

--- a/narwhals/stable/v1.py
+++ b/narwhals/stable/v1.py
@@ -1308,6 +1308,20 @@ def get_native_namespace(obj: Any) -> Any:
     return nw_get_native_namespace(obj)
 
 
+def get_level(
+    obj: DataFrame[Any] | LazyFrame[Any] | Series,
+) -> Literal["full", "metadata"]:
+    """
+    Level of support Narwhals has for current object.
+
+    This can be one of:
+
+    - 'full': full Narwhals API support
+    - 'metadata': only metadata operations are supported (`df.schema`)
+    """
+    return nw.get_level(obj)
+
+
 __all__ = [
     "selectors",
     "concat",
@@ -1318,6 +1332,7 @@ __all__ = [
     "maybe_convert_dtypes",
     "maybe_set_index",
     "get_native_namespace",
+    "get_level",
     "all",
     "all_horizontal",
     "col",

--- a/narwhals/stable/v1.py
+++ b/narwhals/stable/v1.py
@@ -435,18 +435,21 @@ def _stableify(
             obj._compliant_frame,
             is_polars=obj._is_polars,
             backend_version=obj._backend_version,
+            level=obj._level,
         )
     if isinstance(obj, NwLazyFrame):
         return LazyFrame(
             obj._compliant_frame,
             is_polars=obj._is_polars,
             backend_version=obj._backend_version,
+            level=obj._level,
         )
     if isinstance(obj, NwSeries):
         return Series(
             obj._compliant_series,
             is_polars=obj._is_polars,
             backend_version=obj._backend_version,
+            level=obj._level,
         )
     if isinstance(obj, NwExpr):
         return Expr(obj._call)

--- a/narwhals/stable/v1.py
+++ b/narwhals/stable/v1.py
@@ -50,7 +50,6 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from narwhals.dtypes import DType
-    from narwhals.typing import IntoDataFrame
     from narwhals.typing import IntoExpr
 
 T = TypeVar("T")
@@ -461,23 +460,47 @@ def from_native(
     native_dataframe: Any,
     *,
     strict: Literal[False],
-    eager_only: Literal[True],
+    eager_only: None = ...,
+    eager_or_interchange_only: Literal[True],
     series_only: None = ...,
     allow_series: Literal[True],
-    allow_interchange_protocol: bool = ...,
 ) -> Any: ...
 
 
 @overload
 def from_native(
-    native_dataframe: IntoDataFrame | T,
+    native_dataframe: Any,
     *,
     strict: Literal[False],
     eager_only: Literal[True],
+    eager_or_interchange_only: None = ...,
+    series_only: None = ...,
+    allow_series: Literal[True],
+) -> Any: ...
+
+
+@overload
+def from_native(
+    native_dataframe: IntoDataFrameT | T,
+    *,
+    strict: Literal[False],
+    eager_only: None = ...,
+    eager_or_interchange_only: Literal[True],
     series_only: None = ...,
     allow_series: None = ...,
-    allow_interchange_protocol: bool = ...,
-) -> DataFrame[IntoDataFrame] | T: ...
+) -> DataFrame[IntoDataFrameT] | T: ...
+
+
+@overload
+def from_native(
+    native_dataframe: IntoDataFrameT | T,
+    *,
+    strict: Literal[False],
+    eager_only: Literal[True],
+    eager_or_interchange_only: None = ...,
+    series_only: None = ...,
+    allow_series: None = ...,
+) -> DataFrame[IntoDataFrameT] | T: ...
 
 
 @overload
@@ -486,9 +509,9 @@ def from_native(
     *,
     strict: Literal[False],
     eager_only: None = ...,
+    eager_or_interchange_only: None = ...,
     series_only: None = ...,
     allow_series: Literal[True],
-    allow_interchange_protocol: bool = ...,
 ) -> Any: ...
 
 
@@ -498,9 +521,9 @@ def from_native(
     *,
     strict: Literal[False],
     eager_only: None = ...,
+    eager_or_interchange_only: None = ...,
     series_only: Literal[True],
     allow_series: None = ...,
-    allow_interchange_protocol: bool = ...,
 ) -> Any: ...
 
 
@@ -509,29 +532,26 @@ def from_native(
     native_dataframe: IntoFrameT | T,
     *,
     strict: Literal[False],
-    eager_only: bool | None = ...,
-    series_only: bool | None = ...,
-    allow_series: bool | None = ...,
-    allow_interchange_protocol: bool = ...,
-) -> DataFrame[IntoFrameT] | LazyFrame[IntoFrameT] | T:
-    """
-    from_native(df, strict=False)
-    """
+    eager_only: None = ...,
+    eager_or_interchange_only: None = ...,
+    series_only: None = ...,
+    allow_series: None = ...,
+) -> DataFrame[IntoFrameT] | LazyFrame[IntoFrameT] | T: ...
 
 
 @overload
 def from_native(
-    native_dataframe: Any,
+    native_dataframe: IntoDataFrameT,
     *,
     strict: Literal[True] = ...,
-    eager_only: Literal[True],
+    eager_only: None = ...,
+    eager_or_interchange_only: Literal[True],
     series_only: None = ...,
-    allow_series: Literal[True],
-    allow_interchange_protocol: bool = ...,
-) -> DataFrame[Any] | Series:
+    allow_series: None = ...,
+) -> DataFrame[IntoDataFrameT]:
     """
-    from_native(df, strict=True, eager_only=True, allow_series=True)
-    from_native(df, eager_only=True, allow_series=True)
+    from_native(df, strict=True, eager_or_interchange_only=True, allow_series=True)
+    from_native(df, eager_or_interchange_only=True, allow_series=True)
     """
 
 
@@ -541,10 +561,26 @@ def from_native(
     *,
     strict: Literal[True] = ...,
     eager_only: Literal[True],
+    eager_or_interchange_only: None = ...,
     series_only: None = ...,
     allow_series: None = ...,
-    allow_interchange_protocol: bool = ...,
 ) -> DataFrame[IntoDataFrameT]:
+    """
+    from_native(df, strict=True, eager_only=True, allow_series=True)
+    from_native(df, eager_only=True, allow_series=True)
+    """
+
+
+@overload
+def from_native(
+    native_dataframe: Any,
+    *,
+    strict: Literal[True] = ...,
+    eager_only: None = ...,
+    eager_or_interchange_only: None = ...,
+    series_only: None = ...,
+    allow_series: Literal[True],
+) -> DataFrame[Any] | LazyFrame[Any] | Series:
     """
     from_native(df, strict=True, eager_only=True)
     from_native(df, eager_only=True)
@@ -557,25 +593,9 @@ def from_native(
     *,
     strict: Literal[True] = ...,
     eager_only: None = ...,
-    series_only: None = ...,
-    allow_series: Literal[True],
-    allow_interchange_protocol: bool = ...,
-) -> DataFrame[Any] | LazyFrame[Any] | Series:
-    """
-    from_native(df, strict=True, allow_series=True)
-    from_native(df, allow_series=True)
-    """
-
-
-@overload
-def from_native(
-    native_dataframe: Any,
-    *,
-    strict: Literal[True] = ...,
-    eager_only: None = ...,
+    eager_or_interchange_only: None = ...,
     series_only: Literal[True],
     allow_series: None = ...,
-    allow_interchange_protocol: bool = ...,
 ) -> Series:
     """
     from_native(df, strict=True, series_only=True)
@@ -589,9 +609,9 @@ def from_native(
     *,
     strict: Literal[True] = ...,
     eager_only: None = ...,
+    eager_or_interchange_only: None = ...,
     series_only: None = ...,
     allow_series: None = ...,
-    allow_interchange_protocol: bool = ...,
 ) -> DataFrame[IntoFrameT] | LazyFrame[IntoFrameT]:
     """
     from_native(df, strict=True)
@@ -606,9 +626,9 @@ def from_native(
     *,
     strict: bool,
     eager_only: bool | None,
+    eager_or_interchange_only: bool | None = None,
     series_only: bool | None,
     allow_series: bool | None,
-    allow_interchange_protocol: bool = ...,
 ) -> Any: ...
 
 
@@ -617,9 +637,9 @@ def from_native(
     *,
     strict: bool = True,
     eager_only: bool | None = None,
+    eager_or_interchange_only: bool | None = None,
     series_only: bool | None = None,
     allow_series: bool | None = None,
-    allow_interchange_protocol: bool = False,
 ) -> Any:
     """
     Convert dataframe/series to Narwhals DataFrame, LazyFrame, or Series.
@@ -638,10 +658,10 @@ def from_native(
         strict: Whether to raise if object can't be converted (default) or
             to just leave it as-is.
         eager_only: Whether to only allow eager objects.
+        eager_or_interchange_only: Whether to only allow eager objects or objects which
+            implement the Dataframe Interchange Protocol.
         series_only: Whether to only allow series.
         allow_series: Whether to allow series (default is only dataframe / lazyframe).
-        allow_interchange_protocol: Whether to allow objects which only implement `__dataframe__` and
-            are otherwise unsupported by Narwhals.
 
     Returns:
         narwhals.DataFrame or narwhals.LazyFrame or narwhals.Series
@@ -655,9 +675,9 @@ def from_native(
         native_dataframe,
         strict=strict,
         eager_only=eager_only,
+        eager_or_interchange_only=eager_or_interchange_only,
         series_only=series_only,
         allow_series=allow_series,
-        allow_interchange_protocol=allow_interchange_protocol,
     )
     return _stableify(result)
 
@@ -719,6 +739,8 @@ def narwhalify(
         strict: Whether to raise if object can't be converted or to just leave it as-is
             (default).
         eager_only: Whether to only allow eager objects.
+        eager_or_interchange_only: Whether to only allow eager objects or objects which
+            implement the Dataframe Interchange Protocol.
         series_only: Whether to only allow series.
         allow_series: Whether to allow series (default is only dataframe / lazyframe).
     """

--- a/narwhals/stable/v1.py
+++ b/narwhals/stable/v1.py
@@ -464,6 +464,7 @@ def from_native(
     eager_only: Literal[True],
     series_only: None = ...,
     allow_series: Literal[True],
+    allow_interchange_protocol: bool = ...,
 ) -> Any: ...
 
 
@@ -475,6 +476,7 @@ def from_native(
     eager_only: Literal[True],
     series_only: None = ...,
     allow_series: None = ...,
+    allow_interchange_protocol: bool = ...,
 ) -> DataFrame[IntoDataFrame] | T: ...
 
 
@@ -486,6 +488,7 @@ def from_native(
     eager_only: None = ...,
     series_only: None = ...,
     allow_series: Literal[True],
+    allow_interchange_protocol: bool = ...,
 ) -> Any: ...
 
 
@@ -497,6 +500,7 @@ def from_native(
     eager_only: None = ...,
     series_only: Literal[True],
     allow_series: None = ...,
+    allow_interchange_protocol: bool = ...,
 ) -> Any: ...
 
 
@@ -508,6 +512,7 @@ def from_native(
     eager_only: bool | None = ...,
     series_only: bool | None = ...,
     allow_series: bool | None = ...,
+    allow_interchange_protocol: bool = ...,
 ) -> DataFrame[IntoFrameT] | LazyFrame[IntoFrameT] | T:
     """
     from_native(df, strict=False)
@@ -522,6 +527,7 @@ def from_native(
     eager_only: Literal[True],
     series_only: None = ...,
     allow_series: Literal[True],
+    allow_interchange_protocol: bool = ...,
 ) -> DataFrame[Any] | Series:
     """
     from_native(df, strict=True, eager_only=True, allow_series=True)
@@ -537,6 +543,7 @@ def from_native(
     eager_only: Literal[True],
     series_only: None = ...,
     allow_series: None = ...,
+    allow_interchange_protocol: bool = ...,
 ) -> DataFrame[IntoDataFrameT]:
     """
     from_native(df, strict=True, eager_only=True)
@@ -552,6 +559,7 @@ def from_native(
     eager_only: None = ...,
     series_only: None = ...,
     allow_series: Literal[True],
+    allow_interchange_protocol: bool = ...,
 ) -> DataFrame[Any] | LazyFrame[Any] | Series:
     """
     from_native(df, strict=True, allow_series=True)
@@ -567,6 +575,7 @@ def from_native(
     eager_only: None = ...,
     series_only: Literal[True],
     allow_series: None = ...,
+    allow_interchange_protocol: bool = ...,
 ) -> Series:
     """
     from_native(df, strict=True, series_only=True)
@@ -582,6 +591,7 @@ def from_native(
     eager_only: None = ...,
     series_only: None = ...,
     allow_series: None = ...,
+    allow_interchange_protocol: bool = ...,
 ) -> DataFrame[IntoFrameT] | LazyFrame[IntoFrameT]:
     """
     from_native(df, strict=True)
@@ -598,6 +608,7 @@ def from_native(
     eager_only: bool | None,
     series_only: bool | None,
     allow_series: bool | None,
+    allow_interchange_protocol: bool = ...,
 ) -> Any: ...
 
 
@@ -608,6 +619,7 @@ def from_native(
     eager_only: bool | None = None,
     series_only: bool | None = None,
     allow_series: bool | None = None,
+    allow_interchange_protocol: bool = False,
 ) -> Any:
     """
     Convert dataframe/series to Narwhals DataFrame, LazyFrame, or Series.
@@ -628,16 +640,24 @@ def from_native(
         eager_only: Whether to only allow eager objects.
         series_only: Whether to only allow series.
         allow_series: Whether to allow series (default is only dataframe / lazyframe).
+        allow_interchange_protocol: Whether to allow objects which only implement `__dataframe__` and
+            are otherwise unsupported by Narwhals.
 
     Returns:
         narwhals.DataFrame or narwhals.LazyFrame or narwhals.Series
     """
+    # Early returns
+    if isinstance(native_dataframe, (DataFrame, LazyFrame)) and not series_only:
+        return native_dataframe
+    if isinstance(native_dataframe, Series) and (series_only or allow_series):
+        return native_dataframe
     result = nw.from_native(
         native_dataframe,
         strict=strict,
         eager_only=eager_only,
         series_only=series_only,
         allow_series=allow_series,
+        allow_interchange_protocol=allow_interchange_protocol,
     )
     return _stableify(result)
 

--- a/narwhals/stable/v1.py
+++ b/narwhals/stable/v1.py
@@ -1355,7 +1355,7 @@ def get_native_namespace(obj: Any) -> Any:
 
 def get_level(
     obj: DataFrame[Any] | LazyFrame[Any] | Series,
-) -> Literal["full", "metadata"]:
+) -> Literal["full", "interchange"]:
     """
     Level of support Narwhals has for current object.
 

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -401,7 +401,7 @@ def from_native(  # noqa: PLR0915
             InterchangeFrame(native_object.__dataframe__()),
             is_polars=False,
             backend_version=(0,),
-            level="metadata",
+            level="interchange",
         )
     elif hasattr(native_object, "__narwhals_dataframe__"):
         if series_only:

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -342,6 +342,7 @@ def from_native(  # noqa: PLR0915
             InterchangeFrame(native_object.__dataframe__()),
             is_polars=False,
             backend_version=(0,),
+            level="metadata",
         )
     elif hasattr(native_object, "__narwhals_dataframe__"):
         if series_only:

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -270,6 +270,7 @@ def from_native(  # noqa: PLR0915
             native_object,
             is_polars=True,
             backend_version=parse_version(pl.__version__),
+            level="full",
         )
     elif (pl := get_polars()) is not None and isinstance(native_object, pl.LazyFrame):
         if series_only:
@@ -282,6 +283,7 @@ def from_native(  # noqa: PLR0915
             native_object,
             is_polars=True,
             backend_version=parse_version(pl.__version__),
+            level="full",
         )
     elif (pd := get_pandas()) is not None and isinstance(native_object, pd.DataFrame):
         if series_only:
@@ -295,6 +297,7 @@ def from_native(  # noqa: PLR0915
             ),
             is_polars=False,
             backend_version=parse_version(pd.__version__),
+            level="full",
         )
     elif (mpd := get_modin()) is not None and isinstance(native_object, mpd.DataFrame):
         if series_only:
@@ -308,6 +311,7 @@ def from_native(  # noqa: PLR0915
             ),
             is_polars=False,
             backend_version=parse_version(mpd.__version__),
+            level="full",
         )
     elif (cudf := get_cudf()) is not None and isinstance(  # pragma: no cover
         native_object, cudf.DataFrame
@@ -323,6 +327,7 @@ def from_native(  # noqa: PLR0915
             ),
             is_polars=False,
             backend_version=parse_version(cudf.__version__),
+            level="full",
         )
     elif (pa := get_pyarrow()) is not None and isinstance(native_object, pa.Table):
         if series_only:
@@ -332,6 +337,7 @@ def from_native(  # noqa: PLR0915
             ArrowDataFrame(native_object, backend_version=parse_version(pa.__version__)),
             is_polars=False,
             backend_version=parse_version(pa.__version__),
+            level="full",
         )
     elif hasattr(native_object, "__dataframe__"):
         if series_only:
@@ -353,6 +359,7 @@ def from_native(  # noqa: PLR0915
             native_object.__narwhals_dataframe__(),
             is_polars=False,
             backend_version=(0,),
+            level="full",
         )
     elif hasattr(native_object, "__narwhals_lazyframe__"):
         if series_only:
@@ -366,6 +373,7 @@ def from_native(  # noqa: PLR0915
             native_object.__narwhals_lazyframe__(),
             is_polars=False,
             backend_version=(0,),
+            level="full",
         )
     elif (pl := get_polars()) is not None and isinstance(native_object, pl.Series):
         if not allow_series:

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -406,6 +406,7 @@ def from_native(  # noqa: PLR0915
             native_object,
             is_polars=True,
             backend_version=parse_version(pl.__version__),
+            level="full",
         )
     elif (pd := get_pandas()) is not None and isinstance(native_object, pd.Series):
         if not allow_series:
@@ -419,6 +420,7 @@ def from_native(  # noqa: PLR0915
             ),
             is_polars=False,
             backend_version=parse_version(pd.__version__),
+            level="full",
         )
     elif (mpd := get_modin()) is not None and isinstance(native_object, mpd.Series):
         if not allow_series:
@@ -432,6 +434,7 @@ def from_native(  # noqa: PLR0915
             ),
             is_polars=False,
             backend_version=parse_version(mpd.__version__),
+            level="full",
         )
     elif (cudf := get_cudf()) is not None and isinstance(
         native_object, cudf.Series
@@ -447,6 +450,7 @@ def from_native(  # noqa: PLR0915
             ),
             is_polars=False,
             backend_version=parse_version(cudf.__version__),
+            level="full",
         )
     elif (pa := get_pyarrow()) is not None and isinstance(native_object, pa.ChunkedArray):
         if not allow_series:
@@ -458,6 +462,7 @@ def from_native(  # noqa: PLR0915
             ),
             is_polars=False,
             backend_version=parse_version(pa.__version__),
+            level="full",
         )
     elif hasattr(native_object, "__narwhals_series__"):
         if not allow_series:
@@ -465,7 +470,10 @@ def from_native(  # noqa: PLR0915
             raise TypeError(msg)
         # placeholder (0,) version here, as we wouldn't use it in this case anyway.
         return Series(
-            native_object.__narwhals_series__(), backend_version=(0,), is_polars=False
+            native_object.__narwhals_series__(),
+            backend_version=(0,),
+            is_polars=False,
+            level="full",
         )
     elif strict:
         msg = f"Expected pandas-like dataframe, Polars dataframe, or Polars lazyframe, got: {type(native_object)}"

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -249,6 +249,7 @@ def from_native(  # noqa: PLR0915
     """
     from narwhals._arrow.dataframe import ArrowDataFrame
     from narwhals._arrow.series import ArrowSeries
+    from narwhals._interchange.dataframe import InterchangeFrame
     from narwhals._pandas_like.dataframe import PandasLikeDataFrame
     from narwhals._pandas_like.series import PandasLikeSeries
     from narwhals._pandas_like.utils import Implementation
@@ -331,6 +332,16 @@ def from_native(  # noqa: PLR0915
             ArrowDataFrame(native_object, backend_version=parse_version(pa.__version__)),
             is_polars=False,
             backend_version=parse_version(pa.__version__),
+        )
+    elif hasattr(native_object, "__dataframe__"):
+        if series_only:
+            msg = "Cannot only use `series_only` with object which only implements __dataframe__"
+            raise TypeError(msg)
+        # placeholder (0,) version here, as we wouldn't use it in this case anyway.
+        return DataFrame(
+            InterchangeFrame(native_object.__dataframe__()),
+            is_polars=False,
+            backend_version=(0,),
         )
     elif hasattr(native_object, "__narwhals_dataframe__"):
         if series_only:

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -80,10 +80,22 @@ def from_native(
     native_object: Any,
     *,
     strict: Literal[False],
-    eager_only: Literal[True],
+    eager_only: None = ...,
+    eager_or_interchange_only: Literal[True],
     series_only: None = ...,
     allow_series: Literal[True],
-    allow_interchange_protocol: bool = ...,
+) -> Any: ...
+
+
+@overload
+def from_native(
+    native_object: Any,
+    *,
+    strict: Literal[False],
+    eager_only: Literal[True],
+    eager_or_interchange_only: None = ...,
+    series_only: None = ...,
+    allow_series: Literal[True],
 ) -> Any: ...
 
 
@@ -92,10 +104,22 @@ def from_native(
     native_object: IntoDataFrameT | T,
     *,
     strict: Literal[False],
-    eager_only: Literal[True],
+    eager_only: None = ...,
+    eager_or_interchange_only: Literal[True],
     series_only: None = ...,
     allow_series: None = ...,
-    allow_interchange_protocol: bool = ...,
+) -> DataFrame[IntoDataFrameT] | T: ...
+
+
+@overload
+def from_native(
+    native_object: IntoDataFrameT | T,
+    *,
+    strict: Literal[False],
+    eager_only: Literal[True],
+    eager_or_interchange_only: None = ...,
+    series_only: None = ...,
+    allow_series: None = ...,
 ) -> DataFrame[IntoDataFrameT] | T: ...
 
 
@@ -105,9 +129,9 @@ def from_native(
     *,
     strict: Literal[False],
     eager_only: None = ...,
+    eager_or_interchange_only: None = ...,
     series_only: None = ...,
     allow_series: Literal[True],
-    allow_interchange_protocol: bool = ...,
 ) -> Any: ...
 
 
@@ -117,9 +141,9 @@ def from_native(
     *,
     strict: Literal[False],
     eager_only: None = ...,
+    eager_or_interchange_only: None = ...,
     series_only: Literal[True],
     allow_series: None = ...,
-    allow_interchange_protocol: bool = ...,
 ) -> Any: ...
 
 
@@ -129,24 +153,25 @@ def from_native(
     *,
     strict: Literal[False],
     eager_only: None = ...,
+    eager_or_interchange_only: None = ...,
     series_only: None = ...,
     allow_series: None = ...,
-    allow_interchange_protocol: bool = ...,
 ) -> DataFrame[IntoFrameT] | LazyFrame[IntoFrameT] | T: ...
 
 
 @overload
 def from_native(
-    native_object: Any,
+    native_object: IntoDataFrameT,
     *,
     strict: Literal[True] = ...,
-    eager_only: Literal[True],
+    eager_only: None = ...,
+    eager_or_interchange_only: Literal[True],
     series_only: None = ...,
-    allow_series: Literal[True],
-    allow_interchange_protocol: bool = ...,
-) -> DataFrame[Any] | Series:
+    allow_series: None = ...,
+) -> DataFrame[IntoDataFrameT]:
     """
-    from_native(df, strict=False)
+    from_native(df, strict=True, eager_or_interchange_only=True, allow_series=True)
+    from_native(df, eager_or_interchange_only=True, allow_series=True)
     """
 
 
@@ -156,9 +181,9 @@ def from_native(
     *,
     strict: Literal[True] = ...,
     eager_only: Literal[True],
+    eager_or_interchange_only: None = ...,
     series_only: None = ...,
     allow_series: None = ...,
-    allow_interchange_protocol: bool = ...,
 ) -> DataFrame[IntoDataFrameT]:
     """
     from_native(df, strict=True, eager_only=True, allow_series=True)
@@ -172,9 +197,9 @@ def from_native(
     *,
     strict: Literal[True] = ...,
     eager_only: None = ...,
+    eager_or_interchange_only: None = ...,
     series_only: None = ...,
     allow_series: Literal[True],
-    allow_interchange_protocol: bool = ...,
 ) -> DataFrame[Any] | LazyFrame[Any] | Series:
     """
     from_native(df, strict=True, eager_only=True)
@@ -188,9 +213,9 @@ def from_native(
     *,
     strict: Literal[True] = ...,
     eager_only: None = ...,
+    eager_or_interchange_only: None = ...,
     series_only: Literal[True],
     allow_series: None = ...,
-    allow_interchange_protocol: bool = ...,
 ) -> Series:
     """
     from_native(df, strict=True, series_only=True)
@@ -204,9 +229,9 @@ def from_native(
     *,
     strict: Literal[True] = ...,
     eager_only: None = ...,
+    eager_or_interchange_only: None = ...,
     series_only: None = ...,
     allow_series: None = ...,
-    allow_interchange_protocol: bool = ...,
 ) -> DataFrame[IntoFrameT] | LazyFrame[IntoFrameT]:
     """
     from_native(df, strict=True)
@@ -221,9 +246,9 @@ def from_native(
     *,
     strict: bool,
     eager_only: bool | None,
+    eager_or_interchange_only: bool | None = None,
     series_only: bool | None,
     allow_series: bool | None,
-    allow_interchange_protocol: bool = ...,
 ) -> Any: ...
 
 
@@ -232,9 +257,9 @@ def from_native(  # noqa: PLR0915
     *,
     strict: bool = True,
     eager_only: bool | None = None,
+    eager_or_interchange_only: bool | None = None,
     series_only: bool | None = None,
     allow_series: bool | None = None,
-    allow_interchange_protocol: bool = False,
 ) -> Any:
     """
     Convert dataframe/series to Narwhals DataFrame, LazyFrame, or Series.
@@ -253,10 +278,10 @@ def from_native(  # noqa: PLR0915
         strict: Whether to raise if object can't be converted (default) or
             to just leave it as-is.
         eager_only: Whether to only allow eager objects.
+        eager_or_interchange_only: Whether to only allow eager objects or objects which
+            implement the Dataframe Interchange Protocol.
         series_only: Whether to only allow series.
         allow_series: Whether to allow series (default is only dataframe / lazyframe).
-        allow_interchange_protocol: Whether to allow objects which only implement `__dataframe__` and
-            are otherwise unsupported by Narwhals.
 
     Returns:
         narwhals.DataFrame or narwhals.LazyFrame or narwhals.Series
@@ -283,6 +308,9 @@ def from_native(  # noqa: PLR0915
             msg = "Invalid parameter combination: `series_only=True` and `allow_series=False`"
             raise ValueError(msg)
         allow_series = True
+    if eager_only and eager_or_interchange_only:
+        msg = "Invalid parameter combination: `eager_only=True` and `eager_or_interchange_only=True`"
+        raise ValueError(msg)
 
     if (pl := get_polars()) is not None and isinstance(native_object, pl.DataFrame):
         if series_only:
@@ -298,8 +326,8 @@ def from_native(  # noqa: PLR0915
         if series_only:
             msg = "Cannot only use `series_only` with polars.LazyFrame"
             raise TypeError(msg)
-        if eager_only:
-            msg = "Cannot only use `eager_only` with polars.LazyFrame"
+        if eager_only or eager_or_interchange_only:
+            msg = "Cannot only use `eager_only` or `eager_or_interchange_only` with polars.LazyFrame"
             raise TypeError(msg)
         return LazyFrame(
             native_object,
@@ -362,10 +390,10 @@ def from_native(  # noqa: PLR0915
             level="full",
         )
     elif hasattr(native_object, "__dataframe__"):
-        if not allow_interchange_protocol or series_only:
+        if eager_only or series_only:
             msg = (
-                "Cannot only use `series_only=True` or `allow_interchange_protocol=False` "
-                "(the default) with object which only implements __dataframe__"
+                "Cannot only use `series_only=True` or `eager_only=False` "
+                "with object which only implements __dataframe__"
             )
             raise TypeError(msg)
         # placeholder (0,) version here, as we wouldn't use it in this case anyway.
@@ -390,8 +418,8 @@ def from_native(  # noqa: PLR0915
         if series_only:
             msg = "Cannot only use `series_only` with lazyframe"
             raise TypeError(msg)
-        if eager_only:
-            msg = "Cannot only use `eager_only` with lazyframe"
+        if eager_only or eager_or_interchange_only:
+            msg = "Cannot only use `eager_only` or `eager_or_interchange_only` with lazyframe"
             raise TypeError(msg)
         # placeholder (0,) version here, as we wouldn't use it in this case anyway.
         return LazyFrame(
@@ -506,6 +534,7 @@ def narwhalify(
     *,
     strict: bool = False,
     eager_only: bool | None = False,
+    eager_or_interchange_only: bool | None = False,
     series_only: bool | None = False,
     allow_series: bool | None = True,
 ) -> Callable[..., Any]:
@@ -558,6 +587,8 @@ def narwhalify(
         strict: Whether to raise if object can't be converted or to just leave it as-is
             (default).
         eager_only: Whether to only allow eager objects.
+        eager_or_interchange_only: Whether to only allow eager objects or objects which
+            implement the Dataframe Interchange Protocol.
         series_only: Whether to only allow series.
         allow_series: Whether to allow series (default is only dataframe / lazyframe).
     """
@@ -570,6 +601,7 @@ def narwhalify(
                     arg,
                     strict=strict,
                     eager_only=eager_only,
+                    eager_or_interchange_only=eager_or_interchange_only,
                     series_only=series_only,
                     allow_series=allow_series,
                 )
@@ -581,6 +613,7 @@ def narwhalify(
                     value,
                     strict=strict,
                     eager_only=eager_only,
+                    eager_or_interchange_only=eager_or_interchange_only,
                     series_only=series_only,
                     allow_series=allow_series,
                 )

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -28,14 +28,19 @@ if TYPE_CHECKING:
 
         def join(self, *args: Any, **kwargs: Any) -> Any: ...
 
+    class DataFrameLike(Protocol):
+        def __dataframe__(self, *args: Any, **kwargs: Any) -> Any: ...
+
 
 IntoExpr: TypeAlias = Union["Expr", str, "Series"]
 """Anything which can be converted to an expression."""
 
-IntoDataFrame: TypeAlias = Union["NativeFrame", "DataFrame[Any]"]
+IntoDataFrame: TypeAlias = Union["NativeFrame", "DataFrame[Any]", "DataFrameLike"]
 """Anything which can be converted to a Narwhals DataFrame."""
 
-IntoFrame: TypeAlias = Union["NativeFrame", "DataFrame[Any]", "LazyFrame[Any]"]
+IntoFrame: TypeAlias = Union[
+    "NativeFrame", "DataFrame[Any]", "LazyFrame[Any]", "DataFrameLike"
+]
 """Anything which can be converted to a Narwhals DataFrame or LazyFrame."""
 
 Frame: TypeAlias = Union["DataFrame[Any]", "LazyFrame[Any]"]

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -312,7 +312,7 @@ def is_ordered_categorical(series: Series) -> bool:
         isinstance(series._compliant_series, InterchangeSeries)
         and series.dtype == dtypes.Categorical
     ):
-        return series._compliant_series._native_series.describe_categorical()[  # type: ignore[no-any-return]
+        return series._compliant_series._native_series.describe_categorical[  # type: ignore[no-any-return]
             "is_ordered"
         ]
     if series.dtype == dtypes.Enum:

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -306,6 +306,15 @@ def is_ordered_categorical(series: Series) -> bool:
         >>> func(s_pl)
         True
     """
+    from narwhals._interchange.series import InterchangeSeries
+
+    if (
+        isinstance(series._compliant_series, InterchangeSeries)
+        and series.dtype == dtypes.Categorical
+    ):
+        return series._compliant_series._native_series.describe_categorical()[  # type: ignore[no-any-return]
+            "is_ordered"
+        ]
     if series.dtype == dtypes.Enum:
         return True
     if series.dtype != dtypes.Categorical:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 covdefaults
+ibis-framework
 pandas
 polars[timezones]
 pre-commit

--- a/tests/frame/get_column_test.py
+++ b/tests/frame/get_column_test.py
@@ -13,7 +13,7 @@ def test_get_column(constructor_with_pyarrow: Any) -> None:
     result = df.get_column("a")
     assert result.to_list() == [1, 2]
     assert result.name == "a"
-    with pytest.raises(TypeError):
+    with pytest.raises((KeyError, TypeError)):
         # Check that trying to get a column by position is disallowed here.
         nw.from_native(df, eager_only=True).get_column(0)  # type: ignore[arg-type]
 

--- a/tests/frame/get_column_test.py
+++ b/tests/frame/get_column_test.py
@@ -13,7 +13,9 @@ def test_get_column(constructor_with_pyarrow: Any) -> None:
     result = df.get_column("a")
     assert result.to_list() == [1, 2]
     assert result.name == "a"
-    with pytest.raises((KeyError, TypeError)):
+    with pytest.raises(
+        (KeyError, TypeError), match="Expected str|'int' object cannot be converted|0"
+    ):
         # Check that trying to get a column by position is disallowed here.
         nw.from_native(df, eager_only=True).get_column(0)  # type: ignore[arg-type]
 

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -83,6 +83,8 @@ def test_invalid() -> None:
         nw.from_native(tbl, eager_or_interchange_only=True).select("a")
     with pytest.raises(TypeError, match="Cannot only use `series_only=True`"):
         nw.from_native(tbl, eager_only=True)
+    with pytest.raises(ValueError, match="Invalid parameter combination"):
+        nw.from_native(tbl, eager_only=True, eager_or_interchange_only=True)  # type: ignore[call-overload]
 
 
 @pytest.mark.skipif(

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -43,7 +43,7 @@ def test_interchange_schema() -> None:
         },
     )
     tbl = ibis.memtable(df)
-    result = nw.from_native(tbl).schema
+    result = nw.from_native(tbl, allow_interchange_protocol=True).schema
     expected = {
         "a": nw.Int64,
         "b": nw.Int32,
@@ -69,11 +69,13 @@ def test_invalid() -> None:
     with pytest.raises(
         NotImplementedError, match="is not supported for metadata-only dataframes"
     ):
-        nw.from_native(tbl).select("a")
+        nw.from_native(tbl, allow_interchange_protocol=True).select("a")
 
 
 def test_get_level() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     tbl = ibis.memtable(df)
-    assert nw.get_level(nw.from_native(tbl)) == "metadata"
+    assert (
+        nw.get_level(nw.from_native(tbl, allow_interchange_protocol=True)) == "metadata"
+    )
     assert nw.get_level(nw.from_native(df)) == "full"

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -1,0 +1,79 @@
+from datetime import date
+
+import ibis
+import polars as pl
+import pytest
+
+import narwhals.stable.v1 as nw
+
+
+def test_interchange_schema() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [1, 1, 2],
+            "b": [4, 5, 6],
+            "c": [4, 5, 6],
+            "d": [4, 5, 6],
+            "e": [4, 5, 6],
+            "f": [4, 5, 6],
+            "g": [4, 5, 6],
+            "h": [4, 5, 6],
+            "i": [4, 5, 6],
+            "j": [4, 5, 6],
+            "k": ["fdafsd", "fdas", "ad"],
+            "l": ["fdafsd", "fdas", "ad"],
+            "m": [date(2021, 1, 1), date(2021, 1, 1), date(2021, 1, 1)],
+            "n": [True, True, False],
+        },
+        schema={
+            "a": pl.Int64,
+            "b": pl.Int32,
+            "c": pl.Int16,
+            "d": pl.Int8,
+            "e": pl.UInt64,
+            "f": pl.UInt32,
+            "g": pl.UInt16,
+            "h": pl.UInt8,
+            "i": pl.Float64,
+            "j": pl.Float32,
+            "k": pl.String,
+            "l": pl.Categorical,
+            "m": pl.Datetime,
+            "n": pl.Boolean,
+        },
+    )
+    tbl = ibis.memtable(df)
+    result = nw.from_native(tbl).schema
+    expected = {
+        "a": nw.Int64,
+        "b": nw.Int32,
+        "c": nw.Int16,
+        "d": nw.Int8,
+        "e": nw.UInt64,
+        "f": nw.UInt32,
+        "g": nw.UInt16,
+        "h": nw.UInt8,
+        "i": nw.Float64,
+        "j": nw.Float32,
+        "k": nw.String,
+        "l": nw.String,  # https://github.com/ibis-project/ibis/issues/9570
+        "m": nw.Datetime,
+        "n": nw.Boolean,
+    }
+    assert result == expected
+
+
+def test_invalid() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    tbl = ibis.memtable(df)
+    with pytest.raises(
+        NotImplementedError, match="is not supported for metadata-only dataframes"
+    ):
+        nw.from_native(tbl).select("a")
+
+
+def test_get_level() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    tbl = ibis.memtable(df)
+    assert nw.get_level(nw.from_native(tbl)) == "metadata"
+    assert nw.get_level(nw.from_native(df)) == "full"

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -94,5 +94,7 @@ def test_invalid() -> None:
 def test_get_level() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     tbl = ibis.memtable(df)
-    assert nw.get_level(nw.from_native(tbl, eager_or_interchange_only=True)) == "metadata"
+    assert (
+        nw.get_level(nw.from_native(tbl, eager_or_interchange_only=True)) == "interchange"
+    )
     assert nw.get_level(nw.from_native(df)) == "full"

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -70,6 +70,10 @@ def test_interchange_schema() -> None:
     assert df["a"].dtype == nw.Int64
 
 
+@pytest.mark.skipif(
+    parse_version(ibis.__version__) < (6, 0),
+    reason="too old, requires interchange protocol",
+)
 def test_invalid() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     tbl = ibis.memtable(df)
@@ -81,6 +85,10 @@ def test_invalid() -> None:
         nw.from_native(tbl)
 
 
+@pytest.mark.skipif(
+    parse_version(ibis.__version__) < (6, 0),
+    reason="too old, requires interchange protocol",
+)
 def test_get_level() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     tbl = ibis.memtable(df)

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -48,7 +48,7 @@ def test_interchange_schema() -> None:
         },
     )
     tbl = ibis.memtable(df_pl)
-    df = nw.from_native(tbl, eager_only=True, allow_interchange_protocol=True)
+    df = nw.from_native(tbl, eager_or_interchange_only=True)
     result = df.schema
     expected = {
         "a": nw.Int64,
@@ -80,9 +80,9 @@ def test_invalid() -> None:
     with pytest.raises(
         NotImplementedError, match="is not supported for metadata-only dataframes"
     ):
-        nw.from_native(tbl, allow_interchange_protocol=True).select("a")
-    with pytest.raises(TypeError, match="allow_interchange_protocol=False"):
-        nw.from_native(tbl)
+        nw.from_native(tbl, eager_or_interchange_only=True).select("a")
+    with pytest.raises(TypeError, match="Cannot only use `series_only=True`"):
+        nw.from_native(tbl, eager_only=True)
 
 
 @pytest.mark.skipif(
@@ -92,7 +92,5 @@ def test_invalid() -> None:
 def test_get_level() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     tbl = ibis.memtable(df)
-    assert (
-        nw.get_level(nw.from_native(tbl, allow_interchange_protocol=True)) == "metadata"
-    )
+    assert nw.get_level(nw.from_native(tbl, eager_or_interchange_only=True)) == "metadata"
     assert nw.get_level(nw.from_native(df)) == "full"

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -5,8 +5,13 @@ import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
+from narwhals.utils import parse_version
 
 
+@pytest.mark.skipif(
+    parse_version(ibis.__version__) < (6, 0),
+    reason="too old, requires interchange protocol",
+)
 def test_interchange_schema() -> None:
     df_pl = pl.DataFrame(
         {

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -126,7 +126,7 @@ def test_left_join(constructor: Any) -> None:
     compare_dicts(result, expected)
 
 
-@pytest.mark.filterwarnings("ignore: the defaultcoalesce behavior")
+@pytest.mark.filterwarnings("ignore: the default coalesce behavior")
 def test_left_join_multiple_column(constructor: Any) -> None:
     data_left = {"a": [1, 2, 3], "b": [4, 5, 6]}
     data_right = {"a": [1, 2, 3], "c": [4, 5, 6]}

--- a/tests/frame/test_invalid.py
+++ b/tests/frame/test_invalid.py
@@ -28,14 +28,11 @@ def test_validate_laziness() -> None:
 
 
 @pytest.mark.skipif(
-    parse_version(np.__version__) < parse_version("2.0.0"), reason="too old"
+    parse_version(np.__version__) < parse_version("1.26.4"), reason="too old"
 )
 def test_memmap() -> None:
     # the headache this caused me...
-    try:
-        from sklearn.utils import check_X_y
-    except ImportError:  # pragma: no cover
-        return
+    from sklearn.utils import check_X_y
     from sklearn.utils._testing import create_memmap_backed_data
 
     x_any = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})

--- a/tests/frame/test_invalid.py
+++ b/tests/frame/test_invalid.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
@@ -27,7 +28,7 @@ def test_validate_laziness() -> None:
 
 
 @pytest.mark.skipif(
-    parse_version(pd.__version__) < parse_version("2.0.0"), reason="too old"
+    parse_version(np.__version__) < parse_version("2.0.0"), reason="too old"
 )
 def test_memmap() -> None:
     # the headache this caused me...

--- a/tests/series/is_ordered_categorical_test.py
+++ b/tests/series/is_ordered_categorical_test.py
@@ -6,6 +6,7 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
+from narwhals.utils import parse_version
 
 
 def test_is_ordered_categorical() -> None:
@@ -23,6 +24,18 @@ def test_is_ordered_categorical() -> None:
         [pa.array(["a", "b"], type=pa.dictionary(pa.int32(), pa.string()))]
     )
     assert not nw.is_ordered_categorical(nw.from_native(s, series_only=True))
+
+
+@pytest.mark.skipif(
+    parse_version(pd.__version__) < (2, 0), reason="requires interchange protocol"
+)
+def test_is_ordered_categorical_interchange_protocol() -> None:
+    df = pd.DataFrame(
+        {"a": ["a", "b"]}, dtype=pd.CategoricalDtype(ordered=True)
+    ).__dataframe__()
+    assert nw.is_ordered_categorical(
+        nw.from_native(df, eager_only=True, allow_interchange_protocol=True)["a"]
+    )
 
 
 def test_is_definitely_not_ordered_categorical(

--- a/tests/series/is_ordered_categorical_test.py
+++ b/tests/series/is_ordered_categorical_test.py
@@ -34,7 +34,7 @@ def test_is_ordered_categorical_interchange_protocol() -> None:
         {"a": ["a", "b"]}, dtype=pd.CategoricalDtype(ordered=True)
     ).__dataframe__()
     assert nw.is_ordered_categorical(
-        nw.from_native(df, eager_only=True, allow_interchange_protocol=True)["a"]
+        nw.from_native(df, eager_or_interchange_only=True)["a"]
     )
 
 

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -208,7 +208,9 @@ def test_init_series(series: Any, is_polars: Any, context: Any) -> None:
 )
 def test_init_eager(dframe: Any, is_polars: Any, context: Any) -> None:
     with context:
-        result = nw.DataFrame(dframe, is_polars=is_polars, backend_version=(1, 2, 3))  # type: ignore[var-annotated]
+        result = nw.DataFrame(
+            dframe, is_polars=is_polars, backend_version=(1, 2, 3), level="full"
+        )  # type: ignore[var-annotated]
         assert isinstance(result, nw.DataFrame)
 
 
@@ -246,5 +248,7 @@ def test_init_eager(dframe: Any, is_polars: Any, context: Any) -> None:
 )
 def test_init_lazy(dframe: Any, is_polars: Any, context: Any) -> None:
     with context:
-        result = nw.LazyFrame(dframe, is_polars=is_polars, backend_version=(1, 2, 3))  # type: ignore[var-annotated]
+        result = nw.LazyFrame(
+            dframe, is_polars=is_polars, backend_version=(1, 2, 3), level="full"
+        )  # type: ignore[var-annotated]
         assert isinstance(result, nw.LazyFrame)

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -7,6 +7,7 @@ import polars as pl
 import pyarrow as pa
 import pytest
 
+import narwhals as unstable_nw
 import narwhals.stable.v1 as nw
 from tests.utils import maybe_get_modin_df
 
@@ -262,3 +263,21 @@ def test_init_lazy(dframe: Any, is_polars: Any, context: Any) -> None:
             dframe, is_polars=is_polars, backend_version=(1, 2, 3), level="full"
         )  # type: ignore[var-annotated]
         assert isinstance(result, nw.LazyFrame)
+
+
+def test_init_already_narwhals() -> None:
+    df = nw.from_native(pl.DataFrame({"a": [1, 2, 3]}))
+    result = nw.from_native(df)
+    assert result is df  # type: ignore[comparison-overlap]
+    s = df["a"]
+    result_s = nw.from_native(s, allow_series=True)
+    assert result_s is s
+
+
+def test_init_already_narwhals_unstable() -> None:
+    df = unstable_nw.from_native(pl.DataFrame({"a": [1, 2, 3]}))
+    result = unstable_nw.from_native(df)
+    assert result is df  # type: ignore[comparison-overlap]
+    s = df["a"]
+    result_s = unstable_nw.from_native(s, allow_series=True)
+    assert result_s is s

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -170,7 +170,9 @@ def test_pandas_like_validate() -> None:
 )
 def test_init_series(series: Any, is_polars: Any, context: Any) -> None:
     with context:
-        result = nw.Series(series, is_polars=is_polars, backend_version=(1, 2, 3))
+        result = nw.Series(
+            series, is_polars=is_polars, backend_version=(1, 2, 3), level="full"
+        )
         assert isinstance(result, nw.Series)
 
 

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -83,7 +83,9 @@ if extra := set(documented).difference(top_level_functions):
 
 top_level_functions = [
     i
-    for i in nw.Series(pl.Series(), backend_version=(1,), is_polars=True).__dir__()
+    for i in nw.Series(
+        pl.Series(), backend_version=(1,), is_polars=True, level="full"
+    ).__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
 with open("docs/api-reference/series.md") as fd:
@@ -139,7 +141,9 @@ if extra := set(documented).difference(top_level_functions):
 expr = [i for i in nw.Expr(lambda: 0).__dir__() if not i[0].isupper() and i[0] != "_"]
 series = [
     i
-    for i in nw.Series(pl.Series(), backend_version=(1,), is_polars=True).__dir__()
+    for i in nw.Series(
+        pl.Series(), backend_version=(1,), is_polars=True, level="full"
+    ).__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
 

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -37,7 +37,9 @@ if extra := set(documented).difference(top_level_functions):
 
 top_level_functions = [
     i
-    for i in nw.DataFrame(pl.DataFrame(), is_polars=True, backend_version=(0,)).__dir__()
+    for i in nw.DataFrame(
+        pl.DataFrame(), is_polars=True, backend_version=(0,), level="full"
+    ).__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
 with open("docs/api-reference/dataframe.md") as fd:
@@ -58,7 +60,9 @@ if extra := set(documented).difference(top_level_functions).difference({"__getit
 
 top_level_functions = [
     i
-    for i in nw.LazyFrame(pl.LazyFrame(), is_polars=True, backend_version=(0,)).__dir__()
+    for i in nw.LazyFrame(
+        pl.LazyFrame(), is_polars=True, backend_version=(0,), level="full"
+    ).__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
 with open("docs/api-reference/lazyframe.md") as fd:

--- a/utils/check_backend_completeness.py
+++ b/utils/check_backend_completeness.py
@@ -90,7 +90,10 @@ if __name__ == "__main__":
 
     df_pa = ArrowDataFrame(MockDataFrame({"a": [1, 2, 3]}), backend_version=(13, 0))
     df_nw = nw.DataFrame(
-        MockDataFrame({"a": [1, 2, 3]}), is_polars=True, backend_version=(1,)
+        MockDataFrame({"a": [1, 2, 3]}),
+        is_polars=True,
+        backend_version=(1,),
+        level="full",
     )
     pa_methods = [f"DataFrame.{x}" for x in df_pa.__dir__() if not x.startswith("_")]
     nw_methods = [f"DataFrame.{x}" for x in df_nw.__dir__() if not x.startswith("_")]

--- a/utils/check_backend_completeness.py
+++ b/utils/check_backend_completeness.py
@@ -89,20 +89,26 @@ if __name__ == "__main__":
     no_longer_missing = []
 
     df_pa = ArrowDataFrame(MockDataFrame({"a": [1, 2, 3]}), backend_version=(13, 0))
-    df_pd = nw.DataFrame(
+    df_nw = nw.DataFrame(
         MockDataFrame({"a": [1, 2, 3]}), is_polars=True, backend_version=(1,)
     )
     pa_methods = [f"DataFrame.{x}" for x in df_pa.__dir__() if not x.startswith("_")]
-    pd_methods = [f"DataFrame.{x}" for x in df_pd.__dir__() if not x.startswith("_")]
-    missing.extend([x for x in pd_methods if x not in pa_methods and x not in MISSING])
-    no_longer_missing.extend([x for x in MISSING if x in pa_methods and x in pd_methods])
+    nw_methods = [f"DataFrame.{x}" for x in df_nw.__dir__() if not x.startswith("_")]
+    missing.extend(
+        [
+            x
+            for x in nw_methods
+            if x not in pa_methods and x not in MISSING and x not in {"level"}
+        ]
+    )
+    no_longer_missing.extend([x for x in MISSING if x in pa_methods and x in nw_methods])
 
     ser_pa = df_pa["a"]
-    ser_pd = df_pd["a"]
+    ser_pd = df_nw["a"]
     pa_methods = [f"Series.{x}" for x in ser_pa.__dir__() if not x.startswith("_")]
-    pd_methods = [f"Series.{x}" for x in ser_pd.__dir__() if not x.startswith("_")]
-    missing.extend([x for x in pd_methods if x not in pa_methods and x not in MISSING])
-    no_longer_missing.extend([x for x in MISSING if x in pa_methods and x in pd_methods])
+    nw_methods = [f"Series.{x}" for x in ser_pd.__dir__() if not x.startswith("_")]
+    missing.extend([x for x in nw_methods if x not in pa_methods and x not in MISSING])
+    no_longer_missing.extend([x for x in MISSING if x in pa_methods and x in nw_methods])
 
     if missing:
         print(

--- a/utils/generate_random_versions.py
+++ b/utils/generate_random_versions.py
@@ -1,7 +1,7 @@
 import random
 
 PANDAS_AND_NUMPY_VERSION = [
-    ("1.0.5", "1.18.5"),
+    # ("1.0.5", "1.18.5"),  # fails to build in CI  # noqa: ERA001
     ("1.1.5", "1.19.5"),
     ("1.2.5", "1.20.3"),
     ("1.3.5", "1.21.6"),


### PR DESCRIPTION
closes #388 

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.



Maybe `from_native` should return a `SimpleFrame` here, with which you can't really do much other than inspect metadata - but then at least the IDE won't autocomplete things it doesn't support 