### PR TITLE
dask-quantile-draft

### DIFF
--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -4,6 +4,7 @@ from copy import copy
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
+from typing import Literal
 from typing import NoReturn
 
 from narwhals._dask.utils import add_row_index
@@ -514,6 +515,22 @@ class DaskExpr:
             "len",
             returns_scalar=True,
         )
+
+    def quantile(
+        self: Self,
+        quantile: float,
+        interpolation: Literal["nearest", "higher", "lower", "midpoint", "linear"],
+    ) -> Self:
+        if interpolation == "nearest":
+            return self._from_call(
+                lambda _input, quantile: _input.quantile(q=quantile, method="dask"),
+                "quantile",
+                quantile,
+                returns_scalar=True,
+            )
+        else:
+            msg = "`higher`, `lower`, `midpoint`, `linear` - interpolation methods are not supported by Dask. Please use `nearest` instead."
+            raise NotImplementedError(msg)
 
     def is_first_distinct(self: Self) -> Self:
         def func(_input: Any) -> Any:


### PR DESCRIPTION
Hello, that's my attempt at solving Dask `Expr.quantile`- the method works as expected (according to my own tests). However I've been trying to find a way to include dask-case in our tests, since dask can work only with interpolation="nearest" and not the other ones.
What I tried: 
- adding is_dask param to the parameters in tests and running the tests using nullcontext, but compare dict doesn't want to cooperate with error messages,
- writing separate test for dask cases and using `if "dask" in str(contructor)` to call that test but also failed here 
I was thinking about including every single constructor type in the parameters, but that seems a bit too verbose and the number of possible combinations is humongous.
At the moment I'm exploring other options, but feel free to 🛟 *send help* 🛟 if you know how to approach it

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

