### PR TITLE
feat: add  `str.replace` and  `str.replace_all`

### DIFF
--- a/docs/api-reference/expr_str.md
+++ b/docs/api-reference/expr_str.md
@@ -8,6 +8,8 @@
         - ends_with
         - head
         - slice
+        - replace
+        - replace_all
         - starts_with
         - strip_chars
         - tail

--- a/docs/api-reference/series_str.md
+++ b/docs/api-reference/series_str.md
@@ -7,6 +7,8 @@
         - contains
         - ends_with
         - head
+        - replace
+        - replace_all
         - slice
         - starts_with
         - strip_chars

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -444,14 +444,13 @@ class ArrowExprStringNamespace:
         *,
         literal: bool = False,
     ) -> ArrowExpr:
-        return reuse_series_namespace_implementation(  # pragma: no cover , coverage bug?
+        return reuse_series_namespace_implementation(
             self._expr,
             "str",
             "replace_all",
             pattern,
             value,
             literal=literal,
-            n=-1,
         )
 
     def strip_chars(self, characters: str | None = None) -> ArrowExpr:

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -444,7 +444,15 @@ class ArrowExprStringNamespace:
         *,
         literal: bool = False,
     ) -> ArrowExpr:
-        return self.replace(pattern=pattern, value=value, literal=literal, n=-1)
+        return reuse_series_namespace_implementation(  # pragma: no cover , coverage bug?
+            self._expr,
+            "str",
+            "replace_all",
+            pattern,
+            value,
+            literal=literal,
+            n=-1,
+        )
 
     def strip_chars(self, characters: str | None = None) -> ArrowExpr:
         return reuse_series_namespace_implementation(

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -419,6 +419,33 @@ class ArrowExprStringNamespace:
     def __init__(self, expr: ArrowExpr) -> None:
         self._expr = expr
 
+    def replace(
+        self,
+        pattern: str,
+        value: str,
+        *,
+        literal: bool = False,
+        n: int = 1,
+    ) -> ArrowExpr:
+        return reuse_series_namespace_implementation(
+            self._expr,
+            "str",
+            "replace",
+            pattern,
+            value,
+            literal=literal,
+            n=n,
+        )
+
+    def replace_all(
+        self,
+        pattern: str,
+        value: str,
+        *,
+        literal: bool = False,
+    ) -> ArrowExpr:
+        return self.replace(pattern=pattern, value=value, literal=literal, n=-1)
+
     def strip_chars(self, characters: str | None = None) -> ArrowExpr:
         return reuse_series_namespace_implementation(
             self._expr,

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -837,6 +837,24 @@ class ArrowSeriesStringNamespace:
     def __init__(self: Self, series: ArrowSeries) -> None:
         self._arrow_series = series
 
+    def replace(
+        self, pattern: str, value: str, *, literal: bool = False, n: int = 1
+    ) -> ArrowSeries:
+        pc = get_pyarrow_compute()
+        return self._arrow_series._from_native_series(
+            pc.replace_substring_regex(
+                self._arrow_series._native_series,
+                pattern=pattern,
+                replacement=value,
+                max_replacements=n,
+            )
+        )
+
+    def replace_all(
+        self, pattern: str, value: str, *, literal: bool = False
+    ) -> ArrowSeries:
+        return self.replace(pattern, value, n=-1)
+
     def strip_chars(self: Self, characters: str | None = None) -> ArrowSeries:
         pc = get_pyarrow_compute()
         whitespace = " \t\n\r\v\f"

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -841,8 +841,9 @@ class ArrowSeriesStringNamespace:
         self, pattern: str, value: str, *, literal: bool = False, n: int = 1
     ) -> ArrowSeries:
         pc = get_pyarrow_compute()
+        method = "replace_substring" if literal else "replace_substring_regex"
         return self._arrow_series._from_native_series(
-            pc.replace_substring_regex(
+            getattr(pc, method)(
                 self._arrow_series._native_series,
                 pattern=pattern,
                 replacement=value,
@@ -853,7 +854,7 @@ class ArrowSeriesStringNamespace:
     def replace_all(
         self, pattern: str, value: str, *, literal: bool = False
     ) -> ArrowSeries:
-        return self.replace(pattern, value, n=-1)
+        return self.replace(pattern, value, literal=literal, n=-1)
 
     def strip_chars(self: Self, characters: str | None = None) -> ArrowSeries:
         pc = get_pyarrow_compute()

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -517,7 +517,7 @@ class DaskExprStringNamespace:
         *,
         literal: bool = False,
     ) -> DaskExpr:
-        return self._expr._from_call(  # pragma: no cover , coverage bug?
+        return self._expr._from_call(
             lambda _input, _pattern, _value, _literal: _input.str.replace(
                 _pattern, _value, n=-1, regex=not literal
             ),

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -516,9 +516,17 @@ class DaskExprStringNamespace:
         value: str,
         *,
         literal: bool = False,
-        n: int = 1,
     ) -> DaskExpr:
-        return self.replace(pattern=pattern, value=value, literal=literal, n=-1)
+        return self._expr._from_call(  # pragma: no cover , coverage bug?
+            lambda _input, _pattern, _value, _literal: _input.str.replace(
+                _pattern, _value, n=-1, regex=not literal
+            ),
+            "replace",
+            pattern,
+            value,
+            literal,
+            returns_scalar=False,
+        )
 
     def strip_chars(self, characters: str | None = None) -> DaskExpr:
         return self._expr._from_call(

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -490,6 +490,21 @@ class DaskExprStringNamespace:
     def __init__(self, expr: DaskExpr) -> None:
         self._expr = expr
 
+    def replace(
+        self, pattern: str, value: str, *, literal: bool = False, n: int = 1
+    ) -> DaskExpr:
+        return self._expr._from_call(
+            lambda _input, _pattern, _value, _literal, _n: _input.str.replace(
+                _pattern, _value, n=n, regex=not literal
+            ),
+            "replace",
+            pat=pattern,
+            repl=value,
+            n=n,
+            regex=not literal,
+            returns_scalar=False,
+        )
+
     def strip_chars(self, characters: str | None = None) -> DaskExpr:
         return self._expr._from_call(
             lambda _input, characters: _input.str.strip(characters),

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -500,13 +500,13 @@ class DaskExprStringNamespace:
     ) -> DaskExpr:
         return self._expr._from_call(
             lambda _input, _pattern, _value, _literal, _n: _input.str.replace(
-                _pattern, _value, n=n, regex=not literal
+                _pattern, _value, regex=not _literal, n=_n
             ),
             "replace",
             pattern,
             value,
-            n,
             literal,
+            n,
             returns_scalar=False,
         )
 

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -491,19 +491,34 @@ class DaskExprStringNamespace:
         self._expr = expr
 
     def replace(
-        self, pattern: str, value: str, *, literal: bool = False, n: int = 1
+        self,
+        pattern: str,
+        value: str,
+        *,
+        literal: bool = False,
+        n: int = 1,
     ) -> DaskExpr:
         return self._expr._from_call(
             lambda _input, _pattern, _value, _literal, _n: _input.str.replace(
                 _pattern, _value, n=n, regex=not literal
             ),
             "replace",
-            pat=pattern,
-            repl=value,
-            n=n,
-            regex=not literal,
+            pattern,
+            value,
+            n,
+            literal,
             returns_scalar=False,
         )
+
+    def replace_all(
+        self,
+        pattern: str,
+        value: str,
+        *,
+        literal: bool = False,
+        n: int = 1,
+    ) -> DaskExpr:
+        return self.replace(pattern=pattern, value=value, literal=literal, n=-1)
 
     def strip_chars(self, characters: str | None = None) -> DaskExpr:
         return self._expr._from_call(

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -519,7 +519,7 @@ class DaskExprStringNamespace:
     ) -> DaskExpr:
         return self._expr._from_call(
             lambda _input, _pattern, _value, _literal: _input.str.replace(
-                _pattern, _value, n=-1, regex=not literal
+                _pattern, _value, n=-1, regex=not _literal
             ),
             "replace",
             pattern,

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -371,6 +371,27 @@ class PandasLikeExprStringNamespace:
     def __init__(self, expr: PandasLikeExpr) -> None:
         self._expr = expr
 
+    def replace(
+        self,
+        pattern: str,
+        value: str,
+        *,
+        literal: bool = False,
+        n: int = 1,
+    ) -> PandasLikeExpr:
+        return reuse_series_namespace_implementation(
+            self._expr, "str", "replace", pattern, value, literal=literal, n=n
+        )
+
+    def replace_all(
+        self,
+        pattern: str,
+        value: str,
+        *,
+        literal: bool = False,
+    ) -> PandasLikeExpr:
+        return self.replace(pattern=pattern, value=value, literal=literal, n=-1)
+
     def strip_chars(self, characters: str | None = None) -> PandasLikeExpr:
         return reuse_series_namespace_implementation(
             self._expr,

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -390,8 +390,8 @@ class PandasLikeExprStringNamespace:
         *,
         literal: bool = False,
     ) -> PandasLikeExpr:
-        return reuse_series_namespace_implementation(  # pragma: no cover , coverage bug?
-            self._expr, "str", "replace_all", pattern, value, literal=literal, n=-1
+        return reuse_series_namespace_implementation(
+            self._expr, "str", "replace_all", pattern, value, literal=literal
         )
 
     def strip_chars(self, characters: str | None = None) -> PandasLikeExpr:

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -390,7 +390,9 @@ class PandasLikeExprStringNamespace:
         *,
         literal: bool = False,
     ) -> PandasLikeExpr:
-        return self.replace(pattern=pattern, value=value, literal=literal, n=-1)
+        return reuse_series_namespace_implementation(  # pragma: no cover , coverage bug?
+            self._expr, "str", "replace_all", pattern, value, literal=literal, n=-1
+        )
 
     def strip_chars(self, characters: str | None = None) -> PandasLikeExpr:
         return reuse_series_namespace_implementation(

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -675,6 +675,11 @@ class PandasLikeSeriesStringNamespace:
             ),
         )
 
+    def replace_all(
+        self, pattern: str, value: str, *, literal: bool = False
+    ) -> PandasLikeSeries:
+        return self.replace(pattern, value, literal=literal, n=-1)
+
     def strip_chars(self, characters: str | None) -> PandasLikeSeries:
         return self._pandas_series._from_native_series(
             self._pandas_series._native_series.str.strip(characters),

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -666,6 +666,15 @@ class PandasLikeSeriesStringNamespace:
     def __init__(self, series: PandasLikeSeries) -> None:
         self._pandas_series = series
 
+    def replace(
+        self, pattern: str, value: str, *, literal: bool = False, n: int = 1
+    ) -> PandasLikeSeries:
+        return self._pandas_series._from_native_series(
+            self._pandas_series._native_series.str.replace(
+                pat=pattern, repl=value, n=n, regex=not literal
+            ),
+        )
+
     def strip_chars(self, characters: str | None) -> PandasLikeSeries:
         return self._pandas_series._from_native_series(
             self._pandas_series._native_series.str.strip(characters),

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -1949,6 +1949,36 @@ class ExprStringNamespace:
     def __init__(self, expr: Expr) -> None:
         self._expr = expr
 
+    def replace(
+        self, pattern: str, value: str, *, literal: bool = False, n: int = 1
+    ) -> Expr:
+        r"""
+        Replace first matching regex/literal substring with a new string value.
+
+        Arguments:
+            pattern: A valid regular expression pattern
+            value: String that will replace the matched substring.
+            literal: Treat `pattern` as a literal string.
+            n: Number of matches to replace.
+
+        """
+        return self._expr.__class__(
+            lambda plx: self._expr._call(plx).str.replace(
+                pattern, value, literal=literal, n=n
+            )
+        )
+
+    def replace_all(self, pattern: str, value: str, *, literal: bool = False) -> Expr:
+        r"""
+        Replace all matching regex/literal substring with a new string value.
+
+        Arguments:
+            pattern: A valid regular expression pattern
+            value: String that will replace the matched substring.
+            literal: Treat `pattern` as a literal string.
+        """
+        return self.replace(pattern=pattern, value=value, literal=literal, n=-1)
+
     def strip_chars(self, characters: str | None = None) -> Expr:
         r"""
         Remove leading and trailing characters.

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -1956,10 +1956,33 @@ class ExprStringNamespace:
         Replace first matching regex/literal substring with a new string value.
 
         Arguments:
-            pattern: A valid regular expression pattern
+            pattern: A valid regular expression pattern.
             value: String that will replace the matched substring.
             literal: Treat `pattern` as a literal string.
             n: Number of matches to replace.
+
+        Examples:
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> data = {"foo": ["123abc", "abc abc123"]}
+            >>> df_pd = pd.DataFrame(data)
+            >>> df_pl = pl.DataFrame(data)
+
+            We define a dataframe-agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     df = df.with_columns(replaced=nw.col("foo").str.replace("abc", ""))
+            ...     return df.to_dict(as_series=False)
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(df_pd)
+            {'foo': ['123abc', 'abc abc123'], 'replaced': ['123', ' abc123']}
+
+            >>> func(df_pl)
+            {'foo': ['123abc', 'abc abc123'], 'replaced': ['123', ' abc123']}
 
         """
         return self._expr.__class__(
@@ -1973,9 +1996,33 @@ class ExprStringNamespace:
         Replace all matching regex/literal substring with a new string value.
 
         Arguments:
-            pattern: A valid regular expression pattern
+            pattern: A valid regular expression pattern.
             value: String that will replace the matched substring.
             literal: Treat `pattern` as a literal string.
+
+        Examples:
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> data = {"foo": ["123abc", "abc abc123"]}
+            >>> df_pd = pd.DataFrame(data)
+            >>> df_pl = pl.DataFrame(data)
+
+            We define a dataframe-agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     df = df.with_columns(replaced=nw.col("foo").str.replace_all("abc", ""))
+            ...     return df.to_dict(as_series=False)
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(df_pd)
+            {'foo': ['123abc', 'abc abc123'], 'replaced': ['123', ' 123']}
+
+            >>> func(df_pl)
+            {'foo': ['123abc', 'abc abc123'], 'replaced': ['123', ' 123']}
+
         """
         return self.replace(pattern=pattern, value=value, literal=literal, n=-1)
 

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -2024,7 +2024,11 @@ class ExprStringNamespace:
             {'foo': ['123abc', 'abc abc123'], 'replaced': ['123', ' 123']}
 
         """
-        return self.replace(pattern=pattern, value=value, literal=literal, n=-1)
+        return self._expr.__class__(
+            lambda plx: self._expr._call(plx).str.replace_all(
+                pattern, value, literal=literal
+            )
+        )
 
     def strip_chars(self, characters: str | None = None) -> Expr:
         r"""

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2267,6 +2267,21 @@ class SeriesStringNamespace:
             )
         )
 
+    def replace_all(self, pattern: str, value: str, *, literal: bool = False) -> Series:
+        r"""
+        Replace first matching regex/literal substring with a new string value.
+
+        Arguments:
+            pattern: A valid regular expression pattern
+            value: String that will replace the matched substring.
+            literal: Treat `pattern` as a literal string.
+        """
+        return self._narwhals_series._from_compliant_series(
+            self._narwhals_series._compliant_series.str.replace_all(
+                pattern, value, literal=literal
+            )
+        )
+
     def strip_chars(self, characters: str | None = None) -> Series:
         r"""
         Remove leading and trailing characters.

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2249,6 +2249,24 @@ class SeriesStringNamespace:
     def __init__(self, series: Series) -> None:
         self._narwhals_series = series
 
+    def replace(
+        self, pattern: str, value: str, *, literal: bool = False, n: int = 1
+    ) -> Series:
+        r"""
+        Replace first matching regex/literal substring with a new string value.
+
+        Arguments:
+            pattern: A valid regular expression pattern
+            value: String that will replace the matched substring.
+            literal: Treat `pattern` as a literal string.
+            n: Number of matches to replace.
+        """
+        return self._narwhals_series._from_compliant_series(
+            self._narwhals_series._compliant_series.str.replace(
+                pattern, value, literal=literal, n=n
+            )
+        )
+
     def strip_chars(self, characters: str | None = None) -> Series:
         r"""
         Remove leading and trailing characters.

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2256,7 +2256,7 @@ class SeriesStringNamespace:
         Replace first matching regex/literal substring with a new string value.
 
         Arguments:
-            pattern: A valid regular expression pattern
+            pattern: A valid regular expression pattern.
             value: String that will replace the matched substring.
             literal: Treat `pattern` as a literal string.
             n: Number of matches to replace.
@@ -2295,7 +2295,7 @@ class SeriesStringNamespace:
         Replace all matching regex/literal substring with a new string value.
 
         Arguments:
-            pattern: A valid regular expression pattern
+            pattern: A valid regular expression pattern.
             value: String that will replace the matched substring.
             literal: Treat `pattern` as a literal string.
 

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2260,6 +2260,29 @@ class SeriesStringNamespace:
             value: String that will replace the matched substring.
             literal: Treat `pattern` as a literal string.
             n: Number of matches to replace.
+
+        Examples:
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> data = ["123abc", "abc abc123"]
+            >>> s_pd = pd.Series(data)
+            >>> s_pl = pl.Series(data)
+
+            We define a dataframe-agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(s):
+            ...     s = s.str.replace("abc", "")
+            ...     return s.to_list()
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(s_pd)
+            ['123', ' abc123']
+
+            >>> func(s_pl)
+            ['123', ' abc123']
         """
         return self._narwhals_series._from_compliant_series(
             self._narwhals_series._compliant_series.str.replace(
@@ -2269,12 +2292,35 @@ class SeriesStringNamespace:
 
     def replace_all(self, pattern: str, value: str, *, literal: bool = False) -> Series:
         r"""
-        Replace first matching regex/literal substring with a new string value.
+        Replace all matching regex/literal substring with a new string value.
 
         Arguments:
             pattern: A valid regular expression pattern
             value: String that will replace the matched substring.
             literal: Treat `pattern` as a literal string.
+
+        Examples:
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> data = ["123abc", "abc abc123"]
+            >>> s_pd = pd.Series(data)
+            >>> s_pl = pl.Series(data)
+
+            We define a dataframe-agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(s):
+            ...     s = s.str.replace_all("abc", "")
+            ...     return s.to_list()
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(s_pd)
+            ['123', ' 123']
+
+            >>> func(s_pl)
+            ['123', ' 123']
         """
         return self._narwhals_series._from_compliant_series(
             self._narwhals_series._compliant_series.str.replace_all(

--- a/tests/expr_and_series/str/replace_test.py
+++ b/tests/expr_and_series/str/replace_test.py
@@ -80,3 +80,80 @@ def test_str_replace_all_series(
 
     result_series = df["a"].str.replace_all(pattern=pattern, value=value, literal=literal)
     assert result_series.to_list() == expected["a"]
+
+
+@pytest.mark.parametrize(
+    ("data", "pattern", "value", "n", "literal", "expected"),
+    [
+        (
+            {"a": ["123abc", "abc456"]},
+            r"abc\b",
+            "ABC",
+            1,
+            False,
+            {"a": ["123ABC", "abc456"]},
+        ),
+        ({"a": ["abc abc", "abc456"]}, r"abc", "", 1, False, {"a": [" abc", "456"]}),
+        ({"a": ["abc abc abc", "456abc"]}, r"abc", "", -1, False, {"a": ["  ", "456"]}),
+        (
+            {"a": ["Dollar $ign", "literal"]},
+            r"$",
+            "S",
+            -1,
+            True,
+            {"a": ["Dollar Sign", "literal"]},
+        ),
+    ],
+)
+def test_str_replace_expr(
+    constructor_eager: Any,
+    data: dict[str, list[str]],
+    pattern: str,
+    value: str,
+    n: int,
+    literal: bool,  # noqa: FBT001
+    expected: dict[str, list[str]],
+) -> None:
+    df = nw.from_native(constructor_eager(data), eager_only=True)
+
+    result_series = df.select(
+        nw.col("a").str.replace(pattern=pattern, value=value, n=n, literal=literal)
+    )
+    assert result_series["a"].to_list() == expected["a"]
+
+
+@pytest.mark.parametrize(
+    ("data", "pattern", "value", "literal", "expected"),
+    [
+        (
+            {"a": ["123abc", "abc456"]},
+            r"abc\b",
+            "ABC",
+            False,
+            {"a": ["123ABC", "abc456"]},
+        ),
+        ({"a": ["abc abc", "abc456"]}, r"abc", "", False, {"a": [" ", "456"]}),
+        ({"a": ["abc abc abc", "456abc"]}, r"abc", "", False, {"a": ["  ", "456"]}),
+        (
+            {"a": ["Dollar $ign", "literal"]},
+            r"$",
+            "S",
+            True,
+            {"a": ["Dollar Sign", "literal"]},
+        ),
+    ],
+)
+def test_str_replace_all_expr(
+    constructor_eager: Any,
+    data: dict[str, list[str]],
+    pattern: str,
+    value: str,
+    literal: bool,  # noqa: FBT001
+    expected: dict[str, list[str]],
+) -> None:
+    df = nw.from_native(constructor_eager(data), eager_only=True)
+
+    result_series = df.select(
+        nw.col("a").str.replace_all(pattern=pattern, value=value, literal=literal)
+    )
+    assert result_series["a"].to_list() == expected["a"]

--- a/tests/expr_and_series/str/replace_test.py
+++ b/tests/expr_and_series/str/replace_test.py
@@ -122,7 +122,7 @@ def test_str_replace_all_expr(
 ) -> None:
     df = nw.from_native(constructor(data))
 
-    result= df.select(
-            nw.col("a").str.replace_all(pattern=pattern, value=value, literal=literal)
-        )
+    result = df.select(
+        nw.col("a").str.replace_all(pattern=pattern, value=value, literal=literal)
+    )
     compare_dicts(result, expected)

--- a/tests/expr_and_series/str/replace_test.py
+++ b/tests/expr_and_series/str/replace_test.py
@@ -5,30 +5,52 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import compare_dicts
+
+replace_data = [
+    (
+        {"a": ["123abc", "abc456"]},
+        r"abc\b",
+        "ABC",
+        1,
+        False,
+        {"a": ["123ABC", "abc456"]},
+    ),
+    ({"a": ["abc abc", "abc456"]}, r"abc", "", 1, False, {"a": [" abc", "456"]}),
+    ({"a": ["abc abc abc", "456abc"]}, r"abc", "", -1, False, {"a": ["  ", "456"]}),
+    (
+        {"a": ["Dollar $ign", "literal"]},
+        r"$",
+        "S",
+        -1,
+        True,
+        {"a": ["Dollar Sign", "literal"]},
+    ),
+]
+
+replace_all_data = [
+    (
+        {"a": ["123abc", "abc456"]},
+        r"abc\b",
+        "ABC",
+        False,
+        {"a": ["123ABC", "abc456"]},
+    ),
+    ({"a": ["abc abc", "abc456"]}, r"abc", "", False, {"a": [" ", "456"]}),
+    ({"a": ["abc abc abc", "456abc"]}, r"abc", "", False, {"a": ["  ", "456"]}),
+    (
+        {"a": ["Dollar $ign", "literal"]},
+        r"$",
+        "S",
+        True,
+        {"a": ["Dollar Sign", "literal"]},
+    ),
+]
 
 
 @pytest.mark.parametrize(
     ("data", "pattern", "value", "n", "literal", "expected"),
-    [
-        (
-            {"a": ["123abc", "abc456"]},
-            r"abc\b",
-            "ABC",
-            1,
-            False,
-            {"a": ["123ABC", "abc456"]},
-        ),
-        ({"a": ["abc abc", "abc456"]}, r"abc", "", 1, False, {"a": [" abc", "456"]}),
-        ({"a": ["abc abc abc", "456abc"]}, r"abc", "", -1, False, {"a": ["  ", "456"]}),
-        (
-            {"a": ["Dollar $ign", "literal"]},
-            r"$",
-            "S",
-            -1,
-            True,
-            {"a": ["Dollar Sign", "literal"]},
-        ),
-    ],
+    replace_data,
 )
 def test_str_replace_series(
     constructor_eager: Any,
@@ -49,24 +71,7 @@ def test_str_replace_series(
 
 @pytest.mark.parametrize(
     ("data", "pattern", "value", "literal", "expected"),
-    [
-        (
-            {"a": ["123abc", "abc456"]},
-            r"abc\b",
-            "ABC",
-            False,
-            {"a": ["123ABC", "abc456"]},
-        ),
-        ({"a": ["abc abc", "abc456"]}, r"abc", "", False, {"a": [" ", "456"]}),
-        ({"a": ["abc abc abc", "456abc"]}, r"abc", "", False, {"a": ["  ", "456"]}),
-        (
-            {"a": ["Dollar $ign", "literal"]},
-            r"$",
-            "S",
-            True,
-            {"a": ["Dollar Sign", "literal"]},
-        ),
-    ],
+    replace_all_data,
 )
 def test_str_replace_all_series(
     constructor_eager: Any,
@@ -84,29 +89,10 @@ def test_str_replace_all_series(
 
 @pytest.mark.parametrize(
     ("data", "pattern", "value", "n", "literal", "expected"),
-    [
-        (
-            {"a": ["123abc", "abc456"]},
-            r"abc\b",
-            "ABC",
-            1,
-            False,
-            {"a": ["123ABC", "abc456"]},
-        ),
-        ({"a": ["abc abc", "abc456"]}, r"abc", "", 1, False, {"a": [" abc", "456"]}),
-        ({"a": ["abc abc abc", "456abc"]}, r"abc", "", -1, False, {"a": ["  ", "456"]}),
-        (
-            {"a": ["Dollar $ign", "literal"]},
-            r"$",
-            "S",
-            -1,
-            True,
-            {"a": ["Dollar Sign", "literal"]},
-        ),
-    ],
+    replace_data,
 )
 def test_str_replace_expr(
-    constructor_eager: Any,
+    constructor: Any,
     data: dict[str, list[str]],
     pattern: str,
     value: str,
@@ -114,46 +100,31 @@ def test_str_replace_expr(
     literal: bool,  # noqa: FBT001
     expected: dict[str, list[str]],
 ) -> None:
-    df = nw.from_native(constructor_eager(data), eager_only=True)
+    df = nw.from_native(constructor(data))
 
-    result_series = df.select(
+    result_df = df.select(
         nw.col("a").str.replace(pattern=pattern, value=value, n=n, literal=literal)
     )
-    assert result_series["a"].to_list() == expected["a"]
+    compare_dicts(result_df, expected)
 
 
 @pytest.mark.parametrize(
     ("data", "pattern", "value", "literal", "expected"),
-    [
-        (
-            {"a": ["123abc", "abc456"]},
-            r"abc\b",
-            "ABC",
-            False,
-            {"a": ["123ABC", "abc456"]},
-        ),
-        ({"a": ["abc abc", "abc456"]}, r"abc", "", False, {"a": [" ", "456"]}),
-        ({"a": ["abc abc abc", "456abc"]}, r"abc", "", False, {"a": ["  ", "456"]}),
-        (
-            {"a": ["Dollar $ign", "literal"]},
-            r"$",
-            "S",
-            True,
-            {"a": ["Dollar Sign", "literal"]},
-        ),
-    ],
+    replace_all_data,
 )
 def test_str_replace_all_expr(
-    constructor_eager: Any,
+    constructor: Any,
     data: dict[str, list[str]],
     pattern: str,
     value: str,
     literal: bool,  # noqa: FBT001
     expected: dict[str, list[str]],
 ) -> None:
-    df = nw.from_native(constructor_eager(data), eager_only=True)
+    df = nw.from_native(constructor(data))
 
-    result_series = df.select(
-        nw.col("a").str.replace_all(pattern=pattern, value=value, literal=literal)
+    result_df = nw.to_native(
+        df.select(
+            nw.col("a").str.replace_all(pattern=pattern, value=value, literal=literal)
+        )
     )
-    assert result_series["a"].to_list() == expected["a"]
+    compare_dicts(result_df, expected)

--- a/tests/expr_and_series/str/replace_test.py
+++ b/tests/expr_and_series/str/replace_test.py
@@ -122,9 +122,7 @@ def test_str_replace_all_expr(
 ) -> None:
     df = nw.from_native(constructor(data))
 
-    result_df = nw.to_native(
-        df.select(
+    result= df.select(
             nw.col("a").str.replace_all(pattern=pattern, value=value, literal=literal)
         )
-    )
-    compare_dicts(result_df, expected)
+    compare_dicts(result, expected)

--- a/tests/expr_and_series/str/replace_test.py
+++ b/tests/expr_and_series/str/replace_test.py
@@ -8,12 +8,36 @@ import narwhals.stable.v1 as nw
 
 
 @pytest.mark.parametrize(
-    ("data", "pattern", "value", "expected"),
+    ("data", "pattern", "value", "n", "expected"),
     [
-        ({"a": ["123abc", "abc456"]}, r"abc\b", "ABC", {"a": ["123ABC", "abc456"]}),
+        ({"a": ["123abc", "abc456"]}, r"abc\b", "ABC", 1, {"a": ["123ABC", "abc456"]}),
+        ({"a": ["abc abc", "abc456"]}, r"abc", "", 1, {"a": [" abc", "456"]}),
+        ({"a": ["abc abc abc", "456abc"]}, r"abc", "", -1, {"a": ["  ", "456"]}),
     ],
 )
 def test_str_replace_series(
+    constructor_eager: Any,
+    data: dict[str, list[str]],
+    pattern: str,
+    value: str,
+    n: int,
+    expected: dict[str, list[str]],
+) -> None:
+    df = nw.from_native(constructor_eager(data), eager_only=True)
+
+    result_series = df["a"].str.replace(pattern=pattern, value=value, n=n)
+    assert result_series.to_list() == expected["a"]
+
+
+@pytest.mark.parametrize(
+    ("data", "pattern", "value", "expected"),
+    [
+        ({"a": ["123abc", "abc456"]}, r"abc\b", "ABC", {"a": ["123ABC", "abc456"]}),
+        ({"a": ["abc abc", "abc456"]}, r"abc", "", {"a": [" ", "456"]}),
+        ({"a": ["abc abc abc", "456abc"]}, r"abc", "", {"a": ["  ", "456"]}),
+    ],
+)
+def test_str_replace_all_series(
     constructor_eager: Any,
     data: dict[str, list[str]],
     pattern: str,
@@ -22,5 +46,5 @@ def test_str_replace_series(
 ) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
-    result_series = df["a"].str.replace(pattern=pattern, value=value)
+    result_series = df["a"].str.replace_all(pattern=pattern, value=value)
     assert result_series.to_list() == expected["a"]

--- a/tests/expr_and_series/str/replace_test.py
+++ b/tests/expr_and_series/str/replace_test.py
@@ -8,11 +8,26 @@ import narwhals.stable.v1 as nw
 
 
 @pytest.mark.parametrize(
-    ("data", "pattern", "value", "n", "expected"),
+    ("data", "pattern", "value", "n", "literal", "expected"),
     [
-        ({"a": ["123abc", "abc456"]}, r"abc\b", "ABC", 1, {"a": ["123ABC", "abc456"]}),
-        ({"a": ["abc abc", "abc456"]}, r"abc", "", 1, {"a": [" abc", "456"]}),
-        ({"a": ["abc abc abc", "456abc"]}, r"abc", "", -1, {"a": ["  ", "456"]}),
+        (
+            {"a": ["123abc", "abc456"]},
+            r"abc\b",
+            "ABC",
+            1,
+            False,
+            {"a": ["123ABC", "abc456"]},
+        ),
+        ({"a": ["abc abc", "abc456"]}, r"abc", "", 1, False, {"a": [" abc", "456"]}),
+        ({"a": ["abc abc abc", "456abc"]}, r"abc", "", -1, False, {"a": ["  ", "456"]}),
+        (
+            {"a": ["Dollar $ign", "literal"]},
+            r"$",
+            "S",
+            -1,
+            True,
+            {"a": ["Dollar Sign", "literal"]},
+        ),
     ],
 )
 def test_str_replace_series(
@@ -21,20 +36,36 @@ def test_str_replace_series(
     pattern: str,
     value: str,
     n: int,
+    literal: bool,  # noqa: FBT001
     expected: dict[str, list[str]],
 ) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
-    result_series = df["a"].str.replace(pattern=pattern, value=value, n=n)
+    result_series = df["a"].str.replace(
+        pattern=pattern, value=value, n=n, literal=literal
+    )
     assert result_series.to_list() == expected["a"]
 
 
 @pytest.mark.parametrize(
-    ("data", "pattern", "value", "expected"),
+    ("data", "pattern", "value", "literal", "expected"),
     [
-        ({"a": ["123abc", "abc456"]}, r"abc\b", "ABC", {"a": ["123ABC", "abc456"]}),
-        ({"a": ["abc abc", "abc456"]}, r"abc", "", {"a": [" ", "456"]}),
-        ({"a": ["abc abc abc", "456abc"]}, r"abc", "", {"a": ["  ", "456"]}),
+        (
+            {"a": ["123abc", "abc456"]},
+            r"abc\b",
+            "ABC",
+            False,
+            {"a": ["123ABC", "abc456"]},
+        ),
+        ({"a": ["abc abc", "abc456"]}, r"abc", "", False, {"a": [" ", "456"]}),
+        ({"a": ["abc abc abc", "456abc"]}, r"abc", "", False, {"a": ["  ", "456"]}),
+        (
+            {"a": ["Dollar $ign", "literal"]},
+            r"$",
+            "S",
+            True,
+            {"a": ["Dollar Sign", "literal"]},
+        ),
     ],
 )
 def test_str_replace_all_series(
@@ -42,9 +73,10 @@ def test_str_replace_all_series(
     data: dict[str, list[str]],
     pattern: str,
     value: str,
+    literal: bool,  # noqa: FBT001
     expected: dict[str, list[str]],
 ) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
-    result_series = df["a"].str.replace_all(pattern=pattern, value=value)
+    result_series = df["a"].str.replace_all(pattern=pattern, value=value, literal=literal)
     assert result_series.to_list() == expected["a"]

--- a/tests/expr_and_series/str/replace_test.py
+++ b/tests/expr_and_series/str/replace_test.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import narwhals.stable.v1 as nw
+
+
+@pytest.mark.parametrize(
+    ("data", "pattern", "value", "expected"),
+    [
+        ({"a": ["123abc", "abc456"]}, r"abc\b", "ABC", {"a": ["123ABC", "abc456"]}),
+    ],
+)
+def test_str_replace_series(
+    constructor_eager: Any,
+    data: dict[str, list[str]],
+    pattern: str,
+    value: str,
+    expected: dict[str, list[str]],
+) -> None:
+    df = nw.from_native(constructor_eager(data), eager_only=True)
+
+    result_series = df["a"].str.replace(pattern=pattern, value=value)
+    assert result_series.to_list() == expected["a"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,7 +20,10 @@ def zip_strict(left: Sequence[Any], right: Sequence[Any]) -> Iterator[Any]:
 def compare_dicts(result: Any, expected: dict[str, Any]) -> None:
     if hasattr(result, "collect"):
         result = result.collect()
-    if hasattr(result, "columns"):
+    if hasattr(result, "column_names"):  # To handle Pyarrow ChuckedArray:
+        for key in result.column_names:
+            assert key in expected
+    elif hasattr(result, "columns"):
         for key in result.columns:
             assert key in expected
     for key in expected:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,10 +20,7 @@ def zip_strict(left: Sequence[Any], right: Sequence[Any]) -> Iterator[Any]:
 def compare_dicts(result: Any, expected: dict[str, Any]) -> None:
     if hasattr(result, "collect"):
         result = result.collect()
-    if hasattr(result, "column_names"):  # To handle Pyarrow ChuckedArray:
-        for key in result.column_names:
-            assert key in expected
-    elif hasattr(result, "columns"):
+    if hasattr(result, "columns"):
         for key in result.columns:
             assert key in expected
     for key in expected:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #637 #372 
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.

In polars, `Expr.replace` and `Expr.replace_all` also accept and `Expr` for the pattern and value arguments. 
But this seems only to be true when using `pl.lit` as arguments.  
I just implemented the type `str` for this PR.