### PR TITLE
perf: keep `nw.len` totally lazy for dask

### DIFF
--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -88,7 +88,6 @@ class DaskNamespace:
         ).sum()
 
     def len(self) -> DaskExpr:
-        # coverage bug? this is definitely hit
         pd = get_pandas()
         dd = get_dask_dataframe()
 
@@ -99,6 +98,7 @@ class DaskNamespace:
                 df._native_dataframe.loc[:, df.columns[0]].size.to_series().rename("len")
             ]
 
+        # coverage bug? this is definitely hit
         return DaskExpr(  # pragma: no cover
             func,
             depth=0,

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -88,14 +88,19 @@ class DaskNamespace:
         ).sum()
 
     def len(self) -> DaskExpr:
-        dd = get_dask_dataframe()
-        pd = get_pandas()
-
         # coverage bug? this is definitely hit
+        pd = get_pandas()
+        dd = get_dask_dataframe()
+
+        def func(df: DaskLazyFrame) -> list[Any]:
+            if not df.columns:
+                return [dd.from_pandas(pd.Series([0], name="len"))]
+            return [
+                df._native_dataframe.loc[:, df.columns[0]].size.to_series().rename("len")
+            ]
+
         return DaskExpr(  # pragma: no cover
-            lambda df: [
-                dd.from_pandas(pd.Series([len(df._native_dataframe)], name="len"))["len"]
-            ],
+            func,
             depth=0,
             function_name="len",
             root_names=None,

--- a/narwhals/_dask/utils.py
+++ b/narwhals/_dask/utils.py
@@ -62,5 +62,9 @@ def parse_exprs_and_named_exprs(
         if len(_results) != 1:  # pragma: no cover
             msg = "Named expressions must return a single column"
             raise AssertionError(msg)
-        results[name] = _results[0]
+        for _result in _results:
+            if getattr(expr, "_returns_scalar", False):
+                results[name] = _result[0]
+            else:
+                results[name] = _result
     return results

--- a/narwhals/_dask/utils.py
+++ b/narwhals/_dask/utils.py
@@ -63,7 +63,7 @@ def parse_exprs_and_named_exprs(
             msg = "Named expressions must return a single column"
             raise AssertionError(msg)
         for _result in _results:
-            if getattr(expr, "_returns_scalar", False):
+            if getattr(value, "_returns_scalar", False):
                 results[name] = _result[0]
             else:
                 results[name] = _result

--- a/tests/expr_and_series/len_test.py
+++ b/tests/expr_and_series/len_test.py
@@ -5,17 +5,21 @@ import pytest
 import narwhals.stable.v1 as nw
 from tests.utils import compare_dicts
 
-data = {"a": list("xyz"), "b": [1, 2, 1]}
-expected = {"a1": [2], "a2": [1]}
-
 
 def test_len(constructor: Any, request: Any) -> None:
+    data = {"a": list("xyz"), "b": [1, 2, 1]}
+    expected = {"a1": [2], "a2": [1]}
     if "dask" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    df_raw = constructor(data)
-    df = nw.from_native(df_raw).select(
+    df = nw.from_native(constructor(data)).select(
         nw.col("a").filter(nw.col("b") == 1).len().alias("a1"),
         nw.col("a").filter(nw.col("b") == 2).len().alias("a2"),
     )
 
+    compare_dicts(df, expected)
+
+
+def test_namespace_len(constructor: Any) -> None:
+    df = nw.from_native(constructor({"a": [1, 2, 3]})).select(nw.len(), a=nw.len())
+    expected = {"len": [3], "a": [3]}
     compare_dicts(df, expected)

--- a/tests/expr_and_series/len_test.py
+++ b/tests/expr_and_series/len_test.py
@@ -20,6 +20,15 @@ def test_len(constructor: Any, request: Any) -> None:
 
 
 def test_namespace_len(constructor: Any) -> None:
-    df = nw.from_native(constructor({"a": [1, 2, 3]})).select(nw.len(), a=nw.len())
+    df = nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]})).select(
+        nw.len(), a=nw.len()
+    )
     expected = {"len": [3], "a": [3]}
+    compare_dicts(df, expected)
+    df = (
+        nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]}))
+        .select()
+        .select(nw.len(), a=nw.len())
+    )
+    expected = {"len": [0], "a": [0]}
     compare_dicts(df, expected)

--- a/tests/stable_api_test.py
+++ b/tests/stable_api_test.py
@@ -8,7 +8,7 @@ import narwhals.stable.v1 as nw_v1
 from tests.utils import compare_dicts
 
 
-def test_renamed_taxicab_norm(constructor: Any, request: Any) -> None:
+def test_renamed_taxicab_norm(constructor: Any) -> None:
     # Suppose we need to rename `_l1_norm` to `_taxicab_norm`.
     # We need `narwhals.stable.v1` to stay stable. So, we
     # make the change in `narwhals`, and then add the new method
@@ -17,8 +17,6 @@ def test_renamed_taxicab_norm(constructor: Any, request: Any) -> None:
     # API will still be able to use it, without the main namespace
     # getting cluttered by the new name.
 
-    if "dask" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor({"a": [1, 2, 3, -4, 5]}))
     result = df.with_columns(b=nw.col("a")._taxicab_norm())
     expected = {"a": [1, 2, 3, -4, 5], "b": [15] * 5}


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

