### PR TITLE
test: Use compare dicts in is_duplicated_test

### DIFF
--- a/tests/expr_and_series/is_duplicated_test.py
+++ b/tests/expr_and_series/is_duplicated_test.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-import numpy as np
 import pytest
 
 import narwhals.stable.v1 as nw
@@ -28,5 +27,5 @@ def test_is_duplicated_expr(constructor: Any, request: Any) -> None:
 def test_is_duplicated_series(constructor_eager: Any) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)["a"]
     result = series.is_duplicated()
-    expected = np.array([True, True, False])
-    assert (result.to_numpy() == expected).all()
+    expected = {"a": [True, True, False]}
+    compare_dicts({"a": result}, expected)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #804

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
This PR converts tests in `to_string_test` to use `compare_dicts`.
