### PR TITLE
fix: generate backend table

### DIFF
--- a/utils/generate_backend_completeness.py
+++ b/utils/generate_backend_completeness.py
@@ -53,8 +53,10 @@ def parse_module(module_name: str, backend: str, nw_class_name: str) -> list[str
             predicate=lambda c: inspect.isclass(c) and c.__name__.endswith(nw_class_name),
         )
         methods_ = (
-            get_class_methods(class_[0][1]) if class_ else []
-        ) + DIRECTLY_IMPLEMENTED_METHODS
+            get_class_methods(class_[0][1]) + DIRECTLY_IMPLEMENTED_METHODS
+            if class_
+            else []
+        )
 
     except ModuleNotFoundError:
         methods_ = []


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## If you have comments or can explain your changes, please do so below.

After PR from yesterday, `pipe` got added independently of the class, leading to the following rendering:

![image](https://github.com/user-attachments/assets/93b3f47c-8a9c-4d44-abf0-a23d5e508aba)

With this fix, it will appear only if the class matches the backend
