### PR TITLE
feat: add `is_in` to `DaskExpr` and mark `is_duplicated` and `is_unique` as not implemented

### DIFF
--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -545,6 +545,22 @@ class DaskExpr:
             returns_scalar=False,
         )
 
+    def is_duplicated(self: Self) -> Self:
+        msg = "`Expr.is_duplicated` is not support since Dask currently has no native duplicated check"
+        raise NotImplementedError(msg)
+
+    def is_unique(self: Self) -> Self:
+        msg = "`Expr.is_duplicated` is not support since Dask currently has no native duplicated check"
+        raise NotImplementedError(msg)
+
+    def is_in(self: Self, other: Any) -> Self:
+        return self._from_call(
+            lambda _input, other: _input.isin(other),
+            "is_in",
+            other,
+            returns_scalar=False,
+        )
+
     def null_count(self: Self) -> Self:
         return self._from_call(
             lambda _input: _input.isna().sum(),

--- a/tests/expr_and_series/is_in_test.py
+++ b/tests/expr_and_series/is_in_test.py
@@ -8,9 +8,7 @@ from tests.utils import compare_dicts
 data = {"a": [1, 4, 2, 5]}
 
 
-def test_expr_is_in(constructor: Any, request: Any) -> None:
-    if "dask" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
+def test_expr_is_in(constructor: Any) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a").is_in([4, 5]))
     expected = {"a": [False, True, False, True]}


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #637

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Main implementation here is `is_in` which is fairly simple (I've just used Dask's own `isis` method, and then removed the `xfail` from the Dask pytest).

I've also marked in `is_duplicated` and `is_unique` as *not implemented*. I think this is the right call because Dask doesn't have any internal `duplicated` check (at least yet! Looks like it could be on the cards soon-ish)

Here's the Github issues/PRs relating to Dask duplication checks:

- https://github.com/dask/dask/issues/1854
- https://github.com/dask/dask/issues/10374
- https://github.com/dask/dask/pull/10542