### PR TITLE
Feat: Dask filter and __and__ method added

### DIFF
--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -52,3 +52,7 @@ class DaskLazyFrame:
             implementation=Implementation.PANDAS,
             backend_version=parse_version(get_pandas().__version__),
         )
+
+    @property
+    def columns(self) -> list[str]:
+        return self._native_dataframe.columns.tolist()  # type: ignore[no-any-return]

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -207,3 +207,25 @@ class DaskExprStringNamespace:
         return self._expr._from_call(
             lambda _input, prefix: _input.str.startswith(prefix), "starts_with", prefix
         )
+
+    def ends_with(self, suffix: str) -> DaskExpr:
+        return self._expr._from_call(
+            lambda _input, suffix: _input.str.endswith(suffix), "ends_with", suffix
+        )
+
+    def contains(self, pattern: str, *, literal: bool = False) -> DaskExpr:
+        return self._expr._from_call(
+            lambda _input, pat, regex: _input.str.contains(pat=pat, regex=regex),
+            "contains",
+            pattern,
+            not literal,
+        )
+
+    def slice(self, offset: int, length: int | None = None) -> DaskExpr:
+        stop = offset + length if length else None
+        return self._expr._from_call(
+            lambda _input, start, stop: _input.str.slice(start=start, stop=stop),
+            "slice",
+            offset,
+            stop,
+        )

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 
+from narwhals.dependencies import get_dask
 from narwhals.dependencies import get_dask_expr
 
 if TYPE_CHECKING:
@@ -228,4 +229,23 @@ class DaskExprStringNamespace:
             "slice",
             offset,
             stop,
+        )
+
+    def to_datetime(self, format: str | None = None) -> DaskExpr:  # noqa: A002
+        return self._expr._from_call(
+            lambda _input, fmt: get_dask().dataframe.to_datetime(_input, format=fmt),
+            "to_datetime",
+            format,
+        )
+
+    def to_uppercase(self) -> DaskExpr:
+        return self._expr._from_call(
+            lambda _input: _input.str.upper(),
+            "to_uppercase",
+        )
+
+    def to_lowercase(self) -> DaskExpr:
+        return self._expr._from_call(
+            lambda _input: _input.str.lower(),
+            "to_lowercase",
         )

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -51,7 +51,8 @@ class DaskNamespace:
         )
 
     def all_horizontal(self, *exprs: IntoDaskExpr) -> DaskExpr:
-        return reduce(lambda x, y: x & y, flatten(exprs))  # type: ignore[no-any-return]
+        # coverage shows 55->exit as uncovered?
+        return reduce(lambda x, y: x & y, flatten(exprs))  # type: ignore[no-any-return]  # pragma: no cover
 
     def _create_expr_from_series(self, _: Any) -> NoReturn:
         msg = "`_create_expr_from_series` for DaskNamespace exists only for compatibility"

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -8,7 +8,7 @@ from typing import NoReturn
 
 from narwhals import dtypes
 from narwhals._dask.expr import DaskExpr
-from narwhals._expression_parsing import parse_into_exprs
+from narwhals.utils import flatten
 
 if TYPE_CHECKING:
     from narwhals._dask.dataframe import DaskLazyFrame
@@ -51,7 +51,7 @@ class DaskNamespace:
         )
 
     def all_horizontal(self, *exprs: IntoDaskExpr) -> DaskExpr:
-        return reduce(lambda x, y: x & y, parse_into_exprs(*exprs, namespace=self))  # type: ignore[no-any-return, call-overload]
+        return reduce(lambda x, y: x & y, flatten(exprs))  # type: ignore[no-any-return]
 
     def _create_expr_from_series(self, _: Any) -> NoReturn:
         msg = "`_create_expr_from_series` for DaskNamespace exists only for compatibility"

--- a/narwhals/_dask/utils.py
+++ b/narwhals/_dask/utils.py
@@ -42,7 +42,13 @@ def parse_exprs_and_named_exprs(
 ) -> dict[str, Any]:
     results = {}
     for expr in exprs:
-        _results = expr._call(df)
+        if hasattr(expr, "__narwhals_expr__"):
+            _results = expr._call(df)
+        elif isinstance(expr, str):
+            _results = [df._native_dataframe.loc[:, expr]]
+        else:  # pragma: no cover
+            msg = f"Expected expression or column name, got: {expr}"
+            raise TypeError(msg)
         for _result in _results:
             results[_result.name] = _result
     for name, value in named_exprs.items():

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -93,10 +93,7 @@ def evaluate_into_exprs(
         if len(evaluated_expr) > 1:
             msg = "Named expressions must return a single column"  # pragma: no cover
             raise AssertionError(msg)
-        try:
-            to_append = evaluated_expr[0].alias(name)
-        except AttributeError:
-            to_append = evaluated_expr[0].rename(name)  # type: ignore[union-attr]
+        to_append = evaluated_expr[0].alias(name)
         series.append(to_append)  # type: ignore[arg-type]
     return series
 

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -193,7 +193,6 @@ def reuse_series_implementation(
     def func(df: CompliantDataFrame) -> list[CompliantSeries]:
         out: list[CompliantSeries] = []
         for column in expr._call(df):  # type: ignore[arg-type]
-            # ok, so "other" is a list for some reason
             _out = getattr(column, attr)(
                 *[maybe_evaluate_expr(df, arg) for arg in args],
                 **{

--- a/tests/dask_test.py
+++ b/tests/dask_test.py
@@ -260,3 +260,13 @@ def test_str_to_lowercase(
 
     result_frame = df.with_columns(nw.col("a").str.to_lowercase())
     compare_dicts(result_frame, expected)
+
+
+def test_columns() -> None:
+    import dask.dataframe as dd
+
+    dfdd = dd.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": ["cat", "bat", "mat"]}))
+    df = nw.from_native(dfdd)
+
+    result = df.columns
+    assert set(result) == {"a", "b"}

--- a/tests/dask_test.py
+++ b/tests/dask_test.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import sys
 import warnings
+from typing import Any
 
 import pandas as pd
 import pytest
@@ -133,3 +134,54 @@ def test_starts_with(prefix: str, expected: dict[str, list[bool]]) -> None:
     result = df.with_columns(nw.col("a").str.starts_with(prefix))
 
     compare_dicts(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("suffix", "expected"),
+    [
+        ("das", {"a": [True, False]}),
+        ("fas", {"a": [False, True]}),
+        ("asd", {"a": [False, False]}),
+    ],
+)
+def test_ends_with(suffix: str, expected: dict[str, list[bool]]) -> None:
+    import dask.dataframe as dd
+
+    data = {"a": ["fdas", "edfas"]}
+    dfdd = dd.from_pandas(pd.DataFrame(data))
+    df = nw.from_native(dfdd)
+    result = df.with_columns(nw.col("a").str.ends_with(suffix))
+
+    compare_dicts(result, expected)
+
+
+def test_contains() -> None:
+    import dask.dataframe as dd
+
+    data = {"pets": ["cat", "dog", "rabbit and parrot", "dove"]}
+    dfdd = dd.from_pandas(pd.DataFrame(data))
+    df = nw.from_native(dfdd)
+
+    result = df.with_columns(
+        case_insensitive_match=nw.col("pets").str.contains("(?i)parrot|Dove")
+    )
+    expected = {
+        "pets": ["cat", "dog", "rabbit and parrot", "dove"],
+        "case_insensitive_match": [False, False, True, True],
+    }
+    compare_dicts(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("offset", "length", "expected"),
+    [(1, 2, {"a": ["da", "df"]}), (-2, None, {"a": ["as", "as"]})],
+)
+def test_str_slice(offset: int, length: int | None, expected: Any) -> None:
+    import dask.dataframe as dd
+
+    data = {"a": ["fdas", "edfas"]}
+    dfdd = dd.from_pandas(pd.DataFrame(data))
+    df = nw.from_native(dfdd)
+
+    result_frame = df.with_columns(nw.col("a").str.slice(offset, length))
+    compare_dicts(result_frame, expected)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #637

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Following up from: https://github.com/narwhals-dev/narwhals/pull/670

Introduces filter for dask dataframes, plus a few required methods for comparison to get things working into a testable state. (@FBruzzesi hope it's ok, I went ahead and implemented `__and__` - I know you said you'd probably do this, so I hope I haven't stood on any toes! It seemed a quick add and otherwise testing all horizontal was a little messy)

Note: There's a pretty disgusting hack I've added in that should probably come out before anything is merged. Looks like narwhals `evaulate_into_exprs` has this bit:

```python
series.append(evaluated_expr[0].alias(name))0
```

I'm getting an error here because `evalated_exp[0]` is a dask-exp/dask-series (depending on version) which doesn't have an `alias` method.

I've added this fix:

```python
try:
    to_append = evaluated_expr[0].alias(name)
except AttributeError:
    to_append = evaluated_expr[0].rename(name)  # type: ignore[union-attr]
```

Which works, but the only thing is *should I even have an actual dask expressions here?* The code is running fine seemingly with my above hack, but it seems like this point in the code should have a narwhals abstraction instead?