### PR TITLE
test: remove xfail for cudf_constructor on `str_to_uppercase` test

### DIFF
--- a/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
+++ b/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
@@ -81,6 +81,7 @@ def test_str_to_uppercase_series(
             "pandas_constructor",
             "pandas_nullable_constructor",
             "polars_eager_constructor",
+            "cudf_constructor",
         )
     ):
         # We are marking it xfail for these conditions above


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # https://github.com/narwhals-dev/narwhals/issues/862
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
Looks like this one is passing

________ test_str_to_uppercase_series[cudf_constructor-data1-expected1] ________ [XPASS(strict)]