### PR TITLE
test: xfail test_unpivot_mixed_types for cuDF

### DIFF
--- a/tests/frame/unpivot_test.py
+++ b/tests/frame/unpivot_test.py
@@ -95,9 +95,13 @@ def test_unpivot_mixed_types(
     data: dict[str, Any],
     expected_dtypes: list[DType],
 ) -> None:
-    if "dask" in str(constructor) or (
-        "pyarrow_table" in str(constructor)
-        and parse_version(pa.__version__) < parse_version("14.0.0")
+    if (
+        "dask" in str(constructor)
+        or "cudf" in str(constructor)
+        or (
+            "pyarrow_table" in str(constructor)
+            and parse_version(pa.__version__) < parse_version("14.0.0")
+        )
     ):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes # https://github.com/narwhals-dev/narwhals/issues/862

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
Marking this test as xfail for cuDF as it throws an error.

```
>               raise ValueError("all cols in value_vars must have the same dtype")
E               ValueError: all cols in value_vars must have the same dtype
```
And it looks like this is expected:
https://github.com/rapidsai/cudf/blob/branch-24.12/python/cudf/cudf/core/reshape.py#L651-L657