### PR TITLE
chore: Use shiny's Makefile to allow for test commands to change over time

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -115,7 +115,7 @@ jobs:
       - name: install-shiny-dev
         env:
           UV_SYSTEM_PYTHON: 1
-        run: |            
+        run: |
             cd py-shiny
             make narwhals-install-shiny
       - name: install-narwhals-dev

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -113,9 +113,11 @@ jobs:
       - name: install-basics
         run: uv pip install --upgrade tox virtualenv setuptools --system
       - name: install-shiny-dev
-        run: |
+        env:
+          UV_SYSTEM_PYTHON: 1
+        run: |            
             cd py-shiny
-            uv pip install -e ".[dev,test]" --system
+            make narwhals-install-shiny
       - name: install-narwhals-dev
         run: |
             uv pip uninstall narwhals --system
@@ -125,10 +127,4 @@ jobs:
       - name: Run pytest
         run: |
             cd py-shiny
-            python tests/pytest/asyncio_prevent.py
-            pytest
-      - name: Run mypy
-        run: |
-            cd py-shiny
-            uv pip install mypy --system
-            mypy shiny
+            make narwhals-test-integration

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -124,7 +124,7 @@ jobs:
             uv pip install -e . --system
       - name: show-deps
         run: uv pip freeze
-      - name: Run pytest
+      - name: Run `make narwhals-test-integration`
         run: |
             cd py-shiny
             make narwhals-test-integration


### PR DESCRIPTION
Related: 
* posit-dev/py-shiny#1729
* posit-dev/py-shiny#1731

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Re lated issue # NA
- Closes # NA

## Checklist

- [ ] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

The default `pytest` command does cover some tests, but others are ran under default settings. By integrating the make commands, `py-shiny` can update the internal script as things change without need for updates to `narwhals`.