### PR TITLE
test: add specific check for cuDF for test_to_datetime

### DIFF
--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -5,6 +5,11 @@ data = {"a": ["2020-01-01T12:34:56"]}
 
 
 def test_to_datetime(constructor: Constructor) -> None:
+    if "cudf" in str(constructor):
+        expected = "2020-01-01T12:34:56.000000000"
+    else:
+        expected = "2020-01-01 12:34:56"
+
     result = (
         nw.from_native(constructor(data))
         .lazy()
@@ -12,4 +17,4 @@ def test_to_datetime(constructor: Constructor) -> None:
         .collect()
         .item(row=0, column="b")
     )
-    assert str(result) == "2020-01-01 12:34:56"
+    assert str(result) == expected

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -5,7 +5,7 @@ data = {"a": ["2020-01-01T12:34:56"]}
 
 
 def test_to_datetime(constructor: Constructor) -> None:
-    if "cudf" in str(constructor):
+    if "cudf" in str(constructor):  # pragma: no cover
         expected = "2020-01-01T12:34:56.000000000"
     else:
         expected = "2020-01-01 12:34:56"


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # https://github.com/narwhals-dev/narwhals/issues/862
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Currently this test fails with 
```
FAILED tests/expr_and_series/str/to_datetime_test.py::test_to_datetime[cudf_constructor] - AssertionError: assert '2020-01-01T1...:56.000000000' == '2020-01-01 12:34:56'
```
I created these in the native libraries and I see they have different data types and render differently when converted back to a string.
```
import pandas as pd
import cudf

data = {"a": ["2020-01-01T12:34:56"]}

df_cudf = pd.DataFrame(data)
df_pandas = pd.DataFrame(data)

df_pandas_dt = pd.to_datetime(df_pandas.a, format="%Y-%m-%dT%H:%M:%S")
df_cudf_dt = cudf.to_datetime(df_cudf.a, format="%Y-%m-%dT%H:%M:%S")

print(df_pandas_dt[0])
print(type(df_pandas_dt[0]))
print(df_cudf_dt[0])
print(type(df_cudf_dt[0]))
```

```
2020-01-01 12:34:56
<class 'pandas._libs.tslibs.timestamps.Timestamp'>
2020-01-01T12:34:56.000000000
<class 'numpy.datetime64'>
```

Not sure though if this is an acceptable difference and something to just account for in the tests like this though. 
