### PR TITLE
feat: dask namespace `concat` method 

### DIFF
--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -156,7 +156,7 @@ class DaskNamespace:
                 tuple(i.columns) == tuple(native_frames[0].columns) for i in native_frames
             ):
                 msg = "unable to vstack with non-matching columns"
-                raise TypeError(msg)
+                raise AssertionError(msg)
             axis = 0
             join = "inner"
         elif how == "horizontal":

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -169,7 +169,7 @@ class DaskNamespace:
                     f"Columns with name(s): {', '.join(duplicates)} "
                     "have more than one occurrence"
                 )
-                raise TypeError(msg)
+                raise AssertionError(msg)
             axis = 1
             join = "outer"
         else:

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -18,7 +18,6 @@ from narwhals._expression_parsing import parse_into_exprs
 if TYPE_CHECKING:
     import dask_expr
 
-    from narwhals._dask.dataframe import DaskLazyFrame
     from narwhals._dask.typing import IntoDaskExpr
 
 
@@ -153,7 +152,7 @@ class DaskNamespace:
         import dask.dataframe as dd  # ignore-banned-import
 
         if len(list(items)) == 0:
-            msg = "No items to concatenate"
+            msg = "No items to concatenate"  # pragma: no cover
             raise AssertionError(msg)
         native_frames = [i._native_frame for i in items]
         if how == "vertical":

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -147,7 +147,7 @@ class DaskNamespace:
 
         if len(list(items)) == 0:
             msg = "No items to concatenate"
-            raise ValueError(msg)
+            raise AssertionError(msg)
         native_frames = [i._native_frame for i in items]
         axis: int
         join: str

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -160,7 +160,7 @@ class DaskNamespace:
             axis = 0
             join = "inner"
         elif how == "horizontal":
-            all_column_names: list[str] = list(chain(*[i.columns for i in native_frames]))
+            all_column_names: list[str] = [column for frame in native_frames for column in frame.columns]
             if len(all_column_names) != len(set(all_column_names)):
                 duplicates = [
                     i for i in all_column_names if all_column_names.count(i) > 1

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from functools import reduce
-from itertools import chain
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -160,7 +159,9 @@ class DaskNamespace:
             axis = 0
             join = "inner"
         elif how == "horizontal":
-            all_column_names: list[str] = [column for frame in native_frames for column in frame.columns]
+            all_column_names: list[str] = [
+                column for frame in native_frames for column in frame.columns
+            ]
             if len(all_column_names) != len(set(all_column_names)):
                 duplicates = [
                     i for i in all_column_names if all_column_names.count(i) > 1

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -154,7 +154,7 @@ class DaskNamespace:
         if how == "vertical":
             if not all(
                 tuple(i.columns) == tuple(native_frames[0].columns) for i in native_frames
-            ):
+            ):  # pragma: no cover
                 msg = "unable to vstack with non-matching columns"
                 raise AssertionError(msg)
             axis = 0

--- a/tests/frame/concat_test.py
+++ b/tests/frame/concat_test.py
@@ -6,9 +6,7 @@ import narwhals.stable.v1 as nw
 from tests.utils import compare_dicts
 
 
-def test_concat_horizontal(constructor: Any, request: Any) -> None:
-    if "dask" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
+def test_concat_horizontal(constructor: Any) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df_left = nw.from_native(constructor(data))
 
@@ -29,9 +27,7 @@ def test_concat_horizontal(constructor: Any, request: Any) -> None:
         nw.concat([])
 
 
-def test_concat_vertical(constructor: Any, request: Any) -> None:
-    if "dask" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
+def test_concat_vertical(constructor: Any) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df_left = (
         nw.from_native(constructor(data)).rename({"a": "c", "b": "d"}).drop("z").lazy()


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #637

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.

I've added in a `concat` method returning a `DaskLazyFrame`. One thing that *wasn't* tested for the `concat_test` was whether an error gets thrown trying to horizontally concat frames of different length. I'm not 100% sure what happens within polars/pandas when you do this, but dask will throw a confusing assertion error when you try to access anything within the dataframe, so I thought putting in a handy check here was worthwhile.
