### PR TITLE
test: xfail cuDF tests for `join_asof`

### DIFF
--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -353,7 +353,7 @@ def test_join_keys_exceptions(constructor: Any, how: str) -> None:
 
 
 def test_joinasof_numeric(constructor: Any, request: Any) -> None:
-    if "pyarrow_table" in str(constructor):
+    if "pyarrow_table" in str(constructor) or "cudf" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     if parse_version(pd.__version__) < (2, 1) and (
         ("pandas_pyarrow" in str(constructor)) or ("pandas_nullable" in str(constructor))
@@ -409,7 +409,7 @@ def test_joinasof_numeric(constructor: Any, request: Any) -> None:
 
 
 def test_joinasof_time(constructor: Any, request: Any) -> None:
-    if "pyarrow_table" in str(constructor):
+    if "pyarrow_table" in str(constructor) or "cudf" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     if parse_version(pd.__version__) < (2, 1) and ("pandas_pyarrow" in str(constructor)):
         request.applymarker(pytest.mark.xfail)
@@ -487,7 +487,7 @@ def test_joinasof_time(constructor: Any, request: Any) -> None:
 
 
 def test_joinasof_by(constructor: Any, request: Any) -> None:
-    if "pyarrow_table" in str(constructor):
+    if "pyarrow_table" in str(constructor) or "cudf" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     if parse_version(pd.__version__) < (2, 1) and (
         ("pandas_pyarrow" in str(constructor)) or ("pandas_nullable" in str(constructor))


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # https://github.com/narwhals-dev/narwhals/issues/862
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

cuDF doesn't have `merge_asof`, meaning the following tests fail:

```
FAILED tests/frame/join_test.py::test_joinasof_numeric[cudf_constructor] - AttributeError: module 'cudf' has no attribute 'merge_asof'
FAILED tests/frame/join_test.py::test_joinasof_time[cudf_constructor] - AttributeError: module 'cudf' has no attribute 'merge_asof'
FAILED tests/frame/join_test.py::test_joinasof_by[cudf_constructor] - AttributeError: module 'cudf' has no attribute 'merge_asof'
```

There's already an issue open for it https://github.com/rapidsai/cudf/issues/2231
