### PR TITLE
build: Added PR labels so the Release Drafter ignores evil bots 

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,7 @@
 exclude-labels:
-  - skip changelog
+  - ignore
   - release
+  - dependencies
 name-template: 'Narwhals v$RESOLVED_VERSION'
 
 change-template: '- $TITLE (#$NUMBER)' 
@@ -34,6 +35,9 @@ autolabeler:
   - label: release
     title:
       - '/^([Rr]elease)/'
+  - label: ignore
+    title:
+      - '/^\[pre-commit.ci\]/'
       
 version-resolver:
   major:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Bots 🤖 are being added in the Release Drafter as contributors, so I'm trying to correct that:
First added a new label to the repo and called it "ignore".  
That label should be set by the release drafter when the PR is opened by the  pre-commit bot.
Also, the "dependabot" (installed already in the repo) sets a label called "dependencies", but it was not included under the _exclude-labels._ 
