### PR TITLE
fix: Add df`.rows(named=False)` support for cuDF data frames

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -83,6 +83,26 @@ class ArrowDataFrame:
     def row(self, index: int) -> tuple[Any, ...]:
         return tuple(col[index] for col in self._native_frame)
 
+    @overload
+    def rows(
+        self,
+        *,
+        named: Literal[True],
+    ) -> list[dict[str, Any]]: ...
+
+    @overload
+    def rows(
+        self,
+        *,
+        named: Literal[False] = False,
+    ) -> list[tuple[Any, ...]]: ...
+    @overload
+    def rows(
+        self,
+        *,
+        named: bool,
+    ) -> list[tuple[Any, ...]] | list[dict[str, Any]]: ...
+
     def rows(
         self, *, named: bool = False
     ) -> list[tuple[Any, ...]] | list[dict[str, Any]]:
@@ -141,13 +161,15 @@ class ArrowDataFrame:
 
     def __getitem__(
         self,
-        item: str
-        | slice
-        | Sequence[int]
-        | Sequence[str]
-        | tuple[Sequence[int], str | int]
-        | tuple[slice, str | int]
-        | tuple[slice, slice],
+        item: (
+            str
+            | slice
+            | Sequence[int]
+            | Sequence[str]
+            | tuple[Sequence[int], str | int]
+            | tuple[slice, str | int]
+            | tuple[slice, slice]
+        ),
     ) -> ArrowSeries | ArrowDataFrame:
         if isinstance(item, tuple):
             item = tuple(list(i) if is_sequence_but_not_str(i) else i for i in item)
@@ -496,7 +518,9 @@ class ArrowDataFrame:
 
     def collect(self) -> ArrowDataFrame:
         return ArrowDataFrame(
-            self._native_frame, backend_version=self._backend_version, dtypes=self._dtypes
+            self._native_frame,
+            backend_version=self._backend_version,
+            dtypes=self._dtypes,
         )
 
     def clone(self) -> Self:

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -274,7 +274,7 @@ class PandasLikeDataFrame:
     ) -> list[tuple[Any, ...]] | list[dict[str, Any]]:
         if not named:
             # cuDF does not support itertuples. But it does support to_dict!
-            if is_cudf_dataframe(self._native_frame):
+            if self._implementation is Implementation.CUDF:  # pragma: no cover
                 # Extract the row values from the named rows
                 return [tuple(row.values()) for row in self.rows(named=True)]
 

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -262,6 +262,13 @@ class PandasLikeDataFrame:
         named: Literal[False] = False,
     ) -> list[tuple[Any, ...]]: ...
 
+    @overload
+    def rows(
+        self,
+        *,
+        named: bool,
+    ) -> list[tuple[Any, ...]] | list[dict[str, Any]]: ...
+
     def rows(
         self, *, named: bool = False
     ) -> list[tuple[Any, ...]] | list[dict[str, Any]]:

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -16,7 +16,6 @@ from narwhals._pandas_like.utils import create_native_series
 from narwhals._pandas_like.utils import horizontal_concat
 from narwhals._pandas_like.utils import native_to_narwhals_dtype
 from narwhals._pandas_like.utils import validate_dataframe_comparand
-from narwhals.dependencies import is_cudf_dataframe
 from narwhals.dependencies import is_numpy_array
 from narwhals.utils import Implementation
 from narwhals.utils import flatten

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -742,14 +742,16 @@ class DataFrame(BaseFrame[DataFrameT]):
 
     def __getitem__(
         self,
-        item: str
-        | slice
-        | Sequence[int]
-        | Sequence[str]
-        | tuple[Sequence[int], str | int]
-        | tuple[slice, str | int]
-        | tuple[slice | Sequence[int], Sequence[int] | Sequence[str] | slice]
-        | tuple[slice, slice],
+        item: (
+            str
+            | slice
+            | Sequence[int]
+            | Sequence[str]
+            | tuple[Sequence[int], str | int]
+            | tuple[slice, str | int]
+            | tuple[slice | Sequence[int], Sequence[int] | Sequence[str] | slice]
+            | tuple[slice, slice]
+        ),
     ) -> Series | Self:
         """
         Extract column or slice of DataFrame.
@@ -1195,16 +1197,14 @@ class DataFrame(BaseFrame[DataFrameT]):
     def rows(
         self,
         *,
-        named: Literal[False],
+        named: Literal[False] = False,
     ) -> list[tuple[Any, ...]]: ...
-
     @overload
     def rows(
         self,
         *,
         named: Literal[True],
     ) -> list[dict[str, Any]]: ...
-
     @overload
     def rows(
         self,

--- a/tests/frame/rows_test.py
+++ b/tests/frame/rows_test.py
@@ -96,6 +96,32 @@ def test_rows(
     assert result == expected
 
 
+@pytest.mark.parametrize(
+    ("named", "expected"),
+    [
+        (False, [(1, 4, 7.0, 5), (3, 4, 8.0, 6), (2, 6, 9.0, 7)]),
+        (
+            True,
+            [
+                {"a": 1, "_b": 4, "z": 7.0, "1": 5},
+                {"a": 3, "_b": 4, "z": 8.0, "1": 6},
+                {"a": 2, "_b": 6, "z": 9.0, "1": 7},
+            ],
+        ),
+    ],
+)
+def test_rows_eager(
+    constructor_eager: Any,
+    named: bool,  # noqa: FBT001
+    expected: list[tuple[Any, ...]] | list[dict[str, Any]],
+) -> None:
+    # posit-dev/py-shiny relies on `.rows(named=False)` to return unnamed rows
+    data = {"a": [1, 3, 2], "_b": [4, 4, 6], "z": [7.0, 8, 9], "1": [5, 6, 7]}
+    df = nw.from_native(constructor_eager(data), eager_only=True)
+    result = list(df.iter_rows(named=named))
+    assert result == expected
+
+
 @pytest.mark.parametrize("df_raw", [df_pandas_na, df_polars_na])
 def test_rows_with_nulls_unnamed(df_raw: Any) -> None:
     # GIVEN

--- a/tests/frame/rows_test.py
+++ b/tests/frame/rows_test.py
@@ -71,7 +71,9 @@ def test_rows(
     assert result == expected
 
 
-@pytest.mark.filterwarnings(r'ignore:.*Starting with pandas version 3\.0 all arguments of to_dict')
+@pytest.mark.filterwarnings(
+    r"ignore:.*Starting with pandas version 3\.0 all arguments of to_dict"
+)
 @pytest.mark.parametrize(
     ("named", "expected"),
     [

--- a/tests/frame/rows_test.py
+++ b/tests/frame/rows_test.py
@@ -118,7 +118,7 @@ def test_rows_eager(
     # posit-dev/py-shiny relies on `.rows(named=False)` to return unnamed rows
     data = {"a": [1, 3, 2], "_b": [4, 4, 6], "z": [7.0, 8, 9], "1": [5, 6, 7]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
-    result = list(df.iter_rows(named=named))
+    result = df.rows(named=named)
     assert result == expected
 
 

--- a/tests/frame/rows_test.py
+++ b/tests/frame/rows_test.py
@@ -71,6 +71,7 @@ def test_rows(
     assert result == expected
 
 
+@pytest.mark.filterwarnings(r'ignore:.*Starting with pandas version 3\.0 all arguments of to_dict')
 @pytest.mark.parametrize(
     ("named", "expected"),
     [


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # --
- Closes # --

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

`posit-dev/py-shiny` specifically relies on `.rows(named=False)` to return unnamed rows. I'd like to be sure that narwhals also supports `.rows(named=False)` for as many types as possible.

`cuDF` currently does not support `.rows(named=False)`, however `.rows(named=True)` does work!
Reprex notebook: https://colab.research.google.com/drive/16AnZzkt0QpJ3NNad8qrmOqPBfUX_jFxa#scrollTo=uM8arylKIF1U

Reprex code:
```python
import narwhals as nw
import cudf

df = cudf.DataFrame(
    {
        "a": list(range(20)),
        "b": list(reversed(range(20))),
        "c": list(range(20)),
    }
)
print(type(df))
print(df)

nw_df = nw.from_native(df, eager_only = True)

try:
  nw_df.rows(named = False)
except Exception as e:
  print("nw_df.rows(named=False)", str(e))

try:
  list(nw_df.iter_rows(named = False))
except Exception as e:
  print("nw_df.iter_rows(named=False)", str(e))

print("manual row calculations",
    [tuple(row.values()) for row in nw_df.rows(named=True)]
)
``` 
```

import narwhals as nw
import cudf

df = cudf.DataFrame(
    {
        "a": list(range(20)),
        "b": list(reversed(range(20))),
        "c": list(range(20)),
    }
)
…try:
  list(nw_df.iter_rows(named = False))
except Exception as e:
  print("nw_df.iter_rows(named=False)", str(e))

print("manual row calculations",
    [tuple(row.values()) for row in nw_df.rows(named=True)]
)

<class 'cudf.core.dataframe.DataFrame'>
     a   b   c
0    0  19   0
1    1  18   1
2    2  17   2
3    3  16   3
4    4  15   4
5    5  14   5
6    6  13   6
7    7  12   7
8    8  11   8
9    9  10   9
10  10   9  10
11  11   8  11
12  12   7  12
13  13   6  13
14  14   5  14
15  15   4  15
16  16   3  16
17  17   2  17
18  18   1  18
19  19   0  19
manual row calculations [(0, 19, 0), (1, 18, 1), (2, 17, 2), (3, 16, 3), (4, 15, 4), (5, 14, 5), (6, 13, 6), (7, 12, 7), (8, 11, 8), (9, 10, 9), (10, 9, 10), (11, 8, 11), (12, 7, 12), (13, 6, 13), (14, 5, 14), (15, 4, 15), (16, 3, 16), (17, 2, 17), (18, 1, 18), (19, 0, 19)]
nw_df.rows(named=False) cuDF does not support iteration of DataFrame via itertuples. Consider using `.to_pandas().itertuples()` if you wish to iterate over namedtuples.
nw_df.iter_rows(named=False) cuDF does not support iteration of DataFrame via itertuples. Consider using `.to_pandas().itertuples()` if you wish to iterate over namedtuples.
```

