### PR TITLE
fix: move `__len__` to `DataFrame` only

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -41,9 +41,6 @@ class BaseFrame(Generic[FrameT]):
     _compliant_frame: Any
     _level: Literal["full", "interchange"]
 
-    def __len__(self) -> Any:
-        return self._compliant_frame.__len__()
-
     def __native_namespace__(self) -> Any:
         return self._compliant_frame.__native_namespace__()
 
@@ -315,6 +312,9 @@ class DataFrame(BaseFrame[FrameT]):
         else:  # pragma: no cover
             msg = f"Expected an object which implements `__narwhals_dataframe__`, got: {type(df)}"
             raise AssertionError(msg)
+
+    def __len__(self) -> Any:
+        return self._compliant_frame.__len__()
 
     def __array__(self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
         return self._compliant_frame.__array__(dtype, copy=copy)

--- a/tests/frame/len_test.py
+++ b/tests/frame/len_test.py
@@ -9,5 +9,5 @@ data = {
 
 
 def test_len(constructor_eager: Any) -> None:
-    result = len(nw.from_native(constructor_eager(data)))
+    result = len(nw.from_native(constructor_eager(data), eager_only=True))
     assert result == 4


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.

`__len__` should not appear in `dir(some_narwhals_lazy_frame)`, it will raise anyway but pushing the error to the compliant frame