### PR TITLE
feat: add support for `median`

### DIFF
--- a/docs/api-reference/expr.md
+++ b/docs/api-reference/expr.md
@@ -29,6 +29,7 @@
         - len
         - max
         - mean
+        - median
         - min
         - mode
         - null_count

--- a/docs/api-reference/narwhals.md
+++ b/docs/api-reference/narwhals.md
@@ -30,6 +30,7 @@ Here are the top-level functions available in Narwhals.
         - maybe_set_index
         - mean
         - mean_horizontal
+        - median
         - min
         - min_horizontal
         - narwhalify

--- a/docs/api-reference/series.md
+++ b/docs/api-reference/series.md
@@ -36,6 +36,7 @@
         - len
         - max
         - mean
+        - median
         - min
         - mode
         - name

--- a/narwhals/__init__.py
+++ b/narwhals/__init__.py
@@ -40,6 +40,7 @@ from narwhals.expr import max
 from narwhals.expr import max_horizontal
 from narwhals.expr import mean
 from narwhals.expr import mean_horizontal
+from narwhals.expr import median
 from narwhals.expr import min
 from narwhals.expr import min_horizontal
 from narwhals.expr import nth
@@ -99,6 +100,7 @@ __all__ = [
     "max_horizontal",
     "mean",
     "mean_horizontal",
+    "median",
     "min",
     "min_horizontal",
     "nth",

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -205,6 +205,9 @@ class ArrowExpr:
     def mean(self) -> Self:
         return reuse_series_implementation(self, "mean", returns_scalar=True)
 
+    def median(self) -> Self:
+        return reuse_series_implementation(self, "median", returns_scalar=True)
+
     def count(self) -> Self:
         return reuse_series_implementation(self, "count", returns_scalar=True)
 

--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 POLARS_TO_ARROW_AGGREGATIONS = {
     "len": "count",
+    "median": "approximate_median",
     "n_unique": "count_distinct",
     "std": "stddev",
     "var": "variance",  # currently unused, we don't have `var` yet

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -325,6 +325,11 @@ class ArrowNamespace:
             *column_names, backend_version=self._backend_version, dtypes=self._dtypes
         ).mean()
 
+    def median(self, *column_names: str) -> ArrowExpr:
+        return ArrowExpr.from_column_names(
+            *column_names, backend_version=self._backend_version, dtypes=self._dtypes
+        ).median()
+
     def max(self, *column_names: str) -> ArrowExpr:
         return ArrowExpr.from_column_names(
             *column_names, backend_version=self._backend_version, dtypes=self._dtypes

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -261,6 +261,11 @@ class ArrowSeries:
 
         return pc.mean(self._native_series)  # type: ignore[no-any-return]
 
+    def median(self) -> int:
+        import pyarrow.compute as pc  # ignore-banned-import()
+
+        return pc.approximate_median(self._native_series)  # type: ignore[no-any-return]
+
     def min(self) -> int:
         import pyarrow.compute as pc  # ignore-banned-import()
 

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -264,6 +264,12 @@ class ArrowSeries:
     def median(self) -> int:
         import pyarrow.compute as pc  # ignore-banned-import()
 
+        from narwhals._exceptions import InvalidOperationError
+
+        if not self.dtype.is_numeric():
+            msg = "`median` operation not supported for non-numeric input type."
+            raise InvalidOperationError(msg)
+
         return pc.approximate_median(self._native_series)  # type: ignore[no-any-return]
 
     def min(self) -> int:

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -384,11 +384,17 @@ class DaskExpr:
         )
 
     def median(self) -> Self:
-        return self._from_call(
-            lambda _input: _input.median_approximate(),
-            "median",
-            returns_scalar=True,
-        )
+        from dask_expr._shuffle import _is_numeric_cast_type
+
+        from narwhals._exceptions import InvalidOperationError
+
+        def func(_input: dask_expr.Series) -> dask_expr.Series:
+            if not _is_numeric_cast_type(_input.dtype):
+                msg = "`median` operation not supported for non-numeric input type."
+                raise InvalidOperationError(msg)
+            return _input.median_approximate()
+
+        return self._from_call(func, "median", returns_scalar=True)
 
     def min(self) -> Self:
         return self._from_call(

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -383,6 +383,13 @@ class DaskExpr:
             returns_scalar=True,
         )
 
+    def median(self) -> Self:
+        return self._from_call(
+            lambda _input: _input.median_approximate(),
+            "median",
+            returns_scalar=True,
+        )
+
     def min(self) -> Self:
         return self._from_call(
             lambda _input: _input.min(),

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -104,6 +104,11 @@ class DaskNamespace:
             *column_names, backend_version=self._backend_version, dtypes=self._dtypes
         ).mean()
 
+    def median(self, *column_names: str) -> DaskExpr:
+        return DaskExpr.from_column_names(
+            *column_names, backend_version=self._backend_version, dtypes=self._dtypes
+        ).median()
+
     def sum(self, *column_names: str) -> DaskExpr:
         return DaskExpr.from_column_names(
             *column_names, backend_version=self._backend_version, dtypes=self._dtypes

--- a/narwhals/_exceptions.py
+++ b/narwhals/_exceptions.py
@@ -2,3 +2,6 @@ from __future__ import annotations
 
 
 class ColumnNotFoundError(Exception): ...
+
+
+class InvalidOperationError(Exception): ...

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -220,6 +220,9 @@ class PandasLikeExpr:
     def mean(self) -> Self:
         return reuse_series_implementation(self, "mean", returns_scalar=True)
 
+    def median(self) -> Self:
+        return reuse_series_implementation(self, "median", returns_scalar=True)
+
     def std(self, *, ddof: int = 1) -> Self:
         return reuse_series_implementation(self, "std", ddof=ddof, returns_scalar=True)
 

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -177,6 +177,14 @@ class PandasLikeNamespace:
             dtypes=self._dtypes,
         ).mean()
 
+    def median(self, *column_names: str) -> PandasLikeExpr:
+        return PandasLikeExpr.from_column_names(
+            *column_names,
+            implementation=self._implementation,
+            backend_version=self._backend_version,
+            dtypes=self._dtypes,
+        ).median()
+
     def max(self, *column_names: str) -> PandasLikeExpr:
         return PandasLikeExpr.from_column_names(
             *column_names,

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -425,6 +425,10 @@ class PandasLikeSeries:
         ser = self._native_series
         return ser.mean()
 
+    def median(self) -> Any:
+        ser = self._native_series
+        return ser.median()
+
     def std(
         self,
         *,

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -426,6 +426,11 @@ class PandasLikeSeries:
         return ser.mean()
 
     def median(self) -> Any:
+        from narwhals._exceptions import InvalidOperationError
+
+        if not self.dtype.is_numeric():
+            msg = "`median` operation not supported for non-numeric input type."
+            raise InvalidOperationError(msg)
         ser = self._native_series
         return ser.median()
 

--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -145,14 +145,9 @@ class PolarsNamespace:
     def median(self, *column_names: str) -> PolarsExpr:
         import polars as pl  # ignore-banned-import()
 
-        from narwhals._exceptions import InvalidOperationError
         from narwhals._polars.expr import PolarsExpr
 
-        try:
-            return PolarsExpr(pl.median([*column_names]), dtypes=self._dtypes)  # type: ignore[arg-type]
-        except pl.exceptions.InvalidOperationError as e:
-            msg = "`median` operation not supported for non-numeric input type."
-            raise InvalidOperationError(msg) from e
+        return PolarsExpr(pl.median([*column_names]), dtypes=self._dtypes)  # type: ignore[arg-type]
 
     def concat_str(
         self,

--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -147,7 +147,11 @@ class PolarsNamespace:
 
         from narwhals._polars.expr import PolarsExpr
 
-        return PolarsExpr(pl.median([*column_names]), dtypes=self._dtypes)  # type: ignore[arg-type]
+        return PolarsExpr(
+            pl.median([*column_names]),  # type: ignore[arg-type]
+            dtypes=self._dtypes,
+            backend_version=self._backend_version,
+        )
 
     def concat_str(
         self,

--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -142,6 +142,13 @@ class PolarsNamespace:
             backend_version=self._backend_version,
         )
 
+    def median(self, *column_names: str) -> PolarsExpr:
+        import polars as pl  # ignore-banned-import()
+
+        from narwhals._polars.expr import PolarsExpr
+
+        return PolarsExpr(pl.median([*column_names]), dtypes=self._dtypes)  # type: ignore[arg-type]
+
     def concat_str(
         self,
         exprs: Iterable[IntoPolarsExpr],

--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -145,9 +145,14 @@ class PolarsNamespace:
     def median(self, *column_names: str) -> PolarsExpr:
         import polars as pl  # ignore-banned-import()
 
+        from narwhals._exceptions import InvalidOperationError
         from narwhals._polars.expr import PolarsExpr
 
-        return PolarsExpr(pl.median([*column_names]), dtypes=self._dtypes)  # type: ignore[arg-type]
+        try:
+            return PolarsExpr(pl.median([*column_names]), dtypes=self._dtypes)  # type: ignore[arg-type]
+        except pl.exceptions.InvalidOperationError as e:
+            msg = "`median` operation not supported for non-numeric input type."
+            raise InvalidOperationError(msg) from e
 
     def concat_str(
         self,

--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -142,6 +142,15 @@ class PolarsNamespace:
             backend_version=self._backend_version,
         )
 
+    def median(self, *column_names: str) -> PolarsExpr:
+        import polars as pl  # ignore-banned-import()
+
+        from narwhals._polars.expr import PolarsExpr
+
+        if self._backend_version < (0, 20, 4):  # pragma: no cover
+            return PolarsExpr(pl.median([*column_names]), dtypes=self._dtypes)  # type: ignore[arg-type]
+        return PolarsExpr(pl.median(*column_names), dtypes=self._dtypes)
+
     def concat_str(
         self,
         exprs: Iterable[IntoPolarsExpr],

--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -142,15 +142,6 @@ class PolarsNamespace:
             backend_version=self._backend_version,
         )
 
-    def median(self, *column_names: str) -> PolarsExpr:
-        import polars as pl  # ignore-banned-import()
-
-        from narwhals._polars.expr import PolarsExpr
-
-        if self._backend_version < (0, 20, 4):  # pragma: no cover
-            return PolarsExpr(pl.median([*column_names]), dtypes=self._dtypes)  # type: ignore[arg-type]
-        return PolarsExpr(pl.median(*column_names), dtypes=self._dtypes)
-
     def concat_str(
         self,
         exprs: Iterable[IntoPolarsExpr],

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -189,6 +189,15 @@ class PolarsSeries:
     def __invert__(self) -> Self:
         return self._from_native_series(self._native_series.__invert__())
 
+    def median(self) -> Any:
+        from narwhals._exceptions import InvalidOperationError
+
+        if not self.dtype.is_numeric():
+            msg = "`median` operation not supported for non-numeric input type."
+            raise InvalidOperationError(msg)
+
+        return self._native_series.median()
+
     def to_dummies(
         self: Self, *, separator: str = "_", drop_first: bool = False
     ) -> PolarsDataFrame:

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -444,6 +444,40 @@ class Expr:
         """
         return self.__class__(lambda plx: self._call(plx).mean())
 
+    def median(self) -> Self:
+        """
+        Get median value.
+
+        Examples:
+            >>> import polars as pl
+            >>> import pandas as pd
+            >>> import narwhals as nw
+            >>> df_pd = pd.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
+            >>> df_pl = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
+
+            Let's define a dataframe-agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     return df.select(nw.col("a", "b").median())
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(df_pd)
+                 a    b
+            0  3.0  4.0
+            >>> func(df_pl)
+            shape: (1, 2)
+            ┌─────┬─────┐
+            │ a   ┆ b   │
+            │ --- ┆ --- │
+            │ f64 ┆ f64 │
+            ╞═════╪═════╡
+            │ 3.0 ┆ 4.0 │
+            └─────┴─────┘
+        """
+        return self.__class__(lambda plx: self._call(plx).median())
+
     def std(self, *, ddof: int = 1) -> Self:
         """
         Get standard deviation.
@@ -4621,6 +4655,48 @@ def mean(*columns: str) -> Expr:
     """
 
     return Expr(lambda plx: plx.mean(*columns))
+
+
+def median(*columns: str) -> Expr:
+    """
+    Get the median value.
+
+    Note:
+        Syntactic sugar for ``nw.col(columns).median()``
+
+    Arguments:
+        columns: Name(s) of the columns to use in the aggregation function
+
+    Examples:
+        >>> import pandas as pd
+        >>> import polars as pl
+        >>> import narwhals as nw
+        >>> df_pd = pd.DataFrame({"a": [4, 5, 2]})
+        >>> df_pl = pl.DataFrame({"a": [4, 5, 2]})
+
+        We define a dataframe agnostic function:
+
+        >>> @nw.narwhalify
+        ... def func(df):
+        ...     return df.select(nw.median("a"))
+
+        We can then pass either pandas or Polars to `func`:
+
+        >>> func(df_pd)
+             a
+        0  4.0
+        >>> func(df_pl)
+        shape: (1, 1)
+        ┌─────┐
+        │ a   │
+        │ --- │
+        │ f64 │
+        ╞═════╡
+        │ 4.0 │
+        └─────┘
+    """
+
+    return Expr(lambda plx: plx.median(*columns))
 
 
 def min(*columns: str) -> Expr:

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -448,6 +448,9 @@ class Expr:
         """
         Get median value.
 
+        Notes:
+            Results might slightly differ across backends due to differences in the underlying algorithms used to compute the median.
+
         Examples:
             >>> import pandas as pd
             >>> import polars as pl
@@ -4670,8 +4673,9 @@ def median(*columns: str) -> Expr:
     """
     Get the median value.
 
-    Note:
-        Syntactic sugar for ``nw.col(columns).median()``
+    Notes:
+        - Syntactic sugar for ``nw.col(columns).median()``
+        - Results might slightly differ across backends due to differences in the underlying algorithms used to compute the median.
 
     Arguments:
         columns: Name(s) of the columns to use in the aggregation function

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -449,11 +449,13 @@ class Expr:
         Get median value.
 
         Examples:
-            >>> import polars as pl
             >>> import pandas as pd
+            >>> import polars as pl
+            >>> import pyarrow as pa
             >>> import narwhals as nw
             >>> df_pd = pd.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
             >>> df_pl = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
+            >>> df_pa = pa.table({"a": [1, 8, 3], "b": [4, 5, 2]})
 
             Let's define a dataframe-agnostic function:
 
@@ -461,7 +463,7 @@ class Expr:
             ... def func(df):
             ...     return df.select(nw.col("a", "b").median())
 
-            We can then pass either pandas or Polars to `func`:
+            We can then pass any supported library such as pandas, Polars, or PyArrow to `func`:
 
             >>> func(df_pd)
                  a    b
@@ -475,6 +477,13 @@ class Expr:
             ╞═════╪═════╡
             │ 3.0 ┆ 4.0 │
             └─────┴─────┘
+            >>> func(df_pa)
+            pyarrow.Table
+            a: double
+            b: double
+            ----
+            a: [[3]]
+            b: [[4]]
         """
         return self.__class__(lambda plx: self._call(plx).median())
 
@@ -4670,17 +4679,19 @@ def median(*columns: str) -> Expr:
     Examples:
         >>> import pandas as pd
         >>> import polars as pl
+        >>> import pyarrow as pa
         >>> import narwhals as nw
         >>> df_pd = pd.DataFrame({"a": [4, 5, 2]})
         >>> df_pl = pl.DataFrame({"a": [4, 5, 2]})
+        >>> df_pa = pa.table({"a": [4, 5, 2]})
 
-        We define a dataframe agnostic function:
+        Let's define a dataframe agnostic function:
 
         >>> @nw.narwhalify
         ... def func(df):
         ...     return df.select(nw.median("a"))
 
-        We can then pass either pandas or Polars to `func`:
+        We can then pass any supported library such as pandas, Polars, or PyArrow to `func`:
 
         >>> func(df_pd)
              a
@@ -4694,6 +4705,11 @@ def median(*columns: str) -> Expr:
         ╞═════╡
         │ 4.0 │
         └─────┘
+        >>> func(df_pa)
+        pyarrow.Table
+        a: double
+        ----
+        a: [[4]]
     """
 
     return Expr(lambda plx: plx.median(*columns))

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -531,23 +531,27 @@ class Series:
         Examples:
             >>> import pandas as pd
             >>> import polars as pl
+            >>> import pyarrow as pa
             >>> import narwhals as nw
             >>> s = [5, 3, 8]
             >>> s_pd = pd.Series(s)
             >>> s_pl = pl.Series(s)
+            >>> s_pa = pa.chunked_array([s])
 
-            We define a library agnostic function:
+            Let's define a library agnostic function:
 
             >>> @nw.narwhalify
             ... def func(s):
             ...     return s.median()
 
-            We can then pass either pandas or Polars to `func`:
+            We can then pass any supported library such as pandas, Polars, or PyArrow to `func`:
 
             >>> func(s_pd)
             np.float64(5.0)
             >>> func(s_pl)
             5.0
+            >>> func(s_pa)
+            <pyarrow.DoubleScalar: 5.0>
         """
         return self._compliant_series.median()
 

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -528,6 +528,9 @@ class Series:
         """
         Reduce this Series to the median value.
 
+        Notes:
+            Results might slightly differ across backends due to differences in the underlying algorithms used to compute the median.
+
         Examples:
             >>> import pandas as pd
             >>> import polars as pl

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -524,6 +524,33 @@ class Series:
         """
         return self._compliant_series.mean()
 
+    def median(self) -> Any:
+        """
+        Reduce this Series to the median value.
+
+        Examples:
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import narwhals as nw
+            >>> s = [5, 3, 8]
+            >>> s_pd = pd.Series(s)
+            >>> s_pl = pl.Series(s)
+
+            We define a library agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(s):
+            ...     return s.median()
+
+            We can then pass either pandas or Polars to `func`:
+
+            >>> func(s_pd)
+            np.float64(5.0)
+            >>> func(s_pl)
+            5.0
+        """
+        return self._compliant_series.median()
+
     def count(self) -> Any:
         """
         Returns the number of non-null elements in the Series.

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -1633,17 +1633,19 @@ def median(*columns: str) -> Expr:
     Examples:
         >>> import pandas as pd
         >>> import polars as pl
+        >>> import pyarrow as pa
         >>> import narwhals.stable.v1 as nw
         >>> df_pd = pd.DataFrame({"a": [4, 5, 2]})
         >>> df_pl = pl.DataFrame({"a": [4, 5, 2]})
+        >>> df_pa = pa.table({"a": [4, 5, 2]})
 
-        We define a dataframe agnostic function:
+        Let's define a dataframe agnostic function:
 
         >>> @nw.narwhalify
         ... def func(df):
         ...     return df.select(nw.median("a"))
 
-        We can then pass either pandas or Polars to `func`:
+        We can then pass any supported library such as pandas, Polars, or PyArrow to `func`:
 
         >>> func(df_pd)
              a
@@ -1657,6 +1659,11 @@ def median(*columns: str) -> Expr:
         ╞═════╡
         │ 4.0 │
         └─────┘
+        >>> func(df_pa)
+        pyarrow.Table
+        a: double
+        ----
+        a: [[4]]
     """
     return _stableify(nw.median(*columns))
 

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -1624,8 +1624,9 @@ def median(*columns: str) -> Expr:
     """
     Get the median value.
 
-    Note:
-        Syntactic sugar for ``nw.col(columns).median()``
+    Notes:
+        - Syntactic sugar for ``nw.col(columns).median()``
+        - Results might slightly differ across backends due to differences in the underlying algorithms used to compute the median.
 
     Arguments:
         columns: Name(s) of the columns to use in the aggregation function

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -1620,6 +1620,47 @@ def mean(*columns: str) -> Expr:
     return _stableify(nw.mean(*columns))
 
 
+def median(*columns: str) -> Expr:
+    """
+    Get the median value.
+
+    Note:
+        Syntactic sugar for ``nw.col(columns).median()``
+
+    Arguments:
+        columns: Name(s) of the columns to use in the aggregation function
+
+    Examples:
+        >>> import pandas as pd
+        >>> import polars as pl
+        >>> import narwhals.stable.v1 as nw
+        >>> df_pd = pd.DataFrame({"a": [4, 5, 2]})
+        >>> df_pl = pl.DataFrame({"a": [4, 5, 2]})
+
+        We define a dataframe agnostic function:
+
+        >>> @nw.narwhalify
+        ... def func(df):
+        ...     return df.select(nw.median("a"))
+
+        We can then pass either pandas or Polars to `func`:
+
+        >>> func(df_pd)
+             a
+        0  4.0
+        >>> func(df_pl)
+        shape: (1, 1)
+        ┌─────┐
+        │ a   │
+        │ --- │
+        │ f64 │
+        ╞═════╡
+        │ 4.0 │
+        └─────┘
+    """
+    return _stableify(nw.median(*columns))
+
+
 def sum(*columns: str) -> Expr:
     """
     Sum all values.
@@ -2519,6 +2560,7 @@ __all__ = [
     "max_horizontal",
     "mean",
     "mean_horizontal",
+    "median",
     "min",
     "min_horizontal",
     "sum",

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -1635,7 +1635,7 @@ def median(*columns: str) -> Expr:
         >>> import pandas as pd
         >>> import polars as pl
         >>> import pyarrow as pa
-        >>> import narwhals.stable.v1 as nw
+        >>> import narwhals as nw
         >>> df_pd = pd.DataFrame({"a": [4, 5, 2]})
         >>> df_pl = pl.DataFrame({"a": [4, 5, 2]})
         >>> df_pa = pa.table({"a": [4, 5, 2]})

--- a/tests/expr_and_series/median_test.py
+++ b/tests/expr_and_series/median_test.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import narwhals.stable.v1 as nw
+from tests.utils import Constructor
+from tests.utils import compare_dicts
+
+data = {"a": [3, 8, 2], "b": [5, 5, 7], "z": [7.0, 8, 9]}
+
+
+@pytest.mark.parametrize(
+    "expr", [nw.col("a", "b", "z").median(), nw.median("a", "b", "z")]
+)
+def test_expr_median_expr(
+    constructor: Constructor, expr: nw.Expr, request: pytest.FixtureRequest
+) -> None:
+    if "dask_lazy_p2" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
+    df = nw.from_native(constructor(data))
+    result = df.select(expr)
+    expected = {"a": [3.0], "b": [5.0], "z": [8.0]}
+    compare_dicts(result, expected)
+
+
+@pytest.mark.parametrize(("col", "expected"), [("a", 3.0), ("b", 5.0), ("z", 8.0)])
+def test_expr_median_series(constructor_eager: Any, col: str, expected: float) -> None:
+    series = nw.from_native(constructor_eager(data), eager_only=True)[col]
+    result = series.median()
+    compare_dicts({col: [result]}, {col: [expected]})

--- a/tests/expr_and_series/median_test.py
+++ b/tests/expr_and_series/median_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import narwhals.stable.v1 as nw
+from narwhals._exceptions import InvalidOperationError
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -36,3 +37,32 @@ def test_median_series(
     series = nw.from_native(constructor_eager(data), eager_only=True)[col]
     result = series.median()
     assert_equal_data({col: [result]}, {col: [expected]})
+
+
+@pytest.mark.parametrize("expr", [nw.col("s").median(), nw.median("s")])
+def test_median_expr_raises_on_str(
+    constructor: Constructor,
+    expr: nw.Expr,
+    request: pytest.FixtureRequest,
+) -> None:
+    if "polars" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
+
+    df = nw.from_native(constructor(data))
+    with pytest.raises(
+        InvalidOperationError,
+        match="`median` operation not supported for non-numeric input type.",
+    ):
+        df.select(expr)
+
+
+@pytest.mark.parametrize(("col"), [("s")])
+def test_median_series_raises_on_str(
+    constructor_eager: ConstructorEager, col: str
+) -> None:
+    series = nw.from_native(constructor_eager(data), eager_only=True)[col]
+    with pytest.raises(
+        InvalidOperationError,
+        match="`median` operation not supported for non-numeric input type.",
+    ):
+        series.median()

--- a/tests/expr_and_series/median_test.py
+++ b/tests/expr_and_series/median_test.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import ConstructorEager
+from tests.utils import assert_equal_data
 
-data = {"a": [3, 8, 2], "b": [5, 5, 7], "z": [7.0, 8, 9]}
+data = {
+    "a": [3, 8, 2, None],
+    "b": [5, 5, None, 7],
+    "z": [7.0, 8, 9, None],
+    "s": ["f", "a", "x", "x"],
+}
 
 
 @pytest.mark.parametrize(
     "expr", [nw.col("a", "b", "z").median(), nw.median("a", "b", "z")]
 )
-def test_expr_median_expr(
+def test_median_expr(
     constructor: Constructor, expr: nw.Expr, request: pytest.FixtureRequest
 ) -> None:
     if "dask_lazy_p2" in str(constructor):
@@ -22,11 +26,13 @@ def test_expr_median_expr(
     df = nw.from_native(constructor(data))
     result = df.select(expr)
     expected = {"a": [3.0], "b": [5.0], "z": [8.0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(("col", "expected"), [("a", 3.0), ("b", 5.0), ("z", 8.0)])
-def test_expr_median_series(constructor_eager: Any, col: str, expected: float) -> None:
+def test_median_series(
+    constructor_eager: ConstructorEager, col: str, expected: float
+) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)[col]
     result = series.median()
-    compare_dicts({col: [result]}, {col: [expected]})
+    assert_equal_data({col: [result]}, {col: [expected]})

--- a/tests/expr_and_series/unary_test.py
+++ b/tests/expr_and_series/unary_test.py
@@ -10,6 +10,7 @@ def test_unary(constructor: Constructor) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     result = nw.from_native(constructor(data)).select(
         a_mean=nw.col("a").mean(),
+        a_median=nw.col("a").median(),
         a_sum=nw.col("a").sum(),
         b_nunique=nw.col("b").n_unique(),
         z_min=nw.col("z").min(),
@@ -17,6 +18,7 @@ def test_unary(constructor: Constructor) -> None:
     )
     expected = {
         "a_mean": [2],
+        "a_median": [2],
         "a_sum": [6],
         "b_nunique": [2],
         "z_min": [7],
@@ -30,6 +32,7 @@ def test_unary_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = {
         "a_mean": [df["a"].mean()],
+        "a_median": [df["a"].median()],
         "a_sum": [df["a"].sum()],
         "b_nunique": [df["b"].n_unique()],
         "z_min": [df["z"].min()],
@@ -37,6 +40,7 @@ def test_unary_series(constructor_eager: ConstructorEager) -> None:
     }
     expected = {
         "a_mean": [2],
+        "a_median": [2],
         "a_sum": [6],
         "b_nunique": [2],
         "z_min": [7],

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -104,6 +104,18 @@ def test_group_by_len(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
+def test_group_by_median(constructor: Constructor) -> None:
+    data = {"a": [1, 1, 1, 2, 2, 2], "b": [5, 4, 6, 7, 3, 2]}
+    result = (
+        nw.from_native(constructor(data))
+        .group_by("a")
+        .agg(nw.col("b").median())
+        .sort("a")
+    )
+    expected = {"a": [1, 2], "b": [5, 3]}
+    assert_equal_data(result, expected)
+
+
 def test_group_by_n_unique(constructor: Constructor) -> None:
     result = (
         nw.from_native(constructor(data))


### PR DESCRIPTION
<!-- 
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Closes https://github.com/narwhals-dev/narwhals/issues/1190

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.
WIP: I would need to better dig into details for `pyarrow` and `dask`. Already opened the PR to (also) get advices and/or guidance:)

My understanding per now (might be missing bits, though) is the following:

- neither `pyarrow` nor `dask` do implement a "proper" `median`; otoh, they respectively implement `approximate_median` and `median_approximate` (`dask`'s `median_approximate` fails tests when `npartitions=2`, though)
- relying on already implemented `quantile`(s) would come with the following issues: for `pyarrow`, the issue of having an `interpolation` parameter which would not quite fit the `nw.median()` signature; for dask, the issue of having to hardcode a `"linear"` interpolation strategy and having to `xfail` tests as well when encountering `dask_lazy_p2_constructor`.

Also, need to revise docstrings so as to comply with https://github.com/narwhals-dev/narwhals/issues/1000 for `median`.