### PR TITLE
docs: update docstring to fix rendering in generated docs

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -3851,34 +3851,35 @@ class LazyFrame(BaseFrame[FrameT]):
         r"""
         Create a copy of this DataFrame.
 
-        >>> import narwhals as nw
-        >>> import pandas as pd
-        >>> import polars as pl
-        >>> data = {"a": [1, 2], "b": [3, 4]}
-        >>> df_pd = pd.DataFrame(data)
-        >>> df_pl = pl.LazyFrame(data)
+        Examples:
+            >>> import narwhals as nw
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> data = {"a": [1, 2], "b": [3, 4]}
+            >>> df_pd = pd.DataFrame(data)
+            >>> df_pl = pl.LazyFrame(data)
 
-        Let's define a dataframe-agnostic function in which we copy the DataFrame:
+            Let's define a dataframe-agnostic function in which we copy the DataFrame:
 
-        >>> @nw.narwhalify
-        ... def func(df):
-        ...     return df.clone()
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     return df.clone()
 
-        >>> func(df_pd)
-           a  b
-        0  1  3
-        1  2  4
+            >>> func(df_pd)
+            a  b
+            0  1  3
+            1  2  4
 
-        >>> func(df_pl).collect()
-        shape: (2, 2)
-        ┌─────┬─────┐
-        │ a   ┆ b   │
-        │ --- ┆ --- │
-        │ i64 ┆ i64 │
-        ╞═════╪═════╡
-        │ 1   ┆ 3   │
-        │ 2   ┆ 4   │
-        └─────┴─────┘
+            >>> func(df_pl).collect()
+            shape: (2, 2)
+            ┌─────┬─────┐
+            │ a   ┆ b   │
+            │ --- ┆ --- │
+            │ i64 ┆ i64 │
+            ╞═════╪═════╡
+            │ 1   ┆ 3   │
+            │ 2   ┆ 4   │
+            └─────┴─────┘
         """
         return super().clone()
 


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

https://narwhals-dev.github.io/narwhals/api-reference/lazyframe/#narwhals.dataframe.LazyFrame.clone is currently rendering incorrectly.

It looks like it needs to be indented to get it rendering like the other methods. Renders like this now

<img width="996" alt="image" src="https://github.com/user-attachments/assets/1156dce5-f4de-4222-923e-545bca74b330">

