### PR TITLE
fix: use nw.Unknown for unknown dtypes

### DIFF
--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -51,7 +51,7 @@ def translate_dtype(dtype: Any) -> dtypes.DType:
         return dtypes.Duration()
     if pa.types.is_dictionary(dtype):
         return dtypes.Categorical()
-    raise AssertionError
+    return dtypes.Unknown()
 
 
 def narwhals_to_native_dtype(dtype: dtypes.DType | type[dtypes.DType]) -> Any:

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -51,7 +51,7 @@ def translate_dtype(dtype: Any) -> dtypes.DType:
         return dtypes.Duration()
     if pa.types.is_dictionary(dtype):
         return dtypes.Categorical()
-    return dtypes.Unknown()
+    return dtypes.Unknown()  # pragma: no cover
 
 
 def narwhals_to_native_dtype(dtype: dtypes.DType | type[dtypes.DType]) -> Any:

--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -42,7 +42,7 @@ def map_duckdb_dtype_to_narwhals_dtype(
         return dtypes.Boolean()
     if duckdb_dtype == "INTERVAL":
         return dtypes.Duration()
-    return dtypes.Unknown()  # pragma: no cover
+    return dtypes.Unknown()
 
 
 class DuckDBInterchangeFrame:

--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -42,12 +42,7 @@ def map_duckdb_dtype_to_narwhals_dtype(
         return dtypes.Boolean()
     if duckdb_dtype == "INTERVAL":
         return dtypes.Duration()
-    msg = (  # pragma: no cover
-        f"Invalid dtype, got: {duckdb_dtype}.\n\n"
-        "If you believe this dtype should be supported in Narwhals, "
-        "please report an issue at https://github.com/narwhals-dev/narwhals."
-    )
-    raise AssertionError(msg)
+    return dtypes.Unknown()  # pragma: no cover
 
 
 class DuckDBInterchangeFrame:

--- a/narwhals/_ibis/dataframe.py
+++ b/narwhals/_ibis/dataframe.py
@@ -40,12 +40,7 @@ def map_ibis_dtype_to_narwhals_dtype(
         return dtypes.Date()
     if ibis_dtype.is_timestamp():
         return dtypes.Datetime()
-    msg = (  # pragma: no cover
-        f"Invalid dtype, got: {ibis_dtype}.\n\n"
-        "If you believe this dtype should be supported in Narwhals, "
-        "please report an issue at https://github.com/narwhals-dev/narwhals."
-    )
-    raise AssertionError(msg)
+    return dtypes.Unknown()  # pragma: no cover
 
 
 class IbisInterchangeFrame:

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from datetime import timedelta
 
 import duckdb
+import pandas as pd
 import polars as pl
 import pytest
 
@@ -211,3 +212,10 @@ def test_get_level() -> None:
         nw.get_level(nw.from_native(df.__dataframe__(), eager_or_interchange_only=True))
         == "interchange"
     )
+
+
+def test_unknown_dtype() -> None:
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    rel = duckdb.from_df(df).select("cast(a as int128) as a")
+    result = nw.from_native(rel).schema
+    assert result == {"a": nw.Unknown}


### PR DESCRIPTION
Rather than raise an error, we should just use `nw.Unknown`, like we do for the pandas backend. Then at least inspecting `.schema` won't crash. This is useful because you might want to just select, say, all string columns, and not care that there exists some unrecognised type
having said that, we could and should expand which dtypes we recognise

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

