### PR TITLE
fix: pyarrow unpivot upcast numeric

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -682,6 +682,11 @@ class ArrowDataFrame:
 
         n_rows = len(self)
 
+        promote_kwargs = (
+            {"promote_options": "permissive"}
+            if self._backend_version >= (14, 0, 0)
+            else {}
+        )
         return self._from_native_frame(
             pa.concat_tables(
                 [
@@ -695,7 +700,7 @@ class ArrowDataFrame:
                     )
                     for on_col in on_
                 ],
-                promote_options="permissive",
+                **promote_kwargs,
             )
         )
         # TODO(Unassigned): Even with promote_options="permissive", pyarrow does not

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -694,6 +694,9 @@ class ArrowDataFrame:
                         names=[*index_, variable_name, value_name],
                     )
                     for on_col in on_
-                ]
+                ],
+                promote_options="permissive",
             )
         )
+        # TODO(Unassigned): Even with promote_options="permissive", pyarrow does not
+        # upcast numeric to non-numeric (e.g. string) datatypes

--- a/tests/frame/unpivot_test.py
+++ b/tests/frame/unpivot_test.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 
+import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
+from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import compare_dicts
 
@@ -93,7 +95,10 @@ def test_unpivot_mixed_types(
     data: dict[str, Any],
     expected_dtypes: list[DType],
 ) -> None:
-    if "dask" in str(constructor):
+    if "dask" in str(constructor) or (
+        "pyarrow_table" in str(constructor)
+        and parse_version(pa.__version__) < parse_version("14.0.0")
+    ):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     result = df.unpivot(on=["a", "b"], index="idx")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #1139

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

For plotly, this is enough (as one can't plot string values).

Yet I left a TODO, up for discussion, in case we want to allow numeric to be upcasted to string as well - drawback is that we should do that manually.