### PR TITLE
test: xfail test_actual_object for cuDF

### DIFF
--- a/tests/frame/schema_test.py
+++ b/tests/frame/schema_test.py
@@ -61,7 +61,7 @@ def test_string_disguised_as_object() -> None:
 
 
 def test_actual_object(request: pytest.FixtureRequest, constructor_eager: Any) -> None:
-    if any(x in str(constructor_eager) for x in ("modin", "pyarrow_table")):
+    if any(x in str(constructor_eager) for x in ("modin", "pyarrow_table", "cudf")):
         request.applymarker(pytest.mark.xfail)
 
     class Foo: ...


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # https://github.com/narwhals-dev/narwhals/issues/862
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

@MarcoGorelli I took a look at this test and tried to implement what you mentioned here:
https://github.com/narwhals-dev/narwhals/issues/862#issuecomment-2365295750

When I do the following in cuDF directly, the types are `str`, and the docs note here seems to indicate it's not supported:
https://docs.rapids.ai/api/cudf/stable/user_guide/data-types/#a-note-on-object

```
import cudf
data = {'a': [1,2,3]}
df = cudf.DataFrame(data, dtype=object)
type(df['a'][1])
```

I believe that's why we return String here:
https://github.com/narwhals-dev/narwhals/blob/main/narwhals/_pandas_like/utils.py#L291-L299

So marking this as `xfail` seems correct. Let me know if you think there's anything else I could look a here.