### PR TITLE
ci: add downstream tests for `marimo`

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -86,6 +86,10 @@ jobs:
             uv pip install -e . --system
       - name: show-deps
         run: uv pip freeze
+      - name: Debug
+        run: |
+            ls -la marimo/
+            ls -la frontend/
       - name: Create assets directory, copy over index.html
         run: |
           mkdir -p marimo/_static/assets

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -86,6 +86,11 @@ jobs:
             uv pip install -e . --system
       - name: show-deps
         run: uv pip freeze
+      - name: Create assets directory, copy over index.html
+        run: |
+          mkdir -p marimo/_static/assets
+          cp frontend/index.html marimo/_static/index.html
+          cp frontend/public/favicon.ico marimo/_static/favicon.ico
       - name: Run test with minimal dependencies
         if: ${{ matrix.dependencies == 'core' }}
         run: |
@@ -95,8 +100,7 @@ jobs:
         run: |
             hatch run +py=${{ matrix.python-version }} test-optional:test -v tests/ -k "not test_cli"
       - name: Run typechecks
-        run: |
-            hatch run typecheck:check
+        run: hatch run typecheck:check
 
   scikit-lego:
     strategy:

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -94,11 +94,11 @@ jobs:
       - name: Run test with minimal dependencies
         if: ${{ matrix.dependencies == 'core' }}
         run: |
-            hatch run +py=${{ matrix.python-version }} test:test -v tests/ -k "not test_cli"
+            hatch run test:test -v tests/ -k "not test_cli"
       - name: Run test with optional dependencies
         if: ${{ matrix.dependencies == 'core,optional' }}
         run: |
-            hatch run +py=${{ matrix.python-version }} test-optional:test -v tests/ -k "not test_cli"
+            hatch run test-optional:test -v tests/ -k "not test_cli"
       - name: Run typechecks
         run: hatch run typecheck:check
 

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -89,16 +89,13 @@ jobs:
       - name: Run test with minimal dependencies
         if: ${{ matrix.dependencies == 'core' }}
         run: |
-            cd marimo
             hatch run +py=${{ matrix.python-version }} test:test -v tests/ -k "not test_cli"
       - name: Run test with optional dependencies
         if: ${{ matrix.dependencies == 'core,optional' }}
         run: |
-            cd marimo
             hatch run +py=${{ matrix.python-version }} test-optional:test -v tests/ -k "not test_cli"
       - name: Run typechecks
         run: |
-            cd marimo
             hatch run typecheck:check
 
   scikit-lego:

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -86,14 +86,11 @@ jobs:
             uv pip install -e . --system
       - name: show-deps
         run: uv pip freeze
-      - name: Debug
-        run: |
-            ls -la marimo/frontend/
       - name: Create assets directory, copy over index.html
         run: |
-          mkdir -p marimo/_static/assets
-          cp frontend/index.html marimo/_static/index.html
-          cp frontend/public/favicon.ico marimo/_static/favicon.ico
+          mkdir -p marimo/marimo/_static/assets
+          cp marimo/frontend/index.html marimo/marimo/_static/index.html
+          cp marimo/frontend/public/favicon.ico marimo/marimo/_static/favicon.ico
       - name: Run test with minimal dependencies
         if: ${{ matrix.dependencies == 'core' }}
         run: |

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -88,9 +88,13 @@ jobs:
         run: uv pip freeze
       - name: Create assets directory, copy over index.html
         run: |
-          mkdir -p marimo/marimo/_static/assets
-          cp marimo/frontend/index.html marimo/marimo/_static/index.html
-          cp marimo/frontend/public/favicon.ico marimo/marimo/_static/favicon.ico
+            mkdir -p marimo/marimo/_static/assets
+            cp marimo/frontend/index.html marimo/marimo/_static/index.html
+            cp marimo/frontend/public/favicon.ico marimo/marimo/_static/favicon.ico
+      - name: Add further debugging temporary step
+        run: |
+            pwd
+            ls -la
       - name: hatch-envs
         run: hatch env show
       - name: Run test with minimal dependencies

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -71,7 +71,7 @@ jobs:
           cache-dependency-glob: "**requirements*.txt"
       - name: clone-marimo
         run: |
-            git clone https://github.com/marimo-team/marimo.git
+            git clone https://github.com/marimo-team/marimo.git --depth=1
             cd marimo
             git log
       - name: install-basics
@@ -91,12 +91,18 @@ jobs:
             mkdir -p marimo/marimo/_static/assets
             cp marimo/frontend/index.html marimo/marimo/_static/index.html
             cp marimo/frontend/public/favicon.ico marimo/marimo/_static/favicon.ico
-      - name: Run tests
+      - name: Run tests with minimal dependencies
+        if: ${{ matrix.dependencies == 'core' }}
         run: |
             cd marimo
             hatch run +py=${{ matrix.python-version }} test:test -v tests/ -k "not test_cli"
+        timeout-minutes: 15
+      - name: Run tests with optional dependencies
+        if: ${{ matrix.dependencies == 'core,optional' }}
+        run: |
+            cd marimo
             hatch run +py=${{ matrix.python-version }} test-optional:test -v tests/ -k "not test_cli"
-        timeout-minutes: 10
+        timeout-minutes: 15
       - name: Run typechecks
         run: |
             cd marimo

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -94,19 +94,26 @@ jobs:
       - name: Add further debugging temporary step
         run: |
             pwd
+            cd marimo
             ls -la
       - name: hatch-envs
-        run: hatch env show
+        run: |
+            cd marimo
+            hatch env show
       - name: Run test with minimal dependencies
         if: ${{ matrix.dependencies == 'core' }}
         run: |
+            cd marimo
             hatch run test:test -v tests/ -k "not test_cli"
       - name: Run test with optional dependencies
         if: ${{ matrix.dependencies == 'core,optional' }}
         run: |
+            cd marimo
             hatch run test-optional:test -v tests/ -k "not test_cli"
       - name: Run typechecks
-        run: hatch run typecheck:check
+        run: |
+            cd marimo
+            hatch run typecheck:check
 
   scikit-lego:
     strategy:

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -91,6 +91,8 @@ jobs:
           mkdir -p marimo/marimo/_static/assets
           cp marimo/frontend/index.html marimo/marimo/_static/index.html
           cp marimo/frontend/public/favicon.ico marimo/marimo/_static/favicon.ico
+      - name: hatch-envs
+        run: hatch env show
       - name: Run test with minimal dependencies
         if: ${{ matrix.dependencies == 'core' }}
         run: |

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -96,6 +96,7 @@ jobs:
             cd marimo
             hatch run test:test -v tests/ -k "not test_cli"
             hatch run test-optional:test -v tests/ -k "not test_cli"
+        timeout-minutes: 10
       - name: Run typechecks
         run: |
             cd marimo

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -50,6 +50,57 @@ jobs:
             cd altair
             mypy altair tests
 
+  marimo:
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+        os: [ubuntu-latest]
+        dependencies: ["core", "core,optional"]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: "true"
+          cache-suffix: ${{ matrix.python-version }}
+          cache-dependency-glob: "**requirements*.txt"
+      - name: clone-marimo
+        run: |
+            git clone https://github.com/marimo-team/marimo.git --depth=1
+            cd marimo
+            git log
+      - name: install-basics
+        run: uv pip install --upgrade tox virtualenv setuptools hatch --system
+      - name: install-marimo-dev
+        run: |
+            cd marimo
+            uv pip install -e ".[dev]" --system
+      - name: install-narwhals-dev
+        run: |
+            uv pip uninstall narwhals --system
+            uv pip install -e . --system
+      - name: show-deps
+        run: uv pip freeze
+      - name: Run test with minimal dependencies
+        if: ${{ matrix.dependencies == 'core' }}
+        run: |
+            cd marimo
+            hatch run +py=${{ matrix.python-version }} test:test -v tests/ -k "not test_cli"
+      - name: Run test with optional dependencies
+        if: ${{ matrix.dependencies == 'core,optional' }}
+        run: |
+            cd marimo
+            hatch run +py=${{ matrix.python-version }} test-optional:test -v tests/ -k "not test_cli"
+      - name: Run typechecks
+        run: |
+            cd marimo
+            hatch run typecheck:check
+
   scikit-lego:
     strategy:
       matrix:

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -94,9 +94,8 @@ jobs:
       - name: Run tests
         run: |
             cd marimo
-            hatch run test:test -v tests/ -k "not test_cli"
-            hatch run test-optional:test -v tests/ -k "not test_cli"
-        timeout-minutes: 10
+            hatch run +py=${{ matrix.python-version }} test:test -v tests/ -k "not test_cli"
+            hatch run +py=${{ matrix.python-version }} test-optional:test -v tests/ -k "not test_cli"
       - name: Run typechecks
         run: |
             cd marimo

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -91,24 +91,10 @@ jobs:
             mkdir -p marimo/marimo/_static/assets
             cp marimo/frontend/index.html marimo/marimo/_static/index.html
             cp marimo/frontend/public/favicon.ico marimo/marimo/_static/favicon.ico
-      - name: Add further debugging temporary step
-        run: |
-            pwd
-            cd marimo
-            ls -la
-      - name: hatch-envs
-        run: |
-            cd marimo
-            hatch env show
-      - name: Run test with minimal dependencies
-        if: ${{ matrix.dependencies == 'core' }}
+      - name: Run tests
         run: |
             cd marimo
             hatch run test:test -v tests/ -k "not test_cli"
-      - name: Run test with optional dependencies
-        if: ${{ matrix.dependencies == 'core,optional' }}
-        run: |
-            cd marimo
             hatch run test-optional:test -v tests/ -k "not test_cli"
       - name: Run typechecks
         run: |

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -88,8 +88,7 @@ jobs:
         run: uv pip freeze
       - name: Debug
         run: |
-            ls -la marimo/
-            ls -la frontend/
+            ls -la marimo/frontend/
       - name: Create assets directory, copy over index.html
         run: |
           mkdir -p marimo/_static/assets

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -71,7 +71,7 @@ jobs:
           cache-dependency-glob: "**requirements*.txt"
       - name: clone-marimo
         run: |
-            git clone https://github.com/marimo-team/marimo.git --depth=1
+            git clone https://github.com/marimo-team/marimo.git
             cd marimo
             git log
       - name: install-basics
@@ -96,6 +96,7 @@ jobs:
             cd marimo
             hatch run +py=${{ matrix.python-version }} test:test -v tests/ -k "not test_cli"
             hatch run +py=${{ matrix.python-version }} test-optional:test -v tests/ -k "not test_cli"
+        timeout-minutes: 10
       - name: Run typechecks
         run: |
             cd marimo


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Closes #1163

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
Attempt at adding downstream tests for `marimo` to the CI pipeline. 

Notes:
- `marimo`'s full test suite also includes additional tests for frontend/cli etc.; I've omitted them as not relevant to the python backend testing functionality.
- `marimo` leverages on `hatch`, though `pyproject.toml` shows the following
    > [tool.hatch]
    installer = "uv"
- also, `test:test`, `test-optional:test` and `typecheck:check` do refer to the following `pytest` and `mypy` commands 
    > [tool.hatch.envs.test.scripts]
    test = "pytest{env:HATCH_TEST_ARGS:} {args:tests}"
    ...
    [tool.hatch.envs.test-optional]
    template = "test"
    ...
    [tool.hatch.envs.typecheck.scripts]
    check = "mypy marimo/"

All this said, I've kept the commands as-is (trying to align with the approach in https://github.com/narwhals-dev/narwhals/pull/1161, even though I haven't referenced `make` commands as they do hardcode the python version in within).
    
Please let me know your thoughts on these points so that I can tweak accordingly :) (assuming that everything works as intended 🥶)