### PR TITLE
fix: Specialize typing in `dataframe` between `Frame` and `DataFrame`

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -33,10 +33,10 @@ if TYPE_CHECKING:
     from narwhals.typing import IntoDataFrame
     from narwhals.typing import IntoExpr
 
-FrameT = TypeVar("FrameT", bound="IntoDataFrame")
+IntoDataFrameT = TypeVar("IntoDataFrameT", bound="IntoDataFrame")
 
 
-class BaseFrame(Generic[FrameT]):
+class BaseFrame(Generic[IntoDataFrameT]):
     _compliant_frame: Any
     _level: Literal["full", "interchange"]
 
@@ -292,7 +292,7 @@ class BaseFrame(Generic[FrameT]):
         )
 
 
-class DataFrame(BaseFrame[FrameT]):
+class DataFrame(BaseFrame[IntoDataFrameT]):
     """
     Narwhals DataFrame, backed by a native dataframe.
 
@@ -2549,7 +2549,7 @@ class DataFrame(BaseFrame[FrameT]):
         )
 
 
-class LazyFrame(BaseFrame[FrameT]):
+class LazyFrame(BaseFrame[IntoDataFrameT]):
     """
     Narwhals DataFrame, backed by a native dataframe.
 

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -30,13 +30,17 @@ if TYPE_CHECKING:
     from narwhals.group_by import GroupBy
     from narwhals.group_by import LazyGroupBy
     from narwhals.series import Series
+    from narwhals.typing import Frame
     from narwhals.typing import IntoDataFrame
     from narwhals.typing import IntoExpr
+    from narwhals.typing import IntoFrame
 
 IntoDataFrameT = TypeVar("IntoDataFrameT", bound="IntoDataFrame")
+IntoFrameT = TypeVar("IntoFrameT", bound="IntoFrame")
+FrameT = TypeVar("FrameT", bound="Frame")
 
 
-class BaseFrame(Generic[IntoDataFrameT]):
+class BaseFrame(Generic[FrameT]):
     _compliant_frame: Any
     _level: Literal["full", "interchange"]
 
@@ -2549,7 +2553,7 @@ class DataFrame(BaseFrame[IntoDataFrameT]):
         )
 
 
-class LazyFrame(BaseFrame[IntoDataFrameT]):
+class LazyFrame(BaseFrame[IntoFrameT]):
     """
     Narwhals DataFrame, backed by a native dataframe.
 

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -31,10 +31,12 @@ if TYPE_CHECKING:
     from narwhals.group_by import GroupBy
     from narwhals.group_by import LazyGroupBy
     from narwhals.series import Series
+    from narwhals.typing import IntoDataFrame
     from narwhals.typing import IntoExpr
     from narwhals.typing import IntoFrame
 
 FrameT = TypeVar("FrameT", bound="IntoFrame")
+DataFrameT = TypeVar("DataFrameT", bound="IntoDataFrame")
 
 
 class BaseFrame(Generic[FrameT]):
@@ -293,7 +295,7 @@ class BaseFrame(Generic[FrameT]):
         )
 
 
-class DataFrame(BaseFrame[FrameT]):
+class DataFrame(BaseFrame[DataFrameT]):
     """
     Narwhals DataFrame, backed by a native dataframe.
 
@@ -391,7 +393,7 @@ class DataFrame(BaseFrame[FrameT]):
         """
         return super().lazy()
 
-    def to_native(self) -> FrameT:
+    def to_native(self) -> DataFrameT:
         """
         Convert Narwhals DataFrame to native one.
 

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -293,7 +293,7 @@ class BaseFrame(Generic[FrameT]):
         )
 
 
-class DataFrame(BaseFrame[IntoDataFrameT]):
+class DataFrame(BaseFrame[FrameT]):
     """
     Narwhals DataFrame, backed by a native dataframe.
 
@@ -2617,7 +2617,7 @@ class DataFrame(BaseFrame[IntoDataFrameT]):
         )
 
 
-class LazyFrame(BaseFrame[IntoFrameT]):
+class LazyFrame(BaseFrame[FrameT]):
     """
     Narwhals DataFrame, backed by a native dataframe.
 

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -43,8 +43,8 @@ IntoFrame: TypeAlias = Union[
 ]
 """Anything which can be converted to a Narwhals DataFrame or LazyFrame."""
 
-Frame: TypeAlias = Union["IntoFrame", "IntoDataFrame"]
-"""DataFrame or LazyFrame"""
+Frame: TypeAlias = Union["DataFrame[Any]", "LazyFrame[Any]"]
+"""Narwhals DataFrame or Narwhals LazyFrame"""
 
 # TypeVars for some of the above
 IntoFrameT = TypeVar("IntoFrameT", bound="IntoFrame")

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -43,7 +43,7 @@ IntoFrame: TypeAlias = Union[
 ]
 """Anything which can be converted to a Narwhals DataFrame or LazyFrame."""
 
-Frame: TypeAlias = Union["DataFrame[Any]", "LazyFrame[Any]"]
+Frame: TypeAlias = Union["IntoFrame", "IntoDataFrame"]
 """DataFrame or LazyFrame"""
 
 # TypeVars for some of the above

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -49,7 +49,7 @@ Frame: TypeAlias = Union["DataFrame[Any]", "LazyFrame[Any]"]
 # TypeVars for some of the above
 IntoFrameT = TypeVar("IntoFrameT", bound="IntoFrame")
 IntoDataFrameT = TypeVar("IntoDataFrameT", bound="IntoDataFrame")
-FrameT = TypeVar("FrameT", "DataFrame[Any]", "LazyFrame[Any]")
+FrameT = TypeVar("FrameT", bound="Frame")
 DataFrameT = TypeVar("DataFrameT", bound="DataFrame[Any]")
 
 __all__ = [


### PR DESCRIPTION

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Seems it should be `IntoDataFrameT`, without changing anything else, just rename it.
