### PR TITLE
ci: only run nightlies on pushes to main

### DIFF
--- a/.github/workflows/extremes.yml
+++ b/.github/workflows/extremes.yml
@@ -91,7 +91,8 @@ jobs:
       - name: Run doctests
         run: pytest narwhals --doctest-modules
 
-  pandas-nightly-and-dask:
+  nightlies:
+    if: github.event_name == 'push'
     strategy:
       matrix:
         python-version: ["3.11"]

--- a/.github/workflows/extremes.yml
+++ b/.github/workflows/extremes.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           kaggle kernels output "marcogorelli/variable-brink-glacier"
       - name: install-polars
-        run: uv pip install *.whl --system
+        run: pip install *.whl --system
       - name: install-reqs
         run: uv pip install --upgrade tox virtualenv setuptools pip -r requirements-dev.txt --system
       - name: uninstall pyarrow


### PR DESCRIPTION
it took me way too long to figure this out, but github doesn't allow pull requests to access environment variables. which is probably a good thing?

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

