### PR TITLE
ci: Modified drafter's labeller regex to match titles with uppercase

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,31 +9,31 @@ autolabeler:
   - label: breaking
     title:
       # Example: feat!: ...
-      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)(\(.*\))?\!\: /'
+      - '/^([B|b]uild|[C|c]hore|[CI|ci]|[D|d]epr|[D|d]oc|DOC|[F|f]eat|[F|f]ix|[P|p]erf|[R|r]efactor|[R|r]elease|[T|t]est)\! /'
   - label: build
     title:
-      - '/^build/'
+      - '/^[B|b]uild/'
   - label: internal
     title:
-      - '/^(chore|ci|refactor|test|template|bench)/'
+      - '/^[C|c]hore|[CI|ci]|[R|r]efactor|[T|t]est|[T|t]emplate|[B|b]ench/'
   - label: deprecation
     title:
-      - '/^depr/'
+      - '/^[D|d]epr/'
   - label: documentation
     title:
-      - '/(.*doc|.*docstring)/'
+      - '/^[D|d]oc|DOC/'
   - label: enhancement
     title:
-      - '/^(.*feat|.*enh)/'
+      - '/^.*feat|.*enh|Feat|ENH|Enh/'
   - label: fix
     title:
-      - '/^fix/'
+      - '/^[F|f]ix/'
   - label: performance
     title:
-      - '/^perf/'
+      - '/^[P|p]erf/'
   - label: release
     title:
-      - '/^release/'
+      - '/^[R|r]elease/'
       
 version-resolver:
   major:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues 

- Related issue # 
- Closes #https://github.com/narwhals-dev/narwhals/issues/490

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
I tried "smarter" regex expressions to accept uppercase/lowercase but didn't work on github. Specifically (?i) instead of all the cases I added. 

