### PR TITLE
chore: refactor `compare_dicts`

### DIFF
--- a/tests/expr_and_series/abs_test.py
+++ b/tests/expr_and_series/abs_test.py
@@ -2,18 +2,18 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_abs(constructor: Constructor) -> None:
     df = nw.from_native(constructor({"a": [1, 2, 3, -4, 5]}))
     result = df.select(b=nw.col("a").abs())
     expected = {"b": [1, 2, 3, 4, 5]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_abs_series(constructor_eager: Any) -> None:
     df = nw.from_native(constructor_eager({"a": [1, 2, 3, -4, 5]}), eager_only=True)
     result = {"b": df["a"].abs()}
     expected = {"b": [1, 2, 3, 4, 5]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/all_horizontal_test.py
+++ b/tests/expr_and_series/all_horizontal_test.py
@@ -6,7 +6,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize("expr1", ["a", nw.col("a")])
@@ -20,7 +20,7 @@ def test_allh(constructor: Constructor, expr1: Any, expr2: Any) -> None:
     result = df.select(all=nw.all_horizontal(expr1, expr2))
 
     expected = {"all": [False, False, True]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_allh_series(constructor_eager: Any) -> None:
@@ -32,7 +32,7 @@ def test_allh_series(constructor_eager: Any) -> None:
     result = df.select(all=nw.all_horizontal(df["a"], df["b"]))
 
     expected = {"all": [False, False, True]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_allh_all(constructor: Constructor) -> None:
@@ -43,10 +43,10 @@ def test_allh_all(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(all=nw.all_horizontal(nw.all()))
     expected = {"all": [False, False, True]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df.select(nw.all_horizontal(nw.all()))
     expected = {"a": [False, False, True]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_allh_nth(constructor: Constructor, request: pytest.FixtureRequest) -> None:
@@ -59,10 +59,10 @@ def test_allh_nth(constructor: Constructor, request: pytest.FixtureRequest) -> N
     df = nw.from_native(constructor(data))
     result = df.select(nw.all_horizontal(nw.nth(0, 1)))
     expected = {"a": [False, False, True]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df.select(nw.all_horizontal(nw.col("a"), nw.nth(0)))
     expected = {"a": [False, False, True]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_horizontal_expressions_emtpy(constructor: Constructor) -> None:

--- a/tests/expr_and_series/any_all_test.py
+++ b/tests/expr_and_series/any_all_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_any_all(constructor: Constructor) -> None:
@@ -17,10 +17,10 @@ def test_any_all(constructor: Constructor) -> None:
     )
     result = df.select(nw.col("a", "b", "c").all())
     expected = {"a": [False], "b": [True], "c": [False]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df.select(nw.all().any())
     expected = {"a": [True], "b": [True], "c": [False]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_any_all_series(constructor_eager: Any) -> None:
@@ -36,7 +36,7 @@ def test_any_all_series(constructor_eager: Any) -> None:
     )
     result = {"a": [df["a"].all()], "b": [df["b"].all()], "c": [df["c"].all()]}
     expected = {"a": [False], "b": [True], "c": [False]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = {"a": [df["a"].any()], "b": [df["b"].any()], "c": [df["c"].any()]}
     expected = {"a": [True], "b": [True], "c": [False]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/any_horizontal_test.py
+++ b/tests/expr_and_series/any_horizontal_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize("expr1", ["a", nw.col("a")])
@@ -18,7 +18,7 @@ def test_anyh(constructor: Constructor, expr1: Any, expr2: Any) -> None:
     result = df.select(any=nw.any_horizontal(expr1, expr2))
 
     expected = {"any": [False, True, True]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_anyh_all(constructor: Constructor) -> None:
@@ -29,7 +29,7 @@ def test_anyh_all(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(any=nw.any_horizontal(nw.all()))
     expected = {"any": [False, True, True]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df.select(nw.any_horizontal(nw.all()))
     expected = {"a": [False, True, True]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/arg_true_test.py
+++ b/tests/expr_and_series/arg_true_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_arg_true(constructor: Constructor, request: pytest.FixtureRequest) -> None:
@@ -13,12 +13,12 @@ def test_arg_true(constructor: Constructor, request: pytest.FixtureRequest) -> N
     df = nw.from_native(constructor({"a": [1, None, None, 3]}))
     result = df.select(nw.col("a").is_null().arg_true())
     expected = {"a": [1, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_arg_true_series(constructor_eager: Any) -> None:
     df = nw.from_native(constructor_eager({"a": [1, None, None, 3]}), eager_only=True)
     result = df.select(df["a"].is_null().arg_true())
     expected = {"a": [1, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     assert "a" in df  # cheeky test to hit `__contains__` method

--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -13,7 +13,7 @@ from hypothesis import given
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize(
@@ -44,7 +44,7 @@ def test_arithmetic_expr(
     data = {"a": [1.0, 2, 3]}
     df = nw.from_native(constructor(data))
     result = df.select(getattr(nw.col("a"), attr)(rhs))
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 @pytest.mark.parametrize(
@@ -74,7 +74,7 @@ def test_right_arithmetic_expr(
     data = {"a": [1, 2, 3]}
     df = nw.from_native(constructor(data))
     result = df.select(a=getattr(nw.col("a"), attr)(rhs))
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 @pytest.mark.parametrize(
@@ -105,7 +105,7 @@ def test_arithmetic_series(
     data = {"a": [1, 2, 3]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(getattr(df["a"], attr)(rhs))
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 @pytest.mark.parametrize(
@@ -135,7 +135,7 @@ def test_right_arithmetic_series(
     data = {"a": [1, 2, 3]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(a=getattr(df["a"], attr)(rhs))
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 def test_truediv_same_dims(
@@ -147,9 +147,9 @@ def test_truediv_same_dims(
     s_left = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)["a"]
     s_right = nw.from_native(constructor_eager({"a": [2, 2, 1]}), eager_only=True)["a"]
     result = s_left / s_right
-    compare_dicts({"a": result}, {"a": [0.5, 1.0, 3.0]})
+    assert_equal_data({"a": result}, {"a": [0.5, 1.0, 3.0]})
     result = s_left.__rtruediv__(s_right)
-    compare_dicts({"a": result}, {"a": [2, 1, 1 / 3]})
+    assert_equal_data({"a": result}, {"a": [2, 1, 1 / 3]})
 
 
 @pytest.mark.slow
@@ -168,7 +168,7 @@ def test_floordiv(left: int, right: int) -> None:
     result = nw.from_native(pd.DataFrame({"a": [left]}), eager_only=True).select(
         nw.col("a") // right
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     if parse_version(pd.__version__) < (2, 2):  # pragma: no cover
         # Bug in old version of pandas
         pass
@@ -177,19 +177,19 @@ def test_floordiv(left: int, right: int) -> None:
             pd.DataFrame({"a": [left]}).convert_dtypes(dtype_backend="pyarrow"),
             eager_only=True,
         ).select(nw.col("a") // right)
-        compare_dicts(result, expected)
+        assert_equal_data(result, expected)
     result = nw.from_native(
         pd.DataFrame({"a": [left]}).convert_dtypes(), eager_only=True
     ).select(nw.col("a") // right)
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = nw.from_native(pl.DataFrame({"a": [left]}), eager_only=True).select(
         nw.col("a") // right
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = nw.from_native(pa.table({"a": [left]}), eager_only=True).select(
         nw.col("a") // right
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.slow
@@ -208,16 +208,16 @@ def test_mod(left: int, right: int) -> None:
     result = nw.from_native(pd.DataFrame({"a": [left]}), eager_only=True).select(
         nw.col("a") % right
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = nw.from_native(
         pd.DataFrame({"a": [left]}).convert_dtypes(), eager_only=True
     ).select(nw.col("a") % right)
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = nw.from_native(pl.DataFrame({"a": [left]}), eager_only=True).select(
         nw.col("a") % right
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = nw.from_native(pa.table({"a": [left]}), eager_only=True).select(
         nw.col("a") % right
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/binary_test.py
+++ b/tests/expr_and_series/binary_test.py
@@ -1,6 +1,6 @@
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_expr_binary(constructor: Constructor) -> None:
@@ -41,4 +41,4 @@ def test_expr_binary(constructor: Constructor) -> None:
         "l": [0, 1, 1],
         "m": [1, 9, 4],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/cast_test.py
+++ b/tests/expr_and_series/cast_test.py
@@ -11,7 +11,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 from tests.utils import is_windows
 
 data = {
@@ -217,4 +217,4 @@ def test_cast_datetime_tz_aware(
         .cast(nw.String())
         .str.slice(offset=0, length=19)
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/cat/get_categories_test.py
+++ b/tests/expr_and_series/cat/get_categories_test.py
@@ -7,7 +7,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": ["one", "two", "two"]}
 
@@ -23,10 +23,10 @@ def test_get_categories(request: pytest.FixtureRequest, constructor_eager: Any) 
     expected = {"a": ["one", "two"]}
 
     result_expr = df.select(nw.col("a").cat.get_categories())
-    compare_dicts(result_expr, expected)
+    assert_equal_data(result_expr, expected)
 
     result_series = df["a"].cat.get_categories()
-    compare_dicts({"a": result_series}, expected)
+    assert_equal_data({"a": result_series}, expected)
 
 
 def test_get_categories_pyarrow() -> None:
@@ -39,7 +39,7 @@ def test_get_categories_pyarrow() -> None:
     expected = {"a": ["a", "b", "d"]}
 
     result_expr = df.select(nw.col("a").cat.get_categories())
-    compare_dicts(result_expr, expected)
+    assert_equal_data(result_expr, expected)
 
     result_series = df["a"].cat.get_categories()
-    compare_dicts({"a": result_series}, expected)
+    assert_equal_data({"a": result_series}, expected)

--- a/tests/expr_and_series/clip_test.py
+++ b/tests/expr_and_series/clip_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_clip(constructor: Constructor) -> None:
@@ -17,7 +17,7 @@ def test_clip(constructor: Constructor) -> None:
         "upper_only": [1, 2, 3, -4, 4],
         "both": [3, 3, 3, 3, 4],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_clip_series(constructor_eager: Any) -> None:
@@ -33,4 +33,4 @@ def test_clip_series(constructor_eager: Any) -> None:
         "upper_only": [1, 2, 3, -4, 4],
         "both": [3, 3, 3, 3, 4],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [1, 2, 3],
@@ -40,7 +40,7 @@ def test_concat_str(
         .sort("a")
         .select("full_sentence")
     )
-    compare_dicts(result, {"full_sentence": expected})
+    assert_equal_data(result, {"full_sentence": expected})
     result = (
         df.select(
             "a",
@@ -55,4 +55,4 @@ def test_concat_str(
         .sort("a")
         .select("full_sentence")
     )
-    compare_dicts(result, {"full_sentence": expected})
+    assert_equal_data(result, {"full_sentence": expected})

--- a/tests/expr_and_series/convert_time_zone_test.py
+++ b/tests/expr_and_series/convert_time_zone_test.py
@@ -10,7 +10,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 from tests.utils import is_windows
 
 
@@ -34,7 +34,7 @@ def test_convert_time_zone(
     assert result_dtype.time_zone == "Asia/Kathmandu"  # type: ignore[attr-defined]
     result_str = result.select(nw.col("a").dt.to_string("%Y-%m-%dT%H:%M%z"))
     expected = {"a": ["2020-01-01T05:45+0545", "2020-01-02T05:45+0545"]}
-    compare_dicts(result_str, expected)
+    assert_equal_data(result_str, expected)
 
 
 def test_convert_time_zone_series(
@@ -60,7 +60,7 @@ def test_convert_time_zone_series(
     assert result_dtype.time_zone == "Asia/Kathmandu"  # type: ignore[attr-defined]
     result_str = result.select(nw.col("a").dt.to_string("%Y-%m-%dT%H:%M%z"))
     expected = {"a": ["2020-01-01T05:45+0545", "2020-01-02T05:45+0545"]}
-    compare_dicts(result_str, expected)
+    assert_equal_data(result_str, expected)
 
 
 def test_convert_time_zone_from_none(
@@ -93,7 +93,7 @@ def test_convert_time_zone_from_none(
     assert result_dtype.time_zone == "Asia/Kathmandu"  # type: ignore[attr-defined]
     result_str = result.select(nw.col("a").dt.to_string("%Y-%m-%dT%H:%M%z"))
     expected = {"a": ["2020-01-01T05:45+0545", "2020-01-02T05:45+0545"]}
-    compare_dicts(result_str, expected)
+    assert_equal_data(result_str, expected)
 
 
 def test_convert_time_zone_to_none(constructor: Constructor) -> None:

--- a/tests/expr_and_series/count_test.py
+++ b/tests/expr_and_series/count_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_count(constructor: Constructor) -> None:
@@ -10,7 +10,7 @@ def test_count(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a", "b", "z").count())
     expected = {"a": [3], "b": [2], "z": [1]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_count_series(constructor_eager: Any) -> None:
@@ -18,4 +18,4 @@ def test_count_series(constructor_eager: Any) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = {"a": [df["a"].count()], "b": [df["b"].count()], "z": [df["z"].count()]}
     expected = {"a": [3], "b": [2], "z": [1]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/cum_sum_test.py
+++ b/tests/expr_and_series/cum_sum_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [0, 1, 2, 3, 4],
@@ -19,7 +19,7 @@ def test_cum_sum_simple(constructor: Constructor) -> None:
         "b": [1, 3, 6, 11, 14],
         "c": [5, 9, 12, 14, 15],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_cum_sum_simple_series(constructor_eager: Any) -> None:
@@ -34,4 +34,4 @@ def test_cum_sum_simple_series(constructor_eager: Any) -> None:
         df["b"].cum_sum(),
         df["c"].cum_sum(),
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/diff_test.py
+++ b/tests/expr_and_series/diff_test.py
@@ -6,7 +6,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "i": [0, 1, 2, 3, 4],
@@ -29,7 +29,7 @@ def test_diff(constructor: Constructor, request: pytest.FixtureRequest) -> None:
         "c": [4, 3, 2, 1],
         "c_diff": [-1, -1, -1, -1],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_diff_series(constructor_eager: Any, request: pytest.FixtureRequest) -> None:
@@ -46,4 +46,4 @@ def test_diff_series(constructor_eager: Any, request: pytest.FixtureRequest) -> 
         "c_diff": [-1, -1, -1, -1],
     }
     result = df.with_columns(c_diff=df["c"].diff())[1:]
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/double_selected_test.py
+++ b/tests/expr_and_series/double_selected_test.py
@@ -1,6 +1,6 @@
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_double_selected(constructor: Constructor) -> None:
@@ -9,12 +9,12 @@ def test_double_selected(constructor: Constructor) -> None:
 
     result = df.select(nw.col("a", "b") * 2)
     expected = {"a": [2, 6, 4], "b": [8, 8, 12]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     result = df.select("z", nw.col("a", "b") * 2)
     expected = {"z": [7, 8, 9], "a": [2, 6, 4], "b": [8, 8, 12]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     result = df.select("a").select(nw.col("a") + nw.all())
     expected = {"a": [2, 6, 4]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/double_test.py
+++ b/tests/expr_and_series/double_test.py
@@ -1,6 +1,6 @@
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_double(constructor: Constructor) -> None:
@@ -8,7 +8,7 @@ def test_double(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.with_columns(nw.all() * 2)
     expected = {"a": [2, 6, 4], "b": [8, 8, 12], "z": [14.0, 16.0, 18.0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_double_alias(constructor: Constructor) -> None:
@@ -21,4 +21,4 @@ def test_double_alias(constructor: Constructor) -> None:
         "b": [8, 8, 12],
         "z": [14.0, 16.0, 18.0],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/drop_nulls_test.py
+++ b/tests/expr_and_series/drop_nulls_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_drop_nulls(constructor: Constructor, request: pytest.FixtureRequest) -> None:
@@ -30,10 +30,10 @@ def test_drop_nulls(constructor: Constructor, request: pytest.FixtureRequest) ->
     expected_c = {"C": []}  # type: ignore[var-annotated]
     expected_d = {"D": [9, 10, 11, 12]}
 
-    compare_dicts(result_a, expected_a)
-    compare_dicts(result_b, expected_b)
-    compare_dicts(result_c, expected_c)
-    compare_dicts(result_d, expected_d)
+    assert_equal_data(result_a, expected_a)
+    assert_equal_data(result_b, expected_b)
+    assert_equal_data(result_c, expected_c)
+    assert_equal_data(result_d, expected_d)
 
 
 def test_drop_nulls_series(constructor_eager: Any) -> None:
@@ -55,7 +55,7 @@ def test_drop_nulls_series(constructor_eager: Any) -> None:
     expected_c = {"C": []}  # type: ignore[var-annotated]
     expected_d = {"D": [9, 10, 11, 12]}
 
-    compare_dicts(result_a, expected_a)
-    compare_dicts(result_b, expected_b)
-    compare_dicts(result_c, expected_c)
-    compare_dicts(result_d, expected_d)
+    assert_equal_data(result_a, expected_a)
+    assert_equal_data(result_b, expected_b)
+    assert_equal_data(result_c, expected_c)
+    assert_equal_data(result_d, expected_d)

--- a/tests/expr_and_series/dt/datetime_attributes_test.py
+++ b/tests/expr_and_series/dt/datetime_attributes_test.py
@@ -8,7 +8,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [
@@ -51,7 +51,7 @@ def test_datetime_attributes(
 
     df = nw.from_native(constructor(data))
     result = df.select(getattr(nw.col("a").dt, attribute)())
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 @pytest.mark.parametrize(
@@ -87,7 +87,7 @@ def test_datetime_attributes_series(
 
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(getattr(df["a"].dt, attribute)())
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 def test_datetime_chained_attributes(
@@ -100,7 +100,7 @@ def test_datetime_chained_attributes(
 
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(df["a"].dt.date().dt.year())
-    compare_dicts(result, {"a": [2021, 2020]})
+    assert_equal_data(result, {"a": [2021, 2020]})
 
     result = df.select(nw.col("a").dt.date().dt.year())
-    compare_dicts(result, {"a": [2021, 2020]})
+    assert_equal_data(result, {"a": [2021, 2020]})

--- a/tests/expr_and_series/dt/datetime_duration_test.py
+++ b/tests/expr_and_series/dt/datetime_duration_test.py
@@ -12,7 +12,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [
@@ -53,13 +53,13 @@ def test_duration_attributes(
     df = nw.from_native(constructor(data))
 
     result_a = df.select(getattr(nw.col("a").dt, attribute)().fill_null(0))
-    compare_dicts(result_a, {"a": expected_a})
+    assert_equal_data(result_a, {"a": expected_a})
 
     result_b = df.select(getattr(nw.col("b").dt, attribute)().fill_null(0))
-    compare_dicts(result_b, {"b": expected_b})
+    assert_equal_data(result_b, {"b": expected_b})
 
     result_c = df.select(getattr(nw.col("c").dt, attribute)().fill_null(0))
-    compare_dicts(result_c, {"c": expected_c})
+    assert_equal_data(result_c, {"c": expected_c})
 
 
 @pytest.mark.parametrize(
@@ -90,13 +90,13 @@ def test_duration_attributes_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result_a = df.select(getattr(df["a"].dt, attribute)().fill_null(0))
-    compare_dicts(result_a, {"a": expected_a})
+    assert_equal_data(result_a, {"a": expected_a})
 
     result_b = df.select(getattr(df["b"].dt, attribute)().fill_null(0))
-    compare_dicts(result_b, {"b": expected_b})
+    assert_equal_data(result_b, {"b": expected_b})
 
     result_c = df.select(getattr(df["c"].dt, attribute)().fill_null(0))
-    compare_dicts(result_c, {"c": expected_c})
+    assert_equal_data(result_c, {"c": expected_c})
 
 
 @pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
@@ -116,7 +116,7 @@ def test_pyarrow_units(unit: str, attribute: str, expected: int) -> None:
     df = nw.from_native(pa.table({"a": arr}), eager_only=True)
 
     result_expr = df.select(getattr(nw.col("a").dt, attribute)().fill_null(0))
-    compare_dicts(result_expr, {"a": [0, expected]})
+    assert_equal_data(result_expr, {"a": [0, expected]})
 
     result_series = df.select(getattr(df["a"].dt, attribute)().fill_null(0))
-    compare_dicts(result_series, {"a": [0, expected]})
+    assert_equal_data(result_series, {"a": [0, expected]})

--- a/tests/expr_and_series/dt/timestamp_test.py
+++ b/tests/expr_and_series/dt/timestamp_test.py
@@ -13,7 +13,7 @@ import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 from tests.utils import is_windows
 
 data = {
@@ -61,7 +61,7 @@ def test_timestamp_datetimes(
     result = df.select(
         nw.col("a").cast(nw.Datetime(original_time_unit)).dt.timestamp(time_unit)
     )
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 @pytest.mark.parametrize(
@@ -118,7 +118,7 @@ def test_timestamp_datetimes_tz_aware(
         .dt.convert_time_zone("Asia/Kathmandu")
         .dt.timestamp(time_unit)
     )
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 @pytest.mark.parametrize(
@@ -149,7 +149,7 @@ def test_timestamp_dates(
     else:
         df = nw.from_native(constructor(dates))
     result = df.select(nw.col("a").dt.date().dt.timestamp(time_unit))
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 def test_timestamp_invalid_date(

--- a/tests/expr_and_series/dt/to_string_test.py
+++ b/tests/expr_and_series/dt/to_string_test.py
@@ -7,7 +7,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 from tests.utils import is_windows
 
 data = {
@@ -44,7 +44,7 @@ def test_dt_to_string_series(constructor_eager: Any, fmt: str) -> None:
         # the fraction of a second.
         result = {"a": input_series.dt.to_string(fmt).str.replace(r"\.\d+$", "")}
 
-    compare_dicts(result, {"a": expected_col})
+    assert_equal_data(result, {"a": expected_col})
 
 
 @pytest.mark.parametrize(
@@ -70,7 +70,7 @@ def test_dt_to_string_expr(constructor: Constructor, fmt: str) -> None:
         result = input_frame.select(
             nw.col("a").dt.to_string(fmt).str.replace(r"\.\d+$", "").alias("b")
         )
-    compare_dicts(result, {"b": expected_col})
+    assert_equal_data(result, {"b": expected_col})
 
 
 def _clean_string(result: str) -> str:
@@ -138,12 +138,12 @@ def test_dt_to_string_iso_local_datetime_expr(
     result = nw.from_native(df).with_columns(
         _clean_string_expr(nw.col("a").dt.to_string("%Y-%m-%dT%H:%M:%S.%f")).alias("b")
     )
-    compare_dicts(result, {"a": [data], "b": [_clean_string(expected)]})
+    assert_equal_data(result, {"a": [data], "b": [_clean_string(expected)]})
 
     result = nw.from_native(df).with_columns(
         _clean_string_expr(nw.col("a").dt.to_string("%Y-%m-%dT%H:%M:%S%.f")).alias("b")
     )
-    compare_dicts(result, {"a": [data], "b": [_clean_string(expected)]})
+    assert_equal_data(result, {"a": [data], "b": [_clean_string(expected)]})
 
 
 @pytest.mark.parametrize(
@@ -171,4 +171,4 @@ def test_dt_to_string_iso_local_date_expr(
     result = nw.from_native(df).with_columns(
         nw.col("a").dt.to_string("%Y-%m-%d").alias("b")
     )
-    compare_dicts(result, {"a": [data], "b": [expected]})
+    assert_equal_data(result, {"a": [data], "b": [expected]})

--- a/tests/expr_and_series/fill_null_test.py
+++ b/tests/expr_and_series/fill_null_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [0.0, None, 2, 3, 4],
@@ -20,7 +20,7 @@ def test_fill_null(constructor: Constructor) -> None:
         "b": [1.0, 99, 99, 5, 3],
         "c": [5.0, 99, 3, 2, 1],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_fill_null_series(constructor_eager: Any) -> None:
@@ -36,4 +36,4 @@ def test_fill_null_series(constructor_eager: Any) -> None:
         b=df["b"].fill_null(99),
         c=df["c"].fill_null(99),
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/filter_test.py
+++ b/tests/expr_and_series/filter_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "i": [0, 1, 2, 3, 4],
@@ -20,14 +20,14 @@ def test_filter(constructor: Constructor, request: pytest.FixtureRequest) -> Non
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a").filter(nw.col("i") < 2, nw.col("c") == 5))
     expected = {"a": [0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_filter_series(constructor_eager: Any) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(df["a"].filter((df["i"] < 2) & (df["c"] == 5)))
     expected = {"a": [0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result_s = df["a"].filter([True, False, False, False, False])
     expected = {"a": [0]}
-    compare_dicts({"a": result_s}, expected)
+    assert_equal_data({"a": result_s}, expected)

--- a/tests/expr_and_series/gather_every_test.py
+++ b/tests/expr_and_series/gather_every_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": list(range(10))}
 
@@ -21,7 +21,7 @@ def test_gather_every_expr(
     result = df.select(nw.col("a").gather_every(n=n, offset=offset))
     expected = {"a": data["a"][offset::n]}
 
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize("n", [1, 2, 3])
@@ -32,4 +32,4 @@ def test_gather_every_series(constructor_eager: Any, n: int, offset: int) -> Non
     result = series.gather_every(n=n, offset=offset)
     expected = data["a"][offset::n]
 
-    compare_dicts({"a": result}, {"a": expected})
+    assert_equal_data({"a": result}, {"a": expected})

--- a/tests/expr_and_series/head_test.py
+++ b/tests/expr_and_series/head_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize("n", [2, -1])
@@ -18,7 +18,7 @@ def test_head(constructor: Constructor, n: int, request: pytest.FixtureRequest) 
     df = nw.from_native(constructor({"a": [1, 2, 3]}))
     result = df.select(nw.col("a").head(n))
     expected = {"a": [1, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize("n", [2, -1])
@@ -26,4 +26,4 @@ def test_head_series(constructor_eager: Any, n: int) -> None:
     df = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)
     result = df.select(df["a"].head(n))
     expected = {"a": [1, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/is_between_test.py
+++ b/tests/expr_and_series/is_between_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [1, 4, 2, 5],
@@ -26,7 +26,7 @@ def test_is_between(constructor: Constructor, closed: str, expected: list[bool])
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a").is_between(1, 5, closed=closed))
     expected_dict = {"a": expected}
-    compare_dicts(result, expected_dict)
+    assert_equal_data(result, expected_dict)
 
 
 @pytest.mark.parametrize(
@@ -44,4 +44,4 @@ def test_is_between_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.with_columns(a=df["a"].is_between(1, 5, closed=closed))
     expected_dict = {"a": expected}
-    compare_dicts(result, expected_dict)
+    assert_equal_data(result, expected_dict)

--- a/tests/expr_and_series/is_duplicated_test.py
+++ b/tests/expr_and_series/is_duplicated_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 1, 2], "b": [1, 2, 3], "index": [0, 1, 2]}
 
@@ -11,11 +11,11 @@ def test_is_duplicated_expr(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a", "b").is_duplicated(), "index").sort("index")
     expected = {"a": [True, True, False], "b": [False, False, False], "index": [0, 1, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_is_duplicated_series(constructor_eager: Any) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)["a"]
     result = series.is_duplicated()
     expected = {"a": [True, True, False]}
-    compare_dicts({"a": result}, expected)
+    assert_equal_data({"a": result}, expected)

--- a/tests/expr_and_series/is_first_distinct_test.py
+++ b/tests/expr_and_series/is_first_distinct_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [1, 1, 2, 3, 2],
@@ -17,7 +17,7 @@ def test_is_first_distinct_expr(constructor: Constructor) -> None:
         "a": [True, False, True, True, False],
         "b": [True, True, True, False, False],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_is_first_distinct_series(constructor_eager: Any) -> None:
@@ -26,4 +26,4 @@ def test_is_first_distinct_series(constructor_eager: Any) -> None:
     expected = {
         "a": [True, False, True, True, False],
     }
-    compare_dicts({"a": result}, expected)
+    assert_equal_data({"a": result}, expected)

--- a/tests/expr_and_series/is_in_test.py
+++ b/tests/expr_and_series/is_in_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 4, 2, 5]}
 
@@ -14,7 +14,7 @@ def test_expr_is_in(constructor: Constructor) -> None:
     result = df.select(nw.col("a").is_in([4, 5]))
     expected = {"a": [False, True, False, True]}
 
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_ser_is_in(constructor_eager: Any) -> None:
@@ -22,7 +22,7 @@ def test_ser_is_in(constructor_eager: Any) -> None:
     result = {"a": ser.is_in([4, 5])}
     expected = {"a": [False, True, False, True]}
 
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_is_in_other(constructor: Constructor) -> None:

--- a/tests/expr_and_series/is_last_distinct_test.py
+++ b/tests/expr_and_series/is_last_distinct_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [1, 1, 2, 3, 2],
@@ -17,7 +17,7 @@ def test_is_last_distinct_expr(constructor: Constructor) -> None:
         "a": [False, True, False, True, True],
         "b": [False, False, True, True, True],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_is_last_distinct_series(constructor_eager: Any) -> None:
@@ -26,4 +26,4 @@ def test_is_last_distinct_series(constructor_eager: Any) -> None:
     expected = {
         "a": [False, True, False, True, True],
     }
-    compare_dicts({"a": result}, expected)
+    assert_equal_data({"a": result}, expected)

--- a/tests/expr_and_series/is_null_test.py
+++ b/tests/expr_and_series/is_null_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_null(constructor: Constructor) -> None:
@@ -11,7 +11,7 @@ def test_null(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data_na))
     result = df.select(nw.col("a").is_null(), ~nw.col("z").is_null())
 
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_null_series(constructor_eager: Any) -> None:
@@ -20,4 +20,4 @@ def test_null_series(constructor_eager: Any) -> None:
     df = nw.from_native(constructor_eager(data_na), eager_only=True)
     result = {"a": df["a"].is_null(), "z": ~df["z"].is_null()}
 
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/is_unique_test.py
+++ b/tests/expr_and_series/is_unique_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [1, 1, 2],
@@ -19,7 +19,7 @@ def test_is_unique_expr(constructor: Constructor) -> None:
         "b": [True, True, True],
         "index": [0, 1, 2],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_is_unique_series(constructor_eager: Any) -> None:
@@ -28,4 +28,4 @@ def test_is_unique_series(constructor_eager: Any) -> None:
     expected = {
         "a": [False, False, True],
     }
-    compare_dicts({"a": result}, expected)
+    assert_equal_data({"a": result}, expected)

--- a/tests/expr_and_series/len_test.py
+++ b/tests/expr_and_series/len_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_len_no_filter(constructor: Constructor) -> None:
@@ -15,7 +15,7 @@ def test_len_no_filter(constructor: Constructor) -> None:
         (nw.col("a").len() * 2).alias("l2"),
     )
 
-    compare_dicts(df, expected)
+    assert_equal_data(df, expected)
 
 
 def test_len_chaining(constructor: Constructor, request: pytest.FixtureRequest) -> None:
@@ -28,7 +28,7 @@ def test_len_chaining(constructor: Constructor, request: pytest.FixtureRequest) 
         nw.col("a").filter(nw.col("b") == 2).len().alias("a2"),
     )
 
-    compare_dicts(df, expected)
+    assert_equal_data(df, expected)
 
 
 def test_namespace_len(constructor: Constructor) -> None:
@@ -36,14 +36,14 @@ def test_namespace_len(constructor: Constructor) -> None:
         nw.len(), a=nw.len()
     )
     expected = {"len": [3], "a": [3]}
-    compare_dicts(df, expected)
+    assert_equal_data(df, expected)
     df = (
         nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]}))
         .select()
         .select(nw.len(), a=nw.len())
     )
     expected = {"len": [0], "a": [0]}
-    compare_dicts(df, expected)
+    assert_equal_data(df, expected)
 
 
 def test_len_series(constructor_eager: Any) -> None:

--- a/tests/expr_and_series/max_horizontal_test.py
+++ b/tests/expr_and_series/max_horizontal_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 3, None, None], "b": [4, None, 6, None], "z": [3, 1, None, None]}
 expected_values = [4, 3, 6, float("nan")]
@@ -15,11 +15,11 @@ def test_maxh(constructor: Constructor, col_expr: Any) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(horizontal_max=nw.max_horizontal(col_expr, nw.col("b"), "z"))
     expected = {"horizontal_max": expected_values}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_maxh_all(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.max_horizontal(nw.all()), c=nw.max_horizontal(nw.all()))
     expected = {"a": expected_values, "c": expected_values}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/max_test.py
+++ b/tests/expr_and_series/max_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
 
@@ -16,11 +16,11 @@ def test_expr_max_expr(constructor: Constructor, expr: nw.Expr) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(expr)
     expected = {"a": [3], "b": [6], "z": [9.0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(("col", "expected"), [("a", 3), ("b", 6), ("z", 9.0)])
 def test_expr_max_series(constructor_eager: Any, col: str, expected: float) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)[col]
     result = series.max()
-    compare_dicts({col: [result]}, {col: [expected]})
+    assert_equal_data({col: [result]}, {col: [expected]})

--- a/tests/expr_and_series/mean_horizontal_test.py
+++ b/tests/expr_and_series/mean_horizontal_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize("col_expr", [nw.col("a"), "a"])
@@ -13,7 +13,7 @@ def test_meanh(constructor: Constructor, col_expr: Any) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(horizontal_mean=nw.mean_horizontal(col_expr, nw.col("b")))
     expected = {"horizontal_mean": [2.5, 3.0, 6.0, float("nan")]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_meanh_all(constructor: Constructor) -> None:
@@ -23,9 +23,9 @@ def test_meanh_all(constructor: Constructor) -> None:
     expected = {
         "a": [6, 12, 18],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df.select(c=nw.mean_horizontal(nw.all()))
     expected = {
         "c": [6, 12, 18],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/mean_test.py
+++ b/tests/expr_and_series/mean_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 3, 2], "b": [4, 4, 7], "z": [7.0, 8, 9]}
 
@@ -16,11 +16,11 @@ def test_expr_mean_expr(constructor: Constructor, expr: nw.Expr) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(expr)
     expected = {"a": [2.0], "b": [5.0], "z": [8.0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(("col", "expected"), [("a", 2.0), ("b", 5.0), ("z", 8.0)])
 def test_expr_mean_series(constructor_eager: Any, col: str, expected: float) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)[col]
     result = series.mean()
-    compare_dicts({col: [result]}, {col: [expected]})
+    assert_equal_data({col: [result]}, {col: [expected]})

--- a/tests/expr_and_series/min_horizontal_test.py
+++ b/tests/expr_and_series/min_horizontal_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 3, None, None], "b": [4, None, 6, None], "z": [3, 1, None, None]}
 expcted_values = [1, 1, 6, float("nan")]
@@ -15,11 +15,11 @@ def test_minh(constructor: Constructor, col_expr: Any) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(horizontal_min=nw.min_horizontal(col_expr, nw.col("b"), "z"))
     expected = {"horizontal_min": expcted_values}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_minh_all(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.min_horizontal(nw.all()), c=nw.min_horizontal(nw.all()))
     expected = {"a": expcted_values, "c": expcted_values}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/min_test.py
+++ b/tests/expr_and_series/min_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
 
@@ -16,11 +16,11 @@ def test_expr_min_expr(constructor: Constructor, expr: nw.Expr) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(expr)
     expected = {"a": [1], "b": [4], "z": [7.0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(("col", "expected"), [("a", 1), ("b", 4), ("z", 7.0)])
 def test_expr_min_series(constructor_eager: Any, col: str, expected: float) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)[col]
     result = series.min()
-    compare_dicts({col: [result]}, {col: [expected]})
+    assert_equal_data({col: [result]}, {col: [expected]})

--- a/tests/expr_and_series/mode_test.py
+++ b/tests/expr_and_series/mode_test.py
@@ -6,7 +6,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [1, 1, 2, 2, 3],
@@ -23,7 +23,7 @@ def test_mode_single_expr(
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a").mode()).sort("a")
     expected = {"a": [1, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_mode_multi_expr(
@@ -36,11 +36,11 @@ def test_mode_multi_expr(
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a", "b").mode()).sort("a", "b")
     expected = {"a": [1, 2], "b": [3, 3]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_mode_series(constructor_eager: Any) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)["a"]
     result = series.mode().sort()
     expected = {"a": [1, 2]}
-    compare_dicts({"a": result}, expected)
+    assert_equal_data({"a": result}, expected)

--- a/tests/expr_and_series/n_unique_test.py
+++ b/tests/expr_and_series/n_unique_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [1.0, None, None, 3.0],
@@ -14,11 +14,11 @@ def test_n_unique(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.all().n_unique())
     expected = {"a": [3], "b": [4]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_n_unique_series(constructor_eager: Any) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     expected = {"a": [3], "b": [4]}
     result_series = {"a": [df["a"].n_unique()], "b": [df["b"].n_unique()]}
-    compare_dicts(result_series, expected)
+    assert_equal_data(result_series, expected)

--- a/tests/expr_and_series/name/keep_test.py
+++ b/tests/expr_and_series/name/keep_test.py
@@ -7,7 +7,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"foo": [1, 2, 3], "BAR": [4, 5, 6]}
 
@@ -16,14 +16,14 @@ def test_keep(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo", "BAR") * 2).name.keep())
     expected = {k: [e * 2 for e in v] for k, v in data.items()}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_keep_after_alias(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.keep())
     expected = {"foo": data["foo"]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_keep_raise_anonymous(constructor: Constructor) -> None:

--- a/tests/expr_and_series/name/map_test.py
+++ b/tests/expr_and_series/name/map_test.py
@@ -7,7 +7,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"foo": [1, 2, 3], "BAR": [4, 5, 6]}
 
@@ -20,14 +20,14 @@ def test_map(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo", "BAR") * 2).name.map(function=map_func))
     expected = {map_func(k): [e * 2 for e in v] for k, v in data.items()}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_map_after_alias(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.map(function=map_func))
     expected = {map_func("foo"): data["foo"]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_map_raise_anonymous(constructor: Constructor) -> None:

--- a/tests/expr_and_series/name/prefix_test.py
+++ b/tests/expr_and_series/name/prefix_test.py
@@ -7,7 +7,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"foo": [1, 2, 3], "BAR": [4, 5, 6]}
 prefix = "with_prefix_"
@@ -17,14 +17,14 @@ def test_prefix(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo", "BAR") * 2).name.prefix(prefix))
     expected = {prefix + str(k): [e * 2 for e in v] for k, v in data.items()}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_suffix_after_alias(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.prefix(prefix))
     expected = {prefix + "foo": data["foo"]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_prefix_raise_anonymous(constructor: Constructor) -> None:

--- a/tests/expr_and_series/name/suffix_test.py
+++ b/tests/expr_and_series/name/suffix_test.py
@@ -7,7 +7,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"foo": [1, 2, 3], "BAR": [4, 5, 6]}
 suffix = "_with_suffix"
@@ -17,14 +17,14 @@ def test_suffix(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo", "BAR") * 2).name.suffix(suffix))
     expected = {str(k) + suffix: [e * 2 for e in v] for k, v in data.items()}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_suffix_after_alias(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.suffix(suffix))
     expected = {"foo" + suffix: data["foo"]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_suffix_raise_anonymous(constructor: Constructor) -> None:

--- a/tests/expr_and_series/name/to_lowercase_test.py
+++ b/tests/expr_and_series/name/to_lowercase_test.py
@@ -7,7 +7,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"foo": [1, 2, 3], "BAR": [4, 5, 6]}
 
@@ -16,14 +16,14 @@ def test_to_lowercase(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo", "BAR") * 2).name.to_lowercase())
     expected = {k.lower(): [e * 2 for e in v] for k, v in data.items()}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_to_lowercase_after_alias(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("BAR")).alias("ALIAS_FOR_BAR").name.to_lowercase())
     expected = {"bar": data["BAR"]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_to_lowercase_raise_anonymous(constructor: Constructor) -> None:

--- a/tests/expr_and_series/name/to_uppercase_test.py
+++ b/tests/expr_and_series/name/to_uppercase_test.py
@@ -7,7 +7,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"foo": [1, 2, 3], "BAR": [4, 5, 6]}
 
@@ -16,14 +16,14 @@ def test_to_uppercase(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo", "BAR") * 2).name.to_uppercase())
     expected = {k.upper(): [e * 2 for e in v] for k, v in data.items()}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_to_uppercase_after_alias(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.to_uppercase())
     expected = {"FOO": data["foo"]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_to_uppercase_raise_anonymous(constructor: Constructor) -> None:

--- a/tests/expr_and_series/nth_test.py
+++ b/tests/expr_and_series/nth_test.py
@@ -8,7 +8,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8, 9]}
 
@@ -33,7 +33,7 @@ def test_nth(
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     result = df.select(nw.nth(idx))
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.skipif(

--- a/tests/expr_and_series/null_count_test.py
+++ b/tests/expr_and_series/null_count_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [1.0, None, None, 3.0],
@@ -17,7 +17,7 @@ def test_null_count_expr(constructor: Constructor) -> None:
         "a": [2],
         "b": [1],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_null_count_series(constructor_eager: Any) -> None:

--- a/tests/expr_and_series/operators_test.py
+++ b/tests/expr_and_series/operators_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize(
@@ -26,7 +26,7 @@ def test_comparand_operators_scalar_expr(
     data = {"a": [0, 1, 2]}
     df = nw.from_native(constructor(data))
     result = df.select(getattr(nw.col("a"), operator)(1))
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 @pytest.mark.parametrize(
@@ -46,7 +46,7 @@ def test_comparand_operators_expr(
     data = {"a": [0, 1, 1], "b": [0, 0, 2]}
     df = nw.from_native(constructor(data))
     result = df.select(getattr(nw.col("a"), operator)(nw.col("b")))
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 @pytest.mark.parametrize(
@@ -63,7 +63,7 @@ def test_logic_operators_expr(
     df = nw.from_native(constructor(data))
 
     result = df.select(getattr(nw.col("a"), operator)(nw.col("b")))
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 @pytest.mark.parametrize(
@@ -83,7 +83,7 @@ def test_comparand_operators_scalar_series(
     data = {"a": [0, 1, 2]}
     s = nw.from_native(constructor_eager(data), eager_only=True)["a"]
     result = {"a": (getattr(s, operator)(1))}
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 @pytest.mark.parametrize(
@@ -104,7 +104,7 @@ def test_comparand_operators_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
     series, other = df["a"], df["b"]
     result = {"a": getattr(series, operator)(other)}
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})
 
 
 @pytest.mark.parametrize(
@@ -121,4 +121,4 @@ def test_logic_operators_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
     series, other = df["a"], df["b"]
     result = {"a": getattr(series, operator)(other)}
-    compare_dicts(result, {"a": expected})
+    assert_equal_data(result, {"a": expected})

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": ["a", "a", "b", "b", "b"],
@@ -33,7 +33,7 @@ def test_over_single(constructor: Constructor) -> None:
 
     with context:
         result = df.with_columns(c_max=nw.col("c").max().over("a"))
-        compare_dicts(result, expected)
+        assert_equal_data(result, expected)
 
 
 def test_over_multiple(constructor: Constructor) -> None:
@@ -56,7 +56,7 @@ def test_over_multiple(constructor: Constructor) -> None:
 
     with context:
         result = df.with_columns(c_min=nw.col("c").min().over("a", "b"))
-        compare_dicts(result, expected)
+        assert_equal_data(result, expected)
 
 
 def test_over_invalid(request: pytest.FixtureRequest, constructor: Constructor) -> None:

--- a/tests/expr_and_series/pipe_test.py
+++ b/tests/expr_and_series/pipe_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 input_list = {"a": [2, 4, 6, 8]}
 expected = [4, 16, 36, 64]
@@ -11,7 +11,7 @@ expected = [4, 16, 36, 64]
 def test_pipe_expr(constructor: Constructor) -> None:
     df = nw.from_native(constructor(input_list))
     e = df.select(nw.col("a").pipe(lambda x: x**2))
-    compare_dicts(e, {"a": expected})
+    assert_equal_data(e, {"a": expected})
 
 
 def test_pipe_series(
@@ -19,4 +19,4 @@ def test_pipe_series(
 ) -> None:
     s = nw.from_native(constructor_eager(input_list), eager_only=True)["a"]
     result = s.pipe(lambda x: x**2)
-    compare_dicts({"a": result}, {"a": expected})
+    assert_equal_data({"a": result}, {"a": expected})

--- a/tests/expr_and_series/quantile_test.py
+++ b/tests/expr_and_series/quantile_test.py
@@ -8,7 +8,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize(
@@ -47,7 +47,7 @@ def test_quantile_expr(
 
     with context:
         result = df.select(nw.all().quantile(quantile=q, interpolation=interpolation))
-        compare_dicts(result, expected)
+        assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -72,4 +72,4 @@ def test_quantile_series(
         "a"
     ].alias("a")
     result = series.quantile(quantile=q, interpolation=interpolation)
-    compare_dicts({"a": [result]}, {"a": [expected]})
+    assert_equal_data({"a": [result]}, {"a": [expected]})

--- a/tests/expr_and_series/reduction_test.py
+++ b/tests/expr_and_series/reduction_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize(
@@ -32,7 +32,7 @@ def test_scalar_reduction_select(
     data = {"a": [1, 2, 3], "b": [4, 5, 6]}
     df = nw.from_native(constructor(data))
     result = df.select(*expr)
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -58,4 +58,4 @@ def test_scalar_reduction_with_columns(
     data = {"a": [1, 2, 3], "b": [4, 5, 6]}
     df = nw.from_native(constructor(data))
     result = df.with_columns(*expr).select(*expected.keys())
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/replace_time_zone_test.py
+++ b/tests/expr_and_series/replace_time_zone_test.py
@@ -9,7 +9,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 from tests.utils import is_windows
 
 
@@ -35,7 +35,7 @@ def test_replace_time_zone(
     assert result_dtype.time_zone == "Asia/Kathmandu"  # type: ignore[attr-defined]
     result_str = result.select(nw.col("a").dt.to_string("%Y-%m-%dT%H:%M%z"))
     expected = {"a": ["2020-01-01T00:00+0545", "2020-01-02T00:00+0545"]}
-    compare_dicts(result_str, expected)
+    assert_equal_data(result_str, expected)
 
 
 def test_replace_time_zone_none(
@@ -60,7 +60,7 @@ def test_replace_time_zone_none(
     assert result_dtype.time_zone is None  # type: ignore[attr-defined]
     result_str = result.select(nw.col("a").dt.to_string("%Y-%m-%dT%H:%M"))
     expected = {"a": ["2020-01-01T00:00", "2020-01-02T00:00"]}
-    compare_dicts(result_str, expected)
+    assert_equal_data(result_str, expected)
 
 
 def test_replace_time_zone_series(
@@ -91,7 +91,7 @@ def test_replace_time_zone_series(
     assert result_dtype.time_zone == "Asia/Kathmandu"  # type: ignore[attr-defined]
     result_str = result.select(nw.col("a").dt.to_string("%Y-%m-%dT%H:%M%z"))
     expected = {"a": ["2020-01-01T00:00+0545", "2020-01-02T00:00+0545"]}
-    compare_dicts(result_str, expected)
+    assert_equal_data(result_str, expected)
 
 
 def test_replace_time_zone_none_series(
@@ -122,4 +122,4 @@ def test_replace_time_zone_none_series(
     assert result_dtype.time_zone is None  # type: ignore[attr-defined]
     result_str = result.select(df["a"].dt.to_string("%Y-%m-%dT%H:%M"))
     expected = {"a": ["2020-01-01T00:00", "2020-01-02T00:00"]}
-    compare_dicts(result_str, expected)
+    assert_equal_data(result_str, expected)

--- a/tests/expr_and_series/round_test.py
+++ b/tests/expr_and_series/round_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize("decimals", [0, 1, 2])
@@ -17,7 +17,7 @@ def test_round(constructor: Constructor, decimals: int) -> None:
 
     expected_data = {k: [round(e, decimals) for e in v] for k, v in data.items()}
     result_frame = df.select(nw.col("a").round(decimals))
-    compare_dicts(result_frame, expected_data)
+    assert_equal_data(result_frame, expected_data)
 
 
 @pytest.mark.parametrize("decimals", [0, 1, 2])
@@ -29,4 +29,4 @@ def test_round_series(constructor_eager: Any, decimals: int) -> None:
     expected_data = {k: [round(e, decimals) for e in v] for k, v in data.items()}
     result_series = df["a"].round(decimals)
 
-    compare_dicts({"a": result_series}, expected_data)
+    assert_equal_data({"a": result_series}, expected_data)

--- a/tests/expr_and_series/sample_test.py
+++ b/tests/expr_and_series/sample_test.py
@@ -2,7 +2,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_expr_sample(constructor: Constructor, request: pytest.FixtureRequest) -> None:
@@ -57,13 +57,13 @@ def test_sample_with_seed(
         .collect()
     )
 
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     series = df.collect()["a"]
     seed1 = series.sample(n=n, seed=123)
     seed2 = series.sample(n=n, seed=123)
     seed3 = series.sample(n=n, seed=42)
 
-    compare_dicts(
+    assert_equal_data(
         {"res1": [(seed1 == seed2).all()], "res2": [(seed1 == seed3).all()]}, expected
     )

--- a/tests/expr_and_series/shift_test.py
+++ b/tests/expr_and_series/shift_test.py
@@ -4,7 +4,7 @@ import pyarrow as pa
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "i": [0, 1, 2, 3, 4],
@@ -23,7 +23,7 @@ def test_shift(constructor: Constructor) -> None:
         "b": [1, 2, 3],
         "c": [5, 4, 3],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_shift_series(constructor_eager: Any) -> None:
@@ -39,7 +39,7 @@ def test_shift_series(constructor_eager: Any) -> None:
         "b": [1, 2, 3],
         "c": [5, 4, 3],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_shift_multi_chunk_pyarrow() -> None:
@@ -49,12 +49,12 @@ def test_shift_multi_chunk_pyarrow() -> None:
 
     result = df.select(nw.col("a").shift(1))
     expected = {"a": [None, 1, 2, 3, 1, 2, 3, 1, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     result = df.select(nw.col("a").shift(-1))
     expected = {"a": [2, 3, 1, 2, 3, 1, 2, 3, None]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     result = df.select(nw.col("a").shift(0))
     expected = {"a": [1, 2, 3, 1, 2, 3, 1, 2, 3]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/sort_test.py
+++ b/tests/expr_and_series/sort_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import ConstructorEager
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [0, 0, 2, -1], "b": [1, 3, 2, None]}
 
@@ -28,7 +28,7 @@ def test_sort_expr(
         "a",
         nw.col("b").sort(descending=descending, nulls_last=nulls_last),
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/expr_and_series/std_test.py
+++ b/tests/expr_and_series/std_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
 
@@ -23,7 +23,7 @@ def test_std(constructor: Constructor) -> None:
         "b_ddof_2": [1.632993],
         "z_ddof_0": [0.816497],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_std_series(constructor_eager: Any) -> None:
@@ -42,4 +42,4 @@ def test_std_series(constructor_eager: Any) -> None:
         "b_ddof_2": [1.632993],
         "z_ddof_0": [0.816497],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/str/contains_test.py
+++ b/tests/expr_and_series/str/contains_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"pets": ["cat", "dog", "rabbit and parrot", "dove"]}
 
@@ -28,7 +28,7 @@ def test_contains_case_insensitive(
         "pets": ["cat", "dog", "rabbit and parrot", "dove"],
         "result": [False, False, True, True],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_contains_series_case_insensitive(
@@ -45,7 +45,7 @@ def test_contains_series_case_insensitive(
         "pets": ["cat", "dog", "rabbit and parrot", "dove"],
         "case_insensitive_match": [False, False, True, True],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_contains_case_sensitive(constructor: Constructor) -> None:
@@ -55,7 +55,7 @@ def test_contains_case_sensitive(constructor: Constructor) -> None:
         "pets": ["cat", "dog", "rabbit and parrot", "dove"],
         "result": [False, False, True, False],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_contains_series_case_sensitive(constructor_eager: Any) -> None:
@@ -65,4 +65,4 @@ def test_contains_series_case_sensitive(constructor_eager: Any) -> None:
         "pets": ["cat", "dog", "rabbit and parrot", "dove"],
         "case_sensitive_match": [False, False, True, False],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/str/head_test.py
+++ b/tests/expr_and_series/str/head_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": ["foo", "bars"]}
 
@@ -13,7 +13,7 @@ def test_str_head(constructor: Constructor) -> None:
     expected = {
         "a": ["foo", "bar"],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_str_head_series(constructor_eager: Any) -> None:
@@ -22,4 +22,4 @@ def test_str_head_series(constructor_eager: Any) -> None:
         "a": ["foo", "bar"],
     }
     result = df.select(df["a"].str.head(3))
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/str/len_chars_test.py
+++ b/tests/expr_and_series/str/len_chars_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": ["foo", "foobar", "Café", "345", "東京"]}
 
@@ -13,7 +13,7 @@ def test_str_len_chars(constructor: Constructor) -> None:
     expected = {
         "a": [3, 6, 4, 3, 2],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_str_len_chars_series(constructor_eager: Any) -> None:
@@ -22,4 +22,4 @@ def test_str_len_chars_series(constructor_eager: Any) -> None:
         "a": [3, 6, 4, 3, 2],
     }
     result = df.select(df["a"].str.len_chars())
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/str/replace_test.py
+++ b/tests/expr_and_series/str/replace_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 replace_data = [
     (
@@ -67,7 +67,7 @@ def test_str_replace_series(
     result_series = df["a"].str.replace(
         pattern=pattern, value=value, n=n, literal=literal
     )
-    compare_dicts({"a": result_series}, expected)
+    assert_equal_data({"a": result_series}, expected)
 
 
 @pytest.mark.parametrize(
@@ -85,7 +85,7 @@ def test_str_replace_all_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result_series = df["a"].str.replace_all(pattern=pattern, value=value, literal=literal)
-    compare_dicts({"a": result_series}, expected)
+    assert_equal_data({"a": result_series}, expected)
 
 
 @pytest.mark.parametrize(
@@ -106,7 +106,7 @@ def test_str_replace_expr(
     result_df = df.select(
         nw.col("a").str.replace(pattern=pattern, value=value, n=n, literal=literal)
     )
-    compare_dicts(result_df, expected)
+    assert_equal_data(result_df, expected)
 
 
 @pytest.mark.parametrize(
@@ -126,4 +126,4 @@ def test_str_replace_all_expr(
     result = df.select(
         nw.col("a").str.replace_all(pattern=pattern, value=value, literal=literal)
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/str/slice_test.py
+++ b/tests/expr_and_series/str/slice_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": ["fdas", "edfas"]}
 
@@ -20,7 +20,7 @@ def test_str_slice(
 ) -> None:
     df = nw.from_native(constructor(data))
     result_frame = df.select(nw.col("a").str.slice(offset, length))
-    compare_dicts(result_frame, expected)
+    assert_equal_data(result_frame, expected)
 
 
 @pytest.mark.parametrize(
@@ -33,4 +33,4 @@ def test_str_slice_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result_series = df["a"].str.slice(offset, length)
-    compare_dicts({"a": result_series}, expected)
+    assert_equal_data({"a": result_series}, expected)

--- a/tests/expr_and_series/str/starts_with_ends_with_test.py
+++ b/tests/expr_and_series/str/starts_with_ends_with_test.py
@@ -7,7 +7,7 @@ from tests.utils import Constructor
 
 # Don't move this into typechecking block, for coverage
 # purposes
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": ["fdas", "edfas"]}
 
@@ -18,7 +18,7 @@ def test_ends_with(constructor: Constructor) -> None:
     expected = {
         "a": [True, False],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_ends_with_series(constructor_eager: Any) -> None:
@@ -27,7 +27,7 @@ def test_ends_with_series(constructor_eager: Any) -> None:
     expected = {
         "a": [True, False],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_starts_with(constructor: Constructor) -> None:
@@ -36,7 +36,7 @@ def test_starts_with(constructor: Constructor) -> None:
     expected = {
         "a": [True, False],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_starts_with_series(constructor_eager: Any) -> None:
@@ -45,4 +45,4 @@ def test_starts_with_series(constructor_eager: Any) -> None:
     expected = {
         "a": [True, False],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/str/strip_chars_test.py
+++ b/tests/expr_and_series/str/strip_chars_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": ["foobar", "bar\n", " baz"]}
 
@@ -23,7 +23,7 @@ def test_str_strip_chars(
 ) -> None:
     df = nw.from_native(constructor(data))
     result_frame = df.select(nw.col("a").str.strip_chars(characters))
-    compare_dicts(result_frame, expected)
+    assert_equal_data(result_frame, expected)
 
 
 @pytest.mark.parametrize(
@@ -39,4 +39,4 @@ def test_str_strip_chars_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result_series = df["a"].str.strip_chars(characters)
-    compare_dicts({"a": result_series}, expected)
+    assert_equal_data({"a": result_series}, expected)

--- a/tests/expr_and_series/str/tail_test.py
+++ b/tests/expr_and_series/str/tail_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": ["foo", "bars"]}
 
@@ -12,7 +12,7 @@ def test_str_tail(constructor: Constructor) -> None:
     expected = {"a": ["foo", "ars"]}
 
     result_frame = df.select(nw.col("a").str.tail(3))
-    compare_dicts(result_frame, expected)
+    assert_equal_data(result_frame, expected)
 
 
 def test_str_tail_series(constructor_eager: Any) -> None:
@@ -20,4 +20,4 @@ def test_str_tail_series(constructor_eager: Any) -> None:
     expected = {"a": ["foo", "ars"]}
 
     result_series = df["a"].str.tail(3)
-    compare_dicts({"a": result_series}, expected)
+    assert_equal_data({"a": result_series}, expected)

--- a/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
+++ b/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
@@ -8,7 +8,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize(
@@ -49,7 +49,7 @@ def test_str_to_uppercase(
         # smaller cap 'ß' to upper cap 'ẞ' instead of 'SS'
         request.applymarker(pytest.mark.xfail)
 
-    compare_dicts(result_frame, expected)
+    assert_equal_data(result_frame, expected)
 
 
 @pytest.mark.parametrize(
@@ -90,7 +90,7 @@ def test_str_to_uppercase_series(
         request.applymarker(pytest.mark.xfail)
 
     result_series = df["a"].str.to_uppercase()
-    compare_dicts({"a": result_series}, expected)
+    assert_equal_data({"a": result_series}, expected)
 
 
 @pytest.mark.parametrize(
@@ -115,7 +115,7 @@ def test_str_to_lowercase(
 ) -> None:
     df = nw.from_native(constructor(data))
     result_frame = df.select(nw.col("a").str.to_lowercase())
-    compare_dicts(result_frame, expected)
+    assert_equal_data(result_frame, expected)
 
 
 @pytest.mark.parametrize(
@@ -141,4 +141,4 @@ def test_str_to_lowercase_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result_series = df["a"].str.to_lowercase()
-    compare_dicts({"a": result_series}, expected)
+    assert_equal_data({"a": result_series}, expected)

--- a/tests/expr_and_series/sum_horizontal_test.py
+++ b/tests/expr_and_series/sum_horizontal_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize("col_expr", [nw.col("a"), "a"])
@@ -18,7 +18,7 @@ def test_sumh(constructor: Constructor, col_expr: Any) -> None:
         "z": [7.0, 8.0, 9.0],
         "horizontal_sum": [5, 7, 8],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_sumh_nullable(constructor: Constructor) -> None:
@@ -27,7 +27,7 @@ def test_sumh_nullable(constructor: Constructor) -> None:
 
     df = nw.from_native(constructor(data))
     result = df.select(hsum=nw.sum_horizontal("a", "b"))
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_sumh_all(constructor: Constructor) -> None:
@@ -37,9 +37,9 @@ def test_sumh_all(constructor: Constructor) -> None:
     expected = {
         "a": [11, 22, 33],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df.select(c=nw.sum_horizontal(nw.all()))
     expected = {
         "c": [11, 22, 33],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/sum_test.py
+++ b/tests/expr_and_series/sum_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
 
@@ -16,11 +16,11 @@ def test_expr_sum_expr(constructor: Constructor, expr: nw.Expr) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(expr)
     expected = {"a": [6], "b": [14], "z": [24.0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(("col", "expected"), [("a", 6), ("b", 14), ("z", 24.0)])
 def test_expr_sum_series(constructor_eager: Any, col: str, expected: float) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)[col]
     result = series.sum()
-    compare_dicts({col: [result]}, {col: [expected]})
+    assert_equal_data({col: [result]}, {col: [expected]})

--- a/tests/expr_and_series/tail_test.py
+++ b/tests/expr_and_series/tail_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize("n", [2, -1])
@@ -16,7 +16,7 @@ def test_head(constructor: Constructor, n: int, request: pytest.FixtureRequest) 
     df = nw.from_native(constructor({"a": [1, 2, 3]}))
     result = df.select(nw.col("a").tail(n))
     expected = {"a": [2, 3]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize("n", [2, -1])
@@ -24,4 +24,4 @@ def test_head_series(constructor_eager: Any, n: int) -> None:
     df = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)
     result = df.select(df["a"].tail(n))
     expected = {"a": [2, 3]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/unary_test.py
+++ b/tests/expr_and_series/unary_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_unary(constructor: Constructor) -> None:
@@ -26,7 +26,7 @@ def test_unary(constructor: Constructor) -> None:
         "z_min": [7],
         "z_max": [9],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_unary_series(constructor_eager: Any) -> None:
@@ -46,4 +46,4 @@ def test_unary_series(constructor_eager: Any) -> None:
         "z_min": [7],
         "z_max": [9],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/unique_test.py
+++ b/tests/expr_and_series/unique_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 1, 2]}
 
@@ -15,11 +15,11 @@ def test_unique_expr(constructor: Constructor, request: pytest.FixtureRequest) -
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a").unique())
     expected = {"a": [1, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_unique_series(constructor_eager: Any) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)["a"]
     result = series.unique()
     expected = {"a": [1, 2]}
-    compare_dicts({"a": result}, expected)
+    assert_equal_data({"a": result}, expected)

--- a/tests/expr_and_series/when_test.py
+++ b/tests/expr_and_series/when_test.py
@@ -7,7 +7,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [1, 2, 3],
@@ -24,7 +24,7 @@ def test_when(constructor: Constructor) -> None:
     expected = {
         "a_when": [3, np.nan, np.nan],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_when_otherwise(constructor: Constructor) -> None:
@@ -33,7 +33,7 @@ def test_when_otherwise(constructor: Constructor) -> None:
     expected = {
         "a_when": [3, 6, 6],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_multiple_conditions(constructor: Constructor) -> None:
@@ -44,7 +44,7 @@ def test_multiple_conditions(constructor: Constructor) -> None:
     expected = {
         "a_when": [3, np.nan, np.nan],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_no_arg_when_fail(constructor: Constructor) -> None:
@@ -68,7 +68,7 @@ def test_value_numpy_array(
     expected = {
         "a_when": [3, np.nan, np.nan],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_value_series(constructor_eager: Any) -> None:
@@ -80,7 +80,7 @@ def test_value_series(constructor_eager: Any) -> None:
     expected = {
         "a_when": [3, np.nan, np.nan],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_value_expression(constructor: Constructor) -> None:
@@ -89,7 +89,7 @@ def test_value_expression(constructor: Constructor) -> None:
     expected = {
         "a_when": [10, np.nan, np.nan],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_otherwise_numpy_array(
@@ -107,7 +107,7 @@ def test_otherwise_numpy_array(
     expected = {
         "a_when": [-1, 9, 10],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_otherwise_series(constructor_eager: Any) -> None:
@@ -119,7 +119,7 @@ def test_otherwise_series(constructor_eager: Any) -> None:
     expected = {
         "a_when": [-1, 9, 10],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_otherwise_expression(constructor: Constructor) -> None:
@@ -130,18 +130,18 @@ def test_otherwise_expression(constructor: Constructor) -> None:
     expected = {
         "a_when": [-1, 9, 10],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_when_then_otherwise_into_expr(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.when(nw.col("a") > 1).then("c").otherwise("e"))
     expected = {"c": [7, 5, 6]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_when_then_otherwise_lit_str(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.when(nw.col("a") > 1).then(nw.col("b")).otherwise(nw.lit("z")))
     expected = {"b": ["z", "b", "c"]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/frame/add_test.py
+++ b/tests/frame/add_test.py
@@ -1,6 +1,6 @@
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_add(constructor: Constructor) -> None:
@@ -19,4 +19,4 @@ def test_add(constructor: Constructor) -> None:
         "d": [-1.0, 1.0, 0.0],
         "e": [0.0, 2.0, 1.0],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/frame/array_dunder_test.py
+++ b/tests/frame/array_dunder_test.py
@@ -8,7 +8,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_array_dunder(request: pytest.FixtureRequest, constructor_eager: Any) -> None:
@@ -62,4 +62,4 @@ def test_array_dunder_with_copy(
         result = df.__array__(copy=False)
         np.testing.assert_array_equal(result, np.array([[1], [2], [3]], dtype="int64"))
         result[0, 0] = 999
-        compare_dicts(df, {"a": [999, 2, 3]})
+        assert_equal_data(df, {"a": [999, 2, 3]})

--- a/tests/frame/clone_test.py
+++ b/tests/frame/clone_test.py
@@ -2,7 +2,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_clone(request: pytest.FixtureRequest, constructor: Constructor) -> None:
@@ -16,4 +16,4 @@ def test_clone(request: pytest.FixtureRequest, constructor: Constructor) -> None
     df_clone = df.clone()
     assert df is not df_clone
     assert df._compliant_frame is not df_clone._compliant_frame
-    compare_dicts(df_clone, expected)
+    assert_equal_data(df_clone, expected)

--- a/tests/frame/concat_test.py
+++ b/tests/frame/concat_test.py
@@ -2,7 +2,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_concat_horizontal(constructor: Constructor) -> None:
@@ -20,7 +20,7 @@ def test_concat_horizontal(constructor: Constructor) -> None:
         "c": [6, 12, -1],
         "d": [0, -4, 2],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     with pytest.raises(ValueError, match="No items"):
         nw.concat([])
@@ -37,7 +37,7 @@ def test_concat_vertical(constructor: Constructor) -> None:
 
     result = nw.concat([df_left, df_right], how="vertical")
     expected = {"c": [1, 3, 2, 6, 12, -1], "d": [4, 4, 6, 0, -4, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     with pytest.raises(ValueError, match="No items"):
         nw.concat([], how="vertical")

--- a/tests/frame/double_test.py
+++ b/tests/frame/double_test.py
@@ -1,6 +1,6 @@
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_double(constructor: Constructor) -> None:
@@ -9,7 +9,7 @@ def test_double(constructor: Constructor) -> None:
 
     result = df.with_columns(nw.all() * 2)
     expected = {"a": [2, 6, 4], "b": [8, 8, 12], "z": [14.0, 16.0, 18.0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     result = df.with_columns(nw.col("a").alias("o"), nw.all() * 2)
     expected = {
@@ -18,4 +18,4 @@ def test_double(constructor: Constructor) -> None:
         "b": [8, 8, 12],
         "z": [14.0, 16.0, 18.0],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/frame/drop_nulls_test.py
+++ b/tests/frame/drop_nulls_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [1.0, 2.0, None, 4.0],
@@ -18,7 +18,7 @@ def test_drop_nulls(constructor: Constructor) -> None:
         "a": [2.0, 4.0],
         "b": [3.0, 5.0],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -33,4 +33,4 @@ def test_drop_nulls_subset(
     constructor: Constructor, subset: str | list[str], expected: dict[str, float]
 ) -> None:
     result = nw.from_native(constructor(data)).drop_nulls(subset=subset)
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/frame/filter_test.py
+++ b/tests/frame/filter_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_filter(constructor: Constructor) -> None:
@@ -12,7 +12,7 @@ def test_filter(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.filter(nw.col("a") > 1)
     expected = {"a": [3, 2], "b": [4, 6], "z": [8.0, 9.0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_filter_with_boolean_list(constructor: Constructor) -> None:
@@ -31,4 +31,4 @@ def test_filter_with_boolean_list(constructor: Constructor) -> None:
     with context:
         result = df.filter([False, True, True])
         expected = {"a": [3, 2], "b": [4, 6], "z": [8.0, 9.0]}
-        compare_dicts(result, expected)
+        assert_equal_data(result, expected)

--- a/tests/frame/gather_every_test.py
+++ b/tests/frame/gather_every_test.py
@@ -2,7 +2,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": list(range(10))}
 
@@ -13,4 +13,4 @@ def test_gather_every(constructor: Constructor, n: int, offset: int) -> None:
     df = nw.from_native(constructor(data))
     result = df.gather_every(n=n, offset=offset)
     expected = {"a": data["a"][offset::n]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/frame/get_column_test.py
+++ b/tests/frame/get_column_test.py
@@ -4,13 +4,13 @@ import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_get_column(constructor_eager: Any) -> None:
     df = nw.from_native(constructor_eager({"a": [1, 2], "b": [3, 4]}), eager_only=True)
     result = df.get_column("a")
-    compare_dicts({"a": result}, {"a": [1, 2]})
+    assert_equal_data({"a": result}, {"a": [1, 2]})
     assert result.name == "a"
     with pytest.raises(
         (KeyError, TypeError), match="Expected str|'int' object cannot be converted|0"
@@ -22,11 +22,11 @@ def test_get_column(constructor_eager: Any) -> None:
 def test_non_string_name() -> None:
     df = pd.DataFrame({0: [1, 2]})
     result = nw.from_native(df, eager_only=True).get_column(0)  # type: ignore[arg-type]
-    compare_dicts({"a": result}, {"a": [1, 2]})
+    assert_equal_data({"a": result}, {"a": [1, 2]})
     assert result.name == 0  # type: ignore[comparison-overlap]
 
 
 def test_get_single_row() -> None:
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     result = nw.from_native(df, eager_only=True)[0]  # type: ignore[call-overload]
-    compare_dicts(result, {"a": [1], "b": [3]})
+    assert_equal_data(result, {"a": [1], "b": [3]})

--- a/tests/frame/getitem_test.py
+++ b/tests/frame/getitem_test.py
@@ -9,7 +9,7 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
@@ -20,15 +20,15 @@ data = {
 def test_slice_column(constructor_eager: Any) -> None:
     result = nw.from_native(constructor_eager(data))["a"]
     assert isinstance(result, nw.Series)
-    compare_dicts({"a": result}, {"a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
+    assert_equal_data({"a": result}, {"a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
 
 
 def test_slice_rows(constructor_eager: Any) -> None:
     result = nw.from_native(constructor_eager(data))[1:]
-    compare_dicts(result, {"a": [2.0, 3.0, 4.0, 5.0, 6.0], "b": [12, 13, 14, 15, 16]})
+    assert_equal_data(result, {"a": [2.0, 3.0, 4.0, 5.0, 6.0], "b": [12, 13, 14, 15, 16]})
 
     result = nw.from_native(constructor_eager(data))[2:4]
-    compare_dicts(result, {"a": [3.0, 4.0], "b": [13, 14]})
+    assert_equal_data(result, {"a": [3.0, 4.0], "b": [13, 14]})
 
 
 def test_slice_rows_with_step(
@@ -37,7 +37,7 @@ def test_slice_rows_with_step(
     if "pyarrow_table" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
     result = nw.from_native(constructor_eager(data))[1::2]
-    compare_dicts(result, {"a": [2.0, 4.0, 6.0], "b": [12, 14, 16]})
+    assert_equal_data(result, {"a": [2.0, 4.0, 6.0], "b": [12, 14, 16]})
 
 
 def test_slice_rows_with_step_pyarrow() -> None:
@@ -55,7 +55,7 @@ def test_slice_lazy_fails() -> None:
 
 def test_slice_int(constructor_eager: Any) -> None:
     result = nw.from_native(constructor_eager(data), eager_only=True)[1]  # type: ignore[call-overload]
-    compare_dicts(result, {"a": [2], "b": [12]})
+    assert_equal_data(result, {"a": [2], "b": [12]})
 
 
 def test_slice_fails(constructor_eager: Any) -> None:
@@ -72,9 +72,9 @@ def test_gather(constructor_eager: Any) -> None:
         "a": [1.0, 4.0, 2.0],
         "b": [11, 14, 12],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[np.array([0, 3, 1])]
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_gather_pandas_index() -> None:
@@ -82,11 +82,11 @@ def test_gather_pandas_index() -> None:
     df = pd.DataFrame({"a": [4, 1, 2], "b": [1, 4, 2]}, index=[2, 1, 3])
     result = nw.from_native(df, eager_only=True)[[1, 2]]
     expected = {"a": [1, 2], "b": [4, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     result = nw.from_native(df, eager_only=True)[[1, 2], "a"].to_frame()
     expected = {"a": [1, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_gather_rows_cols(constructor_eager: Any) -> None:
@@ -96,10 +96,10 @@ def test_gather_rows_cols(constructor_eager: Any) -> None:
     expected = {"b": [11, 14, 12]}
 
     result = {"b": df[[0, 3, 1], 1]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     result = {"b": df[np.array([0, 3, 1]), "b"]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_slice_both_tuples_of_ints(constructor_eager: Any) -> None:
@@ -107,7 +107,7 @@ def test_slice_both_tuples_of_ints(constructor_eager: Any) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df[[0, 1], [0, 2]]
     expected = {"a": [1, 2], "c": [7, 8]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_slice_int_rows_str_columns(constructor_eager: Any) -> None:
@@ -115,7 +115,7 @@ def test_slice_int_rows_str_columns(constructor_eager: Any) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df[[0, 1], ["a", "c"]]
     expected = {"a": [1, 2], "c": [7, 8]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_slice_slice_columns(constructor_eager: Any) -> None:  # noqa: PLR0915
@@ -123,69 +123,69 @@ def test_slice_slice_columns(constructor_eager: Any) -> None:  # noqa: PLR0915
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df[[0, 1], "b":"c"]  # type: ignore[misc]
     expected = {"b": [4, 5], "c": [7, 8]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[[0, 1], :"c"]  # type: ignore[misc]
     expected = {"a": [1, 2], "b": [4, 5], "c": [7, 8]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[[0, 1], "a":"d":2]  # type: ignore[misc]
     expected = {"a": [1, 2], "c": [7, 8]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[[0, 1], "b":]  # type: ignore[misc]
     expected = {"b": [4, 5], "c": [7, 8], "d": [1, 4]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[[0, 1], 1:3]
     expected = {"b": [4, 5], "c": [7, 8]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[[0, 1], :3]
     expected = {"a": [1, 2], "b": [4, 5], "c": [7, 8]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[[0, 1], 0:4:2]
     expected = {"a": [1, 2], "c": [7, 8]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[[0, 1], 1:]
     expected = {"b": [4, 5], "c": [7, 8], "d": [1, 4]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[:, ["b", "d"]]
     expected = {"b": [4, 5, 6], "d": [1, 4, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[:, [0, 2]]
     expected = {"a": [1, 2, 3], "c": [7, 8, 9]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[:2, [0, 2]]
     expected = {"a": [1, 2], "c": [7, 8]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[:2, ["a", "c"]]
     expected = {"a": [1, 2], "c": [7, 8]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[1:, [0, 2]]
     expected = {"a": [2, 3], "c": [8, 9]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[1:, ["a", "c"]]
     expected = {"a": [2, 3], "c": [8, 9]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[["b", "c"]]
     expected = {"b": [4, 5, 6], "c": [7, 8, 9]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[:2]
     expected = {"a": [1, 2], "b": [4, 5], "c": [7, 8], "d": [1, 4]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[2:]
     expected = {"a": [3], "b": [6], "c": [9], "d": [2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     # mypy says "Slice index must be an integer", but we do in fact support
     # using string slices
     result = df["a":"b"]  # type: ignore[misc]
     expected = {"a": [1, 2, 3], "b": [4, 5, 6]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[(0, 1), :]
     expected = {"a": [1, 2], "b": [4, 5], "c": [7, 8], "d": [1, 4]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[[0, 1], :]
     expected = {"a": [1, 2], "b": [4, 5], "c": [7, 8], "d": [1, 4]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df[[0, 1], df.columns]
     expected = {"a": [1, 2], "b": [4, 5], "c": [7, 8], "d": [1, 4]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_slice_invalid(constructor_eager: Any) -> None:

--- a/tests/frame/head_test.py
+++ b/tests/frame/head_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_head(constructor: Constructor) -> None:
@@ -13,11 +13,11 @@ def test_head(constructor: Constructor) -> None:
     df = nw.from_native(df_raw)
 
     result = df.head(2)
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     result = df.head(2)
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     # negative indices not allowed for lazyframes
     result = df.lazy().collect().head(-1)
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/frame/is_duplicated_test.py
+++ b/tests/frame/is_duplicated_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_is_duplicated(constructor_eager: Any) -> None:
@@ -12,4 +12,4 @@ def test_is_duplicated(constructor_eager: Any) -> None:
     df = nw.from_native(df_raw, eager_only=True)
     result = nw.concat([df, df.head(1)]).is_duplicated()
     expected = {"is_duplicated": [True, False, False, True]}
-    compare_dicts({"is_duplicated": result}, expected)
+    assert_equal_data({"is_duplicated": result}, expected)

--- a/tests/frame/is_unique_test.py
+++ b/tests/frame/is_unique_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_is_unique(constructor_eager: Any) -> None:
@@ -12,4 +12,4 @@ def test_is_unique(constructor_eager: Any) -> None:
     df = nw.from_native(df_raw, eager_only=True)
     result = nw.concat([df, df.head(1)]).is_unique()
     expected = {"is_unique": [False, True, True, False]}
-    compare_dicts({"is_unique": result}, expected)
+    assert_equal_data({"is_unique": result}, expected)

--- a/tests/frame/item_test.py
+++ b/tests/frame/item_test.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize(
@@ -18,8 +18,8 @@ def test_item(
 ) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
-    compare_dicts({"a": [df.item(row, column)]}, {"a": [expected]})
-    compare_dicts({"a": [df.select("a").head(1).item()]}, {"a": [1]})
+    assert_equal_data({"a": [df.item(row, column)]}, {"a": [expected]})
+    assert_equal_data({"a": [df.select("a").head(1).item()]}, {"a": [1]})
 
 
 @pytest.mark.parametrize(

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -12,7 +12,7 @@ import narwhals.stable.v1 as nw
 from narwhals.utils import Implementation
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_inner_join_two_keys(constructor: Constructor) -> None:
@@ -40,8 +40,8 @@ def test_inner_join_two_keys(constructor: Constructor) -> None:
         "zorro_right": [7.0, 8, 9],
         "index": [0, 1, 2],
     }
-    compare_dicts(result, expected)
-    compare_dicts(result_on, expected)
+    assert_equal_data(result, expected)
+    assert_equal_data(result_on, expected)
 
 
 def test_inner_join_single_key(constructor: Constructor) -> None:
@@ -70,8 +70,8 @@ def test_inner_join_single_key(constructor: Constructor) -> None:
         "zorro_right": [7.0, 8, 9],
         "index": [0, 1, 2],
     }
-    compare_dicts(result, expected)
-    compare_dicts(result_on, expected)
+    assert_equal_data(result, expected)
+    assert_equal_data(result_on, expected)
 
 
 def test_cross_join(constructor: Constructor) -> None:
@@ -82,7 +82,7 @@ def test_cross_join(constructor: Constructor) -> None:
         "antananarivo": [1, 1, 1, 2, 2, 2, 3, 3, 3],
         "antananarivo_right": [1, 2, 3, 1, 2, 3, 1, 2, 3],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     with pytest.raises(
         ValueError, match="Can not pass `left_on`, `right_on` or `on` keys for cross join"
@@ -122,7 +122,7 @@ def test_cross_join_suffix(constructor: Constructor, suffix: str) -> None:
         "antananarivo": [1, 1, 1, 2, 2, 2, 3, 3, 3],
         f"antananarivo{suffix}": [1, 2, 3, 1, 2, 3, 1, 2, 3],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_cross_join_non_pandas() -> None:
@@ -135,7 +135,7 @@ def test_cross_join_non_pandas() -> None:
         "antananarivo": [1, 1, 1, 3, 3, 3, 2, 2, 2],
         "antananarivo_right": [1, 3, 2, 1, 3, 2, 1, 3, 2],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -164,7 +164,7 @@ def test_anti_join(
     df = nw.from_native(constructor(data))
     other = df.filter(filter_expr)
     result = df.join(other, how="anti", left_on=join_key, right_on=join_key)  # type: ignore[arg-type]
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -204,7 +204,7 @@ def test_semi_join(
     result = df.join(other, how="semi", left_on=join_key, right_on=join_key).sort(  # type: ignore[arg-type]
         "antananarivo"
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize("how", ["right", "full"])
@@ -258,8 +258,8 @@ def test_left_join(constructor: Constructor) -> None:
         "index": [0, 1, 2],
         "co": [4, 5, 7],
     }
-    compare_dicts(result, expected)
-    compare_dicts(result_on_list, expected_on_list)
+    assert_equal_data(result, expected)
+    assert_equal_data(result_on_list, expected_on_list)
 
 
 @pytest.mark.filterwarnings("ignore: the default coalesce behavior")
@@ -277,7 +277,7 @@ def test_left_join_multiple_column(constructor: Constructor) -> None:
     result = result.sort("index")
     result = result.drop("index_right")
     expected = {"antananarivo": [1, 2, 3], "bob": [4, 5, 6], "index": [0, 1, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.filterwarnings("ignore: the default coalesce behavior")
@@ -306,7 +306,7 @@ def test_left_join_overlapping_column(constructor: Constructor) -> None:
         "d_right": [1, 4, 2],
         "index": [0, 1, 2],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df_left.join(
         df_right,  # type: ignore[arg-type]
         left_on="antananarivo",
@@ -323,7 +323,7 @@ def test_left_join_overlapping_column(constructor: Constructor) -> None:
         "c": [4.0, 6.0, float("nan")],
         "index": [0, 1, 2],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize("how", ["inner", "left", "semi", "anti"])
@@ -403,12 +403,12 @@ def test_joinasof_numeric(
         "val": ["a", "b", "c"],
         "val_right": [1, 6, 7],
     }
-    compare_dicts(result_backward, expected_backward)
-    compare_dicts(result_forward, expected_forward)
-    compare_dicts(result_nearest, expected_nearest)
-    compare_dicts(result_backward_on, expected_backward)
-    compare_dicts(result_forward_on, expected_forward)
-    compare_dicts(result_nearest_on, expected_nearest)
+    assert_equal_data(result_backward, expected_backward)
+    assert_equal_data(result_forward, expected_forward)
+    assert_equal_data(result_nearest, expected_nearest)
+    assert_equal_data(result_backward_on, expected_backward)
+    assert_equal_data(result_forward_on, expected_forward)
+    assert_equal_data(result_nearest_on, expected_nearest)
 
 
 def test_joinasof_time(constructor: Constructor, request: pytest.FixtureRequest) -> None:
@@ -481,12 +481,12 @@ def test_joinasof_time(constructor: Constructor, request: pytest.FixtureRequest)
         "population": [82.19, 82.66, 83.12],
         "gdp": [4164, 4696, 4696],
     }
-    compare_dicts(result_backward, expected_backward)
-    compare_dicts(result_forward, expected_forward)
-    compare_dicts(result_nearest, expected_nearest)
-    compare_dicts(result_backward_on, expected_backward)
-    compare_dicts(result_forward_on, expected_forward)
-    compare_dicts(result_nearest_on, expected_nearest)
+    assert_equal_data(result_backward, expected_backward)
+    assert_equal_data(result_forward, expected_forward)
+    assert_equal_data(result_nearest, expected_nearest)
+    assert_equal_data(result_backward_on, expected_backward)
+    assert_equal_data(result_forward_on, expected_forward)
+    assert_equal_data(result_nearest_on, expected_nearest)
 
 
 def test_joinasof_by(constructor: Constructor, request: pytest.FixtureRequest) -> None:
@@ -518,8 +518,8 @@ def test_joinasof_by(constructor: Constructor, request: pytest.FixtureRequest) -
         "c": [9, 2, 1, 1],
         "d": [1, 3, float("nan"), 4],
     }
-    compare_dicts(result, expected)
-    compare_dicts(result_by, expected)
+    assert_equal_data(result, expected)
+    assert_equal_data(result_by, expected)
 
 
 @pytest.mark.parametrize("strategy", ["back", "furthest"])

--- a/tests/frame/lit_test.py
+++ b/tests/frame/lit_test.py
@@ -8,7 +8,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 if TYPE_CHECKING:
     from narwhals.dtypes import DType
@@ -31,7 +31,7 @@ def test_lit(
         "z": [7.0, 8.0, 9.0],
         "lit": expected_lit,
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_lit_error(constructor: Constructor) -> None:

--- a/tests/frame/null_count_test.py
+++ b/tests/frame/null_count_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_null_count(constructor_eager: Any) -> None:
@@ -12,4 +12,4 @@ def test_null_count(constructor_eager: Any) -> None:
     df = nw.from_native(df_raw, eager_only=True)
     result = df.null_count()
     expected = {"a": [1], "b": [0], "z": [1]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/frame/pipe_test.py
+++ b/tests/frame/pipe_test.py
@@ -1,6 +1,6 @@
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": ["foo", "bars"],
@@ -13,4 +13,4 @@ def test_pipe(constructor: Constructor) -> None:
     columns = df.collect_schema().names()
     result = df.pipe(lambda _df: _df.select([x for x in columns if len(x) == 2]))
     expected = {"ab": ["foo", "bars"]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/frame/reindex_test.py
+++ b/tests/frame/reindex_test.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
 
@@ -14,9 +14,9 @@ def test_reindex(df_raw: Any) -> None:
     df = nw.from_native(df_raw, eager_only=True)
     result = df.select("b", df["a"].sort(descending=True))
     expected = {"b": [4, 4, 6], "a": [3, 2, 1]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df.select("b", nw.col("a").sort(descending=True))
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     s = df["a"]
     result_s = s > s.sort()
@@ -25,6 +25,6 @@ def test_reindex(df_raw: Any) -> None:
     assert not result_s[2]
     result = df.with_columns(s.sort())
     expected = {"a": [1, 2, 3], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}  # type: ignore[list-item]
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     with pytest.raises(ValueError, match="Multi-output expressions are not supported"):
         nw.to_native(df.with_columns(nw.all() + nw.all()))

--- a/tests/frame/rename_test.py
+++ b/tests/frame/rename_test.py
@@ -1,6 +1,6 @@
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_rename(constructor: Constructor) -> None:
@@ -8,4 +8,4 @@ def test_rename(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.rename({"a": "x", "b": "y"})
     expected = {"x": [1, 3, 2], "y": [4, 4, 6], "z": [7.0, 8, 9]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/frame/select_test.py
+++ b/tests/frame/select_test.py
@@ -3,7 +3,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_select(constructor: Constructor) -> None:
@@ -11,7 +11,7 @@ def test_select(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select("a")
     expected = {"a": [1, 3, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_empty_select(constructor: Constructor) -> None:

--- a/tests/frame/sort_test.py
+++ b/tests/frame/sort_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_sort(constructor: Constructor) -> None:
@@ -16,14 +16,14 @@ def test_sort(constructor: Constructor) -> None:
         "b": [4, 6, 4],
         "z": [7.0, 9.0, 8.0],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = df.sort("a", "b", descending=[True, False])
     expected = {
         "a": [3, 2, 1],
         "b": [4, 6, 4],
         "z": [8.0, 9.0, 7.0],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -39,4 +39,4 @@ def test_sort_nulls(
     data = {"a": [0, 0, 2, -1], "b": [1, 3, 2, None]}
     df = nw.from_native(constructor(data))
     result = df.sort("b", descending=True, nulls_last=nulls_last)
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/frame/tail_test.py
+++ b/tests/frame/tail_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_tail(constructor: Constructor) -> None:
@@ -27,13 +27,13 @@ def test_tail(constructor: Constructor) -> None:
 
     with context:
         result = df.tail(2)
-        compare_dicts(result, expected)
+        assert_equal_data(result, expected)
 
         result = df.collect().tail(2)  # type: ignore[assignment]
-        compare_dicts(result, expected)
+        assert_equal_data(result, expected)
 
         result = df.collect().tail(-1)  # type: ignore[assignment]
-        compare_dicts(result, expected)
+        assert_equal_data(result, expected)
 
         result = df.collect().select(nw.col("a").tail(2))  # type: ignore[assignment]
-        compare_dicts(result, {"a": expected["a"]})
+        assert_equal_data(result, {"a": expected["a"]})

--- a/tests/frame/to_dict_test.py
+++ b/tests/frame/to_dict_test.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.filterwarnings(
@@ -23,4 +23,4 @@ def test_to_dict_as_series(constructor_eager: Any) -> None:
     assert isinstance(result["a"], nw.Series)
     assert isinstance(result["b"], nw.Series)
     assert isinstance(result["c"], nw.Series)
-    compare_dicts(result, data)
+    assert_equal_data(result, data)

--- a/tests/frame/unique_test.py
+++ b/tests/frame/unique_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
 
@@ -29,7 +29,7 @@ def test_unique(
     df = nw.from_native(df_raw)
 
     result = df.unique(subset, keep=keep, maintain_order=True)  # type: ignore[arg-type]
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_unique_none(constructor: Constructor) -> None:
@@ -37,4 +37,4 @@ def test_unique_none(constructor: Constructor) -> None:
     df = nw.from_native(df_raw)
 
     result = df.unique(maintain_order=True)
-    compare_dicts(result, data)
+    assert_equal_data(result, data)

--- a/tests/frame/unpivot_test.py
+++ b/tests/frame/unpivot_test.py
@@ -9,7 +9,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 if TYPE_CHECKING:
     from narwhals.stable.v1.dtypes import DType
@@ -44,7 +44,7 @@ def test_unpivot_on(
 ) -> None:
     df = nw.from_native(constructor(data))
     result = df.unpivot(on=on, index=["a"]).sort("variable", "a")
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/frame/with_columns_sequence_test.py
+++ b/tests/frame/with_columns_sequence_test.py
@@ -3,7 +3,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": ["foo", "bars"],
@@ -21,4 +21,4 @@ def test_with_columns(constructor: Constructor, request: pytest.FixtureRequest) 
         .select("d", "e")
     )
     expected = {"d": [4, 5], "e": [5, 6]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/frame/with_columns_test.py
+++ b/tests/frame/with_columns_test.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_with_columns_int_col_name_pandas() -> None:
@@ -23,14 +23,14 @@ def test_with_columns_order(constructor: Constructor) -> None:
     result = df.with_columns(nw.col("a") + 1, d=nw.col("a") - 1)
     assert result.collect_schema().names() == ["a", "b", "z", "d"]
     expected = {"a": [2, 4, 3], "b": [4, 4, 6], "z": [7.0, 8, 9], "d": [0, 2, 1]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_with_columns_empty(constructor: Constructor) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df = nw.from_native(constructor(data))
     result = df.select().with_columns()
-    compare_dicts(result, {})
+    assert_equal_data(result, {})
 
 
 def test_with_columns_order_single_row(constructor: Constructor) -> None:
@@ -39,4 +39,4 @@ def test_with_columns_order_single_row(constructor: Constructor) -> None:
     result = df.with_columns(nw.col("a") + 1, d=nw.col("a") - 1)
     assert result.collect_schema().names() == ["a", "b", "z", "d"]
     expected = {"a": [2], "b": [4], "z": [7.0], "d": [0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/frame/with_row_index_test.py
+++ b/tests/frame/with_row_index_test.py
@@ -1,6 +1,6 @@
 import narwhals.stable.v1 as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": ["foo", "bars"],
@@ -11,4 +11,4 @@ data = {
 def test_with_row_index(constructor: Constructor) -> None:
     result = nw.from_native(constructor(data)).with_row_index()
     expected = {"a": ["foo", "bars"], "ab": ["foo", "bars"], "index": [0, 1]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/from_dict_test.py
+++ b/tests/from_dict_test.py
@@ -3,7 +3,7 @@ import pytest
 import narwhals as nw
 import narwhals.stable.v1 as nw_v1
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_from_dict(constructor: Constructor, request: pytest.FixtureRequest) -> None:
@@ -13,7 +13,7 @@ def test_from_dict(constructor: Constructor, request: pytest.FixtureRequest) -> 
     native_namespace = nw.get_native_namespace(df)
     result = nw.from_dict({"c": [1, 2], "d": [5, 6]}, native_namespace=native_namespace)
     expected = {"c": [1, 2], "d": [5, 6]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     assert isinstance(result, nw.DataFrame)
 
 
@@ -36,7 +36,7 @@ def test_from_dict_schema(
 def test_from_dict_without_namespace(constructor: Constructor) -> None:
     df = nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]})).lazy().collect()
     result = nw.from_dict({"c": df["a"], "d": df["b"]})
-    compare_dicts(result, {"c": [1, 2, 3], "d": [4, 5, 6]})
+    assert_equal_data(result, {"c": [1, 2, 3], "d": [4, 5, 6]})
 
 
 def test_from_dict_without_namespace_invalid(
@@ -53,7 +53,7 @@ def test_from_dict_one_native_one_narwhals(
     df = nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]})).lazy().collect()
     result = nw.from_dict({"c": nw.to_native(df["a"]), "d": df["b"]})
     expected = {"c": [1, 2, 3], "d": [4, 5, 6]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_from_dict_v1(constructor: Constructor, request: pytest.FixtureRequest) -> None:
@@ -63,7 +63,7 @@ def test_from_dict_v1(constructor: Constructor, request: pytest.FixtureRequest) 
     native_namespace = nw.get_native_namespace(df)
     result = nw.from_dict({"c": [1, 2], "d": [5, 6]}, native_namespace=native_namespace)
     expected = {"c": [1, 2], "d": [5, 6]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     assert isinstance(result, nw.DataFrame)
 
 

--- a/tests/from_pycapsule_test.py
+++ b/tests/from_pycapsule_test.py
@@ -9,7 +9,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.xfail(parse_version(pa.__version__) < (14,), reason="too old")
@@ -18,7 +18,7 @@ def test_from_arrow_to_arrow() -> None:
     result = nw.from_arrow(df, native_namespace=pa)
     assert isinstance(result.to_native(), pa.Table)
     expected = {"ab": [1, 2, 3], "ba": [4, 5, 6]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.xfail(parse_version(pa.__version__) < (14,), reason="too old")
@@ -29,7 +29,7 @@ def test_from_arrow_to_polars(monkeypatch: pytest.MonkeyPatch) -> None:
     result = nw.from_arrow(df, native_namespace=pl)
     assert isinstance(result.to_native(), pl.DataFrame)
     expected = {"ab": [1, 2, 3], "ba": [4, 5, 6]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     assert "pandas" not in sys.modules
 
 
@@ -39,7 +39,7 @@ def test_from_arrow_to_pandas() -> None:
     result = nw.from_arrow(df, native_namespace=pd)
     assert isinstance(result.to_native(), pd.DataFrame)
     expected = {"ab": [1, 2, 3], "ba": [4, 5, 6]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_from_arrow_invalid() -> None:

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -11,7 +11,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {"a": [1, 1, 3], "b": [4, 4, 6], "c": [7.0, 8, 9]}
 
@@ -27,13 +27,13 @@ def test_group_by_complex() -> None:
         result = nw.to_native(
             df.group_by("a").agg((nw.col("b") - nw.col("c").mean()).mean()).sort("a")
         )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     lf = nw.from_native(df_lazy).lazy()
     result = nw.to_native(
         lf.group_by("a").agg((nw.col("b") - nw.col("c").mean()).mean()).sort("a")
     )
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_invalid_group_by_dask() -> None:
@@ -80,7 +80,7 @@ def test_group_by_iter(constructor_eager: Any) -> None:
     for key, sub_df in df.group_by("a"):
         if key == (1,):
             expected = {"a": [1, 1], "b": [4, 4], "c": [7.0, 8.0]}
-            compare_dicts(sub_df, expected)
+            assert_equal_data(sub_df, expected)
             assert isinstance(sub_df, nw.DataFrame)
         keys.append(key)
     assert sorted(keys) == sorted(expected_keys)
@@ -100,7 +100,7 @@ def test_group_by_len(constructor: Constructor) -> None:
         nw.from_native(constructor(data)).group_by("a").agg(nw.col("b").len()).sort("a")
     )
     expected = {"a": [1, 3], "b": [2, 1]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_group_by_n_unique(constructor: Constructor) -> None:
@@ -111,7 +111,7 @@ def test_group_by_n_unique(constructor: Constructor) -> None:
         .sort("a")
     )
     expected = {"a": [1, 3], "b": [1, 1]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_group_by_std(constructor: Constructor) -> None:
@@ -120,7 +120,7 @@ def test_group_by_std(constructor: Constructor) -> None:
         nw.from_native(constructor(data)).group_by("a").agg(nw.col("b").std()).sort("a")
     )
     expected = {"a": [1, 2], "b": [0.707107] * 2}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_group_by_n_unique_w_missing(
@@ -149,7 +149,7 @@ def test_group_by_n_unique_w_missing(
         "c_n_min": [4, 5],
         "d_n_unique": [1, 1],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_group_by_same_name_twice() -> None:
@@ -186,7 +186,7 @@ def test_group_by_simple_named(constructor: Constructor) -> None:
         "b_min": [4, 6],
         "b_max": [5, 6],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_group_by_simple_unnamed(constructor: Constructor) -> None:
@@ -206,7 +206,7 @@ def test_group_by_simple_unnamed(constructor: Constructor) -> None:
         "b": [4, 6],
         "c": [7, 1],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_group_by_multiple_keys(constructor: Constructor) -> None:
@@ -227,7 +227,7 @@ def test_group_by_multiple_keys(constructor: Constructor) -> None:
         "c_min": [2, 1],
         "c_max": [7, 1],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_key_with_nulls(constructor: Constructor, request: pytest.FixtureRequest) -> None:
@@ -252,14 +252,14 @@ def test_key_with_nulls(constructor: Constructor, request: pytest.FixtureRequest
             .with_columns(nw.col("b").cast(nw.Float64))
         )
         expected = {"b": [4.0, 5, float("nan")], "len": [1, 1, 1], "a": [1, 2, 3]}
-        compare_dicts(result, expected)
+        assert_equal_data(result, expected)
 
 
 def test_no_agg(constructor: Constructor) -> None:
     result = nw.from_native(constructor(data)).group_by(["a", "b"]).agg().sort("a", "b")
 
     expected = {"a": [1, 3], "b": [4, 6]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_group_by_categorical(
@@ -283,4 +283,4 @@ def test_group_by_categorical(
         .agg(nw.col("x").sum())
         .sort("x")
     )
-    compare_dicts(result, data)
+    assert_equal_data(result, data)

--- a/tests/hypothesis/concat_test.py
+++ b/tests/hypothesis/concat_test.py
@@ -9,7 +9,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 from tests.utils import is_windows
 
 
@@ -62,4 +62,4 @@ def test_concat(  # pragma: no cover
     dframe_pd1 = nw.to_native(dframe_pl)
     dframe_pd2 = nw.to_native(dframe_pd)
 
-    compare_dicts(dframe_pd1, dframe_pd2)
+    assert_equal_data(dframe_pd1, dframe_pd2)

--- a/tests/hypothesis/join_test.py
+++ b/tests/hypothesis/join_test.py
@@ -11,7 +11,7 @@ from pandas.testing import assert_frame_equal
 
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 pl_version = parse_version(pl.__version__)
 pd_version = parse_version(pd.__version__)
@@ -164,7 +164,9 @@ def test_left_join(  # pragma: no cover
             right_on=right_key,
         )
     ).select(pl.all().fill_null(float("nan")))
-    compare_dicts(result_pd.to_dict(as_series=False), result_pl.to_dict(as_series=False))
+    assert_equal_data(
+        result_pd.to_dict(as_series=False), result_pl.to_dict(as_series=False)
+    )
     # For PyArrow, insert an extra sort, as the order of rows isn't guaranteed
     result_pa = (
         nw.from_native(pa.table(data_left), eager_only=True)
@@ -177,7 +179,7 @@ def test_left_join(  # pragma: no cover
         .select(nw.all().cast(nw.Float64).fill_null(float("nan")))
         .pipe(lambda df: df.sort(df.columns))
     )
-    compare_dicts(
+    assert_equal_data(
         result_pa,
         result_pd.pipe(lambda df: df.sort(df.columns)).to_dict(as_series=False),
     )

--- a/tests/new_series_test.py
+++ b/tests/new_series_test.py
@@ -5,7 +5,7 @@ import pytest
 
 import narwhals as nw
 import narwhals.stable.v1 as nw_v1
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_new_series(constructor_eager: Any) -> None:
@@ -15,14 +15,14 @@ def test_new_series(constructor_eager: Any) -> None:
     # all supported libraries auto-infer this to be int64, we can always special-case
     # something different if necessary
     assert result.dtype == nw.Int64
-    compare_dicts(result.to_frame(), expected)
+    assert_equal_data(result.to_frame(), expected)
 
     result = nw.new_series(
         "b", [4, 1, 2], nw.Int32, native_namespace=nw.get_native_namespace(s)
     )
     expected = {"b": [4, 1, 2]}
     assert result.dtype == nw.Int32
-    compare_dicts(result.to_frame(), expected)
+    assert_equal_data(result.to_frame(), expected)
 
 
 def test_new_series_v1(constructor_eager: Any) -> None:
@@ -34,14 +34,14 @@ def test_new_series_v1(constructor_eager: Any) -> None:
     # all supported libraries auto-infer this to be int64, we can always special-case
     # something different if necessary
     assert result.dtype == nw_v1.Int64
-    compare_dicts(result.to_frame(), expected)
+    assert_equal_data(result.to_frame(), expected)
 
     result = nw_v1.new_series(
         "b", [4, 1, 2], nw_v1.Int32, native_namespace=nw_v1.get_native_namespace(s)
     )
     expected = {"b": [4, 1, 2]}
     assert result.dtype == nw_v1.Int32
-    compare_dicts(result.to_frame(), expected)
+    assert_equal_data(result.to_frame(), expected)
 
 
 def test_new_series_dask() -> None:

--- a/tests/selectors_test.py
+++ b/tests/selectors_test.py
@@ -13,7 +13,7 @@ from narwhals.selectors import numeric
 from narwhals.selectors import string
 from narwhals.utils import parse_version
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = {
     "a": [1, 1, 2],
@@ -27,21 +27,21 @@ def test_selectors(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(by_dtype([nw.Int64, nw.Float64]) + 1)
     expected = {"a": [2, 2, 3], "c": [5.1, 6.0, 7.0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_numeric(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(numeric() + 1)
     expected = {"a": [2, 2, 3], "c": [5.1, 6.0, 7.0]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_boolean(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(boolean())
     expected = {"d": [True, False, True]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_string(constructor: Constructor, request: pytest.FixtureRequest) -> None:
@@ -51,7 +51,7 @@ def test_string(constructor: Constructor, request: pytest.FixtureRequest) -> Non
     df = nw.from_native(constructor(data))
     result = df.select(string())
     expected = {"b": ["a", "b", "c"]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_categorical(request: pytest.FixtureRequest, constructor: Constructor) -> None:
@@ -63,7 +63,7 @@ def test_categorical(request: pytest.FixtureRequest, constructor: Constructor) -
 
     df = nw.from_native(constructor(data)).with_columns(nw.col("b").cast(nw.Categorical))
     result = df.select(categorical())
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/series_only/__iter___test.py
+++ b/tests/series_only/__iter___test.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = [1, 2, 3]
 
@@ -17,4 +17,4 @@ def test_iter(constructor_eager: Any, request: pytest.FixtureRequest) -> None:
     s = nw.from_native(constructor_eager({"a": data}), eager_only=True)["a"]
 
     assert isinstance(s, Iterable)
-    compare_dicts({"a": [x for x in s]}, {"a": [1, 2, 3]})  # noqa: C416
+    assert_equal_data({"a": [x for x in s]}, {"a": [1, 2, 3]})  # noqa: C416

--- a/tests/series_only/alias_rename_test.py
+++ b/tests/series_only/alias_rename_test.py
@@ -1,6 +1,6 @@
 import narwhals as nw
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_alias_rename(constructor_eager: Constructor) -> None:
@@ -8,6 +8,6 @@ def test_alias_rename(constructor_eager: Constructor) -> None:
     expected = {"bar": data}
     series = nw.from_native(constructor_eager({"foo": data}), eager_only=True)["foo"]
     result = series.alias("bar").to_frame()
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = series.rename("bar").to_frame()
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/series_only/array_dunder_test.py
+++ b/tests/series_only/array_dunder_test.py
@@ -7,7 +7,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_array_dunder(request: pytest.FixtureRequest, constructor_eager: Any) -> None:
@@ -53,4 +53,4 @@ def test_array_dunder_with_copy(
         result = s.__array__(copy=False)
         np.testing.assert_array_equal(result, np.array([1, 2, 3], dtype="int64"))
         result[0] = 999
-        compare_dicts({"a": s}, {"a": [999, 2, 3]})
+        assert_equal_data({"a": s}, {"a": [999, 2, 3]})

--- a/tests/series_only/is_sorted_test.py
+++ b/tests/series_only/is_sorted_test.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = [1, 3, 2]
 data_dups = [4, 4, 6]
@@ -24,7 +24,7 @@ def test_is_sorted(
 ) -> None:
     series = nw.from_native(constructor_eager({"a": input_data}), eager_only=True)["a"]
     result = series.is_sorted(descending=descending)
-    compare_dicts({"a": [result]}, {"a": [expected]})
+    assert_equal_data({"a": [result]}, {"a": [expected]})
 
 
 def test_is_sorted_invalid(constructor_eager: Any) -> None:

--- a/tests/series_only/item_test.py
+++ b/tests/series_only/item_test.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = [1, 3, 2]
 
@@ -15,8 +15,8 @@ data = [1, 3, 2]
 def test_item(constructor_eager: Any, index: int, expected: int) -> None:
     series = nw.from_native(constructor_eager({"a": data}), eager_only=True)["a"]
     result = series.item(index)
-    compare_dicts({"a": [result]}, {"a": [expected]})
-    compare_dicts({"a": [series.head(1).item()]}, {"a": [1]})
+    assert_equal_data({"a": [result]}, {"a": [expected]})
+    assert_equal_data({"a": [series.head(1).item()]}, {"a": [1]})
 
     with pytest.raises(
         ValueError,

--- a/tests/series_only/scatter_test.py
+++ b/tests/series_only/scatter_test.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 import narwhals as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_scatter(constructor_eager: Any, request: pytest.FixtureRequest) -> None:
@@ -23,7 +23,7 @@ def test_scatter(constructor_eager: Any, request: pytest.FixtureRequest) -> None
         "a": [999, 888, 3],
         "b": [142, 132, 124],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_scatter_unchanged(constructor_eager: Any) -> None:
@@ -37,7 +37,7 @@ def test_scatter_unchanged(constructor_eager: Any) -> None:
         "a": [1, 2, 3],
         "b": [142, 124, 132],
     }
-    compare_dicts(df, expected)
+    assert_equal_data(df, expected)
 
 
 def test_single_series(constructor_eager: Any) -> None:
@@ -47,4 +47,4 @@ def test_single_series(constructor_eager: Any) -> None:
     s = df["a"]
     s.scatter([0, 1], [999, 888])
     expected = {"a": [1, 2, 3]}
-    compare_dicts({"a": s}, expected)
+    assert_equal_data({"a": s}, expected)

--- a/tests/series_only/slice_test.py
+++ b/tests/series_only/slice_test.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_slice(constructor_eager: Any) -> None:
@@ -9,25 +9,25 @@ def test_slice(constructor_eager: Any) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = {"a": df["a"][[0, 1]]}
     expected = {"a": [1, 2]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = {"a": df["a"][1:]}
     expected = {"a": [2, 3]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = {"b": df[:, 1]}
     expected = {"b": [4, 5, 6]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = {"b": df[:, "b"]}
     expected = {"b": [4, 5, 6]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = {"b": df[:2, "b"]}
     expected = {"b": [4, 5]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = {"b": df[:2, 1]}
     expected = {"b": [4, 5]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = {"b": df[[0, 1], 1]}
     expected = {"b": [4, 5]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
     result = {"b": df[[], 1]}
     expected = {"b": []}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/series_only/to_dummy_test.py
+++ b/tests/series_only/to_dummy_test.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = [1, 2, 3]
 
@@ -14,7 +14,7 @@ def test_to_dummies(constructor_eager: Any, sep: str) -> None:
     result = s.to_dummies(separator=sep)
     expected = {f"a{sep}1": [1, 0, 0], f"a{sep}2": [0, 1, 0], f"a{sep}3": [0, 0, 1]}
 
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize("sep", ["_", "-"])
@@ -27,4 +27,4 @@ def test_to_dummies_drop_first(
     result = s.to_dummies(drop_first=True, separator=sep)
     expected = {f"a{sep}2": [0, 1, 0], f"a{sep}3": [0, 0, 1]}
 
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/series_only/to_frame_test.py
+++ b/tests/series_only/to_frame_test.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = [1, 2, 3]
 
@@ -12,4 +12,4 @@ def test_to_frame(constructor_eager: Any) -> None:
         .alias("")
         .to_frame()
     )
-    compare_dicts(df, {"": [1, 2, 3]})
+    assert_equal_data(df, {"": [1, 2, 3]})

--- a/tests/series_only/to_list_test.py
+++ b/tests/series_only/to_list_test.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = [1, 2, 3]
 
@@ -12,4 +12,4 @@ def test_to_list(constructor_eager: Any, request: pytest.FixtureRequest) -> None
     if "cudf" in str(constructor_eager):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
     s = nw.from_native(constructor_eager({"a": data}), eager_only=True)["a"]
-    compare_dicts({"a": s.to_list()}, {"a": [1, 2, 3]})
+    assert_equal_data({"a": s.to_list()}, {"a": [1, 2, 3]})

--- a/tests/series_only/value_counts_test.py
+++ b/tests/series_only/value_counts_test.py
@@ -7,7 +7,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 data = [4, 4, 4, 1, 6, 6, 4, 4, 1, 1]
 
@@ -40,9 +40,9 @@ def test_value_counts(
     )
 
     sorted_result = series.value_counts(sort=True, name=name, normalize=normalize)
-    compare_dicts(sorted_result, expected)
+    assert_equal_data(sorted_result, expected)
 
     unsorted_result = series.value_counts(
         sort=False, name=name, normalize=normalize
     ).sort(expected_name, descending=True)
-    compare_dicts(unsorted_result, expected)
+    assert_equal_data(unsorted_result, expected)

--- a/tests/series_only/zip_with_test.py
+++ b/tests/series_only/zip_with_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import narwhals.stable.v1 as nw
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_zip_with(constructor_eager: Any) -> None:
@@ -15,7 +15,7 @@ def test_zip_with(constructor_eager: Any) -> None:
 
     result = series1.zip_with(mask, series2)
     expected = [1, 4, 2]
-    compare_dicts({"a": result}, {"a": expected})
+    assert_equal_data({"a": result}, {"a": expected})
 
 
 def test_zip_with_length_1(constructor_eager: Any) -> None:
@@ -25,4 +25,4 @@ def test_zip_with_length_1(constructor_eager: Any) -> None:
 
     result = series1.zip_with(mask, series2)
     expected = [4]
-    compare_dicts({"a": result}, {"a": expected})
+    assert_equal_data({"a": result}, {"a": expected})

--- a/tests/stable_api_test.py
+++ b/tests/stable_api_test.py
@@ -8,7 +8,7 @@ import pytest
 import narwhals as nw
 import narwhals.stable.v1 as nw_v1
 from tests.utils import Constructor
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 def test_renamed_taxicab_norm(constructor: Constructor) -> None:
@@ -23,7 +23,7 @@ def test_renamed_taxicab_norm(constructor: Constructor) -> None:
     df = nw.from_native(constructor({"a": [1, 2, 3, -4, 5]}))
     result = df.with_columns(b=nw.col("a")._taxicab_norm())
     expected = {"a": [1, 2, 3, -4, 5], "b": [15] * 5}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     with pytest.raises(AttributeError):
         result = df.with_columns(b=nw.col("a")._l1_norm())  # type: ignore[attr-defined]
@@ -33,11 +33,11 @@ def test_renamed_taxicab_norm(constructor: Constructor) -> None:
     # It's new, so it couldn't be backwards-incompatible.
     result = df.with_columns(b=nw_v1.col("a")._taxicab_norm())
     expected = {"a": [1, 2, 3, -4, 5], "b": [15] * 5}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
     # The older `_l1_norm` still works in the stable api
     result = df.with_columns(b=nw_v1.col("a")._l1_norm())
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_renamed_taxicab_norm_dataframe(constructor: Constructor) -> None:
@@ -51,7 +51,7 @@ def test_renamed_taxicab_norm_dataframe(constructor: Constructor) -> None:
 
     result = nw_v1.from_native(func(constructor({"a": [1, 2, 3, -4, 5]})))
     expected = {"a": [15]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_renamed_taxicab_norm_dataframe_narwhalify(constructor: Constructor) -> None:
@@ -64,7 +64,7 @@ def test_renamed_taxicab_norm_dataframe_narwhalify(constructor: Constructor) -> 
 
     result = nw_v1.from_native(func(constructor({"a": [1, 2, 3, -4, 5]})))
     expected = {"a": [15]}
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 def test_stable_api_completeness() -> None:

--- a/tests/tpch_q1_test.py
+++ b/tests/tpch_q1_test.py
@@ -11,7 +11,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from narwhals.utils import parse_version
-from tests.utils import compare_dicts
+from tests.utils import assert_equal_data
 
 
 @pytest.mark.parametrize(
@@ -87,7 +87,7 @@ def test_q1(library: str, request: pytest.FixtureRequest) -> None:
         "avg_disc": [0.05039473684210526, 0.02, 0.05537414965986395, 0.04507042253521127],
         "count_order": [76, 1, 147, 71],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -155,7 +155,7 @@ def test_q1_w_generic_funcs(library: str, request: pytest.FixtureRequest) -> Non
         "avg_disc": [0.05039473684210526, 0.02, 0.05537414965986395, 0.04507042253521127],
         "count_order": [76, 1, 147, 71],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)
 
 
 @mock.patch.dict(os.environ, {"NARWHALS_FORCE_GENERIC": "1"})
@@ -216,4 +216,4 @@ def test_q1_w_pandas_agg_generic_path() -> None:
         "avg_disc": [0.05039473684210526, 0.02, 0.05537414965986395, 0.04507042253521127],
         "count_order": [76, 1, 147, 71],
     }
-    compare_dicts(result, expected)
+    assert_equal_data(result, expected)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -54,14 +54,14 @@ def assert_equal_data(result: Any, expected: dict[str, Any]) -> None:
         expected_key = expected[key]
         for i, (lhs, rhs) in enumerate(zip_strict(result_key, expected_key)):
             if isinstance(lhs, float) and not math.isnan(lhs):
-                are_valid_values = math.isclose(lhs, rhs, rel_tol=0, abs_tol=1e-6)
+                are_equivalent_values = math.isclose(lhs, rhs, rel_tol=0, abs_tol=1e-6)
             elif isinstance(lhs, float) and math.isnan(lhs) and rhs is not None:
-                are_valid_values = math.isnan(rhs)  # pragma: no cover
+                are_equivalent_values = math.isnan(rhs)  # pragma: no cover
             elif pd.isna(lhs):
-                are_valid_values = pd.isna(rhs)
+                are_equivalent_values = pd.isna(rhs)
             else:
-                are_valid_values = lhs == rhs
-            assert are_valid_values, f"Mismatch at index {i}: {lhs} != {rhs}\nExpected: {expected}\nGot: {result}"
+                are_equivalent_values = lhs == rhs
+            assert are_equivalent_values, f"Mismatch at index {i}: {lhs} != {rhs}\nExpected: {expected}\nGot: {result}"
 
 
 def maybe_get_modin_df(df_pandas: pd.DataFrame) -> Any:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,36 +30,47 @@ def zip_strict(left: Sequence[Any], right: Sequence[Any]) -> Iterator[Any]:
     return zip(left, right)
 
 
+def _to_py_object(value: Any) -> Any:
+    # PyArrow: return scalars as Python objects
+    if hasattr(value, "as_py"):  # pragma: no cover
+        return value.as_py()
+    # cuDF: returns cupy scalars as Python objects
+    if hasattr(value, "item"):  # pragma: no cover
+        return value.item()
+    return value
+
+
+def _to_comparable_list(column_values: Any) -> Any:
+    if (
+        hasattr(column_values, "_compliant_series")
+        and column_values._compliant_series._implementation is Implementation.CUDF
+    ):  # pragma: no cover
+        column_values = column_values.to_pandas()
+    if hasattr(column_values, "to_list"):
+        return column_values.to_list()
+    return [_to_py_object(v) for v in column_values]
+
+
 def assert_equal_data(result: Any, expected: dict[str, Any]) -> None:
     if hasattr(result, "collect"):
         result = result.collect()
     if hasattr(result, "columns"):
         for key in result.columns:
             assert key in expected
+    result = {key: _to_comparable_list(result[key]) for key in expected}
     for key in expected:
         result_key = result[key]
-        if (
-            hasattr(result_key, "_compliant_series")
-            and result_key._compliant_series._implementation is Implementation.CUDF
-        ):  # pragma: no cover
-            result_key = result_key.to_pandas()
-        for lhs, rhs in zip_strict(result_key, expected[key]):
-            if hasattr(lhs, "as_py"):
-                lhs = lhs.as_py()  # noqa: PLW2901
-            if hasattr(rhs, "as_py"):  # pragma: no cover
-                rhs = rhs.as_py()  # noqa: PLW2901
-            if hasattr(lhs, "item"):  # pragma: no cover
-                lhs = lhs.item()  # noqa: PLW2901
-            if hasattr(rhs, "item"):  # pragma: no cover
-                rhs = rhs.item()  # noqa: PLW2901
+        expected_key = expected[key]
+        for i, (lhs, rhs) in enumerate(zip_strict(result_key, expected_key)):
             if isinstance(lhs, float) and not math.isnan(lhs):
-                assert math.isclose(lhs, rhs, rel_tol=0, abs_tol=1e-6), (lhs, rhs)
+                are_valid_values = math.isclose(lhs, rhs, rel_tol=0, abs_tol=1e-6)
             elif isinstance(lhs, float) and math.isnan(lhs) and rhs is not None:
-                assert math.isnan(rhs), (lhs, rhs)  # pragma: no cover
+                are_valid_values = math.isnan(rhs)  # pragma: no cover
             elif pd.isna(lhs):
-                assert pd.isna(rhs), (lhs, rhs)
+                are_valid_values = pd.isna(rhs)
             else:
-                assert lhs == rhs, (lhs, rhs)
+                are_valid_values = lhs == rhs
+            assert are_valid_values, f"Mismatch at index {i}: {lhs} != {rhs}\nExpected: {expected}\nGot: {result}"
 
 
 def maybe_get_modin_df(df_pandas: pd.DataFrame) -> Any:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,6 +10,7 @@ from typing import Sequence
 
 import pandas as pd
 
+import narwhals as nw
 from narwhals.typing import IntoDataFrame
 from narwhals.typing import IntoFrame
 from narwhals.utils import Implementation
@@ -30,16 +31,6 @@ def zip_strict(left: Sequence[Any], right: Sequence[Any]) -> Iterator[Any]:
     return zip(left, right)
 
 
-def _to_py_object(value: Any) -> Any:
-    # PyArrow: return scalars as Python objects
-    if hasattr(value, "as_py"):  # pragma: no cover
-        return value.as_py()
-    # cuDF: returns cupy scalars as Python objects
-    if hasattr(value, "item"):  # pragma: no cover
-        return value.item()
-    return value
-
-
 def _to_comparable_list(column_values: Any) -> Any:
     if (
         hasattr(column_values, "_compliant_series")
@@ -48,7 +39,7 @@ def _to_comparable_list(column_values: Any) -> Any:
         column_values = column_values.to_pandas()
     if hasattr(column_values, "to_list"):
         return column_values.to_list()
-    return [_to_py_object(v) for v in column_values]
+    return [nw.to_py_scalar(v) for v in column_values]
 
 
 def assert_equal_data(result: Any, expected: dict[str, Any]) -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,7 +28,7 @@ def zip_strict(left: Sequence[Any], right: Sequence[Any]) -> Iterator[Any]:
     return zip(left, right)
 
 
-def compare_dicts(result: Any, expected: dict[str, Any]) -> None:
+def assert_equal_data(result: Any, expected: dict[str, Any]) -> None:
     if hasattr(result, "collect"):
         result = result.collect()
     if hasattr(result, "columns"):


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.

I propose a couple of changes:
- I'd like to have a more verbose assertion error message when a unitest fail. Taking inspiration from `pandas`, I'm printing all the values of the columns that differ and the index where the difference was first noticed. This is particularly helpful for dataframes libraries that don't keep row order (* cough cough * _pyspark_ * cough cough *)

```python
def test_select(constructor: Constructor) -> None:
    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
    df = nw.from_native(constructor(data))
    result = df.select("a")
    expected = {"a": [1, 3, 3]}
    compare_dicts(result, expected)
````

Before:
<img width="765" alt="Screenshot 2024-10-18 at 23 50 35" src="https://github.com/user-attachments/assets/dd25696d-b4ee-4a25-bcfb-1078bd131853">


After:
<img width="936" alt="Screenshot 2024-10-18 at 23 49 06" src="https://github.com/user-attachments/assets/2c2f3a0e-e8d9-411c-bb7d-5026199fdcfd">

- I think we should rename `compare_dicts` because we are not actually comparing 2 dictionaries. 😅 I propose something like `assert_equal_data`, any better name? This makes the diff of the PR a bit large, happy to revert if you think we should keep the previous name