### PR TITLE
chore: use compare_dict in series tests

### DIFF
--- a/tests/expr_and_series/gather_every_test.py
+++ b/tests/expr_and_series/gather_every_test.py
@@ -29,4 +29,4 @@ def test_gather_every_series(constructor_eager: Any, n: int, offset: int) -> Non
     result = series.gather_every(n=n, offset=offset)
     expected = data["a"][offset::n]
 
-    assert result.to_list() == expected
+    compare_dicts({"a": result}, {"a": expected})

--- a/tests/expr_and_series/pipe_test.py
+++ b/tests/expr_and_series/pipe_test.py
@@ -17,5 +17,5 @@ def test_pipe_series(
     constructor_eager: Any,
 ) -> None:
     s = nw.from_native(constructor_eager(input_list), eager_only=True)["a"]
-    result = s.pipe(lambda x: x**2).to_list()
-    assert result == expected
+    result = s.pipe(lambda x: x**2)
+    compare_dicts({"a": result}, {"a": expected})

--- a/tests/expr_and_series/pipe_test.py
+++ b/tests/expr_and_series/pipe_test.py
@@ -17,4 +17,5 @@ def test_pipe_series(
     constructor_eager: Any,
 ) -> None:
     s = nw.from_native(constructor_eager(input_list), eager_only=True)["a"]
-    assert s.pipe(lambda x: x**2).to_list() == expected
+    result = s.pipe(lambda x: x**2).to_list()
+    assert result == expected

--- a/tests/expr_and_series/round_test.py
+++ b/tests/expr_and_series/round_test.py
@@ -28,4 +28,4 @@ def test_round_series(constructor_eager: Any, decimals: int) -> None:
     expected_data = {k: [round(e, decimals) for e in v] for k, v in data.items()}
     result_series = df["a"].round(decimals)
 
-    assert result_series.to_list() == expected_data["a"]
+    compare_dicts({"a": result_series}, expected_data)

--- a/tests/expr_and_series/str/replace_test.py
+++ b/tests/expr_and_series/str/replace_test.py
@@ -66,7 +66,7 @@ def test_str_replace_series(
     result_series = df["a"].str.replace(
         pattern=pattern, value=value, n=n, literal=literal
     )
-    assert result_series.to_list() == expected["a"]
+    compare_dicts({"a": result_series}, expected)
 
 
 @pytest.mark.parametrize(
@@ -84,7 +84,7 @@ def test_str_replace_all_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result_series = df["a"].str.replace_all(pattern=pattern, value=value, literal=literal)
-    assert result_series.to_list() == expected["a"]
+    compare_dicts({"a": result_series}, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/expr_and_series/str/slice_test.py
+++ b/tests/expr_and_series/str/slice_test.py
@@ -32,4 +32,4 @@ def test_str_slice_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result_series = df["a"].str.slice(offset, length)
-    assert result_series.to_list() == expected["a"]
+    compare_dicts({"a": result_series.to_list()}, expected)

--- a/tests/expr_and_series/str/slice_test.py
+++ b/tests/expr_and_series/str/slice_test.py
@@ -32,4 +32,4 @@ def test_str_slice_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result_series = df["a"].str.slice(offset, length)
-    compare_dicts({"a": result_series.to_list()}, expected)
+    compare_dicts({"a": result_series}, expected)

--- a/tests/expr_and_series/str/strip_chars_test.py
+++ b/tests/expr_and_series/str/strip_chars_test.py
@@ -36,4 +36,4 @@ def test_str_strip_chars_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result_series = df["a"].str.strip_chars(characters)
-    assert result_series.to_list() == expected["a"]
+    compare_dicts({"a": result_series}, expected)

--- a/tests/expr_and_series/str/tail_test.py
+++ b/tests/expr_and_series/str/tail_test.py
@@ -19,4 +19,4 @@ def test_str_tail_series(constructor_eager: Any) -> None:
     expected = {"a": ["foo", "ars"]}
 
     result_series = df["a"].str.tail(3)
-    assert result_series.to_list() == expected["a"]
+    compare_dicts({"a": result_series}, expected)

--- a/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
+++ b/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
@@ -88,7 +88,7 @@ def test_str_to_uppercase_series(
         request.applymarker(pytest.mark.xfail)
 
     result_series = df["a"].str.to_uppercase()
-    assert result_series.to_numpy().tolist() == expected["a"]
+    compare_dicts({"a": result_series}, expected)
 
 
 @pytest.mark.parametrize(
@@ -139,4 +139,4 @@ def test_str_to_lowercase_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result_series = df["a"].str.to_lowercase()
-    assert result_series.to_numpy().tolist() == expected["a"]
+    compare_dicts({"a": result_series}, expected)

--- a/tests/frame/get_column_test.py
+++ b/tests/frame/get_column_test.py
@@ -4,12 +4,13 @@ import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import compare_dicts
 
 
 def test_get_column(constructor_eager: Any) -> None:
     df = nw.from_native(constructor_eager({"a": [1, 2], "b": [3, 4]}), eager_only=True)
     result = df.get_column("a")
-    assert result.to_list() == [1, 2]
+    compare_dicts({"a": result}, {"a": [1, 2]})
     assert result.name == "a"
     with pytest.raises(
         (KeyError, TypeError), match="Expected str|'int' object cannot be converted|0"
@@ -21,7 +22,7 @@ def test_get_column(constructor_eager: Any) -> None:
 def test_non_string_name() -> None:
     df = pd.DataFrame({0: [1, 2]})
     result = nw.from_native(df, eager_only=True).get_column(0)  # type: ignore[arg-type]
-    assert result.to_list() == [1, 2]
+    compare_dicts({"a": result}, {"a": [1, 2]})
     assert result.name == 0  # type: ignore[comparison-overlap]
     with pytest.raises(TypeError, match="Expected str or slice"):
         # Check that getitem would have raised

--- a/tests/frame/slice_test.py
+++ b/tests/frame/slice_test.py
@@ -20,7 +20,7 @@ data = {
 def test_slice_column(constructor_eager: Any) -> None:
     result = nw.from_native(constructor_eager(data))["a"]
     assert isinstance(result, nw.Series)
-    assert result.to_numpy().tolist() == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    compare_dicts({"a": result}, {"a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
 
 
 def test_slice_rows(constructor_eager: Any) -> None:

--- a/tests/series_only/to_list_test.py
+++ b/tests/series_only/to_list_test.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import compare_dicts
 
 data = [1, 2, 3]
 
@@ -11,4 +12,4 @@ def test_to_list(constructor_eager: Any, request: Any) -> None:
     if "cudf" in str(constructor_eager):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
     s = nw.from_native(constructor_eager({"a": data}), eager_only=True)["a"]
-    assert s.to_list() == [1, 2, 3]
+    compare_dicts({"a": s}, {"a": [1, 2, 3]})

--- a/tests/series_only/to_list_test.py
+++ b/tests/series_only/to_list_test.py
@@ -1,10 +1,14 @@
 from typing import Any
 
+import pytest
+
 import narwhals.stable.v1 as nw
 
 data = [1, 2, 3]
 
 
-def test_to_list(constructor_eager: Any) -> None:
+def test_to_list(constructor_eager: Any, request: Any) -> None:
+    if "cudf" in str(constructor_eager):  # pragma: no cover
+        request.applymarker(pytest.mark.xfail)
     s = nw.from_native(constructor_eager({"a": data}), eager_only=True)["a"]
     assert s.to_list() == [1, 2, 3]

--- a/tests/series_only/zip_with_test.py
+++ b/tests/series_only/zip_with_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import narwhals.stable.v1 as nw
+from tests.utils import compare_dicts
 
 
 def test_zip_with(constructor_eager: Any) -> None:
@@ -14,4 +15,4 @@ def test_zip_with(constructor_eager: Any) -> None:
 
     result = series1.zip_with(mask, series2)
     expected = [1, 4, 2]
-    assert result.to_list() == expected
+    compare_dicts({"a": result}, {"a": expected})


### PR DESCRIPTION
this enables more tests to pass for cudf (which doesn't support tolist? srs?) https://www.kaggle.com/code/marcogorelli/testing-cudf-in-narwhals?scriptVersionId=192865185

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

