### PR TITLE
chore: nox doctests only in Python 3.12

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -582,9 +582,9 @@ class DataFrame(BaseFrame[DataFrameT]):
 
             We can then pass either pandas, Polars or PyArrow to `func`:
 
-            >>> func(df_pd)
-            >>> func(df_pl)
-            >>> func(df_pa)
+            >>> func(df_pd)  # doctest:+SKIP
+            >>> func(df_pl)  # doctest:+SKIP
+            >>> func(df_pa)  # doctest:+SKIP
         """
         self._compliant_frame.write_parquet(file)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,7 +21,9 @@ def run_common(session: Session, coverage_threshold: float) -> None:
         f"--cov-fail-under={coverage_threshold}",
         "--runslow",
     )
-    session.run("pytest", "narwhals", "--doctest-modules")
+
+    if session.python == "3.12":
+        session.run("pytest", "narwhals", "--doctest-modules")
 
 
 @nox.session(python=PYTHON_VERSIONS)  # type: ignore[misc]


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues 

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

To be consistent with CI #1189 we should just run doctests in Python 3.12 in `nox`