### PR TITLE
test: xfail empty string test in `test_unpivot`

### DIFF
--- a/tests/frame/unpivot_test.py
+++ b/tests/frame/unpivot_test.py
@@ -51,7 +51,11 @@ def test_unpivot_var_value_names(
     constructor: Constructor,
     variable_name: str | None,
     value_name: str | None,
+    request: pytest.FixtureRequest,
 ) -> None:
+    if variable_name == "" and "cudf" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
+
     df = nw.from_native(constructor(data))
     result = df.unpivot(
         on=["b", "c"], index=["a"], variable_name=variable_name, value_name=value_name


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # https://github.com/narwhals-dev/narwhals/issues/862
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

This was a new failing test for a recently added test:

```
>       assert result.collect_schema().names()[-2:] == [variable_name, value_name]
E       AssertionError: assert ['variable', ...m_value_name'] == ['', 'custom_value_name']
E         
E         At index 0 diff: 'variable' != ''
E         Use -v to get more diff
```

It looks like the empty string is treated as if it were None for `var_name` for `cudf.melt` (https://github.com/rapidsai/cudf/blob/branch-24.12/python/cudf/cudf/core/reshape.py#L684-L685)

Input
```
import cudf
import pandas as pd

data = {
        "a": ["x", "y", "z"],
        "b": [1, 3, 5],
        "c": [2, 4, 6],
    }

df_cudf = cudf.DataFrame(data)
df_pd = pd.DataFrame(data)

variable_name, value_name = "", "custom_value_name"

print(df_cudf.melt(id_vars=["a"], value_vars=["b", "c"], var_name=variable_name ,value_name=value_name))
print(df_pd.melt(id_vars=["a"], value_vars=["b", "c"], var_name=variable_name ,value_name=value_name))
```

Output:
```
   a variable  custom_value_name
0  x        b                  1
1  y        b                  3
2  z        b                  5
3  x        c                  2
4  y        c                  4
5  z        c                  6


   a     custom_value_name
0  x  b                  1
1  y  b                  3
2  z  b                  5
3  x  c                  2
4  y  c                  4
5  z  c                  6
```
@MarcoGorelli do you think it would be worthwhile for me to raise an issue in cuDF for this? 
