### PR TITLE
test: remove `to_numpy` and `to_list` in tests

### DIFF
--- a/tests/expr_and_series/dt/to_string_test.py
+++ b/tests/expr_and_series/dt/to_string_test.py
@@ -105,16 +105,16 @@ def test_dt_to_string_iso_local_datetime_series(
     result = (
         nw.from_native(df, eager_only=True)["a"]
         .dt.to_string("%Y-%m-%dT%H:%M:%S.%f")
-        .to_list()[0]
+        .item(0)
     )
-    assert _clean_string(result) == _clean_string(expected)
+    assert _clean_string(str(result)) == _clean_string(expected)
 
     result = (
         nw.from_native(df, eager_only=True)["a"]
         .dt.to_string("%Y-%m-%dT%H:%M:%S%.f")
-        .to_list()[0]
+        .item(0)
     )
-    assert _clean_string(result) == _clean_string(expected)
+    assert _clean_string(str(result)) == _clean_string(expected)
 
 
 @pytest.mark.parametrize(
@@ -156,10 +156,8 @@ def test_dt_to_string_iso_local_date_series(
     constructor_eager: Any, data: datetime, expected: str
 ) -> None:
     df = constructor_eager({"a": [data]})
-    result = (
-        nw.from_native(df, eager_only=True)["a"].dt.to_string("%Y-%m-%d").to_list()[0]
-    )
-    assert result == expected
+    result = nw.from_native(df, eager_only=True)["a"].dt.to_string("%Y-%m-%d").item(0)
+    assert str(result) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/frame/slice_test.py
+++ b/tests/frame/slice_test.py
@@ -5,10 +5,8 @@ import pandas as pd
 import polars as pl
 import pyarrow as pa
 import pytest
-from pandas.testing import assert_series_equal
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import compare_dicts
 
 data = {
@@ -83,21 +81,14 @@ def test_gather_pandas_index() -> None:
 def test_gather_rows_cols(constructor_eager: Any) -> None:
     native_df = constructor_eager(data)
     df = nw.from_native(native_df, eager_only=True)
-    is_pandas_wo_pyarrow = parse_version(pd.__version__) < parse_version("1.0.0")
-    if isinstance(native_df, pa.Table) or is_pandas_wo_pyarrow:
-        # PyArrowSeries do not have `to_pandas`
-        result = df[[0, 3, 1], 1].to_numpy()
-        expected = np.array([11, 14, 12])
-        assert np.array_equal(result, expected)
-        result = df[np.array([0, 3, 1]), "b"].to_numpy()
-        assert np.array_equal(result, expected)
-    else:
-        result = df[[0, 3, 1], 1].to_pandas()
-        expected_index = range(3) if isinstance(native_df, pl.DataFrame) else [0, 3, 1]
-        expected = pd.Series([11, 14, 12], name="b", index=expected_index)
-        assert_series_equal(result, expected, check_dtype=False)
-        result = df[np.array([0, 3, 1]), "b"].to_pandas()
-        assert_series_equal(result, expected, check_dtype=False)
+
+    expected = {"b": [11, 14, 12]}
+
+    result = {"b": df[[0, 3, 1], 1]}
+    compare_dicts(result, expected)
+
+    result = {"b": df[np.array([0, 3, 1]), "b"]}
+    compare_dicts(result, expected)
 
 
 def test_slice_both_tuples_of_ints(constructor_eager: Any) -> None:

--- a/tests/series_only/to_list_test.py
+++ b/tests/series_only/to_list_test.py
@@ -12,4 +12,4 @@ def test_to_list(constructor_eager: Any, request: Any) -> None:
     if "cudf" in str(constructor_eager):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
     s = nw.from_native(constructor_eager({"a": data}), eager_only=True)["a"]
-    compare_dicts({"a": s}, {"a": [1, 2, 3]})
+    compare_dicts({"a": s.to_list()}, {"a": [1, 2, 3]})


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Closes #804 

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Tiny trick for pyarrow using `str(value)` 