### PR TITLE
test: xfail cuDF tests that use iteration

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -801,6 +801,9 @@ class DataFrame(BaseFrame[FrameT]):
         Arguments:
             index: Row number.
 
+        Notes:
+            cuDF doesn't support this method.
+
         Examples:
             >>> import narwhals as nw
             >>> import pandas as pd
@@ -1136,6 +1139,9 @@ class DataFrame(BaseFrame[FrameT]):
             buffer_size: Determines the number of rows that are buffered
                 internally while iterating over the data.
                 See https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.iter_rows.html
+
+        Notes:
+            cuDF doesn't support this method.
 
         Examples:
             >>> import pandas as pd

--- a/tests/frame/row_test.py
+++ b/tests/frame/row_test.py
@@ -1,9 +1,14 @@
 from typing import Any
 
+import pytest
+
 import narwhals.stable.v1 as nw
 
 
-def test_row_column(constructor_eager: Any) -> None:
+def test_row_column(request: Any, constructor_eager: Any) -> None:
+    if "cudf" in str(constructor_eager):
+        request.applymarker(pytest.mark.xfail)
+
     data = {
         "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
         "b": [11, 12, 13, 14, 15, 16],

--- a/tests/frame/rows_test.py
+++ b/tests/frame/rows_test.py
@@ -55,10 +55,14 @@ df_polars_na = pl.DataFrame({"a": [None, 3, 2], "b": [4, 4, 6], "z": [7.0, None,
     ],
 )
 def test_iter_rows(
+    request: Any,
     constructor_eager: Any,
     named: bool,  # noqa: FBT001
     expected: list[tuple[Any, ...]] | list[dict[str, Any]],
 ) -> None:
+    if "cudf" in str(constructor_eager):
+        request.applymarker(pytest.mark.xfail)
+
     data = {"a": [1, 3, 2], "_b": [4, 4, 6], "z": [7.0, 8, 9], "1": [5, 6, 7]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = list(df.iter_rows(named=named))


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # https://github.com/narwhals-dev/narwhals/issues/862
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

These tests currently fail:

```
FAILED tests/frame/row_test.py::test_row_column[cudf_constructor] - TypeError: Series object is not iterable. Consider using `.to_arrow()`, `.t...
FAILED tests/frame/rows_test.py::test_iter_rows[cudf_constructor-False-expected0] - TypeError: cuDF does not support iteration of DataFrame via itertuples. Con...
FAILED tests/frame/rows_test.py::test_iter_rows[cudf_constructor-True-expected1] - TypeError: cuDF does not support iteration of DataFrame via itertuples. Con...
```

Marking as `xfail` as iteration isn't supported here.

https://docs.rapids.ai/api/cudf/stable/user_guide/pandas-comparison/#iteration
https://docs.rapids.ai/api/cudf/stable/user_guide/api_docs/api/cudf.dataframe.itertuples/#cudf.DataFrame.itertuples