### PR TITLE
feat: add dunder divisions methods

### DIFF
--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -125,6 +125,18 @@ class ArrowExpr:
     def __rpow__(self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__rpow__", other)
 
+    def __truediv__(self, other: ArrowExpr | Any) -> Self:
+        return reuse_series_implementation(self, "__truediv__", other)
+
+    def __rtruediv__(self, other: ArrowExpr | Any) -> Self:
+        return reuse_series_implementation(self, "__rtruediv__", other)
+
+    def __floordiv__(self, other: ArrowExpr | Any) -> Self:
+        return reuse_series_implementation(self, "__floordiv__", other)
+
+    def __rfloordiv__(self, other: ArrowExpr | Any) -> Self:
+        return reuse_series_implementation(self, "__rfloordiv__", other)
+
     def __invert__(self) -> Self:
         return reuse_series_implementation(self, "__invert__")
 

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -139,6 +139,32 @@ class ArrowSeries:
         other = validate_column_comparand(other)
         return self._from_native_series(pc.power(other, ser))
 
+    def __truediv__(self, other: Any) -> Self:
+        pc = get_pyarrow_compute()
+        pa = get_pyarrow()
+        ser = pc.cast(self._native_series, pa.float32())
+        other = pc.cast(validate_column_comparand(other), pa.float32())
+        return self._from_native_series(pc.divide(ser, other))
+
+    def __rtruediv__(self, other: Any) -> Self:
+        pc = get_pyarrow_compute()
+        pa = get_pyarrow()
+        ser = pc.cast(self._native_series, pa.float32())
+        other = pc.cast(validate_column_comparand(other), pa.float32())
+        return self._from_native_series(pc.divide(other, ser))
+
+    def __floordiv__(self, other: Any) -> Self:
+        pc = get_pyarrow_compute()
+        ser = self._native_series
+        other = validate_column_comparand(other)
+        return self._from_native_series(pc.floor(pc.divide(ser, other)))
+
+    def __rfloordiv__(self, other: Any) -> Self:
+        pc = get_pyarrow_compute()
+        ser = self._native_series
+        other = validate_column_comparand(other)
+        return self._from_native_series(pc.floor(pc.divide(other, ser)))
+
     def __invert__(self) -> Self:
         pc = get_pyarrow_compute()
         return self._from_native_series(pc.invert(self._native_series))

--- a/tests/expr/arithmetic_test.py
+++ b/tests/expr/arithmetic_test.py
@@ -28,8 +28,6 @@ def test_arithmetic(
 
     # pyarrow case
     if "pyarrow_table" in str(constructor) and attr in {
-        "__truediv__",
-        "__floordiv__",
         "__mod__",
     }:
         request.applymarker(pytest.mark.xfail)
@@ -60,8 +58,6 @@ def test_right_arithmetic(
 
     # pyarrow case
     if "table" in str(constructor) and attr in {
-        "__rtruediv__",
-        "__rfloordiv__",
         "__rmod__",
     }:
         request.applymarker(pytest.mark.xfail)

--- a/tests/series/arithmetic_test.py
+++ b/tests/series/arithmetic_test.py
@@ -33,8 +33,6 @@ def test_arithmetic(
         request.applymarker(pytest.mark.xfail)
 
     if "pyarrow_series" in str(constructor_series) and attr in {
-        "__truediv__",
-        "__floordiv__",
         "__mod__",
     }:
         request.applymarker(pytest.mark.xfail)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issues https://github.com/narwhals-dev/narwhals/issues/372 https://github.com/narwhals-dev/narwhals/pull/491
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Re-using existing tests, just removing the `pytest.xfail` marking where applicable.
This was a bit trickier than I first envisaged, please see my remarks below.

### Remakrs:

### A. Casting to `float32` for `__truediv__` and `__rdiv__`
I had to arbitrarily cast to float32 for truediv:
I believe `pyarrow.compute.divide` is "preserving" the types of the Series which means that  1 / 2  = 0  instead of 0.5 

Arbitrarily casting to float is a quick fix but not necessarily the desired one:
e.g:
1 / 1  = 1.0 instead of 1
Tests are passing because 1 == 1.0 is `True` in Python 

Here are the two solutions I considered: 

1- Arbitrarily casting to `pyarrow.float32` (current implementation)
2- Custom check for the Series type (could be more expensive than option 1?)

Opted for option 1, please let me know your thoughts 🙏🥲

### B. `__floordiv__` and `__rfloordiv__` nested functions

Opted to combine `pyarrow.compute.floor` and `pyarrow.compute.divide`  - Seems to be working just fine!

Thanks for reading this far, feedback is always appreciated!