### PR TITLE
docs: separate out DataFrame and LazyFrame in api-completeness

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,12 +19,12 @@ nav:
   - extending.md
   - how_it_works.md
   - Roadmap and related projects: roadmap_and_related.md
-  # Commented-out until https://github.com/narwhals-dev/narwhals/issues/1004 is addressed
-  # - API Completeness:
-  #   - api-completeness/index.md
-  #   - Supported DataFrame methods: api-completeness/dataframe.md
-  #   - Supported Expr methods: api-completeness/expr.md
-  #   - Supported Series methods: api-completeness/series.md
+  - API Completeness:
+    - api-completeness/index.md
+    - Supported DataFrame methods: api-completeness/dataframe.md
+    - Supported LazyFrame methods: api-completeness/lazyframe.md
+    - Supported Expr methods: api-completeness/expr.md
+    - Supported Series methods: api-completeness/series.md
   - API Reference:
     - api-reference/narwhals.md
     - api-reference/dataframe.md

--- a/utils/generate_backend_completeness.py
+++ b/utils/generate_backend_completeness.py
@@ -116,7 +116,7 @@ def get_backend_completeness_table() -> None:
 
             nw_methods = get_class_methods(nw_class)
 
-            narhwals = pl.DataFrame(
+            narwhals = pl.DataFrame(
                 {"Class": nw_class_name, "Backend": "narwhals", "Method": nw_methods}
             )
 
@@ -136,11 +136,11 @@ def get_backend_completeness_table() -> None:
                 for backend in BACKENDS
             ]
 
-            results.extend([narhwals, *backend_methods])
+            results.extend([narwhals, *backend_methods])
 
             if nw_class_name in {"DataFrame", "LazyFrame"}:
                 render_table_and_write_to_output(
-                    results=[narhwals, *backend_methods],
+                    results=[narwhals, *backend_methods],
                     title=nw_class_name,
                     output_filename=nw_class_name.lower(),
                 )


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Closes https://github.com/narwhals-dev/narwhals/issues/1004

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.
Separate out `DataFrame` and `LazyFrame` so as to create separate pages in the `api-completeness` section, while leaving `Series` and `Expr` as is.

Page rendering for `DataFrame` and `LazyFrame` is handled at "class-level", page rendering for `Series` and `Expr` remains at "module-level" (making sure `DataFrame` is not "processed" in both contexts).
