### PR TITLE
feat: dask expr `is_unique` & `is_duplicated`

### DIFF
--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -546,12 +546,30 @@ class DaskExpr:
         )
 
     def is_duplicated(self: Self) -> Self:
-        msg = "`Expr.is_duplicated` is not support since Dask currently has no native duplicated check"
-        raise NotImplementedError(msg)
+        def func(_input: Any) -> Any:
+            _name = _input.name
+            return (
+                _input.to_frame().groupby(_name).transform("size", meta=(_name, int)) > 1
+            )
+
+        return self._from_call(
+            func,
+            "is_duplicated",
+            returns_scalar=False,
+        )
 
     def is_unique(self: Self) -> Self:
-        msg = "`Expr.is_duplicated` is not support since Dask currently has no native duplicated check"
-        raise NotImplementedError(msg)
+        def func(_input: Any) -> Any:
+            _name = _input.name
+            return (
+                _input.to_frame().groupby(_name).transform("size", meta=(_name, int)) == 1
+            )
+
+        return self._from_call(
+            func,
+            "is_unique",
+            returns_scalar=False,
+        )
 
     def is_in(self: Self, other: Any) -> Self:
         return self._from_call(

--- a/tests/expr_and_series/is_duplicated_test.py
+++ b/tests/expr_and_series/is_duplicated_test.py
@@ -13,8 +13,6 @@ data = {
 
 
 def test_is_duplicated_expr(constructor: Any, request: Any) -> None:
-    if "dask" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
     if "modin" in str(constructor):
         # TODO(unassigned): why is Modin failing here?
         request.applymarker(pytest.mark.xfail)

--- a/tests/expr_and_series/is_unique_test.py
+++ b/tests/expr_and_series/is_unique_test.py
@@ -13,8 +13,6 @@ data = {
 
 
 def test_is_unique_expr(constructor: Any, request: Any) -> None:
-    if "dask" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
     if "modin" in str(constructor):
         # TODO(unassigned): why is Modin failing here?
         request.applymarker(pytest.mark.xfail)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #637 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Edit: I just read @benrutter [comment](https://github.com/narwhals-dev/narwhals/issues/637#issuecomment-2293078216). 

I don't think we should limit ourselves to what comes out of the box. It may not be the most performant operation, but if I had to have a logic such as:
```py
if polars:
    ...
elif dask:
    ...
```
I would probably end up with something similar because that is not natively supported