### PR TITLE
test: xfail cuDF tests that use `total_seconds`

### DIFF
--- a/tests/expr_and_series/dt/datetime_duration_test.py
+++ b/tests/expr_and_series/dt/datetime_duration_test.py
@@ -46,6 +46,8 @@ def test_duration_attributes(
 ) -> None:
     if parse_version(pd.__version__) < (2, 2) and "pandas_pyarrow" in str(constructor):
         request.applymarker(pytest.mark.xfail)
+    if "cudf" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor(data))
 
@@ -80,6 +82,8 @@ def test_duration_attributes_series(
     if parse_version(pd.__version__) < (2, 2) and "pandas_pyarrow" in str(
         constructor_eager
     ):
+        request.applymarker(pytest.mark.xfail)
+    if "cudf" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor_eager(data), eager_only=True)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #  https://github.com/narwhals-dev/narwhals/issues/862
- Closes # 

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

There are ten tests here currently failing because it looks like `TimedeltaProperties` in cuDF doesn't have a `total_seconds` and all these tests depend on it.

https://github.com/rapidsai/cudf/blob/branch-24.10/docs/cudf/source/user_guide/api_docs/series.rst#timedelta-properties
docs start here: https://docs.rapids.ai/api/cudf/stable/user_guide/api_docs/api/cudf.core.series.timedeltaproperties.days/ 

```
FAILED tests/expr_and_series/dt/datetime_duration_test.py::test_duration_attributes[cudf_constructor-total_minutes-expected_a0-expected_b0-expected_c0] - AttributeError: 'TimedeltaProperties' object has no attribute 'total_seconds'
FAILED tests/expr_and_series/dt/datetime_duration_test.py::test_duration_attributes[cudf_constructor-total_seconds-expected_a1-expected_b1-expected_c1] - AttributeError: 'TimedeltaProperties' object has no attribute 'total_seconds'
FAILED tests/expr_and_series/dt/datetime_duration_test.py::test_duration_attributes[cudf_constructor-total_milliseconds-expected_a2-expected_b2-expected_c2] - AttributeError: 'TimedeltaProperties' object has no attribute 'total_seconds'
FAILED tests/expr_and_series/dt/datetime_duration_test.py::test_duration_attributes[cudf_constructor-total_microseconds-expected_a3-expected_b3-expected_c3] - AttributeError: 'TimedeltaProperties' object has no attribute 'total_seconds'
FAILED tests/expr_and_series/dt/datetime_duration_test.py::test_duration_attributes[cudf_constructor-total_nanoseconds-expected_a4-expected_b4-expected_c4] - AttributeError: 'TimedeltaProperties' object has no attribute 'total_seconds'
FAILED tests/expr_and_series/dt/datetime_duration_test.py::test_duration_attributes_series[cudf_constructor-total_minutes-expected_a0-expected_b0-expected_c0] - AttributeError: 'TimedeltaProperties' object has no attribute 'total_seconds'
FAILED tests/expr_and_series/dt/datetime_duration_test.py::test_duration_attributes_series[cudf_constructor-total_seconds-expected_a1-expected_b1-expected_c1] - AttributeError: 'TimedeltaProperties' object has no attribute 'total_seconds'
FAILED tests/expr_and_series/dt/datetime_duration_test.py::test_duration_attributes_series[cudf_constructor-total_milliseconds-expected_a2-expected_b2-expected_c2] - AttributeError: 'TimedeltaProperties' object has no attribute 'total_seconds'
FAILED tests/expr_and_series/dt/datetime_duration_test.py::test_duration_attributes_series[cudf_constructor-total_microseconds-expected_a3-expected_b3-expected_c3] - AttributeError: 'TimedeltaProperties' object has no attribute 'total_seconds'
FAILED tests/expr_and_series/dt/datetime_duration_test.py::test_duration_attributes_series[cudf_constructor-total_nanoseconds-expected_a4-expected_b4-expected_c4] - AttributeError: 'TimedeltaProperties' object has no attribute 'total_seconds'
```

@MarcoGorelli do you think it would be a good idea to document these and any others that aren't currently supported. I was thinking that it might be helpful, but also that it may be hard to keep this info up to date. Though, I suppose when running the tests, it would be easy enough to see if any of these pass in the future.