### PR TITLE
ci: Correct labeller regex

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,31 +9,31 @@ autolabeler:
   - label: breaking
     title:
       # Example: feat!: ...
-      - '/^([B|b]uild|[C|c]hore|[CI|ci]|[D|d]epr|[D|d]oc|DOC|[F|f]eat|[F|f]ix|[P|p]erf|[R|r]efactor|[R|r]elease|[T|t]est)\! /'
+      - '/^([Bb]uild|[Cc]hore|CI|ci|[Dd]epr|[Dd]oc|DOC|[Ff]eat|[Ff]ix|[Pp]erf|[Rr]efactor|[Rr]elease|[Tt]est)\! /'
   - label: build
     title:
-      - '/^([B|b]uild)/'
+      - '/^([Bb]uild)/'
   - label: internal
     title:
       - '/^(chore|ci|refactor|test|template|bench|Chore|CI|Refactor|Test|Template|Bench)'
   - label: deprecation
     title:
-      - '/^([D|d]epr)/'
+      - '/^([Dd]epr)/'
   - label: documentation
     title:
-      - '/^([D|d]oc|DOC)/'
+      - '/^([Dd]oc|DOC)/'
   - label: enhancement
     title:
       - '/^(feat|enh|Feat|ENH|Enh)/'
   - label: fix
     title:
-      - '/^([F|f]ix)/'
+      - '/^([Ff]ix)/'
   - label: performance
     title:
-      - '/^([P|p]erf)/'
+      - '/^([Pp]erf)/'
   - label: release
     title:
-      - '/^([R|r]elease)/'
+      - '/^([Rr]elease)/'
       
 version-resolver:
   major:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,7 +15,7 @@ autolabeler:
       - '/^([Bb]uild)/'
   - label: internal
     title:
-      - '/^(chore|ci|refactor|test|template|bench|Chore|CI|Refactor|Test|Template|Bench)'
+      - '/^(chore|ci|refactor|test|template|bench|Chore|CI|Refactor|Test|Template|Bench)/'
   - label: deprecation
     title:
       - '/^([Dd]epr)/'


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
It seems that the labeller is still having "issues". This PR was not labeled: https://github.com/narwhals-dev/narwhals/pull/850
The `|` inside the square brackets are not needed but should not cause a problem. 
If this doesn't fix it, maybe I should go back to the original setting of the release-drafter. Regex seems to work differently than locally. (What a surprise 🤓).
