### PR TITLE
fix: pyarrow `unique` in `group_by` context

### DIFF
--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -20,6 +20,7 @@ POLARS_TO_ARROW_AGGREGATIONS = {
     "n_unique": "count_distinct",
     "std": "stddev",
     "var": "variance",  # currently unused, we don't have `var` yet
+    "unique": "distinct",
 }
 
 
@@ -32,6 +33,7 @@ def get_function_name_option(function_name: str) -> Any | None:
         "count_distinct": pc.CountOptions(mode="all"),
         "stddev": pc.VarianceOptions(ddof=1),
         "variance": pc.VarianceOptions(ddof=1),
+        "distinct": pc.CountOptions(mode="all"),
     }
     return function_name_to_options.get(function_name)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

May come in handy for plotly

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

I was not able to add tests... I tried to nest a bunch of checks but also the order inside the list type is not guaranteed..
any idea?