### PR TITLE
feat: `ArrowGroupBy.__iter__` method

### DIFF
--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -53,10 +53,7 @@ def test_invalid_group_by() -> None:
         )
 
 
-def test_group_by_iter(request: Any, constructor_eager: Any) -> None:
-    if "pyarrow_table" in str(constructor_eager):
-        request.applymarker(pytest.mark.xfail)
-
+def test_group_by_iter(constructor_eager: Any) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     expected_keys = [(1,), (3,)]
     keys = []


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Closes #714 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Possibly not the most performant implementation, but it does the job.
Using numpy unique would not work if any column to group by is not numeric.
