### PR TITLE
patch: Fix incosistent between tying and comments in 'from_native' when 'strict=True'

### DIFF
--- a/narwhals/stable/v1.py
+++ b/narwhals/stable/v1.py
@@ -600,7 +600,7 @@ def from_native(
     eager_only: None = ...,
     eager_or_interchange_only: Literal[True],
     series_only: None = ...,
-    allow_series: None = ...,
+    allow_series: Literal[True] = ...,
 ) -> DataFrame[IntoDataFrameT]:
     """
     from_native(df, strict=True, eager_or_interchange_only=True, allow_series=True)
@@ -616,7 +616,7 @@ def from_native(
     eager_only: Literal[True],
     eager_or_interchange_only: None = ...,
     series_only: None = ...,
-    allow_series: None = ...,
+    allow_series: Literal[True] = ...,
 ) -> DataFrame[IntoDataFrameT]:
     """
     from_native(df, strict=True, eager_only=True, allow_series=True)
@@ -629,10 +629,10 @@ def from_native(
     native_dataframe: Any,
     *,
     strict: Literal[True] = ...,
-    eager_only: None = ...,
+    eager_only: Literal[True] = ...,
     eager_or_interchange_only: None = ...,
     series_only: None = ...,
-    allow_series: Literal[True],
+    allow_series: None = ...,
 ) -> DataFrame[Any] | LazyFrame[Any] | Series:
     """
     from_native(df, strict=True, eager_only=True)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #833 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

I believe this branch should be merged from my personal repository into our development repository. This is a careless mistake which I push locally wrong to our dev. Sorry for mass up, if need, I would like to deleted the current and reopen one.