### PR TITLE
feat: add `DaskExpr.total_minutes`, `total_seconds`, `total_milliseconds`, `total_microseconds`, `total_nanoseconds`

### DIFF
--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -798,6 +798,41 @@ class DaskExprDateTimeNamespace:
             returns_scalar=False,
         )
 
+    def total_minutes(self) -> DaskExpr:
+        return self._expr._from_call(
+            lambda _input: _input.dt.total_seconds() // 60,
+            "total_minutes",
+            returns_scalar=False,
+        )
+
+    def total_seconds(self) -> DaskExpr:
+        return self._expr._from_call(
+            lambda _input: _input.dt.total_seconds() // 1,
+            "total_seconds",
+            returns_scalar=False,
+        )
+
+    def total_milliseconds(self) -> DaskExpr:
+        return self._expr._from_call(
+            lambda _input: _input.dt.total_seconds() * 1000 // 1,
+            "total_milliseconds",
+            returns_scalar=False,
+        )
+
+    def total_microseconds(self) -> DaskExpr:
+        return self._expr._from_call(
+            lambda _input: _input.dt.total_seconds() * 1_000_000 // 1,
+            "total_microseconds",
+            returns_scalar=False,
+        )
+
+    def total_nanoseconds(self) -> DaskExpr:
+        return self._expr._from_call(
+            lambda _input: _input.dt.total_seconds() * 1_000_000_000 // 1,
+            "total_nanoseconds",
+            returns_scalar=False,
+        )
+
 
 class DaskExprNameNamespace:
     def __init__(self: Self, expr: DaskExpr) -> None:

--- a/tests/expr_and_series/dt/datetime_duration_test.py
+++ b/tests/expr_and_series/dt/datetime_duration_test.py
@@ -44,9 +44,7 @@ def test_duration_attributes(
     expected_b: list[int],
     expected_c: list[int],
 ) -> None:
-    if "dask_lazy" in str(constructor) or (
-        parse_version(pd.__version__) < (2, 2) and "pandas_pyarrow" in str(constructor)
-    ):
+    if parse_version(pd.__version__) < (2, 2) and "pandas_pyarrow" in str(constructor):
         request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor(data))


### PR DESCRIPTION

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #637
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

It uses a little trick, `//1`, to obtain an integer, but I’m unsure if this approach is appreciated. Without it, some tests will fail, while others may not.
