### PR TITLE
feat: dask `columns` property & `filter` method

### DIFF
--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -52,3 +52,7 @@ class DaskLazyFrame:
             implementation=Implementation.PANDAS,
             backend_version=parse_version(get_pandas().__version__),
         )
+
+    @property
+    def columns(self) -> list[str]:
+        return self._native_dataframe.columns.tolist()  # type: ignore[no-any-return]

--- a/tests/dask_test.py
+++ b/tests/dask_test.py
@@ -260,3 +260,13 @@ def test_str_to_lowercase(
 
     result_frame = df.with_columns(nw.col("a").str.to_lowercase())
     compare_dicts(result_frame, expected)
+
+
+def test_columns() -> None:
+    import dask.dataframe as dd
+
+    dfdd = dd.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": ["cat", "bat", "mat"]}))
+    df = nw.from_native(dfdd)
+
+    result = df.columns
+    assert set(result) == {"a", "b"}


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #637

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

This is a pretty small PR! I mainly wanted to get a feel for the API 😁 (initially made lots of changes as if it was a regular DataFrame and then remembered it was lazy!)

Adds in a `columns` property for the DaskLazyFrame.

EDIT: Ok, I couldn't resist tinkering. This now applies a fair bit more functionality, getting 'filter' to work (at least for some basic cases since the expressions still aren't fully complete).

I've added in "not-implemented" functions (i.e. empty functions that just raise an error) to appease mypy type checking. I figured this was a better move that `# type: ignore` annotation since they actually will be needed at some point, but let me know if the other approach would be better!
