### PR TITLE
test: Add `cudf_constructor` to conftest

### DIFF
--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -224,7 +224,7 @@ class PandasLikeSeries:
         import numpy as np  # ignore-banned-import
 
         ser = self._native_series
-        res = np.flatnonzero(ser)
+        res = np.nonzero(ser)[0]
         return self._from_native_series(
             native_series_from_iterable(
                 res,

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -221,18 +221,9 @@ class PandasLikeSeries:
         return self._from_native_series(res)
 
     def arg_true(self) -> PandasLikeSeries:
-        import numpy as np  # ignore-banned-import
-
         ser = self._native_series
-        res = np.nonzero(ser)[0]
-        return self._from_native_series(
-            native_series_from_iterable(
-                res,
-                name=self.name,
-                index=range(len(res)),
-                implementation=self._implementation,
-            )
-        )
+        result = ser.__class__(range(len(ser)), name=ser.name, index=ser.index).loc[ser]
+        return self._from_native_series(result)
 
     # Binary comparisons
 

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -210,7 +210,11 @@ def set_axis(
         kwargs["copy"] = False
     else:  # pragma: no cover
         pass
-    return obj.set_axis(index, axis=0, **kwargs)  # type: ignore[no-any-return, attr-defined]
+    if hasattr(obj, "set_axis"):
+        return obj.set_axis(index, axis=0, **kwargs)  # type: ignore[no-any-return, attr-defined]
+    obj = obj.copy(deep=False)
+    obj.index = index
+    return obj
 
 
 def translate_dtype(column: Any) -> DType:

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -211,9 +211,9 @@ def set_axis(
     else:  # pragma: no cover
         pass
     if hasattr(obj, "set_axis"):
-        return obj.set_axis(index, axis=0, **kwargs)  # type: ignore[no-any-return, attr-defined]
-    obj = obj.copy(deep=False)
-    obj.index = index
+        return obj.set_axis(index, axis=0, **kwargs)  # type: ignore[no-any-return]
+    obj = obj.copy(deep=False)  # type: ignore[attr-defined]
+    obj.index = index  # type: ignore[attr-defined]
     return obj
 
 

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -197,6 +197,10 @@ def set_axis(
     implementation: Implementation,
     backend_version: tuple[int, ...],
 ) -> T:
+    if implementation is Implementation.CUDF:  # pragma: no cover
+        obj = obj.copy(deep=False)  # type: ignore[attr-defined]
+        obj.index = index  # type: ignore[attr-defined]
+        return obj
     if implementation is Implementation.PANDAS and backend_version < (
         1,
     ):  # pragma: no cover
@@ -210,11 +214,7 @@ def set_axis(
         kwargs["copy"] = False
     else:  # pragma: no cover
         pass
-    if hasattr(obj, "set_axis"):
-        return obj.set_axis(index, axis=0, **kwargs)  # type: ignore[no-any-return]
-    obj = obj.copy(deep=False)  # type: ignore[attr-defined]
-    obj.index = index  # type: ignore[attr-defined]
-    return obj
+    return obj.set_axis(index, axis=0, **kwargs)  # type: ignore[attr-defined, no-any-return]
 
 
 def translate_dtype(column: Any) -> DType:

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -1114,8 +1114,8 @@ class Expr:
 
             >>> func(df_pd)
                a
-            0  1
-            1  2
+            1  1
+            2  2
             >>> func(df_pl)
             shape: (2, 1)
             ┌─────┐

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -766,8 +766,8 @@ class Series:
             We can then pass either pandas or Polars to `func`:
 
             >>> func(s_pd)
-            0    1
-            1    2
+            1    1
+            2    2
             Name: a, dtype: int64
             >>> func(s_pl)  # doctest: +NORMALIZE_WHITESPACE
             shape: (2,)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 covdefaults
 pandas
-polars[timezones]
+polars
 pre-commit
 pyarrow
 pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     import dask.dataframe  # noqa: F401
 with contextlib.suppress(ImportError):
-    pass
+    import cudf  # noqa: F401
 
 
 def pytest_addoption(parser: Any) -> None:
@@ -96,7 +96,7 @@ lazy_constructors = [polars_lazy_constructor]
 if get_modin() is not None:  # pragma: no cover
     eager_constructors.append(modin_constructor)
 if get_cudf() is not None:
-    eager_constructors.append(modin_constructor)  # pragma: no cover
+    eager_constructors.append(cudf_constructor)  # pragma: no cover
 if get_dask_dataframe() is not None:  # pragma: no cover
     lazy_constructors.append(dask_lazy_constructor)  # type: ignore  # noqa: PGH003
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import polars as pl
 import pyarrow as pa
 import pytest
 
+from narwhals.dependencies import get_cudf
 from narwhals.dependencies import get_dask_dataframe
 from narwhals.dependencies import get_modin
 from narwhals.typing import IntoDataFrame
@@ -17,6 +18,8 @@ with contextlib.suppress(ImportError):
     import modin.pandas  # noqa: F401
 with contextlib.suppress(ImportError):
     import dask.dataframe  # noqa: F401
+with contextlib.suppress(ImportError):
+    pass
 
 
 def pytest_addoption(parser: Any) -> None:
@@ -56,6 +59,11 @@ def modin_constructor(obj: Any) -> IntoDataFrame:  # pragma: no cover
     return mpd.DataFrame(pd.DataFrame(obj)).convert_dtypes(dtype_backend="pyarrow")  # type: ignore[no-any-return]
 
 
+def cudf_constructor(obj: Any) -> IntoDataFrame:  # pragma: no cover
+    cudf = get_cudf()
+    return cudf.DataFrame(obj)  # type: ignore[no-any-return]
+
+
 def polars_eager_constructor(obj: Any) -> IntoDataFrame:
     return pl.DataFrame(obj)
 
@@ -87,7 +95,8 @@ lazy_constructors = [polars_lazy_constructor]
 
 if get_modin() is not None:  # pragma: no cover
     eager_constructors.append(modin_constructor)
-# TODO(unassigned): when Dask gets better support, remove the "False and" part
+if get_cudf() is not None:
+    eager_constructors.append(modin_constructor)  # pragma: no cover
 if get_dask_dataframe() is not None:  # pragma: no cover
     lazy_constructors.append(dask_lazy_constructor)  # type: ignore  # noqa: PGH003
 


### PR DESCRIPTION
Test cudf.DataFrame if installed

We can't test it in CI (unless Nvidia sponsors us 😉 ), but we can at least run the tests manually on Kaggle notebooks once every whenever we feel like it, like this: https://www.kaggle.com/code/marcogorelli/testing-cudf-in-narwhals/notebook

Gradually fixing up the failing cuDF tests can then make for good sprint material - we're got a few coming up

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

