### PR TITLE
ci: fix hypothesis failure, remove ibis from tests

### DIFF
--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -28,7 +28,13 @@ class PandasLikeGroupBy:
     def __init__(self, df: PandasLikeDataFrame, keys: list[str]) -> None:
         self._df = df
         self._keys = list(keys)
-        if self._df._backend_version < (1, 0):  # pragma: no cover
+        if (
+            self._df._implementation is Implementation.PANDAS
+            and self._df._backend_version < (1, 0)
+        ):  # pragma: no cover
+            if self._df._native_dataframe.loc[:, self._keys].isna().any().any():
+                msg = "Grouping by null values is not supported in pandas < 1.0.0"
+                raise NotImplementedError(msg)
             self._grouped = self._df._native_dataframe.groupby(
                 list(self._keys),
                 sort=False,

--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -28,12 +28,19 @@ class PandasLikeGroupBy:
     def __init__(self, df: PandasLikeDataFrame, keys: list[str]) -> None:
         self._df = df
         self._keys = list(keys)
-        self._grouped = self._df._native_dataframe.groupby(
-            list(self._keys),
-            sort=False,
-            as_index=True,
-            dropna=False,
-        )
+        if self._df._backend_version < (1, 0):  # pragma: no cover
+            self._grouped = self._df._native_dataframe.groupby(
+                list(self._keys),
+                sort=False,
+                as_index=True,
+            )
+        else:
+            self._grouped = self._df._native_dataframe.groupby(
+                list(self._keys),
+                sort=False,
+                as_index=True,
+                dropna=False,
+            )
 
     def agg(
         self,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 covdefaults
-ibis-framework[polars]
 pandas
 polars[timezones]
 pre-commit

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -55,7 +55,7 @@ def test_interchange_schema() -> None:
         "i": nw.Float64,
         "j": nw.Float32,
         "k": nw.String,
-        "l": nw.String,  # https://github.com/ibis-project/ibis/issues/9570
+        "l": nw.Categorical,
         "m": nw.Datetime,
         "n": nw.Boolean,
     }
@@ -76,8 +76,9 @@ def test_invalid() -> None:
 
 
 def test_get_level() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3]}).__dataframe__()
-    assert (
-        nw.get_level(nw.from_native(df, eager_or_interchange_only=True)) == "interchange"
-    )
+    df = pl.DataFrame({"a": [1, 2, 3]})
     assert nw.get_level(nw.from_native(df)) == "full"
+    assert (
+        nw.get_level(nw.from_native(df.__dataframe__(), eager_or_interchange_only=True))
+        == "interchange"
+    )

--- a/tests/hypothesis/test_join.py
+++ b/tests/hypothesis/test_join.py
@@ -136,6 +136,7 @@ def test_cross_join(  # pragma: no cover
     ),
 )
 @pytest.mark.slow()
+@pytest.mark.filterwarnings("ignore:the default coalesce behavior")
 def test_left_join(  # pragma: no cover
     a_left_data: list[int],
     b_left_data: list[int],

--- a/tests/series_only/arithmetic_test.py
+++ b/tests/series_only/arithmetic_test.py
@@ -65,6 +65,9 @@ def test_truediv_same_dims(constructor_series: Any, request: Any) -> None:
     left=st.integers(-100, 100),
     right=st.integers(-100, 100),
 )
+@pytest.mark.skipif(
+    parse_version(pd.__version__) < (2, 0), reason="convert_dtypes not available"
+)
 def test_mod(left: int, right: int) -> None:
     # hypothesis complains if we add `constructor` as an argument, so this
     # test is a bit manual unfortunately


### PR DESCRIPTION
Ibis put upper bounds on their deps, which is interfering with our testing here

We can test the interchange part just by explicitly calling `__dataframe__` ourselves

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

