### PR TITLE
fix: add cuDF specific implementation for join how="anti"

### DIFF
--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -485,17 +485,27 @@ class PandasLikeDataFrame:
                 )
                 .drop_duplicates()
             )
-            return self._from_native_frame(
-                self._native_frame.merge(
-                    other_native,
-                    how="outer",
-                    indicator=indicator_token,
-                    left_on=left_on,
-                    right_on=left_on,
+            if self._implementation is Implementation.CUDF:
+                return self._from_native_frame(
+                    self._native_frame.merge(
+                        other_native,
+                        how="leftanti",
+                        left_on=left_on,
+                        right_on=left_on,
+                    )
                 )
-                .loc[lambda t: t[indicator_token] == "left_only"]
-                .drop(columns=indicator_token)
-            )
+            else:
+                return self._from_native_frame(
+                    self._native_frame.merge(
+                        other_native,
+                        how="outer",
+                        indicator=indicator_token,
+                        left_on=left_on,
+                        right_on=left_on,
+                    )
+                    .loc[lambda t: t[indicator_token] == "left_only"]
+                    .drop(columns=indicator_token)
+                )
 
         if how == "semi":
             other_native = (

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -485,7 +485,7 @@ class PandasLikeDataFrame:
                 )
                 .drop_duplicates()
             )
-            if self._implementation is Implementation.CUDF:
+            if self._implementation is Implementation.CUDF:  # pragma: no cover
                 return self._from_native_frame(
                     self._native_frame.merge(
                         other_native,

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -159,7 +159,11 @@ def test_anti_join(
     join_key: list[str],
     filter_expr: nw.Expr,
     expected: dict[str, list[Any]],
+    request: pytest.FixtureRequest,
 ) -> None:
+    if "cudf" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
+
     data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zorro": [7.0, 8, 9]}
     df = nw.from_native(constructor(data))
     other = df.filter(filter_expr)

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -159,11 +159,7 @@ def test_anti_join(
     join_key: list[str],
     filter_expr: nw.Expr,
     expected: dict[str, list[Any]],
-    request: pytest.FixtureRequest,
 ) -> None:
-    if "cudf" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
-
     data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zorro": [7.0, 8, 9]}
     df = nw.from_native(constructor(data))
     other = df.filter(filter_expr)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # https://github.com/narwhals-dev/narwhals/issues/862
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
Right now these tests fail with
`NotImplementedError: Only indicator=False is currently supported`
So the current implementation of `df.join` `how="anti"` won't work.

https://docs.rapids.ai/api/cudf/stable/user_guide/api_docs/api/cudf.dataframe.merge/

Seemed like best to mark it as expected to fail for now. @MarcoGorelli what do you think would make sense here. Maybe a note in the docs and a follow up issue to see if we can implement it in another way for cuDF?