### PR TITLE
Bug: fix an issue with string keys in left and semi joins in Dask, add Dask to tpch benchmarks

### DIFF
--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -280,6 +280,9 @@ class DaskLazyFrame:
                 suffixes=("", suffix),
             )
             extra = []
+            if isinstance(left_on, str) and isinstance(right_on, str):
+                left_on = [left_on]
+                right_on = [right_on]
             for left_key, right_key in zip(left_on, right_on):  # type: ignore[arg-type]
                 if right_key != left_key and right_key not in self.columns:
                     extra.append(right_key)

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -504,6 +504,13 @@ class DaskExpr:
             returns_scalar=True,
         )
 
+    def unique(self: Self) -> Self:
+        return self._from_call(
+            lambda _input: _input.unique(),
+            "unique",
+            returns_scalar=False,
+        )
+
     def is_null(self: Self) -> Self:
         return self._from_call(
             lambda _input: _input.isna(),

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -431,6 +431,11 @@ class DaskExpr:
             returns_scalar=False,
         )
 
+    def unique(self) -> NoReturn:
+        # We can't (yet?) allow methods which modify the index
+        msg = "`Expr.unique` is not supported for the Dask backend. Please use `LazyFrame.unique` instead."
+        raise NotImplementedError(msg)
+
     def drop_nulls(self) -> NoReturn:
         # We can't (yet?) allow methods which modify the index
         msg = "`Expr.drop_nulls` is not supported for the Dask backend. Please use `LazyFrame.drop_nulls` instead."
@@ -502,13 +507,6 @@ class DaskExpr:
             lambda _input: _input.nunique(dropna=False),
             "n_unique",
             returns_scalar=True,
-        )
-
-    def unique(self: Self) -> Self:
-        return self._from_call(
-            lambda _input: _input.unique(),
-            "unique",
-            returns_scalar=False,
         )
 
     def is_null(self: Self) -> Self:

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -170,6 +170,11 @@ def test_anti_join(
     ("join_key", "filter_expr", "expected"),
     [
         (
+            "antananarivo",
+            (nw.col("bob") > 5),
+            {"antananarivo": [2], "bob": [6], "zorro": [9]},
+        ),
+        (
             ["antananarivo"],
             (nw.col("bob") > 5),
             {"antananarivo": [2], "bob": [6], "zorro": [9]},

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -227,10 +227,14 @@ def test_left_join(constructor: Any) -> None:
         "bob": [4.0, 5, 6],
         "index": [0.0, 1.0, 2.0],
     }
-    data_right = {"antananarivo": [1.0, 2, 3], "c": [4.0, 5, 7], "index": [0.0, 1.0, 2.0]}
+    data_right = {
+        "antananarivo": [1.0, 2, 3],
+        "co": [4.0, 5, 7],
+        "index": [0.0, 1.0, 2.0],
+    }
     df_left = nw.from_native(constructor(data_left))
     df_right = nw.from_native(constructor(data_right))
-    result = df_left.join(df_right, left_on="bob", right_on="c", how="left").select(  # type: ignore[arg-type]
+    result = df_left.join(df_right, left_on="bob", right_on="co", how="left").select(  # type: ignore[arg-type]
         nw.all().fill_null(float("nan"))
     )
     result = result.sort("index")
@@ -241,7 +245,20 @@ def test_left_join(constructor: Any) -> None:
         "antananarivo_right": [1, 2, float("nan")],
         "index": [0, 1, 2],
     }
+    result_on_list = df_left.join(
+        df_right,  # type: ignore[arg-type]
+        on=["antananarivo", "index"],
+        how="left",
+    ).select(nw.all().fill_null(float("nan")))
+    result_on_list = result_on_list.sort("index")
+    expected_on_list = {
+        "antananarivo": [1, 2, 3],
+        "bob": [4, 5, 6],
+        "index": [0, 1, 2],
+        "co": [4, 5, 7],
+    }
     compare_dicts(result, expected)
+    compare_dicts(result_on_list, expected_on_list)
 
 
 @pytest.mark.filterwarnings("ignore: the default coalesce behavior")

--- a/tpch/execute/q10.py
+++ b/tpch/execute/q10.py
@@ -17,3 +17,7 @@ print(q10.query(fn(customer), fn(nation), fn(lineitem), fn(orders)).collect())
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q10.query(fn(customer), fn(nation), fn(lineitem), fn(orders)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q10.query(fn(customer), fn(nation), fn(lineitem), fn(orders)).compute())

--- a/tpch/execute/q11.py
+++ b/tpch/execute/q11.py
@@ -16,3 +16,7 @@ print(q11.query(fn(nation), fn(partsupp), fn(supplier)).collect())
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q11.query(fn(nation), fn(partsupp), fn(supplier)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q11.query(fn(nation), fn(partsupp), fn(supplier)).compute())

--- a/tpch/execute/q12.py
+++ b/tpch/execute/q12.py
@@ -8,10 +8,14 @@ tool = "pandas[pyarrow]"
 fn = IO_FUNCS[tool]
 print(q12.query(fn(line_item), fn(orders)))
 
-tool = "polars[lazy]"
+tool = "polars[eager]"
 fn = IO_FUNCS[tool]
-print(q12.query(fn(line_item), fn(orders)).collect())
+print(q12.query(fn(line_item), fn(orders)))
 
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q12.query(fn(line_item), fn(orders)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q12.query(fn(line_item), fn(orders)).compute())

--- a/tpch/execute/q12.py
+++ b/tpch/execute/q12.py
@@ -8,9 +8,9 @@ tool = "pandas[pyarrow]"
 fn = IO_FUNCS[tool]
 print(q12.query(fn(line_item), fn(orders)))
 
-tool = "polars[eager]"
+tool = "polars[lazy]"
 fn = IO_FUNCS[tool]
-print(q12.query(fn(line_item), fn(orders)))
+print(q12.query(fn(line_item), fn(orders)).collect())
 
 tool = "pyarrow"
 fn = IO_FUNCS[tool]

--- a/tpch/execute/q13.py
+++ b/tpch/execute/q13.py
@@ -15,3 +15,7 @@ print(q13.query(fn(customer), fn(orders)).collect())
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q13.query(fn(customer), fn(orders)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q13.query(fn(customer), fn(orders)).compute())

--- a/tpch/execute/q14.py
+++ b/tpch/execute/q14.py
@@ -15,3 +15,7 @@ print(q14.query(fn(line_item), fn(part)).collect())
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q14.query(fn(line_item), fn(part)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q14.query(fn(line_item), fn(part)).compute())

--- a/tpch/execute/q15.py
+++ b/tpch/execute/q15.py
@@ -15,3 +15,7 @@ print(q15.query(fn(lineitem), fn(supplier)).collect())
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q15.query(fn(lineitem), fn(supplier)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q15.query(fn(lineitem), fn(supplier)).compute())

--- a/tpch/execute/q16.py
+++ b/tpch/execute/q16.py
@@ -16,3 +16,7 @@ print(q16.query(fn(part), fn(partsupp), fn(supplier)).collect())
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q16.query(fn(part), fn(partsupp), fn(supplier)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q16.query(fn(part), fn(partsupp), fn(supplier)).compute())

--- a/tpch/execute/q17.py
+++ b/tpch/execute/q17.py
@@ -15,3 +15,7 @@ print(q17.query(fn(lineitem), fn(part)).collect())
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q17.query(fn(lineitem), fn(part)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q17.query(fn(lineitem), fn(part)).compute())

--- a/tpch/execute/q18.py
+++ b/tpch/execute/q18.py
@@ -16,3 +16,7 @@ print(q18.query(fn(customer), fn(lineitem), fn(orders)).collect())
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q18.query(fn(customer), fn(lineitem), fn(orders)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q18.query(fn(customer), fn(lineitem), fn(orders)).compute())

--- a/tpch/execute/q18.py
+++ b/tpch/execute/q18.py
@@ -16,7 +16,3 @@ print(q18.query(fn(customer), fn(lineitem), fn(orders)).collect())
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q18.query(fn(customer), fn(lineitem), fn(orders)))
-
-tool = "dask"
-fn = IO_FUNCS[tool]
-print(q18.query(fn(customer), fn(lineitem), fn(orders)).compute())

--- a/tpch/execute/q19.py
+++ b/tpch/execute/q19.py
@@ -7,8 +7,11 @@ from . import part
 fn = IO_FUNCS["pandas[pyarrow]"]
 print(q19.query(fn(lineitem), fn(part)))
 
-fn = IO_FUNCS["polars[lazy]"]
-print(q19.query(fn(lineitem), fn(part)).collect())
+fn = IO_FUNCS["polars[eager]"]
+print(q19.query(fn(lineitem), fn(part)))
 
 fn = IO_FUNCS["pyarrow"]
 print(q19.query(fn(lineitem), fn(part)))
+
+fn = IO_FUNCS["dask"]
+print(q19.query(fn(lineitem), fn(part)).compute())

--- a/tpch/execute/q19.py
+++ b/tpch/execute/q19.py
@@ -7,8 +7,8 @@ from . import part
 fn = IO_FUNCS["pandas[pyarrow]"]
 print(q19.query(fn(lineitem), fn(part)))
 
-fn = IO_FUNCS["polars[eager]"]
-print(q19.query(fn(lineitem), fn(part)))
+fn = IO_FUNCS["polars[lazy]"]
+print(q19.query(fn(lineitem), fn(part)).collect())
 
 fn = IO_FUNCS["pyarrow"]
 print(q19.query(fn(lineitem), fn(part)))

--- a/tpch/execute/q20.py
+++ b/tpch/execute/q20.py
@@ -15,3 +15,6 @@ print(q20.query(fn(part), fn(partsupp), fn(nation), fn(lineitem), fn(supplier)).
 
 fn = IO_FUNCS["pyarrow"]
 print(q20.query(fn(part), fn(partsupp), fn(nation), fn(lineitem), fn(supplier)))
+
+fn = IO_FUNCS["dask"]
+print(q20.query(fn(part), fn(partsupp), fn(nation), fn(lineitem), fn(supplier)).compute())

--- a/tpch/execute/q20.py
+++ b/tpch/execute/q20.py
@@ -15,6 +15,3 @@ print(q20.query(fn(part), fn(partsupp), fn(nation), fn(lineitem), fn(supplier)).
 
 fn = IO_FUNCS["pyarrow"]
 print(q20.query(fn(part), fn(partsupp), fn(nation), fn(lineitem), fn(supplier)))
-
-fn = IO_FUNCS["dask"]
-print(q20.query(fn(part), fn(partsupp), fn(nation), fn(lineitem), fn(supplier)).compute())

--- a/tpch/execute/q21.py
+++ b/tpch/execute/q21.py
@@ -9,8 +9,11 @@ from . import supplier
 fn = IO_FUNCS["pandas[pyarrow]"]
 print(q21.query(fn(lineitem), fn(nation), fn(orders), fn(supplier)))
 
-fn = IO_FUNCS["polars[lazy]"]
-print(q21.query(fn(lineitem), fn(nation), fn(orders), fn(supplier)).collect())
+fn = IO_FUNCS["polars[eager]"]
+print(q21.query(fn(lineitem), fn(nation), fn(orders), fn(supplier)))
 
 fn = IO_FUNCS["pyarrow"]
 print(q21.query(fn(lineitem), fn(nation), fn(orders), fn(supplier)))
+
+fn = IO_FUNCS["dask"]
+print(q21.query(fn(lineitem), fn(nation), fn(orders), fn(supplier)).compute())

--- a/tpch/execute/q21.py
+++ b/tpch/execute/q21.py
@@ -9,8 +9,8 @@ from . import supplier
 fn = IO_FUNCS["pandas[pyarrow]"]
 print(q21.query(fn(lineitem), fn(nation), fn(orders), fn(supplier)))
 
-fn = IO_FUNCS["polars[eager]"]
-print(q21.query(fn(lineitem), fn(nation), fn(orders), fn(supplier)))
+fn = IO_FUNCS["polars[lazy]"]
+print(q21.query(fn(lineitem), fn(nation), fn(orders), fn(supplier)).collect())
 
 fn = IO_FUNCS["pyarrow"]
 print(q21.query(fn(lineitem), fn(nation), fn(orders), fn(supplier)))

--- a/tpch/execute/q22.py
+++ b/tpch/execute/q22.py
@@ -15,3 +15,7 @@ print(q22.query(fn(customer), fn(orders)).collect())
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q22.query(fn(customer), fn(orders)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q22.query(fn(customer), fn(orders)).compute())

--- a/tpch/execute/q3.py
+++ b/tpch/execute/q3.py
@@ -16,3 +16,7 @@ print(q3.query(fn(customer), fn(lineitem), fn(orders)).collect())
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q3.query(fn(customer), fn(lineitem), fn(orders)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q3.query(fn(customer), fn(lineitem), fn(orders)).compute())

--- a/tpch/execute/q4.py
+++ b/tpch/execute/q4.py
@@ -15,3 +15,7 @@ print(q4.query(fn(line_item), fn(orders)).collect())
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q4.query(fn(line_item), fn(orders)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q4.query(fn(line_item), fn(orders)).compute())

--- a/tpch/execute/q5.py
+++ b/tpch/execute/q5.py
@@ -31,3 +31,11 @@ print(
         fn(region), fn(nation), fn(customer), fn(line_item), fn(orders), fn(supplier)
     )
 )
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(
+    q5.query(
+        fn(region), fn(nation), fn(customer), fn(line_item), fn(orders), fn(supplier)
+    ).compute()
+)

--- a/tpch/execute/q6.py
+++ b/tpch/execute/q6.py
@@ -7,10 +7,14 @@ tool = "pandas[pyarrow]"
 fn = IO_FUNCS[tool]
 print(q6.query(fn(lineitem)))
 
-tool = "polars[lazy]"
+tool = "polars[eager]"
 fn = IO_FUNCS[tool]
-print(q6.query(fn(lineitem)).collect())
+print(q6.query(fn(lineitem)))
 
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q6.query(fn(lineitem)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(q6.query(fn(lineitem)).compute())

--- a/tpch/execute/q6.py
+++ b/tpch/execute/q6.py
@@ -7,9 +7,9 @@ tool = "pandas[pyarrow]"
 fn = IO_FUNCS[tool]
 print(q6.query(fn(lineitem)))
 
-tool = "polars[eager]"
+tool = "polars[lazy]"
 fn = IO_FUNCS[tool]
-print(q6.query(fn(lineitem)))
+print(q6.query(fn(lineitem)).collect())
 
 tool = "pyarrow"
 fn = IO_FUNCS[tool]

--- a/tpch/execute/q7.py
+++ b/tpch/execute/q7.py
@@ -20,3 +20,9 @@ print(
 tool = "pyarrow"
 fn = IO_FUNCS[tool]
 print(q7.query(fn(nation), fn(customer), fn(lineitem), fn(orders), fn(supplier)))
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(
+    q7.query(fn(nation), fn(customer), fn(lineitem), fn(orders), fn(supplier)).compute()
+)

--- a/tpch/execute/q8.py
+++ b/tpch/execute/q8.py
@@ -51,3 +51,17 @@ print(
         fn(region),
     )
 )
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(
+    q8.query(
+        fn(part),
+        fn(supplier),
+        fn(lineitem),
+        fn(orders),
+        fn(customer),
+        fn(nation),
+        fn(region),
+    ).compute()
+)

--- a/tpch/execute/q9.py
+++ b/tpch/execute/q9.py
@@ -27,3 +27,11 @@ fn = IO_FUNCS[tool]
 print(
     q9.query(fn(part), fn(partsupp), fn(nation), fn(lineitem), fn(orders), fn(supplier))
 )
+
+tool = "dask"
+fn = IO_FUNCS[tool]
+print(
+    q9.query(
+        fn(part), fn(partsupp), fn(nation), fn(lineitem), fn(orders), fn(supplier)
+    ).compute()
+)

--- a/tpch/queries/q20.py
+++ b/tpch/queries/q20.py
@@ -28,7 +28,8 @@ def query(
 
     return (
         part_ds.filter(nw.col("p_name").str.starts_with(var4))
-        .select(nw.col("p_partkey").unique())
+        .select("p_partkey")
+        .unique("p_partkey")
         .join(partsupp_ds, left_on="p_partkey", right_on="ps_partkey")
         .join(
             query1,
@@ -36,7 +37,8 @@ def query(
             right_on=["l_suppkey", "l_partkey"],
         )
         .filter(nw.col("ps_availqty") > nw.col("sum_quantity"))
-        .select(nw.col("ps_suppkey").unique())
+        .select("ps_suppkey")
+        .unique("ps_suppkey")
         .join(query3, left_on="ps_suppkey", right_on="s_suppkey")
         .select("s_name", "s_address")
         .sort("s_name")

--- a/tpch/queries/q22.py
+++ b/tpch/queries/q22.py
@@ -14,8 +14,10 @@ def query(customer_ds: FrameT, orders_ds: FrameT) -> FrameT:
         nw.col("c_acctbal").mean().alias("avg_acctbal")
     )
 
-    q3 = orders_ds.select(nw.col("o_custkey").unique()).with_columns(
-        nw.col("o_custkey").alias("c_custkey")
+    q3 = (
+        orders_ds.select("o_custkey")
+        .unique("o_custkey")
+        .with_columns(nw.col("o_custkey").alias("c_custkey"))
     )
 
     return (


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
 - Fix an issue with string keys in left and semi joins in Dask;
 - Added an error message of `Expr.unique` is not supported for the Dask backend as it modifies the index;
 - Added Dask to tpch benchmarks;
