### PR TITLE
ci: only check doctests on Python3.12

### DIFF
--- a/.github/workflows/extremes.yml
+++ b/.github/workflows/extremes.yml
@@ -59,8 +59,6 @@ jobs:
         run: uv pip freeze
       - name: Run pytest
         run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=50 --runslow
-      - name: Run doctests
-        run: pytest narwhals --doctest-modules
 
   not_so_old_versions:
     strategy:
@@ -88,8 +86,6 @@ jobs:
         run: uv pip freeze
       - name: Run pytest
         run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=50 --runslow
-      - name: Run doctests
-        run: pytest narwhals --doctest-modules
 
   nightlies:
     strategy:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,9 +30,6 @@ jobs:
         run: uv pip freeze
       - name: Run pytest
         run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=85
-      - name: Run doctests
-        if: startsWith(matrix.os, 'windows') != true
-        run: pytest narwhals --doctest-modules
 
   pytest-windows:
     strategy:
@@ -60,8 +57,6 @@ jobs:
         run: uv pip freeze
       - name: Run pytest
         run: pytest tests --cov=narwhals --cov=tests --runslow --cov-fail-under=95
-      - name: Run doctests
-        run: pytest narwhals --doctest-modules
 
   pytest-coverage:
     strategy:
@@ -95,4 +90,5 @@ jobs:
       - name: Run pytest
         run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=100 --runslow
       - name: Run doctests
+        if: matrix.python-version == '3.12'
         run: pytest narwhals --doctest-modules

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -546,12 +546,12 @@ class DataFrame(BaseFrame[DataFrameT]):
 
             We can pass any supported library such as pandas, Polars or PyArrow to `func`:
 
-            >>> func(df_pd)  # doctest: +SKIP
+            >>> func(df_pd)
             'foo,bar,ham\n1,6.0,a\n2,7.0,b\n3,8.0,c\n'
-            >>> func(df_pl)  # doctest: +SKIP
+            >>> func(df_pl)
             'foo,bar,ham\n1,6.0,a\n2,7.0,b\n3,8.0,c\n'
-            >>> func(df_pa)  # doctest: +SKIP
-            'foo,bar,ham\n1,6.0,a\n2,7.0,b\n3,8.0,c\n'
+            >>> func(df_pa)
+            '"foo","bar","ham"\n1,6,"a"\n2,7,"b"\n3,8,"c"\n'
 
             If we had passed a file name to `write_csv`, it would have been
             written to that file.
@@ -582,9 +582,9 @@ class DataFrame(BaseFrame[DataFrameT]):
 
             We can then pass either pandas, Polars or PyArrow to `func`:
 
-            >>> func(df_pd)  # doctest:+SKIP
-            >>> func(df_pl)  # doctest:+SKIP
-            >>> func(df_pa)  # doctest:+SKIP
+            >>> func(df_pd)
+            >>> func(df_pl)
+            >>> func(df_pa)
         """
         self._compliant_frame.write_parquet(file)
 
@@ -1116,12 +1116,12 @@ class DataFrame(BaseFrame[DataFrameT]):
             You can pass either pandas or Polars to `func`:
 
             >>> df_pd_schema = func(df_pd)
-            >>> df_pd_schema  # doctest:+SKIP
-            Schema({'foo': Int64, 'bar': Float64, 'ham', String})
+            >>> df_pd_schema
+            Schema({'foo': Int64, 'bar': Float64, 'ham': String})
 
             >>> df_pl_schema = func(df_pl)
-            >>> df_pl_schema  # doctest:+SKIP
-            Schema({'foo': Int64, 'bar': Float64, 'ham', String})
+            >>> df_pl_schema
+            Schema({'foo': Int64, 'bar': Float64, 'ham': String})
         """
         return super().schema
 
@@ -1150,12 +1150,12 @@ class DataFrame(BaseFrame[DataFrameT]):
             You can pass either pandas or Polars to `func`:
 
             >>> df_pd_schema = func(df_pd)
-            >>> df_pd_schema  # doctest:+SKIP
-            Schema({'foo': Int64, 'bar': Float64, 'ham', String})
+            >>> df_pd_schema
+            Schema({'foo': Int64, 'bar': Float64, 'ham': String})
 
             >>> df_pl_schema = func(df_pl)
-            >>> df_pl_schema  # doctest:+SKIP
-            Schema({'foo': Int64, 'bar': Float64, 'ham', String})
+            >>> df_pl_schema
+            Schema({'foo': Int64, 'bar': Float64, 'ham': String})
         """
         return super().collect_schema()
 
@@ -2478,8 +2478,8 @@ class DataFrame(BaseFrame[DataFrameT]):
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(df_pd, 1, 1), func(df_pd, 2, "b")  # doctest:+SKIP
-            (5, 6)
+            >>> func(df_pd, 1, 1), func(df_pd, 2, "b")
+            (np.int64(5), np.int64(6))
 
             >>> func(df_pl, 1, 1), func(df_pl, 2, "b")
             (5, 6)
@@ -2581,7 +2581,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             ... def func(df):
             ...     return df.to_arrow()
 
-            >>> func(df_pd)  # doctest:+SKIP
+            >>> func(df_pd)
             pyarrow.Table
             foo: int64
             bar: string
@@ -3010,7 +3010,7 @@ class LazyFrame(BaseFrame[FrameT]):
             ...     }
             ... )
             >>> lf = nw.from_native(lf_pl)
-            >>> lf.schema  # doctest:+SKIP
+            >>> lf.schema  # doctest: +SKIP
             Schema({'foo': Int64, 'bar': Float64, 'ham', String})
         """
         return super().schema
@@ -3030,8 +3030,8 @@ class LazyFrame(BaseFrame[FrameT]):
             ...     }
             ... )
             >>> lf = nw.from_native(lf_pl)
-            >>> lf.collect_schema()  # doctest:+SKIP
-            Schema({'foo': Int64, 'bar': Float64, 'ham', String})
+            >>> lf.collect_schema()
+            Schema({'foo': Int64, 'bar': Float64, 'ham': String})
         """
         return super().collect_schema()
 

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -1262,12 +1262,12 @@ class Expr:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(df_pd)  # doctest:+SKIP
+            >>> func(df_pd)  # doctest: +SKIP
                a
             2  3
             0  1
             2  3
-            >>> func(df_pl)  # doctest:+SKIP
+            >>> func(df_pl)  # doctest: +SKIP
             shape: (3, 1)
             ┌─────┐
             │ a   │
@@ -2662,9 +2662,7 @@ class ExprDateTimeNamespace:
             >>> from datetime import datetime
             >>> import narwhals as nw
             >>> data = {"a": [datetime(2012, 1, 7, 10, 20), datetime(2023, 3, 10, 11, 32)]}
-            >>> df_pd = pd.DataFrame(data).convert_dtypes(
-            ...     dtype_backend="pyarrow"
-            ... )  # doctest:+SKIP
+            >>> df_pd = pd.DataFrame(data).convert_dtypes(dtype_backend="pyarrow")
             >>> df_pl = pl.DataFrame(data)
 
             We define a library agnostic function:
@@ -2675,7 +2673,7 @@ class ExprDateTimeNamespace:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(df_pd)  # doctest:+SKIP
+            >>> func(df_pd)
                         a
             0  2012-01-07
             1  2023-03-10
@@ -3546,7 +3544,7 @@ class ExprDateTimeNamespace:
             │ 2024-01-01 00:00:00 +0545    │
             │ 2024-01-02 00:00:00 +0545    │
             └──────────────────────────────┘
-            >>> func(df_pa)  # doctest:+SKIP
+            >>> func(df_pa)
             pyarrow.Table
             a: timestamp[us, tz=Asia/Kathmandu]
             ----
@@ -3601,7 +3599,7 @@ class ExprDateTimeNamespace:
             │ 2024-01-01 05:45:00 +0545    │
             │ 2024-01-02 05:45:00 +0545    │
             └──────────────────────────────┘
-            >>> func(df_pa)  # doctest:+SKIP
+            >>> func(df_pa)
             pyarrow.Table
             a: timestamp[us, tz=Asia/Kathmandu]
             ----
@@ -3898,7 +3896,7 @@ def nth(*indices: int | Sequence[int]) -> Expr:
            a
         0  2
         1  4
-        >>> func(df_pl)  # doctest: +SKIP
+        >>> func(df_pl)
         shape: (2, 1)
         ┌─────┐
         │ a   │

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -469,7 +469,7 @@ def show_versions() -> None:
     Examples:
 
         >>> from narwhals import show_versions
-        >>> show_versions()  # doctest:+SKIP
+        >>> show_versions()  # doctest: +SKIP
     """
 
     sys_info = _get_sys_info()

--- a/narwhals/schema.py
+++ b/narwhals/schema.py
@@ -35,7 +35,7 @@ class Schema(BaseSchema):
 
         >>> import narwhals as nw
         >>> schema = nw.Schema({"foo": nw.Int8(), "bar": nw.String()})
-        >>> schema  # doctest:+SKIP
+        >>> schema
         Schema({'foo': Int8, 'bar': String})
 
         Access the data type associated with a specific column name.

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -512,7 +512,7 @@ class Series:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(s_pd)  # doctest:+SKIP
+            >>> func(s_pd)
             np.float64(2.0)
             >>> func(s_pl)
             2.0
@@ -539,7 +539,7 @@ class Series:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(s_pd)  # doctest:+SKIP
+            >>> func(s_pd)
             np.int64(3)
             >>> func(s_pl)
             3
@@ -570,7 +570,7 @@ class Series:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(s_pd)  # doctest:+SKIP
+            >>> func(s_pd)
             np.True_
             >>> func(s_pl)
             True
@@ -597,7 +597,7 @@ class Series:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(s_pd)  # doctest:+SKIP
+            >>> func(s_pd)
             np.False_
             >>> func(s_pl)
             False
@@ -625,7 +625,7 @@ class Series:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(s_pd)  # doctest:+SKIP
+            >>> func(s_pd)
             np.int64(1)
             >>> func(s_pl)
             1
@@ -652,7 +652,7 @@ class Series:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(s_pd)  # doctest:+SKIP
+            >>> func(s_pd)
             np.int64(3)
             >>> func(s_pl)
             3
@@ -679,7 +679,7 @@ class Series:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(s_pd)  # doctest:+SKIP
+            >>> func(s_pd)
             np.int64(6)
             >>> func(s_pl)
             6
@@ -710,7 +710,7 @@ class Series:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(s_pd)  # doctest:+SKIP
+            >>> func(s_pd)
             np.float64(1.0)
             >>> func(s_pl)
             1.0
@@ -1175,13 +1175,13 @@ class Series:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(s_pd)  # doctest:+SKIP
+            >>> func(s_pd)  # doctest: +SKIP
                a
             2  3
             1  2
             3  4
             3  4
-            >>> func(s_pl)  # doctest:+SKIP
+            >>> func(s_pl)  # doctest: +SKIP
             shape: (4,)
             Series: '' [i64]
             [
@@ -1867,8 +1867,8 @@ class Series:
             ...     return s.null_count()
 
             We can then pass either pandas or Polars to `func`:
-            >>> func(s_pd)  # doctest:+SKIP
-            1
+            >>> func(s_pd)
+            np.int64(1)
             >>> func(s_pl)
             2
         """
@@ -2082,8 +2082,8 @@ class Series:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(s_pd)  # doctest: +SKIP
-            [5, 12, 24, 37, 44]
+            >>> func(s_pd)
+            [np.int64(5), np.int64(12), np.int64(24), np.int64(37), np.int64(44)]
 
             >>> func(s_pl)  # doctest: +NORMALIZE_WHITESPACE
             [5.0, 12.0, 25.0, 37.0, 44.0]
@@ -2166,8 +2166,8 @@ class Series:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(pl.Series("a", [1]), None), func(pd.Series([1]), None)  # doctest:+SKIP
-            (1, 1)
+            >>> func(pl.Series("a", [1]), None), func(pd.Series([1]), None)
+            (1, np.int64(1))
 
             >>> func(pl.Series("a", [9, 8, 7]), -1), func(pl.Series([9, 8, 7]), -2)
             (7, 8)
@@ -3175,9 +3175,7 @@ class SeriesDateTimeNamespace:
             >>> from datetime import datetime
             >>> import narwhals as nw
             >>> dates = [datetime(2012, 1, 7, 10, 20), datetime(2023, 3, 10, 11, 32)]
-            >>> s_pd = pd.Series(dates).convert_dtypes(
-            ...     dtype_backend="pyarrow"
-            ... )  # doctest:+SKIP
+            >>> s_pd = pd.Series(dates).convert_dtypes(dtype_backend="pyarrow")
             >>> s_pl = pl.Series(dates)
 
             We define a library agnostic function:
@@ -3188,7 +3186,7 @@ class SeriesDateTimeNamespace:
 
             We can then pass either pandas or Polars to `func`:
 
-            >>> func(s_pd)  # doctest:+SKIP
+            >>> func(s_pd)
             0    2012-01-07
             1    2023-03-10
             dtype: date32[day][pyarrow]
@@ -3935,7 +3933,7 @@ class SeriesDateTimeNamespace:
                 2024-01-01 00:00:00 +0545
                 2024-01-02 00:00:00 +0545
             ]
-            >>> func(s_pa)  # doctest: +SKIP
+            >>> func(s_pa)
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -3988,7 +3986,7 @@ class SeriesDateTimeNamespace:
                 2024-01-01 05:45:00 +0545
                 2024-01-02 05:45:00 +0545
             ]
-            >>> func(s_pa)  # doctest: +SKIP
+            >>> func(s_pa)
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -514,7 +514,7 @@ class Schema(NwSchema):
 
         >>> import narwhals.stable.v1 as nw
         >>> schema = nw.Schema({"foo": nw.Int8(), "bar": nw.String()})
-        >>> schema  # doctest:+SKIP
+        >>> schema
         Schema({'foo': Int8, 'bar': String})
 
         Access the data type associated with a specific column name.
@@ -1059,7 +1059,7 @@ def nth(*indices: int | Sequence[int]) -> Expr:
            a
         0  2
         1  4
-        >>> func(df_pl)  # doctest: +SKIP
+        >>> func(df_pl)
         shape: (2, 1)
         ┌─────┐
         │ a   │


### PR DESCRIPTION
It's frustrating to have to skip a lot of doctests because of version differences

I think we can just test them on the latest versions (like Polars does) - they're just intended to demonstrate functionality anyway, the proper testing is done in `tests`

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

