### PR TITLE
chore: run mypy only on `narwhals/` and `tests/`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   hooks:
     - id: mypy
       additional_dependencies: ['polars==1.4.1', 'pytest==8.3.2']
-      exclude: utils|tpch
+      files: ^(narwhals|tests)/
 - repo: https://github.com/codespell-project/codespell
   rev: 'v2.3.0'
   hooks:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,15 +15,15 @@ def test_maybe_align_index_pandas() -> None:
     result = nw.maybe_align_index(df, s)
     expected = pd.DataFrame({"a": [2, 1, 3]}, index=[2, 1, 0])
     assert_frame_equal(nw.to_native(result), expected)
-    result = nw.maybe_align_index(s, df)
-    expected = pd.Series([2, 1, 3], index=[1, 2, 0])
-    assert_series_equal(nw.to_native(result), expected)
-    result = nw.maybe_align_index(s, s.sort(descending=True))
-    expected = pd.Series([3, 2, 1], index=[0, 1, 2])
-    assert_series_equal(nw.to_native(result), expected)
     result = nw.maybe_align_index(df, df.sort("a", descending=True))
     expected = pd.DataFrame({"a": [3, 2, 1]}, index=[0, 2, 1])
     assert_frame_equal(nw.to_native(result), expected)
+    result_s = nw.maybe_align_index(s, df)
+    expected_s = pd.Series([2, 1, 3], index=[1, 2, 0])
+    assert_series_equal(nw.to_native(result_s), expected_s)
+    result_s = nw.maybe_align_index(s, s.sort(descending=True))
+    expected_s = pd.Series([3, 2, 1], index=[0, 1, 2])
+    assert_series_equal(nw.to_native(result_s), expected_s)
 
 
 def test_with_columns_sort() -> None:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

the previous regex seems to ignore anything that has `utils` in the path name (e.g. test_utils.py) 👀
