### PR TITLE
test: xfail case insensitive regex tests for cuDF

### DIFF
--- a/tests/expr_and_series/str/contains_test.py
+++ b/tests/expr_and_series/str/contains_test.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import pandas as pd
 import polars as pl
+import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
@@ -13,7 +14,10 @@ df_pandas = pd.DataFrame(data)
 df_polars = pl.DataFrame(data)
 
 
-def test_contains(constructor: Constructor) -> None:
+def test_contains(constructor: Constructor, request: pytest.FixtureRequest) -> None:
+    if "cudf" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
+
     df = nw.from_native(constructor(data))
     result = df.with_columns(
         nw.col("pets").str.contains("(?i)parrot|Dove").alias("result")
@@ -25,7 +29,10 @@ def test_contains(constructor: Constructor) -> None:
     compare_dicts(result, expected)
 
 
-def test_contains_series(constructor_eager: Any) -> None:
+def test_contains_series(constructor_eager: Any, request: pytest.FixtureRequest) -> None:
+    if "cudf" in str(constructor_eager):
+        request.applymarker(pytest.mark.xfail)
+
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.with_columns(
         case_insensitive_match=df["pets"].str.contains("(?i)parrot|Dove")


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #  https://github.com/narwhals-dev/narwhals/issues/862
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

These tests fail with a runtime error:
```
FAILED tests/expr_and_series/str/contains_test.py::test_contains[cudf_constructor] - RuntimeError: CUDF failure at:/opt/conda/conda-bld/work/cpp/src/strings/reg...
```
What I can find is that `(?i)` is likely not supported for cuDF. That's what it sounds like from https://github.com/rapidsai/cudf/issues/5217 (the issue was opened for `str.replace`).
