### PR TITLE
test: xfail `dt.date` tests for cuDF

### DIFF
--- a/tests/expr_and_series/dt/datetime_attributes_test.py
+++ b/tests/expr_and_series/dt/datetime_attributes_test.py
@@ -42,6 +42,8 @@ def test_datetime_attributes(
         and "pyarrow" not in str(constructor)
     ):
         request.applymarker(pytest.mark.xfail)
+    if attribute == "date" and "cudf" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor(data))
     result = df.select(getattr(nw.col("a").dt, attribute)())
@@ -73,6 +75,8 @@ def test_datetime_attributes_series(
         and "pyarrow" not in str(constructor_eager)
     ):
         request.applymarker(pytest.mark.xfail)
+    if attribute == "date" and "cudf" in str(constructor_eager):
+        request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(getattr(df["a"].dt, attribute)())
@@ -81,6 +85,8 @@ def test_datetime_attributes_series(
 
 def test_datetime_chained_attributes(request: Any, constructor_eager: Any) -> None:
     if "pandas" in str(constructor_eager) and "pyarrow" not in str(constructor_eager):
+        request.applymarker(pytest.mark.xfail)
+    if "cudf" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor_eager(data), eager_only=True)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # https://github.com/narwhals-dev/narwhals/issues/862
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

 xfail tests that use `dt.date` for cuDF as `dt.date` is not implemented
