### PR TITLE
doc: update drop_nulls for series documentation

### DIFF
--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -783,12 +783,9 @@ class Series:
         """
         Drop all null values.
 
-        See Also:
-          drop_nans
-
         Notes:
-          A null value is not the same as a NaN value.
-          To drop NaN values, use :func:`drop_nans`.
+          pandas and Polars handle null values differently. Polars distinguishes
+          between NaN and Null, whereas pandas doesn't.
 
         Examples:
           >>> import pandas as pd


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

It looks like `drop_nans` isn't implemented. 
Was also thinking to update to use an example similar to https://narwhals-dev.github.io/narwhals/api-reference/expr/#narwhals.Expr.drop_nulls so it's easy to see the difference between Polars and pandas with `float("nan")`. What do you think @MarcoGorelli? Also, I'm curious - if `drop_nans` was to be implemented, would the expectation be that it would do the same as `drop_nulls` for pandas-like series?

