### PR TITLE
enh: Add `.rows(named=False)` support for pyarrow

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -87,8 +87,8 @@ class ArrowDataFrame:
         self, *, named: bool = False
     ) -> list[tuple[Any, ...]] | list[dict[str, Any]]:
         if not named:
-            return list(self.iter_rows(named=False))
-        return self._native_frame.to_pylist()
+            return list(self.iter_rows(named=False))  # type: ignore[return-value]
+        return self._native_frame.to_pylist()  # type: ignore[no-any-return]
 
     def iter_rows(
         self,

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -88,7 +88,7 @@ class ArrowDataFrame:
     ) -> list[tuple[Any, ...]] | list[dict[str, Any]]:
         if not named:
             return list(self.iter_rows(named=False))
-        return self._native_frame.to_pylist()  # type: ignore[no-any-return]
+        return self._native_frame.to_pylist()
 
     def iter_rows(
         self,

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -87,8 +87,7 @@ class ArrowDataFrame:
         self, *, named: bool = False
     ) -> list[tuple[Any, ...]] | list[dict[str, Any]]:
         if not named:
-            msg = "Unnamed rows are not yet supported on PyArrow tables"
-            raise NotImplementedError(msg)
+            return list(self.iter_rows(named=False))
         return self._native_frame.to_pylist()  # type: ignore[no-any-return]
 
     def iter_rows(

--- a/tests/frame/rows_test.py
+++ b/tests/frame/rows_test.py
@@ -92,14 +92,6 @@ def test_rows(
     expected: list[tuple[Any, ...]] | list[dict[str, Any]],
 ) -> None:
     df = nw.from_native(df_raw, eager_only=True)
-    if isinstance(df_raw, pa.Table) and not named:
-        with pytest.raises(
-            NotImplementedError,
-            match="Unnamed rows are not yet supported on PyArrow tables",
-        ):
-            df.rows(named=named)
-        return
-
     result = df.rows(named=named)
     assert result == expected
 


### PR DESCRIPTION
I'm in the camp of _slow support is better than no support_.

If there ever comes a time that pyarrow supports retrieving row values more natively, then this code can be updated.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # NA
- Closes # NA

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

posit-dev/py-shiny uses `.rows(named=False)` to retrieve the values 
