### PR TITLE
chore: factor `test_empty_select` out of `test_common` (to existing `select_test.py`)

### DIFF
--- a/tests/frame/select_test.py
+++ b/tests/frame/select_test.py
@@ -10,3 +10,8 @@ def test_select(constructor: Any) -> None:
     result = df.select("a")
     expected = {"a": [1, 3, 2]}
     compare_dicts(result, expected)
+
+
+def test_empty_select(constructor: Any) -> None:
+    result = nw.from_native(constructor({"a": [1, 2, 3]}), eager_only=True).select()
+    assert result.shape == (0, 0)

--- a/tests/frame/test_common.py
+++ b/tests/frame/test_common.py
@@ -19,11 +19,6 @@ data_na = {"a": [None, 3, 2], "b": [4, 4, 6], "z": [7.0, None, 9]}
 data_right = {"c": [6, 12, -1], "d": [0, -4, 2]}
 
 
-def test_empty_select(constructor: Any) -> None:
-    result = nw.from_native(constructor({"a": [1, 2, 3]}), eager_only=True).select()
-    assert result.shape == (0, 0)
-
-
 def test_std(constructor: Any) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue: https://github.com/narwhals-dev/narwhals/issues/401

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

