### PR TITLE
test: toggle coverage for dask group_by

### DIFF
--- a/narwhals/_dask/group_by.py
+++ b/narwhals/_dask/group_by.py
@@ -41,8 +41,7 @@ class DaskLazyGroupBy:
         )
         output_names: list[str] = copy(self._keys)
         for expr in exprs:
-            # TODO(unassigned): Need to implement `.all()` for Dask first, part of GH 637
-            if expr._output_names is None:  # pragma: no cover
+            if expr._output_names is None:
                 msg = (
                     "Anonymous expressions are not supported in group_by.agg.\n"
                     "Instead of `nw.all()`, try using a named expression, such as "

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -48,6 +48,11 @@ def test_invalid_group_by_dask() -> None:
     with pytest.raises(RuntimeError, match="does your"):
         nw.from_native(df_dask).group_by("a").agg(nw.col("b"))
 
+    with pytest.raises(
+        ValueError, match=r"Anonymous expressions are not supported in group_by\.agg"
+    ):
+        nw.from_native(df_dask).group_by("a").agg(nw.all().mean())
+
 
 def test_invalid_group_by() -> None:
     df = nw.from_native(df_pandas)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Toggling coverage for a dask group_by since, `.all()` was implemented for dask and we can now add corresponding test that improves coverage for `group_by` implementation.