### PR TITLE
fix: Update `copy` param on `to_numpy` to default to `True` for cuDF

### DIFF
--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -590,8 +590,8 @@ class PandasLikeDataFrame:
         from narwhals._pandas_like.series import PANDAS_TO_NUMPY_DTYPE_MISSING
 
         if copy is None:
-            # pandas default differs from Polars
-            copy = False
+            # pandas default differs from Polars, but cuDF default is True
+            copy = self._implementation is Implementation.CUDF
 
         if dtype is not None:
             return self._native_frame.to_numpy(dtype=dtype, copy=copy)

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -473,7 +473,7 @@ class PandasLikeSeries:
     def to_numpy(self, dtype: Any = None, copy: bool | None = None) -> Any:
         # the default is meant to be None, but pandas doesn't allow it?
         # https://numpy.org/doc/stable/reference/generated/numpy.ndarray.__array__.html
-        copy = copy or False
+        copy = copy or self._implementation is Implementation.CUDF
 
         has_missing = self._native_series.isna().any()
         if (


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue [#862](https://github.com/narwhals-dev/narwhals/issues/862)
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

This PR fixes issue seen in tests:
` ValueError: copy=False is not supported because conversion to a numpy array always copies the data.`

And reduces the number of failing tests by 7.

@MarcoGorelli the cuDF docs show `copy` defaults to `True` on cuDF. So I think that it should set `copy=True` here when it's `None` for cuDF. What do you think - Is that the right approach?

https://docs.rapids.ai/api/cudf/stable/user_guide/api_docs/api/cudf.series.to_numpy/
https://docs.rapids.ai/api/cudf/stable/user_guide/api_docs/api/cudf.dataframe.to_numpy/
