### PR TITLE
docs: add missing Series str methods in api reference

### DIFF
--- a/docs/api-reference/series_str.md
+++ b/docs/api-reference/series_str.md
@@ -14,6 +14,8 @@
         - starts_with
         - strip_chars
         - to_datetime
+        - to_lowercase
+        - to_uppercase
         - tail
       show_source: false
       show_bases: false

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -159,7 +159,31 @@ if missing := set(dtypes).difference(documented).difference(BASE_DTYPES):
 
 # dt
 
-# str
+# Series.str methods
+series_str_methods = [
+    i
+    for i in nw.from_native(pl.Series(), series_only=True).str.__dir__()
+    if not i[0].isupper() and i[0] != "_"
+]
+
+with open("docs/api-reference/series_str.md") as fd:
+    content = fd.read()
+
+documented = [
+    remove_prefix(i, "        - ")
+    for i in content.splitlines()
+    if i.startswith("        - ") and not i.startswith("        - _")
+]
+
+if missing := set(series_str_methods).difference(documented):
+    print("Series.str: not documented")  # noqa: T201
+    print(missing)  # noqa: T201
+    ret = 1
+
+if extra := set(documented).difference(series_str_methods):
+    print("Series.str: outdated")  # noqa: T201
+    print(extra)  # noqa: T201
+    ret = 1
 
 # Check Expr vs Series
 expr = [i for i in nw.Expr(lambda: 0).__dir__() if not i[0].isupper() and i[0] != "_"]


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Closes https://github.com/narwhals-dev/narwhals/issues/1133

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Extends `utils/check_api_reference.py` to `Series.str` methods.
