### PR TITLE
docs: add missing methods in api reference

### DIFF
--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -121,71 +121,30 @@ if extra := set(documented).difference(series_methods):
     print(extra)  # noqa: T201
     ret = 1
 
-# Series.cat methods
-series_cat_methods = [
-    i
-    for i in nw.from_native(pl.Series(), series_only=True).cat.__dir__()
-    if not i[0].isupper() and i[0] != "_"
-]
-with open("docs/api-reference/series_cat.md") as fd:
-    content = fd.read()
-documented = [
-    remove_prefix(i, "        - ")
-    for i in content.splitlines()
-    if i.startswith("        - ") and not i.startswith("        - _")
-]
-if missing := set(series_cat_methods).difference(documented):
-    print("Series.cat: not documented")  # noqa: T201
-    print(missing)  # noqa: T201
-    ret = 1
-if extra := set(documented).difference(series_cat_methods):
-    print("Series.cat: outdated")  # noqa: T201
-    print(extra)  # noqa: T201
-    ret = 1
-
-# Series.dt methods
-series_dt_methods = [
-    i
-    for i in nw.from_native(pl.Series(), series_only=True).dt.__dir__()
-    if not i[0].isupper() and i[0] != "_"
-]
-with open("docs/api-reference/series_dt.md") as fd:
-    content = fd.read()
-documented = [
-    remove_prefix(i, "        - ")
-    for i in content.splitlines()
-    if i.startswith("        - ") and not i.startswith("        - _")
-]
-if missing := set(series_dt_methods).difference(documented):
-    print("Series.dt: not documented")  # noqa: T201
-    print(missing)  # noqa: T201
-    ret = 1
-if extra := set(documented).difference(series_dt_methods):
-    print("Series.dt: outdated")  # noqa: T201
-    print(extra)  # noqa: T201
-    ret = 1
-
-# Series.str methods
-series_str_methods = [
-    i
-    for i in nw.from_native(pl.Series(), series_only=True).str.__dir__()
-    if not i[0].isupper() and i[0] != "_"
-]
-with open("docs/api-reference/series_str.md") as fd:
-    content = fd.read()
-documented = [
-    remove_prefix(i, "        - ")
-    for i in content.splitlines()
-    if i.startswith("        - ") and not i.startswith("        - _")
-]
-if missing := set(series_str_methods).difference(documented):
-    print("Series.str: not documented")  # noqa: T201
-    print(missing)  # noqa: T201
-    ret = 1
-if extra := set(documented).difference(series_str_methods):
-    print("Series.str: outdated")  # noqa: T201
-    print(extra)  # noqa: T201
-    ret = 1
+# Series.{cat, dt, str} methods
+for namespace in NAMESPACES.difference({"name"}):
+    series_methods = [
+        i
+        for i in getattr(
+            nw.from_native(pl.Series(), series_only=True), namespace
+        ).__dir__()
+        if not i[0].isupper() and i[0] != "_"
+    ]
+    with open(f"docs/api-reference/series_{namespace}.md") as fd:
+        content = fd.read()
+    documented = [
+        remove_prefix(i, "        - ")
+        for i in content.splitlines()
+        if i.startswith("        - ") and not i.startswith("        - _")
+    ]
+    if missing := set(series_methods).difference(documented):
+        print(f"Series.{namespace}: not documented")  # noqa: T201
+        print(missing)  # noqa: T201
+        ret = 1
+    if extra := set(documented).difference(series_methods):
+        print(f"Series.{namespace}: outdated")  # noqa: T201
+        print(extra)  # noqa: T201
+        ret = 1
 
 # Expr methods
 expr_methods = [
@@ -207,85 +166,28 @@ if extra := set(documented).difference(expr_methods):
     print(extra)  # noqa: T201
     ret = 1
 
-# Expr.cat methods
-expr_cat_methods = [
-    i for i in nw.Expr(lambda: 0).cat.__dir__() if not i[0].isupper() and i[0] != "_"
-]
-with open("docs/api-reference/expr_cat.md") as fd:
-    content = fd.read()
-documented = [
-    remove_prefix(i, "        - ")
-    for i in content.splitlines()
-    if i.startswith("        - ")
-]
-if missing := set(expr_cat_methods).difference(documented):
-    print("Expr.cat: not documented")  # noqa: T201
-    print(missing)  # noqa: T201
-    ret = 1
-if extra := set(documented).difference(expr_cat_methods):
-    print("Expr.cat: outdated")  # noqa: T201
-    print(extra)  # noqa: T201
-    ret = 1
-
-# Expr.dt methods
-expr_dt_methods = [
-    i for i in nw.Expr(lambda: 0).dt.__dir__() if not i[0].isupper() and i[0] != "_"
-]
-with open("docs/api-reference/expr_dt.md") as fd:
-    content = fd.read()
-documented = [
-    remove_prefix(i, "        - ")
-    for i in content.splitlines()
-    if i.startswith("        - ")
-]
-if missing := set(expr_dt_methods).difference(documented):
-    print("Expr.dt: not documented")  # noqa: T201
-    print(missing)  # noqa: T201
-    ret = 1
-if extra := set(documented).difference(expr_dt_methods):
-    print("Expr.dt: outdated")  # noqa: T201
-    print(extra)  # noqa: T201
-    ret = 1
-
-# Expr.name methods
-expr_name_methods = [
-    i for i in nw.Expr(lambda: 0).name.__dir__() if not i[0].isupper() and i[0] != "_"
-]
-with open("docs/api-reference/expr_name.md") as fd:
-    content = fd.read()
-documented = [
-    remove_prefix(i, "        - ")
-    for i in content.splitlines()
-    if i.startswith("        - ")
-]
-if missing := set(expr_name_methods).difference(documented):
-    print("Expr.name: not documented")  # noqa: T201
-    print(missing)  # noqa: T201
-    ret = 1
-if extra := set(documented).difference(expr_name_methods):
-    print("Expr.name: outdated")  # noqa: T201
-    print(extra)  # noqa: T201
-    ret = 1
-
-# Expr.str methods
-expr_str_methods = [
-    i for i in nw.Expr(lambda: 0).str.__dir__() if not i[0].isupper() and i[0] != "_"
-]
-with open("docs/api-reference/expr_str.md") as fd:
-    content = fd.read()
-documented = [
-    remove_prefix(i, "        - ")
-    for i in content.splitlines()
-    if i.startswith("        - ")
-]
-if missing := set(expr_str_methods).difference(documented):
-    print("Expr.str: not documented")  # noqa: T201
-    print(missing)  # noqa: T201
-    ret = 1
-if extra := set(documented).difference(expr_str_methods):
-    print("Expr.str: outdated")  # noqa: T201
-    print(extra)  # noqa: T201
-    ret = 1
+# Expr.{cat, dt, name, str} methods
+for namespace in NAMESPACES:
+    expr_methods = [
+        i
+        for i in getattr(nw.Expr(lambda: 0), namespace).__dir__()
+        if not i[0].isupper() and i[0] != "_"
+    ]
+    with open(f"docs/api-reference/expr_{namespace}.md") as fd:
+        content = fd.read()
+    documented = [
+        remove_prefix(i, "        - ")
+        for i in content.splitlines()
+        if i.startswith("        - ")
+    ]
+    if missing := set(expr_methods).difference(documented):
+        print(f"Expr.{namespace}: not documented")  # noqa: T201
+        print(missing)  # noqa: T201
+        ret = 1
+    if extra := set(documented).difference(expr_methods):
+        print(f"Expr.{namespace}: outdated")  # noqa: T201
+        print(extra)  # noqa: T201
+        ret = 1
 
 # DTypes
 dtypes = [

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -121,6 +121,72 @@ if extra := set(documented).difference(series_methods):
     print(extra)  # noqa: T201
     ret = 1
 
+# Series.cat methods
+series_cat_methods = [
+    i
+    for i in nw.from_native(pl.Series(), series_only=True).cat.__dir__()
+    if not i[0].isupper() and i[0] != "_"
+]
+with open("docs/api-reference/series_cat.md") as fd:
+    content = fd.read()
+documented = [
+    remove_prefix(i, "        - ")
+    for i in content.splitlines()
+    if i.startswith("        - ") and not i.startswith("        - _")
+]
+if missing := set(series_cat_methods).difference(documented):
+    print("Series.cat: not documented")  # noqa: T201
+    print(missing)  # noqa: T201
+    ret = 1
+if extra := set(documented).difference(series_cat_methods):
+    print("Series.cat: outdated")  # noqa: T201
+    print(extra)  # noqa: T201
+    ret = 1
+
+# Series.dt methods
+series_dt_methods = [
+    i
+    for i in nw.from_native(pl.Series(), series_only=True).dt.__dir__()
+    if not i[0].isupper() and i[0] != "_"
+]
+with open("docs/api-reference/series_dt.md") as fd:
+    content = fd.read()
+documented = [
+    remove_prefix(i, "        - ")
+    for i in content.splitlines()
+    if i.startswith("        - ") and not i.startswith("        - _")
+]
+if missing := set(series_dt_methods).difference(documented):
+    print("Series.dt: not documented")  # noqa: T201
+    print(missing)  # noqa: T201
+    ret = 1
+if extra := set(documented).difference(series_dt_methods):
+    print("Series.dt: outdated")  # noqa: T201
+    print(extra)  # noqa: T201
+    ret = 1
+
+# Series.str methods
+series_str_methods = [
+    i
+    for i in nw.from_native(pl.Series(), series_only=True).str.__dir__()
+    if not i[0].isupper() and i[0] != "_"
+]
+with open("docs/api-reference/series_str.md") as fd:
+    content = fd.read()
+documented = [
+    remove_prefix(i, "        - ")
+    for i in content.splitlines()
+    if i.startswith("        - ") and not i.startswith("        - _")
+]
+if missing := set(series_str_methods).difference(documented):
+    print("Series.str: not documented")  # noqa: T201
+    print(missing)  # noqa: T201
+    ret = 1
+if extra := set(documented).difference(series_str_methods):
+    print("Series.str: outdated")  # noqa: T201
+    print(extra)  # noqa: T201
+    ret = 1
+
 # Expr methods
 expr_methods = [
     i for i in nw.Expr(lambda: 0).__dir__() if not i[0].isupper() and i[0] != "_"
@@ -236,74 +302,8 @@ if missing := set(dtypes).difference(documented).difference(BASE_DTYPES):
     print("Dtype: not documented")  # noqa: T201
     print(missing)  # noqa: T201
     ret = 1
-if extra := set(documented).difference(dtypes).difference(BASE_DTYPES):
+if extra := set(documented).difference(dtypes):
     print("Dtype: outdated")  # noqa: T201
-    print(extra)  # noqa: T201
-    ret = 1
-
-# Series.cat methods
-series_cat_methods = [
-    i
-    for i in nw.from_native(pl.Series(), series_only=True).cat.__dir__()
-    if not i[0].isupper() and i[0] != "_"
-]
-with open("docs/api-reference/series_cat.md") as fd:
-    content = fd.read()
-documented = [
-    remove_prefix(i, "        - ")
-    for i in content.splitlines()
-    if i.startswith("        - ") and not i.startswith("        - _")
-]
-if missing := set(series_cat_methods).difference(documented):
-    print("Series.cat: not documented")  # noqa: T201
-    print(missing)  # noqa: T201
-    ret = 1
-if extra := set(documented).difference(series_cat_methods):
-    print("Series.cat: outdated")  # noqa: T201
-    print(extra)  # noqa: T201
-    ret = 1
-
-# Series.dt methods
-series_dt_methods = [
-    i
-    for i in nw.from_native(pl.Series(), series_only=True).dt.__dir__()
-    if not i[0].isupper() and i[0] != "_"
-]
-with open("docs/api-reference/series_dt.md") as fd:
-    content = fd.read()
-documented = [
-    remove_prefix(i, "        - ")
-    for i in content.splitlines()
-    if i.startswith("        - ") and not i.startswith("        - _")
-]
-if missing := set(series_dt_methods).difference(documented):
-    print("Series.dt: not documented")  # noqa: T201
-    print(missing)  # noqa: T201
-    ret = 1
-if extra := set(documented).difference(series_dt_methods):
-    print("Series.dt: outdated")  # noqa: T201
-    print(extra)  # noqa: T201
-    ret = 1
-
-# Series.str methods
-series_str_methods = [
-    i
-    for i in nw.from_native(pl.Series(), series_only=True).str.__dir__()
-    if not i[0].isupper() and i[0] != "_"
-]
-with open("docs/api-reference/series_str.md") as fd:
-    content = fd.read()
-documented = [
-    remove_prefix(i, "        - ")
-    for i in content.splitlines()
-    if i.startswith("        - ") and not i.startswith("        - _")
-]
-if missing := set(series_str_methods).difference(documented):
-    print("Series.str: not documented")  # noqa: T201
-    print(missing)  # noqa: T201
-    ret = 1
-if extra := set(documented).difference(series_str_methods):
-    print("Series.str: outdated")  # noqa: T201
     print(extra)  # noqa: T201
     ret = 1
 

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -141,6 +141,86 @@ if extra := set(documented).difference(expr_methods):
     print(extra)  # noqa: T201
     ret = 1
 
+# Expr.cat methods
+expr_cat_methods = [
+    i for i in nw.Expr(lambda: 0).cat.__dir__() if not i[0].isupper() and i[0] != "_"
+]
+with open("docs/api-reference/expr_cat.md") as fd:
+    content = fd.read()
+documented = [
+    remove_prefix(i, "        - ")
+    for i in content.splitlines()
+    if i.startswith("        - ")
+]
+if missing := set(expr_cat_methods).difference(documented):
+    print("Expr.cat: not documented")  # noqa: T201
+    print(missing)  # noqa: T201
+    ret = 1
+if extra := set(documented).difference(expr_cat_methods):
+    print("Expr.cat: outdated")  # noqa: T201
+    print(extra)  # noqa: T201
+    ret = 1
+
+# Expr.dt methods
+expr_dt_methods = [
+    i for i in nw.Expr(lambda: 0).dt.__dir__() if not i[0].isupper() and i[0] != "_"
+]
+with open("docs/api-reference/expr_dt.md") as fd:
+    content = fd.read()
+documented = [
+    remove_prefix(i, "        - ")
+    for i in content.splitlines()
+    if i.startswith("        - ")
+]
+if missing := set(expr_dt_methods).difference(documented):
+    print("Expr.dt: not documented")  # noqa: T201
+    print(missing)  # noqa: T201
+    ret = 1
+if extra := set(documented).difference(expr_dt_methods):
+    print("Expr.dt: outdated")  # noqa: T201
+    print(extra)  # noqa: T201
+    ret = 1
+
+# Expr.name methods
+expr_name_methods = [
+    i for i in nw.Expr(lambda: 0).name.__dir__() if not i[0].isupper() and i[0] != "_"
+]
+with open("docs/api-reference/expr_name.md") as fd:
+    content = fd.read()
+documented = [
+    remove_prefix(i, "        - ")
+    for i in content.splitlines()
+    if i.startswith("        - ")
+]
+if missing := set(expr_name_methods).difference(documented):
+    print("Expr.name: not documented")  # noqa: T201
+    print(missing)  # noqa: T201
+    ret = 1
+if extra := set(documented).difference(expr_name_methods):
+    print("Expr.name: outdated")  # noqa: T201
+    print(extra)  # noqa: T201
+    ret = 1
+
+# Expr.str methods
+expr_str_methods = [
+    i for i in nw.Expr(lambda: 0).str.__dir__() if not i[0].isupper() and i[0] != "_"
+]
+with open("docs/api-reference/expr_str.md") as fd:
+    content = fd.read()
+documented = [
+    remove_prefix(i, "        - ")
+    for i in content.splitlines()
+    if i.startswith("        - ")
+]
+if missing := set(expr_str_methods).difference(documented):
+    print("Expr.str: not documented")  # noqa: T201
+    print(missing)  # noqa: T201
+    ret = 1
+if extra := set(documented).difference(expr_str_methods):
+    print("Expr.str: outdated")  # noqa: T201
+    print(extra)  # noqa: T201
+    ret = 1
+
 # DTypes
 dtypes = [
     i for i in nw.dtypes.__dir__() if i[0].isupper() and not i.isupper() and i[0] != "_"

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -163,21 +163,17 @@ series_cat_methods = [
     for i in nw.from_native(pl.Series(), series_only=True).cat.__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
-
 with open("docs/api-reference/series_cat.md") as fd:
     content = fd.read()
-
 documented = [
     remove_prefix(i, "        - ")
     for i in content.splitlines()
     if i.startswith("        - ") and not i.startswith("        - _")
 ]
-
 if missing := set(series_cat_methods).difference(documented):
     print("Series.cat: not documented")  # noqa: T201
     print(missing)  # noqa: T201
     ret = 1
-
 if extra := set(documented).difference(series_cat_methods):
     print("Series.cat: outdated")  # noqa: T201
     print(extra)  # noqa: T201
@@ -189,21 +185,17 @@ series_dt_methods = [
     for i in nw.from_native(pl.Series(), series_only=True).dt.__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
-
 with open("docs/api-reference/series_dt.md") as fd:
     content = fd.read()
-
 documented = [
     remove_prefix(i, "        - ")
     for i in content.splitlines()
     if i.startswith("        - ") and not i.startswith("        - _")
 ]
-
 if missing := set(series_dt_methods).difference(documented):
     print("Series.dt: not documented")  # noqa: T201
     print(missing)  # noqa: T201
     ret = 1
-
 if extra := set(documented).difference(series_dt_methods):
     print("Series.dt: outdated")  # noqa: T201
     print(extra)  # noqa: T201
@@ -215,21 +207,17 @@ series_str_methods = [
     for i in nw.from_native(pl.Series(), series_only=True).str.__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
-
 with open("docs/api-reference/series_str.md") as fd:
     content = fd.read()
-
 documented = [
     remove_prefix(i, "        - ")
     for i in content.splitlines()
     if i.startswith("        - ") and not i.startswith("        - _")
 ]
-
 if missing := set(series_str_methods).difference(documented):
     print("Series.str: not documented")  # noqa: T201
     print(missing)  # noqa: T201
     ret = 1
-
 if extra := set(documented).difference(series_str_methods):
     print("Series.str: outdated")  # noqa: T201
     print(extra)  # noqa: T201

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -157,7 +157,31 @@ if missing := set(dtypes).difference(documented).difference(BASE_DTYPES):
     print(missing)  # noqa: T201
     ret = 1
 
-# dt
+# Series.dt methods
+series_dt_methods = [
+    i
+    for i in nw.from_native(pl.Series(), series_only=True).dt.__dir__()
+    if not i[0].isupper() and i[0] != "_"
+]
+
+with open("docs/api-reference/series_dt.md") as fd:
+    content = fd.read()
+
+documented = [
+    remove_prefix(i, "        - ")
+    for i in content.splitlines()
+    if i.startswith("        - ") and not i.startswith("        - _")
+]
+
+if missing := set(series_dt_methods).difference(documented):
+    print("Series.str: not documented")  # noqa: T201
+    print(missing)  # noqa: T201
+    ret = 1
+
+if extra := set(documented).difference(series_dt_methods):
+    print("Series.str: outdated")  # noqa: T201
+    print(extra)  # noqa: T201
+    ret = 1
 
 # Series.str methods
 series_str_methods = [

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -157,6 +157,32 @@ if missing := set(dtypes).difference(documented).difference(BASE_DTYPES):
     print(missing)  # noqa: T201
     ret = 1
 
+# Series.cat methods
+series_cat_methods = [
+    i
+    for i in nw.from_native(pl.Series(), series_only=True).cat.__dir__()
+    if not i[0].isupper() and i[0] != "_"
+]
+
+with open("docs/api-reference/series_cat.md") as fd:
+    content = fd.read()
+
+documented = [
+    remove_prefix(i, "        - ")
+    for i in content.splitlines()
+    if i.startswith("        - ") and not i.startswith("        - _")
+]
+
+if missing := set(series_cat_methods).difference(documented):
+    print("Series.cat: not documented")  # noqa: T201
+    print(missing)  # noqa: T201
+    ret = 1
+
+if extra := set(documented).difference(series_cat_methods):
+    print("Series.cat: outdated")  # noqa: T201
+    print(extra)  # noqa: T201
+    ret = 1
+
 # Series.dt methods
 series_dt_methods = [
     i
@@ -174,12 +200,12 @@ documented = [
 ]
 
 if missing := set(series_dt_methods).difference(documented):
-    print("Series.str: not documented")  # noqa: T201
+    print("Series.dt: not documented")  # noqa: T201
     print(missing)  # noqa: T201
     ret = 1
 
 if extra := set(documented).difference(series_dt_methods):
-    print("Series.str: outdated")  # noqa: T201
+    print("Series.dt: outdated")  # noqa: T201
     print(extra)  # noqa: T201
     ret = 1
 

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -156,6 +156,10 @@ if missing := set(dtypes).difference(documented).difference(BASE_DTYPES):
     print("Dtype: not documented")  # noqa: T201
     print(missing)  # noqa: T201
     ret = 1
+if extra := set(documented).difference(dtypes).difference(BASE_DTYPES):
+    print("Dtype: outdated")  # noqa: T201
+    print(extra)  # noqa: T201
+    ret = 1
 
 # Series.cat methods
 series_cat_methods = [


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue https://github.com/narwhals-dev/narwhals/pull/1143#pullrequestreview-2350534830

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.

Extends `utils/check_api_reference.py` to include methods from `Series.cat`, `Series.dt`, `Expr.cat`, `Expr.dt`, `Expr.name` and `Expr.str`. (Hope I haven't missed anything:))