### PR TITLE
fix: update no_agg to work with cuDF

### DIFF
--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -212,7 +212,9 @@ def agg_pandas(  # noqa: PLR0915
             result_aggs = result_simple_aggs
         else:
             # No aggregation provided
-            result_aggs = native_namespace.DataFrame(grouped.groups.keys(), columns=keys)
+            result_aggs = native_namespace.DataFrame(
+                list(grouped.groups.keys()), columns=keys
+            )
         return from_dataframe(result_aggs.loc[:, output_names])
 
     if dataframe_is_empty:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes # https://github.com/narwhals-dev/narwhals/issues/862

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

This is the final failing test on https://github.com/narwhals-dev/narwhals/issues/862 !

Currently it fails here:

```
narwhals/_pandas_like/group_by.py:215: in agg_pandas
    result_aggs = native_namespace.DataFrame(grouped.groups.keys(), columns=keys)
/opt/conda/lib/python3.10/site-packages/cudf/utils/performance_tracking.py:51: in wrapper
    return func(*args, **kwargs)
```
with
```
            else:
                if not is_dict_like(data):
>                   raise TypeError("data must be list or dict-like")
E                   TypeError: data must be list or dict-like

/opt/conda/lib/python3.10/site-packages/cudf/core/dataframe.py:852: TypeError
```

It looks like the `cudf.DataFrame` doesn't accept the `dict_keys` for `data`.

For example, this fails when it tries to create the cuDF dataframe. 

```
import cudf
import pandas as pd

x = dict(a=1,b=2)
print(type(x.keys()))

print(pd.DataFrame(x.keys()))
print(cudf.DataFrame(x.keys()))
```

```
File /opt/conda/lib/python3.10/site-packages/cudf/core/dataframe.py:852, in DataFrame.__init__(self, data, index, columns, dtype, copy, nan_as_null)
    850 else:
    851     if not is_dict_like(data):
--> 852         raise TypeError("data must be list or dict-like")
    854     self._init_from_dict_like(
    855         data, index=index, columns=columns, nan_as_null=nan_as_null
    856     )
    857     self._check_data_index_length_match()

TypeError: data must be list or dict-like
```

So, here, I'm converting it to a list. Not 100% certain though if the update should come here.
Might count as a bug with `data` parameter on cudf.DataFrame. not sure though.