### PR TITLE
test: `xfail` test using None on `to_numpy` for cuDF

### DIFF
--- a/tests/series_only/to_numpy_test.py
+++ b/tests/series_only/to_numpy_test.py
@@ -10,8 +10,10 @@ import narwhals.stable.v1 as nw
 
 
 def test_to_numpy(constructor_eager: Any, request: pytest.FixtureRequest) -> None:
-    if "pandas_constructor" in str(constructor_eager) or "modin_constructor" in str(
-        constructor_eager or "cudf_constructor" in str(constructor_eager)
+    if (
+        "pandas_constructor" in str(constructor_eager)
+        or "modin_constructor" in str(constructor_eager)
+        or "cudf_constructor" in str(constructor_eager)
     ):
         request.applymarker(pytest.mark.xfail)
 

--- a/tests/series_only/to_numpy_test.py
+++ b/tests/series_only/to_numpy_test.py
@@ -11,7 +11,7 @@ import narwhals.stable.v1 as nw
 
 def test_to_numpy(constructor_eager: Any, request: pytest.FixtureRequest) -> None:
     if "pandas_constructor" in str(constructor_eager) or "modin_constructor" in str(
-        constructor_eager
+        constructor_eager or "cudf_constructor" in str(constructor_eager)
     ):
         request.applymarker(pytest.mark.xfail)
 


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # https://github.com/narwhals-dev/narwhals/issues/862
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
It looks like cuDF doesn't allow `to_numpy` with nulls. Couldn't find much documentation, but it looks like maybe you need to specify an `na_value`

https://docs.rapids.ai/api/cudf/stable/user_guide/api_docs/api/cudf.series.to_numpy/#cudf.Series.to_numpy

