### PR TITLE
feat: `concat_str`

### DIFF
--- a/docs/api-reference/narwhals.md
+++ b/docs/api-reference/narwhals.md
@@ -11,6 +11,7 @@ Here are the top-level functions available in Narwhals.
         - any_horizontal
         - col
         - concat
+        - concat_str
         - from_dict
         - from_native
         - get_level

--- a/narwhals/__init__.py
+++ b/narwhals/__init__.py
@@ -30,6 +30,7 @@ from narwhals.expr import all_ as all
 from narwhals.expr import all_horizontal
 from narwhals.expr import any_horizontal
 from narwhals.expr import col
+from narwhals.expr import concat_str
 from narwhals.expr import len_ as len
 from narwhals.expr import lit
 from narwhals.expr import max
@@ -80,6 +81,7 @@ __all__ = [
     "all_horizontal",
     "any_horizontal",
     "col",
+    "concat_str",
     "len",
     "lit",
     "min",

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -300,14 +300,13 @@ class ArrowNamespace:
 
     def concat_str(
         self,
-        exprs: IntoArrowExpr | Iterable[IntoArrowExpr],
+        exprs: Iterable[IntoArrowExpr],
         *more_exprs: IntoArrowExpr,
         separator: str = "",
         ignore_nulls: bool = False,
     ) -> ArrowExpr:
         import pyarrow.compute as pc  # ignore-banned-import
 
-        exprs = [exprs] if not isinstance(exprs, Iterable) else exprs
         parsed_exprs: list[ArrowExpr] = [
             *parse_into_exprs(*exprs, namespace=self),
             *parse_into_exprs(*more_exprs, namespace=self),

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -312,7 +312,7 @@ class ArrowNamespace:
             return [
                 ArrowSeries(
                     native_series=result_series,
-                    name=reduce_output_names(parsed_exprs) or "",
+                    name="",
                     backend_version=self._backend_version,
                     dtypes=self._dtypes,
                 )

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -312,7 +312,7 @@ class ArrowNamespace:
             return [
                 ArrowSeries(
                     native_series=result_series,
-                    name=reduce_output_names(parsed_exprs),
+                    name=reduce_output_names(parsed_exprs) or "",
                     backend_version=self._backend_version,
                     dtypes=self._dtypes,
                 )

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -293,11 +293,7 @@ class DaskNamespace:
         ]
 
         def func(df: DaskLazyFrame) -> list[dask_expr.Series]:
-            series = (
-                s
-                for _expr in parsed_exprs
-                for s in _expr.cast(self._dtypes.String())._call(df)
-            )
+            series = (s.astype(str) for _expr in parsed_exprs for s in _expr._call(df))
             null_mask = [s for _expr in parsed_exprs for s in _expr.is_null()._call(df)]
 
             if not ignore_nulls:

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -301,12 +301,11 @@ class DaskNamespace:
 
     def concat_str(
         self,
-        exprs: IntoDaskExpr | Iterable[IntoDaskExpr],
+        exprs: Iterable[IntoDaskExpr],
         *more_exprs: IntoDaskExpr,
         separator: str = "",
         ignore_nulls: bool = False,
     ) -> DaskExpr:
-        exprs = [exprs] if not isinstance(exprs, Iterable) else exprs
         parsed_exprs: list[DaskExpr] = [
             *parse_into_exprs(*exprs, namespace=self),
             *parse_into_exprs(*more_exprs, namespace=self),

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -279,6 +279,60 @@ class DaskNamespace:
             condition, self._backend_version, returns_scalar=False, dtypes=self._dtypes
         )
 
+    def concat_str(
+        self,
+        exprs: IntoDaskExpr | Iterable[IntoDaskExpr],
+        *more_exprs: IntoDaskExpr,
+        separator: str = "",
+        ignore_nulls: bool = False,
+    ) -> DaskExpr:
+        exprs = [exprs] if not isinstance(exprs, Iterable) else exprs
+        parsed_exprs: list[DaskExpr] = [
+            *parse_into_exprs(*exprs, namespace=self),
+            *parse_into_exprs(*more_exprs, namespace=self),
+        ]
+
+        def func(df: DaskLazyFrame) -> list[dask_expr.Series]:
+            series = (
+                s
+                for _expr in parsed_exprs
+                for s in _expr.cast(self._dtypes.String())._call(df)
+            )
+            null_mask = [s for _expr in parsed_exprs for s in _expr.is_null()._call(df)]
+
+            if not ignore_nulls:
+                null_mask_result = reduce(lambda x, y: x | y, null_mask)
+                result = reduce(lambda x, y: x + separator + y, series).where(
+                    ~null_mask_result, None
+                )
+            else:
+                init_value, *values = [
+                    s.where(~nm, "") for s, nm in zip(series, null_mask)
+                ]
+
+                separators = (
+                    nm.map({True: "", False: separator}, meta=str)
+                    for nm in null_mask[:-1]
+                )
+                result = reduce(
+                    lambda x, y: x + y,
+                    (s + v for s, v in zip(separators, values)),
+                    init_value,
+                )
+
+            return [result]
+
+        return DaskExpr(
+            call=func,
+            depth=max(x._depth for x in parsed_exprs) + 1,
+            function_name="concat_str",
+            root_names=combine_root_names(parsed_exprs),
+            output_names=reduce_output_names(parsed_exprs),
+            returns_scalar=False,
+            backend_version=self._backend_version,
+            dtypes=self._dtypes,
+        )
+
 
 class DaskWhen:
     def __init__(

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -328,12 +328,11 @@ class PandasLikeNamespace:
 
     def concat_str(
         self,
-        exprs: IntoPandasLikeExpr | Iterable[IntoPandasLikeExpr],
+        exprs: Iterable[IntoPandasLikeExpr],
         *more_exprs: IntoPandasLikeExpr,
         separator: str = "",
         ignore_nulls: bool = False,
     ) -> PandasLikeExpr:
-        exprs = [exprs] if not isinstance(exprs, Iterable) else exprs
         parsed_exprs: list[PandasLikeExpr] = [
             *parse_into_exprs(*exprs, namespace=self),
             *parse_into_exprs(*more_exprs, namespace=self),

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -338,9 +338,9 @@ class PandasLikeNamespace:
             null_mask = [s for _expr in parsed_exprs for s in _expr.is_null()._call(df)]
 
             if not ignore_nulls:
-                null_mask = reduce(lambda x, y: x | y, null_mask)
+                null_mask_result = reduce(lambda x, y: x | y, null_mask)
                 result = reduce(lambda x, y: x + separator + y, series).zip_with(
-                    ~null_mask, None
+                    ~null_mask_result, None
                 )
             else:
                 init_value, *values = [

--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -133,32 +133,48 @@ class PolarsNamespace:
 
         exprs = [exprs] if not isinstance(exprs, Iterable) else exprs
 
-        pl_exprs = parse_into_exprs(*exprs, namespace=self)
-        pl_more_exprs = parse_into_exprs(*more_exprs, namespace=self)
+        pl_exprs: list[pl.Expr] = [
+            expr._native_expr
+            for expr in (
+                *parse_into_exprs(*exprs, namespace=self),
+                *parse_into_exprs(*more_exprs, namespace=self),
+            )
+        ]
 
         if self._backend_version < (0, 20, 6):  # pragma: no cover
-            if ignore_nulls:
-                pl_exprs = (
-                    expr.cast(self._dtypes.String()).fill_null("") for expr in pl_exprs
+            null_mask = [expr.is_null() for expr in pl_exprs]
+            sep = pl.lit(separator)
+
+            if not ignore_nulls:
+                null_mask_result = pl.any_horizontal(*null_mask)
+                output_expr = pl.reduce(
+                    lambda x, y: x.cast(pl.String()) + sep + y.cast(pl.String()),  # type: ignore[arg-type,return-value]
+                    pl_exprs,
                 )
-                pl_more_exprs = (
-                    expr.cast(self._dtypes.String()).fill_null("")
-                    for expr in pl_more_exprs
+                result = pl.when(~null_mask_result).then(output_expr)
+            else:
+                init_value, *values = [
+                    pl.when(nm).then(pl.lit("")).otherwise(expr.cast(pl.String()))
+                    for expr, nm in zip(pl_exprs, null_mask)
+                ]
+                separators = [
+                    pl.when(~nm).then(sep).otherwise(pl.lit("")) for nm in null_mask[:-1]
+                ]
+
+                result = pl.fold(  # type: ignore[assignment]
+                    acc=init_value,
+                    function=lambda x, y: x + y,
+                    exprs=[s + v for s, v in zip(separators, values)],
                 )
 
             return PolarsExpr(
-                pl.concat_str(
-                    [e._native_expr for e in pl_exprs],
-                    *[e._native_expr for e in pl_more_exprs],
-                    separator=separator,
-                ),
+                result,
                 dtypes=self._dtypes,
-            )  # type: ignore[arg-type]
+            )
 
         return PolarsExpr(
             pl.concat_str(
-                [e._native_expr for e in pl_exprs],
-                *[e._native_expr for e in pl_more_exprs],
+                *pl_exprs,
                 separator=separator,
                 ignore_nulls=ignore_nulls,
             ),

--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -171,7 +171,7 @@ class PolarsNamespace:
 
         return PolarsExpr(
             pl.concat_str(
-                *pl_exprs,
+                pl_exprs,
                 separator=separator,
                 ignore_nulls=ignore_nulls,
             ),

--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -119,7 +119,7 @@ class PolarsNamespace:
 
     def concat_str(
         self,
-        exprs: IntoPolarsExpr | Iterable[IntoPolarsExpr],
+        exprs: Iterable[IntoPolarsExpr],
         *more_exprs: IntoPolarsExpr,
         separator: str = "",
         ignore_nulls: bool = False,
@@ -127,8 +127,6 @@ class PolarsNamespace:
         import polars as pl  # ignore-banned-import()
 
         from narwhals._polars.expr import PolarsExpr
-
-        exprs = [exprs] if not isinstance(exprs, Iterable) else exprs
 
         pl_exprs: list[pl.Expr] = [
             expr._native_expr

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -4424,6 +4424,57 @@ def concat_str(
             null values, the output is null.
 
     Examples:
+        >>> import narwhals as nw
+        >>> import pandas as pd
+        >>> import polars as pl
+        >>> import pyarrow as pa
+        >>> data = {
+        ...     "a": [1, 2, 3],
+        ...     "b": ["dogs", "cats", None],
+        ...     "c": ["play", "swim", "walk"],
+        ... }
+
+        We define a dataframe-agnostic function that computes the horizontal string
+        concatenation of different columns
+
+        >>> @nw.narwhalify
+        ... def func(df):
+        ...     return df.select(
+        ...         nw.concat_str(
+        ...             [
+        ...                 nw.col("a") * 2,
+        ...                 nw.col("b"),
+        ...                 nw.col("c"),
+        ...             ],
+        ...             separator=" ",
+        ...         ).alias("full_sentence")
+        ...     )
+
+        We can then pass either pandas, Polars or PyArrow to `func`:
+
+        >>> func(pd.DataFrame(data))
+          full_sentence
+        0   2 dogs play
+        1   4 cats swim
+        2          None
+
+        >>> func(pl.DataFrame(data))
+        shape: (3, 1)
+        ┌───────────────┐
+        │ full_sentence │
+        │ ---           │
+        │ str           │
+        ╞═══════════════╡
+        │ 2 dogs play   │
+        │ 4 cats swim   │
+        │ null          │
+        └───────────────┘
+
+        >>> func(pa.table(data))
+        pyarrow.Table
+        full_sentence: string
+        ----
+        full_sentence: [["2 dogs play","4 cats swim",null]]
     """
     return Expr(
         lambda plx: plx.concat_str(

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -4403,6 +4403,38 @@ def mean_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     )
 
 
+def concat_str(
+    exprs: IntoExpr | Iterable[IntoExpr],
+    *more_exprs: IntoExpr,
+    separator: str = "",
+    ignore_nulls: bool = False,
+) -> Expr:
+    r"""
+    Horizontally concatenate columns into a single string column.
+
+    Arguments:
+        exprs: Columns to concatenate into a single string column. Accepts expression
+            input. Strings are parsed as column names, other non-expression inputs are
+            parsed as literals. Non-`String` columns are cast to `String`.
+        *more_exprs: Additional columns to concatenate into a single string column,
+            specified as positional arguments.
+        separator: String that will be used to separate the values of each column.
+        ignore_nulls: Ignore null values (default is `False`).
+            If set to `False`, null values will be propagated and if the row contains any
+            null values, the output is null.
+
+    Examples:
+    """
+    return Expr(
+        lambda plx: plx.concat_str(
+            [extract_compliant(plx, v) for v in flatten(exprs)],
+            *[extract_compliant(plx, v) for v in more_exprs],
+            separator=separator,
+            ignore_nulls=ignore_nulls,
+        )
+    )
+
+
 __all__ = [
     "Expr",
 ]

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -4486,7 +4486,7 @@ def concat_str(
     """
     return Expr(
         lambda plx: plx.concat_str(
-            [extract_compliant(plx, v) for v in flatten(exprs)],
+            [extract_compliant(plx, v) for v in flatten([exprs])],
             *[extract_compliant(plx, v) for v in more_exprs],
             separator=separator,
             ignore_nulls=ignore_nulls,

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -1649,6 +1649,85 @@ def concat(
     return _stableify(nw.concat(items, how=how))  # type: ignore[no-any-return]
 
 
+def concat_str(
+    exprs: IntoExpr | Iterable[IntoExpr],
+    *more_exprs: IntoExpr,
+    separator: str = "",
+    ignore_nulls: bool = False,
+) -> Expr:
+    r"""
+    Horizontally concatenate columns into a single string column.
+
+    Arguments:
+        exprs: Columns to concatenate into a single string column. Accepts expression
+            input. Strings are parsed as column names, other non-expression inputs are
+            parsed as literals. Non-`String` columns are cast to `String`.
+        *more_exprs: Additional columns to concatenate into a single string column,
+            specified as positional arguments.
+        separator: String that will be used to separate the values of each column.
+        ignore_nulls: Ignore null values (default is `False`).
+            If set to `False`, null values will be propagated and if the row contains any
+            null values, the output is null.
+
+    Examples:
+        >>> import narwhals.stable.v1 as nw
+        >>> import pandas as pd
+        >>> import polars as pl
+        >>> import pyarrow as pa
+        >>> data = {
+        ...     "a": [1, 2, 3],
+        ...     "b": ["dogs", "cats", None],
+        ...     "c": ["play", "swim", "walk"],
+        ... }
+
+        We define a dataframe-agnostic function that computes the horizontal string
+        concatenation of different columns
+
+        >>> @nw.narwhalify
+        ... def func(df):
+        ...     return df.select(
+        ...         nw.concat_str(
+        ...             [
+        ...                 nw.col("a") * 2,
+        ...                 nw.col("b"),
+        ...                 nw.col("c"),
+        ...             ],
+        ...             separator=" ",
+        ...         ).alias("full_sentence")
+        ...     )
+
+        We can then pass either pandas, Polars or PyArrow to `func`:
+
+        >>> func(pd.DataFrame(data))
+          full_sentence
+        0   2 dogs play
+        1   4 cats swim
+        2          None
+
+        >>> func(pl.DataFrame(data))
+        shape: (3, 1)
+        ┌───────────────┐
+        │ full_sentence │
+        │ ---           │
+        │ str           │
+        ╞═══════════════╡
+        │ 2 dogs play   │
+        │ 4 cats swim   │
+        │ null          │
+        └───────────────┘
+
+        >>> func(pa.table(data))
+        pyarrow.Table
+        full_sentence: string
+        ----
+        full_sentence: [["2 dogs play","4 cats swim",null]]
+    """
+
+    return _stableify(
+        nw.concat_str(exprs, *more_exprs, separator=separator, ignore_nulls=ignore_nulls)
+    )
+
+
 def is_ordered_categorical(series: Series) -> bool:
     """
     Return whether indices of categories are semantically meaningful.
@@ -2070,6 +2149,7 @@ __all__ = [
     "all_horizontal",
     "any_horizontal",
     "col",
+    "concat_str",
     "nth",
     "len",
     "lit",

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -40,5 +40,19 @@ def test_concat_str(
         .sort("a")
         .select("full_sentence")
     )
-
+    compare_dicts(result, {"full_sentence": expected})
+    result = (
+        df.select(
+            "a",
+            nw.concat_str(
+                nw.col("a") * 2,
+                nw.col("b"),
+                nw.col("c"),
+                separator=" ",
+                ignore_nulls=ignore_nulls,  # default behavior is False
+            ).alias("full_sentence"),
+        )
+        .sort("a")
+        .select("full_sentence")
+    )
     compare_dicts(result, {"full_sentence": expected})

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+import narwhals.stable.v1 as nw
+from tests.utils import Constructor
+from tests.utils import compare_dicts
+
+data = {
+    "a": [1, 2, 3],
+    "b": ["dogs", "cats", None],
+    "c": ["play", "swim", "walk"],
+}
+
+
+@pytest.mark.parametrize(
+    ("ignore_nulls", "expected"),
+    [
+        (True, ["2 dogs play", "4 cats swim", "6 walk"]),
+        (False, ["2 dogs play", "4 cats swim", None]),
+    ],
+)
+def test_concat_str(
+    constructor: Constructor, *, ignore_nulls: bool, expected: list[str]
+) -> None:
+    df = nw.from_native(constructor(data))
+    result = (
+        df.select(
+            "a",
+            nw.concat_str(
+                [
+                    nw.col("a") * 2,
+                    nw.col("b"),
+                    nw.col("c"),
+                ],
+                separator=" ",
+                ignore_nulls=ignore_nulls,  # default behavior is False
+            ).alias("full_sentence"),
+        )
+        .sort("a")
+        .select("full_sentence")
+    )
+
+    compare_dicts(result, {"full_sentence": expected})


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Closes #1116 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.

This was a bit harder/more complex than expected to get right. The idea being that polars can switch between:

- `ignore_nulls=False` (default), which means that a single null in the row will be propagated to the final result.
- `ignore_nulls=True`, when this happens, it is not as simple as replacing the null with an empty string, since otherwise the separator will get repeated (I am using a reduce). Also the separator "attached" to the same column and row needs to be nullified to empty string.

All this comes out of the box with polars>=0.20.6 and pyarrow (not sure about min version, CI will tell). On the other hand for pandas, dask and polars<0.20.6, a fair bit of manipulation had to be done, especially for `ignore_nulls=True`. 

The gist of it is using a null_mask, a list of series corresponding to the null values of the original series, and use it to map both the null values and the separators to an empty string.

It has also been a long day, so maybe tomorrow I can take another look with some fresh eyes