### PR TITLE
test: xfail uppecase for dask and pyarrow 11.0.0

### DIFF
--- a/tests/dask_test.py
+++ b/tests/dask_test.py
@@ -18,6 +18,7 @@ import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
+from narwhals.utils import parse_version
 from tests.utils import compare_dicts
 
 pytest.importorskip("dask")
@@ -221,10 +222,18 @@ def test_to_datetime() -> None:
     ],
 )
 def test_str_to_uppercase(
+    request: pytest.FixtureRequest,
     data: dict[str, list[str]],
     expected: dict[str, list[str]],
 ) -> None:
     import dask.dataframe as dd
+    import pyarrow as pa
+
+    if (parse_version(pa.__version__) < (12, 0, 0)) and ("ß" in data["a"][0]):
+        # We are marking it xfail for these conditions above
+        # since the pyarrow backend will convert
+        # smaller cap 'ß' to upper cap 'ẞ' instead of 'SS'
+        request.applymarker(pytest.mark.xfail)
 
     dfdd = dd.from_pandas(pd.DataFrame(data))
     df = nw.from_native(dfdd)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

As [Iron Maiden taught us](https://en.wikipedia.org/wiki/The_Number_of_the_Beast_(song)), the number 666 may be cursed. The `random-version` test took that literally and failed ([run 666](https://github.com/narwhals-dev/narwhals/actions/runs/10148205433/job/28060389675)) in a dask test. I could reproduce with `pyarrow==11.0.0`. It seems to be the same known error with `ß` that I was mentioned in various places in the code base.

I added an `xfail` let me know what you think :)
