### PR TITLE
docs : docstrings examples - dtypes

### DIFF
--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -58,25 +58,194 @@ class Int64(NumericType):
     """
 
 
-class Int32(NumericType): ...
+class Int32(NumericType):
+    """32-bit signed integer type.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import polars as pl
+        >>> import pyarrow as pa
+        >>> import narwhals as nw
+        >>> data = [2, 1, 3, 7]
+        >>> ser_pd = pd.Series(data)
+        >>> ser_pl = pl.Series(data)
+        >>> ser_pa = pa.chunked_array([data])
+
+        >>> def func(ser):
+        ...     ser_nw = nw.from_native(ser, series_only=True)
+        ...     return ser_nw.cast(nw.Int32).dtype
+
+        >>> func(ser_pd)
+        Int32
+        >>> func(ser_pl)
+        Int32
+        >>> func(ser_pa)
+        Int32
+    """
 
 
-class Int16(NumericType): ...
+class Int16(NumericType):
+    """16-bit signed integer type.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import polars as pl
+        >>> import pyarrow as pa
+        >>> import narwhals as nw
+        >>> data = [2, 1, 3, 7]
+        >>> ser_pd = pd.Series(data)
+        >>> ser_pl = pl.Series(data)
+        >>> ser_pa = pa.chunked_array([data])
+
+       >>> def func(ser):
+       ...     ser_nw = nw.from_native(ser, series_only=True)
+       ...     return ser_nw.cast(nw.Int16).dtype
 
 
-class Int8(NumericType): ...
+       >>> func(ser_pd)
+       Int16
+       >>> func(ser_pl)
+       Int16
+       >>> func(ser_pa)
+       Int16
+    """
 
 
-class UInt64(NumericType): ...
+class Int8(NumericType):
+    """8-bit signed integer type.
+
+    Examples:
+       >>> import pandas as pd
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> data = [2, 1, 3, 7]
+       >>> ser_pd = pd.Series(data)
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
 
 
-class UInt32(NumericType): ...
+       >>> def func(ser):
+       ...     ser_nw = nw.from_native(ser, series_only=True)
+       ...     return ser_nw.cast(nw.Int8).dtype
 
 
-class UInt16(NumericType): ...
+       >>> func(ser_pd)
+       Int8
+       >>> func(ser_pl)
+       Int8
+       >>> func(ser_pa)
+       Int8
+    """
 
 
-class UInt8(NumericType): ...
+class UInt64(NumericType):
+    """64-bit unsigned integer type.
+
+    Examples:
+       >>> import pandas as pd
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> data = [2, 1, 3, 7]
+       >>> ser_pd = pd.Series(data)
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
+
+
+       >>> def func(ser):
+       ...     ser_nw = nw.from_native(ser, series_only=True)
+       ...     return ser_nw.cast(nw.UInt64).dtype
+
+
+       >>> func(ser_pd)
+       UInt64
+       >>> func(ser_pl)
+       UInt64
+       >>> func(ser_pa)
+       UInt64
+    """
+
+
+class UInt32(NumericType):
+    """32-bit unsigned integer type.
+
+    Examples:
+       >>> import pandas as pd
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> data = [2, 1, 3, 7]
+       >>> ser_pd = pd.Series(data)
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
+
+
+       >>> def func(ser):
+       ...     ser_nw = nw.from_native(ser, series_only=True)
+       ...     return ser_nw.cast(nw.UInt32).dtype
+
+
+       >>> func(ser_pd)
+       UInt32
+       >>> func(ser_pl)
+       UInt32
+       >>> func(ser_pa)
+       UInt32
+    """
+
+
+class UInt16(NumericType):
+    """16-bit unsigned integer type.
+
+    Examples:
+       >>> import pandas as pd
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> data = [2, 1, 3, 7]
+       >>> ser_pd = pd.Series(data)
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
+
+       >>> def func(ser):
+       ...     ser_nw = nw.from_native(ser, series_only=True)
+       ...     return ser_nw.cast(nw.UInt16).dtype
+
+       >>> func(ser_pd)
+       UInt16
+       >>> func(ser_pl)
+       UInt16
+       >>> func(ser_pa)
+       UInt16
+    """
+
+
+class UInt8(NumericType):
+    """8-bit unsigned integer type.
+
+    Examples:
+       >>> import pandas as pd
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> data = [2, 1, 3, 7]
+       >>> ser_pd = pd.Series(data)
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
+
+
+       >>> def func(ser):
+       ...     ser_nw = nw.from_native(ser, series_only=True)
+       ...     return ser_nw.cast(nw.UInt8).dtype
+
+       >>> func(ser_pd)
+       UInt8
+       >>> func(ser_pl)
+       UInt8
+       >>> func(ser_pa)
+       UInt8
+    """
 
 
 class Float64(NumericType):
@@ -101,13 +270,78 @@ class Float64(NumericType):
     """
 
 
-class Float32(NumericType): ...
+class Float32(NumericType):
+    """32-bit floating point type.
+
+    Examples:
+       >>> import pandas as pd
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> data = [0.001, 0.1, 0.01, 0.1]
+       >>> ser_pd = pd.Series(data)
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
 
 
-class String(DType): ...
+       >>> def func(ser):
+       ...     ser_nw = nw.from_native(ser, series_only=True)
+       ...     return ser_nw.cast(nw.Float32).dtype
 
 
-class Boolean(DType): ...
+       >>> func(ser_pd)
+       Float32
+       >>> func(ser_pl)
+       Float32
+       >>> func(ser_pa)
+       Float32
+    """
+
+
+class String(DType):
+    """UTF-8 encoded string type.
+
+    Examples:
+       >>> import pandas as pd
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> data = ["beluga", "narwhal", "orca", "vaquita"]
+       >>> ser_pd = pd.Series(data)
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
+
+
+       >>> nw.from_native(ser_pd, series_only=True).dtype
+       String
+       >>> nw.from_native(ser_pl, series_only=True).dtype
+       String
+       >>> nw.from_native(ser_pa, series_only=True).dtype
+       String
+    """
+
+
+class Boolean(DType):
+    """Boolean type.
+
+    Examples:
+       >>> import pandas as pd
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> data = [True, False, False, True]
+       >>> ser_pd = pd.Series(data)
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
+
+
+       >>> nw.from_native(ser_pd, series_only=True).dtype
+       Boolean
+       >>> nw.from_native(ser_pl, series_only=True).dtype
+       Boolean
+       >>> nw.from_native(ser_pa, series_only=True).dtype
+       Boolean
+    """
 
 
 class Object(DType): ...
@@ -207,7 +441,27 @@ class Duration(TemporalType):
         return f"{class_name}(time_unit={self.time_unit!r})"
 
 
-class Categorical(DType): ...
+class Categorical(DType):
+    """A categorical encoding of a set of strings.
+
+    Examples:
+       >>> import pandas as pd
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> data = ["beluga", "narwhal", "orca", "vaquita"]
+       >>> ser_pd = pd.Series(data)
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
+
+
+       >>> nw.from_native(ser_pd, series_only=True).cast(nw.Categorical).dtype
+       Categorical
+       >>> nw.from_native(ser_pl, series_only=True).cast(nw.Categorical).dtype
+       Categorical
+       >>> nw.from_native(ser_pa, series_only=True).cast(nw.Categorical).dtype
+       Categorical
+    """
 
 
 class Enum(DType): ...
@@ -247,6 +501,20 @@ class Struct(DType):
 
     Arguments:
         fields: The fields that make up the struct. Can be either a sequence of Field objects or a mapping of column names to data types.
+
+    Examples:
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> data = [{"a": 1, "b": ["narwhal", "beluga"]}, {"a": 2, "b": ["orca"]}]
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
+
+
+       >>> nw.from_native(ser_pl, series_only=True).dtype
+       Struct({'a': Int64, 'b': List(String)})
+       >>> nw.from_native(ser_pa, series_only=True).dtype
+       Struct({'a': Int64, 'b': List(String)})
     """
 
     fields: list[Field]
@@ -292,6 +560,26 @@ class Struct(DType):
 
 
 class List(DType):
+    """Variable length list type.
+
+    Examples:
+       >>> import pandas as pd
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> data = [["narwhal", "orca"], ["beluga", "vaquita"]]
+       >>> ser_pd = pd.Series(data, dtype=pd.ArrowDtype(pa.large_list(pa.large_string())))
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
+
+       >>> nw.from_native(ser_pd, series_only=True).dtype
+       List(String)
+       >>> nw.from_native(ser_pl, series_only=True).dtype
+       List(String)
+       >>> nw.from_native(ser_pa, series_only=True).dtype
+       List(String)
+    """
+
     def __init__(self, inner: DType | type[DType]) -> None:
         self.inner = inner
 

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -36,7 +36,26 @@ class NumericType(DType): ...
 class TemporalType(DType): ...
 
 
-class Int64(NumericType): ...
+class Int64(NumericType):
+    """64-bit signed integer type.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import polars as pl
+        >>> import pyarrow as pa
+        >>> import narwhals as nw
+        >>> data = [2, 1, 3, 7]
+        >>> ser_pd = pd.Series(data)
+        >>> ser_pl = pl.Series(data)
+        >>> ser_pa = pa.chunked_array([data])
+
+        >>> nw.from_native(ser_pd, series_only=True).dtype
+        Int64
+        >>> nw.from_native(ser_pl, series_only=True).dtype
+        Int64
+        >>> nw.from_native(ser_pa, series_only=True).dtype
+        Int64
+    """
 
 
 class Int32(NumericType): ...
@@ -60,7 +79,26 @@ class UInt16(NumericType): ...
 class UInt8(NumericType): ...
 
 
-class Float64(NumericType): ...
+class Float64(NumericType):
+    """64-bit floating point type.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import polars as pl
+        >>> import pyarrow as pa
+        >>> import narwhals as nw
+        >>> data = [0.001, 0.1, 0.01, 0.1]
+        >>> ser_pd = pd.Series(data)
+        >>> ser_pl = pl.Series(data)
+        >>> ser_pa = pa.chunked_array([data])
+
+        >>> nw.from_native(ser_pd, series_only=True).dtype
+        Float64
+        >>> nw.from_native(ser_pl, series_only=True).dtype
+        Float64
+        >>> nw.from_native(ser_pa, series_only=True).dtype
+        Float64
+    """
 
 
 class Float32(NumericType): ...


### PR DESCRIPTION
Just a quick check: considering I'll have to use cast to get some of the datatypes, maybe I should wrap the from_native into a func after all?
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #1077
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

