### PR TITLE
perf: remove as_py from _arrow implementation wherever possible

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -182,7 +182,9 @@ class ArrowDataFrame:
             if name in new_column_name_to_new_column_map:
                 to_concat.append(
                     validate_dataframe_comparand(
-                        length=length, other=new_column_name_to_new_column_map.pop(name)
+                        length=length,
+                        other=new_column_name_to_new_column_map.pop(name),
+                        backend_version=self._backend_version,
                     )
                 )
             else:
@@ -191,7 +193,9 @@ class ArrowDataFrame:
         for s in new_column_name_to_new_column_map:
             to_concat.append(
                 validate_dataframe_comparand(
-                    length=length, other=new_column_name_to_new_column_map[s]
+                    length=length,
+                    other=new_column_name_to_new_column_map[s],
+                    backend_version=self._backend_version,
                 )
             )
             output_names.append(s)

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -371,14 +371,14 @@ class ArrowDataFrame:
                     f" frame has shape {self.shape!r}"
                 )
                 raise ValueError(msg)
-            return self._native_dataframe[0][0].as_py()
+            return self._native_dataframe[0][0]
 
         elif row is None or column is None:
             msg = "cannot call `.item()` with only one of `row` or `column`"
             raise ValueError(msg)
 
         _col = self.columns.index(column) if isinstance(column, str) else column
-        return self._native_dataframe[_col][row].as_py()
+        return self._native_dataframe[_col][row]
 
     def rename(self, mapping: dict[str, str]) -> Self:
         df = self._native_dataframe

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -218,8 +218,7 @@ class ArrowSeries:
     def n_unique(self) -> int:
         pc = get_pyarrow_compute()
         unique_values = pc.unique(self._native_series)
-        count_unique = pc.count(unique_values, mode="all")
-        return count_unique.as_py()  # type: ignore[no-any-return]
+        return pc.count(unique_values, mode="all")  # type: ignore[no-any-return]
 
     def __narwhals_namespace__(self) -> ArrowNamespace:
         from narwhals._arrow.namespace import ArrowNamespace
@@ -341,8 +340,8 @@ class ArrowSeries:
                     f" or an explicit index is provided (Series is of length {len(self)})"
                 )
                 raise ValueError(msg)
-            return self._native_series[0].as_py()
-        return self._native_series[index].as_py()
+            return self._native_series[0]
+        return self._native_series[index]
 
     def value_counts(self: Self, *, sort: bool = False, parallel: bool = False) -> Any:  # noqa: ARG002
         """Parallel is unused, exists for compatibility"""
@@ -464,9 +463,9 @@ class ArrowSeries:
         pc = get_pyarrow_compute()
         ser = self._native_series
         if descending:
-            return pc.all(pc.greater_equal(ser[:-1], ser[1:])).as_py()  # type: ignore[no-any-return]
+            return pc.all(pc.greater_equal(ser[:-1], ser[1:]))  # type: ignore[no-any-return]
         else:
-            return pc.all(pc.less_equal(ser[:-1], ser[1:])).as_py()  # type: ignore[no-any-return]
+            return pc.all(pc.less_equal(ser[:-1], ser[1:]))  # type: ignore[no-any-return]
 
     def unique(self: Self) -> ArrowSeries:
         pc = get_pyarrow_compute()

--- a/tests/expr_and_series/n_unique_test.py
+++ b/tests/expr_and_series/n_unique_test.py
@@ -17,6 +17,5 @@ def test_n_unique(constructor: Any) -> None:
         "b": [4],
     }
     compare_dicts(result, expected)
-    assert df["a"].n_unique() == 3
-    assert df["b"].n_unique() == 4
-    compare_dicts(result, expected)
+    result_series = {"a": [df["a"].n_unique()], "b": [df["b"].n_unique()]}
+    compare_dicts(result_series, expected)

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Any
 
 import narwhals.stable.v1 as nw
@@ -12,4 +11,4 @@ def test_to_datetime(constructor: Any) -> None:
         .select(b=nw.col("a").str.to_datetime(format="%Y-%m-%dT%H:%M:%S"))
         .item(row=0, column="b")
     )
-    assert result == datetime(2020, 1, 1, 12, 34, 56)
+    assert str(result) == "2020-01-01 12:34:56"

--- a/tests/frame/item_test.py
+++ b/tests/frame/item_test.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import compare_dicts
 
 
 @pytest.mark.parametrize(
@@ -17,8 +18,8 @@ def test_item(
 ) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df = nw.from_native(constructor(data), eager_only=True)
-    assert df.item(row, column) == expected
-    assert df.select("a").head(1).item() == 1
+    compare_dicts({"a": [df.item(row, column)]}, {"a": [expected]})
+    compare_dicts({"a": [df.select("a").head(1).item()]}, {"a": [1]})
 
 
 @pytest.mark.parametrize(

--- a/tests/series_only/is_sorted_test.py
+++ b/tests/series_only/is_sorted_test.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import compare_dicts
 
 data = [1, 3, 2]
 data_dups = [4, 4, 6]
@@ -23,7 +24,7 @@ def test_is_sorted(
 ) -> None:
     series = nw.from_native(constructor_series(input_data), series_only=True)
     result = series.is_sorted(descending=descending)
-    assert result == expected
+    compare_dicts({"a": [result]}, {"a": [expected]})
 
 
 def test_is_sorted_invalid(constructor_series: Any) -> None:

--- a/tests/series_only/test_common.py
+++ b/tests/series_only/test_common.py
@@ -12,6 +12,7 @@ from pandas.testing import assert_series_equal
 
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
+from tests.utils import compare_dicts
 
 data = [1, 3, 2]
 data_dups = [4, 4, 6]
@@ -167,8 +168,8 @@ def test_cast_string() -> None:
 def test_item(constructor_series: Any, index: int, expected: int) -> None:
     series = nw.from_native(constructor_series(data), series_only=True)
     result = series.item(index)
-    assert result == expected
-    assert series.head(1).item() == 1
+    compare_dicts({"a": [result]}, {"a": [expected]})
+    compare_dicts({"a": [series.head(1).item()]}, {"a": [1]})
 
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
closes #557

we're already doing this where we need it: https://github.com/narwhals-dev/narwhals/blob/1790c81712c3337000f2b5f95342bfe2dc1a7557/narwhals/_arrow/namespace.py#L81-L82

pandas is often returning non-Python scalars (e.g. pd.Timestamp, np.int64, ...) - I think we should aim to keep things native as much as possible. These scalars are designed to be mostly interchangeable with the stdlib ones anyway, but overcome some limitations (e.g. `pd.Timestamp` has 'ns' resolution, whereas stdlib datetime only `'us'`)

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

