### PR TITLE
feat: make DataFrame.select stricter: non-string columns can only be selected using `nw.col`

### DIFF
--- a/docs/other/column_names.md
+++ b/docs/other/column_names.md
@@ -16,7 +16,7 @@ create one with _two_ such columns!
 What does Narwhals do about this?
 
 - In general, non-string column names are supported. In some places where this might
-  create ambiguity (such as `DataFrame.__getitem__`) we may be strict and only
+  create ambiguity (such as `DataFrame.__getitem__` or `DataFrame.select`) we may be strict and only
   allow passing in column names if they're strings.
 - If you have a use-case that's
   failing for non-string column names, please report it to [https://github.com/narwhals-dev/narwhals/issues](https://github.com/narwhals-dev/narwhals/issues)

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -2493,11 +2493,15 @@ class LazyFrame(BaseFrame[FrameT]):
 
         Arguments:
             *exprs: Column(s) to select, specified as positional arguments.
-                     Accepts expression input. Strings are parsed as column names,
-                     other non-expression inputs are parsed as literals.
-
+                Accepts expression input. Strings are parsed as column names.
             **named_exprs: Additional columns to select, specified as keyword arguments.
-                            The columns will be renamed to the keyword used.
+                The columns will be renamed to the keyword used.
+
+        Notes:
+            If you'd like to select a column whose name isn't a string (for example,
+            if you're working with pandas) then you should explicitly use `nw.col` instead
+            of just passing the column name. For example, to select a column named
+            `0` use `df.select(nw.col(0))`, not `df.select(0)`.
 
         Examples:
             >>> import pandas as pd

--- a/tests/frame/select_test.py
+++ b/tests/frame/select_test.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pandas as pd
+import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import compare_dicts
@@ -21,5 +22,12 @@ def test_empty_select(constructor: Any) -> None:
 
 def test_non_string_select() -> None:
     df = nw.from_native(pd.DataFrame({0: [1, 2], "b": [3, 4]}))
-    result = nw.to_native(df.select(0))  # type: ignore[arg-type]
-    pd.testing.assert_frame_equal(result, pd.Series([1, 2], name=0).to_frame())
+    result = nw.to_native(df.select(nw.col(0)))  # type: ignore[arg-type]
+    expected = pd.Series([1, 2], name=0).to_frame()
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_non_string_select_invalid() -> None:
+    df = nw.from_native(pd.DataFrame({0: [1, 2], "b": [3, 4]}))
+    with pytest.raises(TypeError, match="\n\nHint: if you were trying to select"):
+        nw.to_native(df.select(0))  # type: ignore[arg-type]


### PR DESCRIPTION
Quickly reverting https://github.com/narwhals-dev/narwhals/pull/828 before anyone uses it 🙈 

Parsing non-strings as expressions creates other problems, which I noticed while reviewing the when-then-otherwise PR

If people want to select columns which might not be strings, then can use `nw.col` and be explicit 😇 

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

