### PR TITLE
chore: Add more lazy tests

### DIFF
--- a/tests/expr_and_series/abs_test.py
+++ b/tests/expr_and_series/abs_test.py
@@ -11,8 +11,8 @@ def test_abs(constructor: Any) -> None:
     compare_dicts(result, expected)
 
 
-def test_abs_series(constructor_eager: Any) -> None:
-    df = nw.from_native(constructor_eager({"a": [1, 2, 3, -4, 5]}), eager_only=True)
-    result = {"b": df["a"].abs()}
+def test_abs_series(constructor: Any) -> None:
+    df = nw.from_native(constructor({"a": [1, 2, 3, -4, 5]}))
+    result = df.with_columns(b=nw.col("a").abs()).select("b")
     expected = {"b": [1, 2, 3, 4, 5]}
     compare_dicts(result, expected)

--- a/tests/expr_and_series/count_test.py
+++ b/tests/expr_and_series/count_test.py
@@ -12,9 +12,9 @@ def test_count(constructor: Any) -> None:
     compare_dicts(result, expected)
 
 
-def test_count_series(constructor_eager: Any) -> None:
+def test_count_series(constructor: Any) -> None:
     data = {"a": [1, 3, 2], "b": [4, None, 6], "z": [7.0, None, None]}
-    df = nw.from_native(constructor_eager(data), eager_only=True)
-    result = {"a": [df["a"].count()], "b": [df["b"].count()], "z": [df["z"].count()]}
+    df = nw.from_native(constructor(data))
+    result = df.with_columns(nw.col("a", "b", "z").count()).select("a", "b", "z").unique()
     expected = {"a": [3], "b": [2], "z": [1]}
     compare_dicts(result, expected)

--- a/tests/expr_and_series/diff_test.py
+++ b/tests/expr_and_series/diff_test.py
@@ -31,18 +31,18 @@ def test_diff(constructor: Any, request: Any) -> None:
     compare_dicts(result, expected)
 
 
-def test_diff_series(constructor_eager: Any, request: Any) -> None:
-    if "pyarrow_table_constructor" in str(constructor_eager) and parse_version(
+def test_diff_series(constructor: Any, request: Any) -> None:
+    if "pyarrow_table_constructor" in str(constructor) and parse_version(
         pa.__version__
     ) < (13,):
         # pc.pairwisediff is available since pyarrow 13.0.0
         request.applymarker(pytest.mark.xfail)
-    df = nw.from_native(constructor_eager(data), eager_only=True)
+    df = nw.from_native(constructor(data))
     expected = {
-        "i": [1, 2, 3, 4],
-        "b": [2, 3, 5, 3],
-        "c": [4, 3, 2, 1],
-        "c_diff": [-1, -1, -1, -1],
+        "i": [0, 1, 2, 3, 4],
+        "b": [1, 2, 3, 5, 3],
+        "c": [5, 4, 3, 2, 1],
+        "c_diff": [float("nan"), -1, -1, -1, -1],
     }
-    result = df.with_columns(c_diff=df["c"].diff())[1:]
+    result = df.with_columns(c_diff=nw.col("c").diff())
     compare_dicts(result, expected)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [X] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [X] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #659  

## Checklist

- [X] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
Replaced `constructor_eager` with `constructor` in the following tests:

- abs_tests.py -> test_abs_series()
- count_test.py -> test_count_series()
- diff_test.py -> test_diff_series()

In the last one, I had to modify the expected dictionary, as I couldn't find a way to remove the first row of the DataFrame that passes all tests (Polars LazyFrame has `slice()`, but doesn't allow `__get_item__`). Is it ok as workaround or am I missing something?
