### PR TITLE
test: xfail __iter___test for cuDF

### DIFF
--- a/tests/series_only/__iter___test.py
+++ b/tests/series_only/__iter___test.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
+import pytest
+
 import narwhals.stable.v1 as nw
 from tests.utils import compare_dicts
 
 data = [1, 2, 3]
 
 
-def test_to_list(constructor_eager: Any) -> None:
+def test_to_list(constructor_eager: Any, request: pytest.FixtureRequest) -> None:
+    if "cudf" in str(constructor_eager):
+        request.applymarker(pytest.mark.xfail)
     s = nw.from_native(constructor_eager({"a": data}), eager_only=True)["a"]
 
     assert isinstance(s, Iterable)

--- a/tests/series_only/__iter___test.py
+++ b/tests/series_only/__iter___test.py
@@ -11,7 +11,7 @@ from tests.utils import compare_dicts
 data = [1, 2, 3]
 
 
-def test_to_list(constructor_eager: Any, request: pytest.FixtureRequest) -> None:
+def test_iter(constructor_eager: Any, request: pytest.FixtureRequest) -> None:
     if "cudf" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
     s = nw.from_native(constructor_eager({"a": data}), eager_only=True)["a"]


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # https://github.com/narwhals-dev/narwhals/issues/862
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Test currently fails with :

```
FAILED tests/series_only/__iter___test.py::test_to_list[cudf_constructor] - TypeError: Series object is not iterable. Consider using `.to_arrow()`, `.t...
```

Because it's testing the iteration and that's not supported on cuDF, https://docs.rapids.ai/api/cudf/stable/user_guide/pandas-comparison/#iteration, it seems correct to xfail this one. 

