### PR TITLE
bug: fix `iter_rows` inconsistency in pandas

### DIFF
--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -196,9 +196,11 @@ class PandasLikeDataFrame:
         if not named:
             yield from self._native_dataframe.itertuples(index=False, name=None)
         else:
+            col_names = self._native_dataframe.columns
             yield from (
-                row._asdict() for row in self._native_dataframe.itertuples(index=False)
-            )
+                dict(zip(col_names, row))
+                for row in self._native_dataframe.itertuples(index=False)
+            )  # type: ignore[misc]
 
     @property
     def schema(self) -> dict[str, DType]:

--- a/tests/frame/rows_test.py
+++ b/tests/frame/rows_test.py
@@ -43,13 +43,13 @@ df_polars_na = pl.DataFrame({"a": [None, 3, 2], "b": [4, 4, 6], "z": [7.0, None,
 @pytest.mark.parametrize(
     ("named", "expected"),
     [
-        (False, [(1, 4, 7.0), (3, 4, 8.0), (2, 6, 9.0)]),
+        (False, [(1, 4, 7.0, 5), (3, 4, 8.0, 6), (2, 6, 9.0, 7)]),
         (
             True,
             [
-                {"a": 1, "b": 4, "z": 7.0},
-                {"a": 3, "b": 4, "z": 8.0},
-                {"a": 2, "b": 6, "z": 9.0},
+                {"a": 1, "_b": 4, "z": 7.0, "1": 5},
+                {"a": 3, "_b": 4, "z": 8.0, "1": 6},
+                {"a": 2, "_b": 6, "z": 9.0, "1": 7},
             ],
         ),
     ],
@@ -59,7 +59,7 @@ def test_iter_rows(
     named: bool,  # noqa: FBT001
     expected: list[tuple[Any, ...]] | list[dict[str, Any]],
 ) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "_b": [4, 4, 6], "z": [7.0, 8, 9], "1": [5, 6, 7]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = list(df.iter_rows(named=named))
     assert result == expected


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

While using `narwhals` in a small library of mine, I noticed a little inconsistency with `PandasLikeDataFrame.iter_rows` when the columns are "renamed to positional names if they are invalid Python identifiers, repeated, or start with an underscore." ([pandas docs](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.itertuples.html))

To reproduce:
```python
import narwhals as nw
import pandas as pd
import polars as pl

df = pd.DataFrame(
    [[1, 2, 3,4], [6, 7, 8, 9]],
    columns=["a", "_b", 1, "2"]
)
pl_df = pl.DataFrame(df)

def func(df):
    df = nw.from_native(df)
    return list(df.iter_rows(named=True))

func(df)
# [{'a': 1, '_1': 2, '_2': 3, '_3': 4}, {'a': 6, '_1': 7, '_2': 8, '_3': 9}]
func(pl_df)
# [{'a': 1, '_b': 2, '1': 3, '2': 4}, {'a': 6, '_b': 7, '1': 8, '2': 9}]
```

This should fix that 👀