### PR TITLE
chore: make module versions as constants for use in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from narwhals.dependencies import get_cudf
 from narwhals.dependencies import get_dask_dataframe
 from narwhals.dependencies import get_modin
 from narwhals.utils import parse_version
+from tests.utils import get_module_version_as_tuple
 
 if TYPE_CHECKING:
     from narwhals.typing import IntoDataFrame
@@ -26,6 +27,13 @@ with contextlib.suppress(ImportError):
     import dask.dataframe  # noqa: F401
 with contextlib.suppress(ImportError):
     import cudf  # noqa: F401
+
+
+IBIS_VERSION: tuple[int, ...] = get_module_version_as_tuple("ibis")
+NUMPY_VERSION: tuple[int, ...] = get_module_version_as_tuple("numpy")
+PANDAS_VERSION: tuple[int, ...] = get_module_version_as_tuple("pandas")
+POLARS_VERSION: tuple[int, ...] = get_module_version_as_tuple("polars")
+PYARROW_VERSION: tuple[int, ...] = get_module_version_as_tuple("pyarrow")
 
 
 def pytest_addoption(parser: Any) -> None:
@@ -122,3 +130,28 @@ def constructor_eager(
 @pytest.fixture(params=[*eager_constructors, *lazy_constructors])
 def constructor(request: pytest.FixtureRequest) -> Constructor:
     return request.param  # type: ignore[no-any-return]
+
+
+@pytest.fixture
+def ibis_version() -> tuple[int, ...]:
+    return IBIS_VERSION
+
+
+@pytest.fixture
+def numpy_version() -> tuple[int, ...]:
+    return NUMPY_VERSION
+
+
+@pytest.fixture
+def pandas_version() -> tuple[int, ...]:
+    return PANDAS_VERSION
+
+
+@pytest.fixture
+def polars_version() -> tuple[int, ...]:
+    return POLARS_VERSION
+
+
+@pytest.fixture
+def pyarrow_version() -> tuple[int, ...]:
+    return PYARROW_VERSION

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,26 +132,26 @@ def constructor(request: pytest.FixtureRequest) -> Constructor:
     return request.param  # type: ignore[no-any-return]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def ibis_version() -> tuple[int, ...]:
     return IBIS_VERSION
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def numpy_version() -> tuple[int, ...]:
     return NUMPY_VERSION
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def pandas_version() -> tuple[int, ...]:
     return PANDAS_VERSION
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def polars_version() -> tuple[int, ...]:
     return POLARS_VERSION
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def pyarrow_version() -> tuple[int, ...]:
     return PYARROW_VERSION

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,7 @@ import pytest
 from narwhals.dependencies import get_cudf
 from narwhals.dependencies import get_dask_dataframe
 from narwhals.dependencies import get_modin
-from narwhals.utils import parse_version
-from tests.utils import get_module_version_as_tuple
+from tests.utils import PANDAS_VERSION
 
 if TYPE_CHECKING:
     from narwhals.typing import IntoDataFrame
@@ -27,13 +26,6 @@ with contextlib.suppress(ImportError):
     import dask.dataframe  # noqa: F401
 with contextlib.suppress(ImportError):
     import cudf  # noqa: F401
-
-
-IBIS_VERSION: tuple[int, ...] = get_module_version_as_tuple("ibis")
-NUMPY_VERSION: tuple[int, ...] = get_module_version_as_tuple("numpy")
-PANDAS_VERSION: tuple[int, ...] = get_module_version_as_tuple("pandas")
-POLARS_VERSION: tuple[int, ...] = get_module_version_as_tuple("polars")
-PYARROW_VERSION: tuple[int, ...] = get_module_version_as_tuple("pyarrow")
 
 
 def pytest_addoption(parser: Any) -> None:
@@ -100,7 +92,7 @@ def pyarrow_table_constructor(obj: Any) -> IntoDataFrame:
     return pa.table(obj)  # type: ignore[no-any-return]
 
 
-if parse_version(pd.__version__) >= parse_version("2.0.0"):
+if PANDAS_VERSION >= (2, 0, 0):
     eager_constructors = [
         pandas_constructor,
         pandas_nullable_constructor,
@@ -130,28 +122,3 @@ def constructor_eager(
 @pytest.fixture(params=[*eager_constructors, *lazy_constructors])
 def constructor(request: pytest.FixtureRequest) -> Constructor:
     return request.param  # type: ignore[no-any-return]
-
-
-@pytest.fixture(scope="session")
-def ibis_version() -> tuple[int, ...]:
-    return IBIS_VERSION
-
-
-@pytest.fixture(scope="session")
-def numpy_version() -> tuple[int, ...]:
-    return NUMPY_VERSION
-
-
-@pytest.fixture(scope="session")
-def pandas_version() -> tuple[int, ...]:
-    return PANDAS_VERSION
-
-
-@pytest.fixture(scope="session")
-def polars_version() -> tuple[int, ...]:
-    return POLARS_VERSION
-
-
-@pytest.fixture(scope="session")
-def pyarrow_version() -> tuple[int, ...]:
-    return PYARROW_VERSION

--- a/tests/expr_and_series/all_horizontal_test.py
+++ b/tests/expr_and_series/all_horizontal_test.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import POLARS_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -53,9 +54,8 @@ def test_allh_all(constructor: Constructor) -> None:
 def test_allh_nth(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    polars_version: tuple[int, ...],
 ) -> None:
-    if "polars" in str(constructor) and polars_version < (1, 0):
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 0):
         request.applymarker(pytest.mark.xfail)
     data = {
         "a": [False, False, True],

--- a/tests/expr_and_series/all_horizontal_test.py
+++ b/tests/expr_and_series/all_horizontal_test.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -52,8 +50,12 @@ def test_allh_all(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
-def test_allh_nth(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if "polars" in str(constructor) and parse_version(pl.__version__) < (1, 0):
+def test_allh_nth(
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    polars_version: tuple[int, ...],
+) -> None:
+    if "polars" in str(constructor) and polars_version < (1, 0):
         request.applymarker(pytest.mark.xfail)
     data = {
         "a": [False, False, True],

--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -11,6 +11,7 @@ from hypothesis import assume
 from hypothesis import given
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -157,14 +158,8 @@ def test_truediv_same_dims(
     left=st.integers(-100, 100),
     right=st.integers(-100, 100),
 )
-def test_floordiv(
-    left: int,
-    right: int,
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
-) -> None:
-    if pandas_version < (2, 0):
-        request.applymarker(pytest.mark.skip(reason="convert_dtypes not available"))
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
+def test_floordiv(left: int, right: int) -> None:
     # hypothesis complains if we add `constructor` as an argument, so this
     # test is a bit manual unfortunately
     assume(right != 0)
@@ -173,7 +168,7 @@ def test_floordiv(
         nw.col("a") // right
     )
     assert_equal_data(result, expected)
-    if pandas_version < (2, 2):  # pragma: no cover
+    if PANDAS_VERSION < (2, 2):  # pragma: no cover
         # Bug in old version of pandas
         pass
     else:
@@ -201,14 +196,8 @@ def test_floordiv(
     left=st.integers(-100, 100),
     right=st.integers(-100, 100),
 )
-def test_mod(
-    left: int,
-    right: int,
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
-) -> None:
-    if pandas_version < (2, 0):
-        request.applymarker(pytest.mark.skip(reason="convert_dtypes not available"))
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
+def test_mod(left: int, right: int) -> None:
     # hypothesis complains if we add `constructor` as an argument, so this
     # test is a bit manual unfortunately
     assume(right != 0)

--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -11,7 +11,6 @@ from hypothesis import assume
 from hypothesis import given
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -158,10 +157,14 @@ def test_truediv_same_dims(
     left=st.integers(-100, 100),
     right=st.integers(-100, 100),
 )
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < (2, 0), reason="convert_dtypes not available"
-)
-def test_floordiv(left: int, right: int) -> None:
+def test_floordiv(
+    left: int,
+    right: int,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+) -> None:
+    if pandas_version < (2, 0):
+        request.applymarker(pytest.mark.skipif(reason="convert_dtypes not available"))
     # hypothesis complains if we add `constructor` as an argument, so this
     # test is a bit manual unfortunately
     assume(right != 0)
@@ -170,7 +173,7 @@ def test_floordiv(left: int, right: int) -> None:
         nw.col("a") // right
     )
     assert_equal_data(result, expected)
-    if parse_version(pd.__version__) < (2, 2):  # pragma: no cover
+    if pandas_version < (2, 2):  # pragma: no cover
         # Bug in old version of pandas
         pass
     else:
@@ -198,10 +201,14 @@ def test_floordiv(left: int, right: int) -> None:
     left=st.integers(-100, 100),
     right=st.integers(-100, 100),
 )
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < (2, 0), reason="convert_dtypes not available"
-)
-def test_mod(left: int, right: int) -> None:
+def test_mod(
+    left: int,
+    right: int,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+) -> None:
+    if pandas_version < (2, 0):
+        request.applymarker(pytest.mark.skipif(reason="convert_dtypes not available"))
     # hypothesis complains if we add `constructor` as an argument, so this
     # test is a bit manual unfortunately
     assume(right != 0)

--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -164,7 +164,7 @@ def test_floordiv(
     pandas_version: tuple[int, ...],
 ) -> None:
     if pandas_version < (2, 0):
-        request.applymarker(pytest.mark.skipif(reason="convert_dtypes not available"))
+        request.applymarker(pytest.mark.skip(reason="convert_dtypes not available"))
     # hypothesis complains if we add `constructor` as an argument, so this
     # test is a bit manual unfortunately
     assume(right != 0)
@@ -208,7 +208,7 @@ def test_mod(
     pandas_version: tuple[int, ...],
 ) -> None:
     if pandas_version < (2, 0):
-        request.applymarker(pytest.mark.skipif(reason="convert_dtypes not available"))
+        request.applymarker(pytest.mark.skip(reason="convert_dtypes not available"))
     # hypothesis complains if we add `constructor` as an argument, so this
     # test is a bit manual unfortunately
     assume(right != 0)

--- a/tests/expr_and_series/cast_test.py
+++ b/tests/expr_and_series/cast_test.py
@@ -167,7 +167,7 @@ def test_cast_string(
     request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
 ) -> None:
     if pandas_version < (1, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="too old for convert_dtypes"))
+        request.applymarker(pytest.mark.skip(reason="too old for convert_dtypes"))
     s_pd = pd.Series([1, 2]).convert_dtypes()
     s = nw.from_native(s_pd, series_only=True)
     s = s.cast(nw.String)

--- a/tests/expr_and_series/cast_test.py
+++ b/tests/expr_and_series/cast_test.py
@@ -8,6 +8,8 @@ import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
+from tests.utils import PYARROW_VERSION
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 from tests.utils import is_windows
@@ -54,9 +56,8 @@ schema = {
 def test_cast(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table_constructor" in str(constructor) and pyarrow_version <= (
+    if "pyarrow_table_constructor" in str(constructor) and PYARROW_VERSION <= (
         15,
     ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
@@ -108,9 +109,8 @@ def test_cast(
 def test_cast_series(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table_constructor" in str(constructor) and pyarrow_version <= (
+    if "pyarrow_table_constructor" in str(constructor) and PYARROW_VERSION <= (
         15,
     ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
@@ -163,11 +163,8 @@ def test_cast_series(
     assert result.schema == expected
 
 
-def test_cast_string(
-    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
-) -> None:
-    if pandas_version < (1, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="too old for convert_dtypes"))
+@pytest.mark.skipif(PANDAS_VERSION < (1, 0, 0), reason="too old for convert_dtypes")
+def test_cast_string() -> None:
     s_pd = pd.Series([1, 2]).convert_dtypes()
     s = nw.from_native(s_pd, series_only=True)
     s = s.cast(nw.String)
@@ -178,9 +175,8 @@ def test_cast_string(
 def test_cast_raises_for_unknown_dtype(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table_constructor" in str(constructor) and pyarrow_version <= (
+    if "pyarrow_table_constructor" in str(constructor) and PYARROW_VERSION <= (
         15,
     ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)

--- a/tests/expr_and_series/cat/get_categories_test.py
+++ b/tests/expr_and_series/cat/get_categories_test.py
@@ -4,7 +4,6 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -12,11 +11,11 @@ data = {"a": ["one", "two", "two"]}
 
 
 def test_get_categories(
-    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
+    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager,
+    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and parse_version(
-        pa.__version__
-    ) < parse_version("15.0.0"):
+    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (15, 0, 0):
         request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor_eager(data), eager_only=True)

--- a/tests/expr_and_series/cat/get_categories_test.py
+++ b/tests/expr_and_series/cat/get_categories_test.py
@@ -4,6 +4,7 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PYARROW_VERSION
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -13,9 +14,8 @@ data = {"a": ["one", "two", "two"]}
 def test_get_categories(
     request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (15, 0, 0):
+    if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (15, 0, 0):
         request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor_eager(data), eager_only=True)

--- a/tests/expr_and_series/convert_time_zone_test.py
+++ b/tests/expr_and_series/convert_time_zone_test.py
@@ -4,13 +4,9 @@ from datetime import datetime
 from datetime import timezone
 from typing import TYPE_CHECKING
 
-import pandas as pd
-import polars as pl
-import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 from tests.utils import is_windows
@@ -20,14 +16,13 @@ if TYPE_CHECKING:
 
 
 def test_convert_time_zone(
-    constructor: Constructor, request: pytest.FixtureRequest
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
 ) -> None:
     if (
         (any(x in str(constructor) for x in ("pyarrow", "modin")) and is_windows())
-        or (
-            "pandas_pyarrow" in str(constructor)
-            and parse_version(pd.__version__) < (2, 1)
-        )
+        or ("pandas_pyarrow" in str(constructor) and pandas_version < (2, 1))
         or ("cudf" in str(constructor))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -48,14 +43,13 @@ def test_convert_time_zone(
 
 
 def test_convert_time_zone_series(
-    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
+    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
 ) -> None:
     if (
         (any(x in str(constructor_eager) for x in ("pyarrow", "modin")) and is_windows())
-        or (
-            "pandas_pyarrow" in str(constructor_eager)
-            and parse_version(pd.__version__) < (2, 1)
-        )
+        or ("pandas_pyarrow" in str(constructor_eager) and pandas_version < (2, 1))
         or ("cudf" in str(constructor_eager))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -76,19 +70,20 @@ def test_convert_time_zone_series(
 
 
 def test_convert_time_zone_from_none(
-    constructor: Constructor, request: pytest.FixtureRequest
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+    polars_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
 ) -> None:
     if (
         (any(x in str(constructor) for x in ("pyarrow", "modin")) and is_windows())
-        or (
-            "pandas_pyarrow" in str(constructor)
-            and parse_version(pd.__version__) < (2, 1)
-        )
-        or ("pyarrow_table" in str(constructor) and parse_version(pa.__version__) < (12,))
+        or ("pandas_pyarrow" in str(constructor) and pandas_version < (2, 1))
+        or ("pyarrow_table" in str(constructor) and pyarrow_version < (12,))
         or ("cudf" in str(constructor))
     ):
         request.applymarker(pytest.mark.xfail)
-    if "polars" in str(constructor) and parse_version(pl.__version__) < (0, 20, 7):
+    if "polars" in str(constructor) and polars_version < (0, 20, 7):
         # polars used to disallow this
         request.applymarker(pytest.mark.xfail)
     data = {

--- a/tests/expr_and_series/convert_time_zone_test.py
+++ b/tests/expr_and_series/convert_time_zone_test.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
+from tests.utils import POLARS_VERSION
+from tests.utils import PYARROW_VERSION
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 from tests.utils import is_windows
@@ -18,11 +21,10 @@ if TYPE_CHECKING:
 def test_convert_time_zone(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
 ) -> None:
     if (
         (any(x in str(constructor) for x in ("pyarrow", "modin")) and is_windows())
-        or ("pandas_pyarrow" in str(constructor) and pandas_version < (2, 1))
+        or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2, 1))
         or ("cudf" in str(constructor))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -45,11 +47,10 @@ def test_convert_time_zone(
 def test_convert_time_zone_series(
     constructor_eager: ConstructorEager,
     request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
 ) -> None:
     if (
         (any(x in str(constructor_eager) for x in ("pyarrow", "modin")) and is_windows())
-        or ("pandas_pyarrow" in str(constructor_eager) and pandas_version < (2, 1))
+        or ("pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2, 1))
         or ("cudf" in str(constructor_eager))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -70,20 +71,16 @@ def test_convert_time_zone_series(
 
 
 def test_convert_time_zone_from_none(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
-    polars_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
+    constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if (
         (any(x in str(constructor) for x in ("pyarrow", "modin")) and is_windows())
-        or ("pandas_pyarrow" in str(constructor) and pandas_version < (2, 1))
-        or ("pyarrow_table" in str(constructor) and pyarrow_version < (12,))
+        or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2, 1))
+        or ("pyarrow_table" in str(constructor) and PYARROW_VERSION < (12,))
         or ("cudf" in str(constructor))
     ):
         request.applymarker(pytest.mark.xfail)
-    if "polars" in str(constructor) and polars_version < (0, 20, 7):
+    if "polars" in str(constructor) and POLARS_VERSION < (0, 20, 7):
         # polars used to disallow this
         request.applymarker(pytest.mark.xfail)
     data = {

--- a/tests/expr_and_series/diff_test.py
+++ b/tests/expr_and_series/diff_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PYARROW_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -17,9 +18,8 @@ data = {
 def test_diff(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table_constructor" in str(constructor) and pyarrow_version < (13,):
+    if "pyarrow_table_constructor" in str(constructor) and PYARROW_VERSION < (13,):
         # pc.pairwisediff is available since pyarrow 13.0.0
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
@@ -36,9 +36,8 @@ def test_diff(
 def test_diff_series(
     constructor_eager: ConstructorEager,
     request: pytest.FixtureRequest,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table_constructor" in str(constructor_eager) and pyarrow_version < (13,):
+    if "pyarrow_table_constructor" in str(constructor_eager) and PYARROW_VERSION < (13,):
         # pc.pairwisediff is available since pyarrow 13.0.0
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor_eager(data), eager_only=True)

--- a/tests/expr_and_series/diff_test.py
+++ b/tests/expr_and_series/diff_test.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -16,10 +14,12 @@ data = {
 }
 
 
-def test_diff(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if "pyarrow_table_constructor" in str(constructor) and parse_version(
-        pa.__version__
-    ) < (13,):
+def test_diff(
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    pyarrow_version: tuple[int, ...],
+) -> None:
+    if "pyarrow_table_constructor" in str(constructor) and pyarrow_version < (13,):
         # pc.pairwisediff is available since pyarrow 13.0.0
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
@@ -34,11 +34,11 @@ def test_diff(constructor: Constructor, request: pytest.FixtureRequest) -> None:
 
 
 def test_diff_series(
-    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
+    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest,
+    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table_constructor" in str(constructor_eager) and parse_version(
-        pa.__version__
-    ) < (13,):
+    if "pyarrow_table_constructor" in str(constructor_eager) and pyarrow_version < (13,):
         # pc.pairwisediff is available since pyarrow 13.0.0
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor_eager(data), eager_only=True)

--- a/tests/expr_and_series/dt/datetime_duration_test.py
+++ b/tests/expr_and_series/dt/datetime_duration_test.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 from datetime import timedelta
 
 import numpy as np
-import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -44,8 +42,9 @@ def test_duration_attributes(
     expected_a: list[int],
     expected_b: list[int],
     expected_c: list[int],
+    pandas_version: tuple[int, ...],
 ) -> None:
-    if parse_version(pd.__version__) < (2, 2) and "pandas_pyarrow" in str(constructor):
+    if pandas_version < (2, 2) and "pandas_pyarrow" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     if "cudf" in str(constructor):
         request.applymarker(pytest.mark.xfail)
@@ -79,10 +78,9 @@ def test_duration_attributes_series(
     expected_a: list[int],
     expected_b: list[int],
     expected_c: list[int],
+    pandas_version: tuple[int, ...],
 ) -> None:
-    if parse_version(pd.__version__) < (2, 2) and "pandas_pyarrow" in str(
-        constructor_eager
-    ):
+    if pandas_version < (2, 2) and "pandas_pyarrow" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
     if "cudf" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)

--- a/tests/expr_and_series/dt/datetime_duration_test.py
+++ b/tests/expr_and_series/dt/datetime_duration_test.py
@@ -8,6 +8,7 @@ import pyarrow.compute as pc
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -42,9 +43,8 @@ def test_duration_attributes(
     expected_a: list[int],
     expected_b: list[int],
     expected_c: list[int],
-    pandas_version: tuple[int, ...],
 ) -> None:
-    if pandas_version < (2, 2) and "pandas_pyarrow" in str(constructor):
+    if PANDAS_VERSION < (2, 2) and "pandas_pyarrow" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     if "cudf" in str(constructor):
         request.applymarker(pytest.mark.xfail)
@@ -78,9 +78,8 @@ def test_duration_attributes_series(
     expected_a: list[int],
     expected_b: list[int],
     expected_c: list[int],
-    pandas_version: tuple[int, ...],
 ) -> None:
-    if pandas_version < (2, 2) and "pandas_pyarrow" in str(constructor_eager):
+    if PANDAS_VERSION < (2, 2) and "pandas_pyarrow" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
     if "cudf" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)

--- a/tests/expr_and_series/dt/ordinal_day_test.py
+++ b/tests/expr_and_series/dt/ordinal_day_test.py
@@ -19,7 +19,7 @@ def test_ordinal_day(
     pandas_version: tuple[int, ...],
 ) -> None:
     if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="pyarrow dtype not available"))
+        request.applymarker(pytest.mark.skip(reason="pyarrow dtype not available"))
     result_pd = nw.from_native(pd.Series([dates]), series_only=True).dt.ordinal_day()[0]
     result_pdms = nw.from_native(
         pd.Series([dates]).dt.as_unit("ms"), series_only=True

--- a/tests/expr_and_series/dt/ordinal_day_test.py
+++ b/tests/expr_and_series/dt/ordinal_day_test.py
@@ -9,17 +9,16 @@ import pytest
 from hypothesis import given
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 
 
 @given(dates=st.datetimes(min_value=datetime(1960, 1, 1), max_value=datetime(1980, 1, 1)))  # type: ignore[misc]
+@pytest.mark.skipif(
+    PANDAS_VERSION < (2, 0, 0),
+    reason="pyarrow dtype not available",
+)
 @pytest.mark.slow
-def test_ordinal_day(
-    dates: datetime,
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
-) -> None:
-    if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="pyarrow dtype not available"))
+def test_ordinal_day(dates: datetime) -> None:
     result_pd = nw.from_native(pd.Series([dates]), series_only=True).dt.ordinal_day()[0]
     result_pdms = nw.from_native(
         pd.Series([dates]).dt.as_unit("ms"), series_only=True

--- a/tests/expr_and_series/dt/ordinal_day_test.py
+++ b/tests/expr_and_series/dt/ordinal_day_test.py
@@ -9,16 +9,17 @@ import pytest
 from hypothesis import given
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 
 @given(dates=st.datetimes(min_value=datetime(1960, 1, 1), max_value=datetime(1980, 1, 1)))  # type: ignore[misc]
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < parse_version("2.0.0"),
-    reason="pyarrow dtype not available",
-)
 @pytest.mark.slow
-def test_ordinal_day(dates: datetime) -> None:
+def test_ordinal_day(
+    dates: datetime,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+) -> None:
+    if pandas_version < (2, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="pyarrow dtype not available"))
     result_pd = nw.from_native(pd.Series([dates]), series_only=True).dt.ordinal_day()[0]
     result_pdms = nw.from_native(
         pd.Series([dates]).dt.as_unit("ms"), series_only=True

--- a/tests/expr_and_series/dt/timestamp_test.py
+++ b/tests/expr_and_series/dt/timestamp_test.py
@@ -10,7 +10,8 @@ import pytest
 from hypothesis import given
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
+from tests.utils import PANDAS_VERSION
+from tests.utils import PYARROW_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -50,7 +51,7 @@ def test_timestamp_datetimes(
 ) -> None:
     if original_time_unit == "s" and "polars" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    if "pandas_pyarrow" in str(constructor) and parse_version(pd.__version__) < (
+    if "pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (
         2,
         2,
     ):  # pragma: no cover
@@ -90,18 +91,18 @@ def test_timestamp_datetimes_tz_aware(
 ) -> None:
     if (
         (any(x in str(constructor) for x in ("pyarrow",)) and is_windows())
-        or ("pandas_pyarrow" in str(constructor) and parse_version(pd.__version__) < (2,))
-        or ("pyarrow_table" in str(constructor) and parse_version(pa.__version__) < (12,))
+        or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2,))
+        or ("pyarrow_table" in str(constructor) and PYARROW_VERSION < (12,))
         or ("cudf" in str(constructor))
     ):
         request.applymarker(pytest.mark.xfail)
-    if "pandas_pyarrow" in str(constructor) and parse_version(pd.__version__) < (
+    if "pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (
         2,
         2,
     ):  # pragma: no cover
         # pyarrow-backed timestamps were too inconsistent and unreliable before 2.2
         request.applymarker(pytest.mark.xfail(strict=False))
-    if "dask" in str(constructor) and parse_version(pd.__version__) < (
+    if "dask" in str(constructor) and PANDAS_VERSION < (
         2,
         1,
     ):  # pragma: no cover
@@ -196,15 +197,13 @@ def test_timestamp_invalid_unit_series(constructor_eager: ConstructorEager) -> N
     # We keep 'ms' out for now due to an upstream bug: https://github.com/pola-rs/polars/issues/19309
     starting_time_unit=st.sampled_from(["us", "ns"]),
 )
-@pytest.mark.skipif(parse_version(pd.__version__) < (2, 2), reason="bug in old pandas")
+@pytest.mark.skipif(PANDAS_VERSION < (2, 2), reason="bug in old pandas")
 def test_timestamp_hypothesis(
     inputs: datetime,
     time_unit: Literal["ms", "us", "ns"],
     starting_time_unit: Literal["ms", "us", "ns"],
 ) -> None:
-    import pandas as pd
     import polars as pl
-    import pyarrow as pa
 
     @nw.narwhalify
     def func(s: nw.Series) -> nw.Series:

--- a/tests/expr_and_series/dt/total_minutes_test.py
+++ b/tests/expr_and_series/dt/total_minutes_test.py
@@ -9,7 +9,6 @@ import pytest
 from hypothesis import given
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 
 @given(
@@ -18,12 +17,14 @@ from narwhals.utils import parse_version
         max_value=timedelta(days=3, minutes=90, seconds=60),
     )
 )  # type: ignore[misc]
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < parse_version("2.2.0"),
-    reason="pyarrow dtype not available",
-)
 @pytest.mark.slow
-def test_total_minutes(timedeltas: timedelta) -> None:
+def test_total_minutes(
+    timedeltas: timedelta,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+) -> None:
+    if pandas_version < (2, 2, 0):
+        request.applymarker(pytest.mark.skipif(reason="pyarrow dtype not available"))
     result_pd = nw.from_native(
         pd.Series([timedeltas]), series_only=True
     ).dt.total_minutes()[0]

--- a/tests/expr_and_series/dt/total_minutes_test.py
+++ b/tests/expr_and_series/dt/total_minutes_test.py
@@ -24,7 +24,7 @@ def test_total_minutes(
     pandas_version: tuple[int, ...],
 ) -> None:
     if pandas_version < (2, 2, 0):
-        request.applymarker(pytest.mark.skipif(reason="pyarrow dtype not available"))
+        request.applymarker(pytest.mark.skip(reason="pyarrow dtype not available"))
     result_pd = nw.from_native(
         pd.Series([timedeltas]), series_only=True
     ).dt.total_minutes()[0]

--- a/tests/expr_and_series/dt/total_minutes_test.py
+++ b/tests/expr_and_series/dt/total_minutes_test.py
@@ -9,6 +9,7 @@ import pytest
 from hypothesis import given
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 
 
 @given(
@@ -17,14 +18,12 @@ import narwhals.stable.v1 as nw
         max_value=timedelta(days=3, minutes=90, seconds=60),
     )
 )  # type: ignore[misc]
+@pytest.mark.skipif(
+    PANDAS_VERSION < (2, 2, 0),
+    reason="pyarrow dtype not available",
+)
 @pytest.mark.slow
-def test_total_minutes(
-    timedeltas: timedelta,
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
-) -> None:
-    if pandas_version < (2, 2, 0):
-        request.applymarker(pytest.mark.skip(reason="pyarrow dtype not available"))
+def test_total_minutes(timedeltas: timedelta) -> None:
     result_pd = nw.from_native(
         pd.Series([timedeltas]), series_only=True
     ).dt.total_minutes()[0]

--- a/tests/expr_and_series/mode_test.py
+++ b/tests/expr_and_series/mode_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import POLARS_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -28,10 +29,9 @@ def test_mode_single_expr(
 def test_mode_multi_expr(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    polars_version: tuple[int, ...],
 ) -> None:
     if "dask" in str(constructor) or (
-        "polars" in str(constructor) and polars_version >= (1, 7, 0)
+        "polars" in str(constructor) and POLARS_VERSION >= (1, 7, 0)
     ):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))

--- a/tests/expr_and_series/mode_test.py
+++ b/tests/expr_and_series/mode_test.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -28,10 +26,12 @@ def test_mode_single_expr(
 
 
 def test_mode_multi_expr(
-    constructor: Constructor, request: pytest.FixtureRequest
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    polars_version: tuple[int, ...],
 ) -> None:
     if "dask" in str(constructor) or (
-        "polars" in str(constructor) and parse_version(pl.__version__) >= (1, 7, 0)
+        "polars" in str(constructor) and polars_version >= (1, 7, 0)
     ):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))

--- a/tests/expr_and_series/nth_test.py
+++ b/tests/expr_and_series/nth_test.py
@@ -4,6 +4,7 @@ import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import POLARS_VERSION
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
@@ -23,20 +24,19 @@ def test_nth(
     idx: int | list[int],
     expected: dict[str, list[int]],
     request: pytest.FixtureRequest,
-    polars_version: tuple[int, ...],
 ) -> None:
-    if "polars" in str(constructor) and polars_version < (1, 0, 0):
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 0, 0):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     result = df.select(nw.nth(idx))
     assert_equal_data(result, expected)
 
 
-def test_nth_not_supported(
-    polars_version: tuple[int, ...],
-) -> None:  # pragma: no cover
-    if polars_version >= (1, 0, 0):
-        pytest.skip(reason="1.0.0")
+@pytest.mark.skipif(
+    POLARS_VERSION >= (1, 0, 0),
+    reason="1.0.0",
+)
+def test_nth_not_supported() -> None:  # pragma: no cover
     df = nw.from_native(pl.DataFrame(data))
     with pytest.raises(
         AttributeError, match="`nth` is only supported for Polars>=1.0.0."

--- a/tests/expr_and_series/nth_test.py
+++ b/tests/expr_and_series/nth_test.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
-
 import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
@@ -25,22 +22,21 @@ def test_nth(
     constructor: Constructor,
     idx: int | list[int],
     expected: dict[str, list[int]],
-    request: Any,
+    request: pytest.FixtureRequest,
+    polars_version: tuple[int, ...],
 ) -> None:
-    if "polars" in str(constructor) and parse_version(pl.__version__) < parse_version(
-        "1.0.0"
-    ):
+    if "polars" in str(constructor) and polars_version < (1, 0, 0):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     result = df.select(nw.nth(idx))
     assert_equal_data(result, expected)
 
 
-@pytest.mark.skipif(
-    parse_version(pl.__version__) >= parse_version("1.0.0"),
-    reason="1.0.0",
-)
-def test_nth_not_supported() -> None:  # pragma: no cover
+def test_nth_not_supported(
+    polars_version: tuple[int, ...],
+) -> None:  # pragma: no cover
+    if polars_version >= (1, 0, 0):
+        pytest.skip(reason="1.0.0")
     df = nw.from_native(pl.DataFrame(data))
     with pytest.raises(
         AttributeError, match="`nth` is only supported for Polars>=1.0.0."

--- a/tests/expr_and_series/replace_time_zone_test.py
+++ b/tests/expr_and_series/replace_time_zone_test.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
+from tests.utils import PYARROW_VERSION
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 from tests.utils import is_windows
@@ -16,15 +18,12 @@ if TYPE_CHECKING:
 
 
 def test_replace_time_zone(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
+    constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if (
         (any(x in str(constructor) for x in ("pyarrow", "modin")) and is_windows())
-        or ("pandas_pyarrow" in str(constructor) and pandas_version < (2,))
-        or ("pyarrow_table" in str(constructor) and pyarrow_version < (12,))
+        or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2,))
+        or ("pyarrow_table" in str(constructor) and PYARROW_VERSION < (12,))
         or ("cudf" in str(constructor))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -45,15 +44,12 @@ def test_replace_time_zone(
 
 
 def test_replace_time_zone_none(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
+    constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if (
         (any(x in str(constructor) for x in ("pyarrow", "modin")) and is_windows())
-        or ("pandas_pyarrow" in str(constructor) and pandas_version < (2,))
-        or ("pyarrow_table" in str(constructor) and pyarrow_version < (12,))
+        or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2,))
+        or ("pyarrow_table" in str(constructor) and PYARROW_VERSION < (12,))
     ):
         request.applymarker(pytest.mark.xfail)
     data = {
@@ -73,15 +69,12 @@ def test_replace_time_zone_none(
 
 
 def test_replace_time_zone_series(
-    constructor_eager: ConstructorEager,
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
+    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
 ) -> None:
     if (
         (any(x in str(constructor_eager) for x in ("pyarrow", "modin")) and is_windows())
-        or ("pandas_pyarrow" in str(constructor_eager) and pandas_version < (2,))
-        or ("pyarrow_table" in str(constructor_eager) and pyarrow_version < (12,))
+        or ("pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2,))
+        or ("pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (12,))
         or ("cudf" in str(constructor_eager))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -102,15 +95,12 @@ def test_replace_time_zone_series(
 
 
 def test_replace_time_zone_none_series(
-    constructor_eager: ConstructorEager,
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
+    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
 ) -> None:
     if (
         (any(x in str(constructor_eager) for x in ("pyarrow", "modin")) and is_windows())
-        or ("pandas_pyarrow" in str(constructor_eager) and pandas_version < (2,))
-        or ("pyarrow_table" in str(constructor_eager) and pyarrow_version < (12,))
+        or ("pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2,))
+        or ("pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (12,))
     ):
         request.applymarker(pytest.mark.xfail)
     data = {

--- a/tests/expr_and_series/replace_time_zone_test.py
+++ b/tests/expr_and_series/replace_time_zone_test.py
@@ -4,12 +4,9 @@ from datetime import datetime
 from datetime import timezone
 from typing import TYPE_CHECKING
 
-import pandas as pd
-import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 from tests.utils import is_windows
@@ -19,12 +16,15 @@ if TYPE_CHECKING:
 
 
 def test_replace_time_zone(
-    constructor: Constructor, request: pytest.FixtureRequest
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
 ) -> None:
     if (
         (any(x in str(constructor) for x in ("pyarrow", "modin")) and is_windows())
-        or ("pandas_pyarrow" in str(constructor) and parse_version(pd.__version__) < (2,))
-        or ("pyarrow_table" in str(constructor) and parse_version(pa.__version__) < (12,))
+        or ("pandas_pyarrow" in str(constructor) and pandas_version < (2,))
+        or ("pyarrow_table" in str(constructor) and pyarrow_version < (12,))
         or ("cudf" in str(constructor))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -45,12 +45,15 @@ def test_replace_time_zone(
 
 
 def test_replace_time_zone_none(
-    constructor: Constructor, request: pytest.FixtureRequest
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
 ) -> None:
     if (
         (any(x in str(constructor) for x in ("pyarrow", "modin")) and is_windows())
-        or ("pandas_pyarrow" in str(constructor) and parse_version(pd.__version__) < (2,))
-        or ("pyarrow_table" in str(constructor) and parse_version(pa.__version__) < (12,))
+        or ("pandas_pyarrow" in str(constructor) and pandas_version < (2,))
+        or ("pyarrow_table" in str(constructor) and pyarrow_version < (12,))
     ):
         request.applymarker(pytest.mark.xfail)
     data = {
@@ -70,18 +73,15 @@ def test_replace_time_zone_none(
 
 
 def test_replace_time_zone_series(
-    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
+    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
 ) -> None:
     if (
         (any(x in str(constructor_eager) for x in ("pyarrow", "modin")) and is_windows())
-        or (
-            "pandas_pyarrow" in str(constructor_eager)
-            and parse_version(pd.__version__) < (2,)
-        )
-        or (
-            "pyarrow_table" in str(constructor_eager)
-            and parse_version(pa.__version__) < (12,)
-        )
+        or ("pandas_pyarrow" in str(constructor_eager) and pandas_version < (2,))
+        or ("pyarrow_table" in str(constructor_eager) and pyarrow_version < (12,))
         or ("cudf" in str(constructor_eager))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -102,18 +102,15 @@ def test_replace_time_zone_series(
 
 
 def test_replace_time_zone_none_series(
-    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
+    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
 ) -> None:
     if (
         (any(x in str(constructor_eager) for x in ("pyarrow", "modin")) and is_windows())
-        or (
-            "pandas_pyarrow" in str(constructor_eager)
-            and parse_version(pd.__version__) < (2,)
-        )
-        or (
-            "pyarrow_table" in str(constructor_eager)
-            and parse_version(pa.__version__) < (12,)
-        )
+        or ("pandas_pyarrow" in str(constructor_eager) and pandas_version < (2,))
+        or ("pyarrow_table" in str(constructor_eager) and pyarrow_version < (12,))
     ):
         request.applymarker(pytest.mark.xfail)
     data = {

--- a/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
+++ b/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PYARROW_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -28,7 +29,6 @@ def test_str_to_uppercase(
     data: dict[str, list[str]],
     expected: dict[str, list[str]],
     request: pytest.FixtureRequest,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
     df = nw.from_native(constructor(data))
     result_frame = df.select(nw.col("a").str.to_uppercase())
@@ -40,7 +40,7 @@ def test_str_to_uppercase(
             "pyarrow_table_constructor",
             "modin_constructor",
         )
-        or ("dask" in str(constructor) and pyarrow_version >= (12,))
+        or ("dask" in str(constructor) and PYARROW_VERSION >= (12,))
     ):
         # We are marking it xfail for these conditions above
         # since the pyarrow backend will convert

--- a/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
+++ b/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -30,6 +28,7 @@ def test_str_to_uppercase(
     data: dict[str, list[str]],
     expected: dict[str, list[str]],
     request: pytest.FixtureRequest,
+    pyarrow_version: tuple[int, ...],
 ) -> None:
     df = nw.from_native(constructor(data))
     result_frame = df.select(nw.col("a").str.to_uppercase())
@@ -41,7 +40,7 @@ def test_str_to_uppercase(
             "pyarrow_table_constructor",
             "modin_constructor",
         )
-        or ("dask" in str(constructor) and parse_version(pa.__version__) >= (12,))
+        or ("dask" in str(constructor) and pyarrow_version >= (12,))
     ):
         # We are marking it xfail for these conditions above
         # since the pyarrow backend will convert

--- a/tests/frame/array_dunder_test.py
+++ b/tests/frame/array_dunder_test.py
@@ -4,6 +4,9 @@ import numpy as np
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
+from tests.utils import POLARS_VERSION
+from tests.utils import PYARROW_VERSION
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -11,9 +14,8 @@ from tests.utils import assert_equal_data
 def test_array_dunder(
     request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (
+    if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (
         16,
         0,
         0,
@@ -28,9 +30,8 @@ def test_array_dunder(
 def test_array_dunder_with_dtype(
     request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (
+    if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (
         16,
         0,
         0,
@@ -45,17 +46,14 @@ def test_array_dunder_with_dtype(
 def test_array_dunder_with_copy(
     request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
-    pandas_version: tuple[int, ...],
-    polars_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (
+    if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (
         16,
         0,
         0,
     ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
-    if "polars" in str(constructor_eager) and polars_version < (
+    if "polars" in str(constructor_eager) and POLARS_VERSION < (
         0,
         20,
         28,
@@ -65,7 +63,7 @@ def test_array_dunder_with_copy(
     df = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)
     result = df.__array__(copy=True)
     np.testing.assert_array_equal(result, np.array([[1], [2], [3]], dtype="int64"))
-    if "pandas_constructor" in str(constructor_eager) and pandas_version < (3,):
+    if "pandas_constructor" in str(constructor_eager) and PANDAS_VERSION < (3,):
         # If it's pandas, we know that `copy=False` definitely took effect.
         # So, let's check it!
         result = df.__array__(copy=False)

--- a/tests/frame/array_dunder_test.py
+++ b/tests/frame/array_dunder_test.py
@@ -1,23 +1,23 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
-import polars as pl
-import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
 
 def test_array_dunder(
-    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
+    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager,
+    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and parse_version(
-        pa.__version__
-    ) < parse_version("16.0.0"):  # pragma: no cover
+    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (
+        16,
+        0,
+        0,
+    ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)
@@ -26,11 +26,15 @@ def test_array_dunder(
 
 
 def test_array_dunder_with_dtype(
-    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
+    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager,
+    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and parse_version(
-        pa.__version__
-    ) < parse_version("16.0.0"):  # pragma: no cover
+    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (
+        16,
+        0,
+        0,
+    ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)
@@ -39,15 +43,19 @@ def test_array_dunder_with_dtype(
 
 
 def test_array_dunder_with_copy(
-    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
+    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager,
+    pandas_version: tuple[int, ...],
+    polars_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and parse_version(pa.__version__) < (
+    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (
         16,
         0,
         0,
     ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
-    if "polars" in str(constructor_eager) and parse_version(pl.__version__) < (
+    if "polars" in str(constructor_eager) and polars_version < (
         0,
         20,
         28,
@@ -57,9 +65,7 @@ def test_array_dunder_with_copy(
     df = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)
     result = df.__array__(copy=True)
     np.testing.assert_array_equal(result, np.array([[1], [2], [3]], dtype="int64"))
-    if "pandas_constructor" in str(constructor_eager) and parse_version(
-        pd.__version__
-    ) < (3,):
+    if "pandas_constructor" in str(constructor_eager) and pandas_version < (3,):
         # If it's pandas, we know that `copy=False` definitely took effect.
         # So, let's check it!
         result = df.__array__(copy=False)

--- a/tests/frame/arrow_c_stream_test.py
+++ b/tests/frame/arrow_c_stream_test.py
@@ -6,33 +6,26 @@ import pyarrow.compute as pc
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import POLARS_VERSION
+from tests.utils import PYARROW_VERSION
 
 
-def test_arrow_c_stream_test(
-    request: pytest.FixtureRequest,
-    polars_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
-) -> None:
-    if polars_version < (1, 3):  # pragma: no cover
-        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in Polars"))
-    if pyarrow_version < (16, 0, 0):  # pragma: no cover
-        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in PyArrow"))
+@pytest.mark.skipif(POLARS_VERSION < (1, 3), reason="too old for pycapsule in Polars")
+@pytest.mark.skipif(
+    PYARROW_VERSION < (16, 0, 0), reason="too old for pycapsule in PyArrow"
+)
+def test_arrow_c_stream_test() -> None:
     df = nw.from_native(pl.Series([1, 2, 3]).to_frame("a"), eager_only=True)
     result = pa.table(df)
     expected = pa.table({"a": [1, 2, 3]})
     assert pc.all(pc.equal(result["a"], expected["a"])).as_py()
 
 
-def test_arrow_c_stream_test_invalid(
-    monkeypatch: pytest.MonkeyPatch,
-    request: pytest.FixtureRequest,
-    polars_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
-) -> None:
-    if polars_version < (1, 3):  # pragma: no cover
-        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in Polars"))
-    if pyarrow_version < (16, 0, 0):  # pragma: no cover
-        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in PyArrow"))
+@pytest.mark.skipif(POLARS_VERSION < (1, 3), reason="too old for pycapsule in Polars")
+@pytest.mark.skipif(
+    PYARROW_VERSION < (16, 0, 0), reason="too old for pycapsule in PyArrow"
+)
+def test_arrow_c_stream_test_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
     # "poison" the dunder method to make sure it actually got called above
     monkeypatch.setattr(
         "narwhals.dataframe.DataFrame.__arrow_c_stream__", lambda *_: 1 / 0
@@ -42,16 +35,11 @@ def test_arrow_c_stream_test_invalid(
         pa.table(df)
 
 
-def test_arrow_c_stream_test_fallback(
-    monkeypatch: pytest.MonkeyPatch,
-    request: pytest.FixtureRequest,
-    polars_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
-) -> None:
-    if polars_version < (1, 3):  # pragma: no cover
-        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in Polars"))
-    if pyarrow_version < (16, 0, 0):  # pragma: no cover
-        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in PyArrow"))
+@pytest.mark.skipif(POLARS_VERSION < (1, 3), reason="too old for pycapsule in Polars")
+@pytest.mark.skipif(
+    PYARROW_VERSION < (16, 0, 0), reason="too old for pycapsule in PyArrow"
+)
+def test_arrow_c_stream_test_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     # Check that fallback to PyArrow works
     monkeypatch.delattr("polars.DataFrame.__arrow_c_stream__")
     df = nw.from_native(pl.Series([1, 2, 3]).to_frame("a"), eager_only=True)

--- a/tests/frame/arrow_c_stream_test.py
+++ b/tests/frame/arrow_c_stream_test.py
@@ -14,9 +14,9 @@ def test_arrow_c_stream_test(
     pyarrow_version: tuple[int, ...],
 ) -> None:
     if polars_version < (1, 3):  # pragma: no cover
-        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in Polars"))
+        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in Polars"))
     if pyarrow_version < (16, 0, 0):  # pragma: no cover
-        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in PyArrow"))
+        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in PyArrow"))
     df = nw.from_native(pl.Series([1, 2, 3]).to_frame("a"), eager_only=True)
     result = pa.table(df)
     expected = pa.table({"a": [1, 2, 3]})
@@ -30,9 +30,9 @@ def test_arrow_c_stream_test_invalid(
     pyarrow_version: tuple[int, ...],
 ) -> None:
     if polars_version < (1, 3):  # pragma: no cover
-        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in Polars"))
+        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in Polars"))
     if pyarrow_version < (16, 0, 0):  # pragma: no cover
-        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in PyArrow"))
+        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in PyArrow"))
     # "poison" the dunder method to make sure it actually got called above
     monkeypatch.setattr(
         "narwhals.dataframe.DataFrame.__arrow_c_stream__", lambda *_: 1 / 0
@@ -49,9 +49,9 @@ def test_arrow_c_stream_test_fallback(
     pyarrow_version: tuple[int, ...],
 ) -> None:
     if polars_version < (1, 3):  # pragma: no cover
-        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in Polars"))
+        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in Polars"))
     if pyarrow_version < (16, 0, 0):  # pragma: no cover
-        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in PyArrow"))
+        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in PyArrow"))
     # Check that fallback to PyArrow works
     monkeypatch.delattr("polars.DataFrame.__arrow_c_stream__")
     df = nw.from_native(pl.Series([1, 2, 3]).to_frame("a"), eager_only=True)

--- a/tests/frame/arrow_c_stream_test.py
+++ b/tests/frame/arrow_c_stream_test.py
@@ -6,29 +6,33 @@ import pyarrow.compute as pc
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 
-@pytest.mark.skipif(
-    parse_version(pl.__version__) < (1, 3), reason="too old for pycapsule in Polars"
-)
-@pytest.mark.skipif(
-    parse_version(pa.__version__) < (16, 0, 0), reason="too old for pycapsule in PyArrow"
-)
-def test_arrow_c_stream_test() -> None:
+def test_arrow_c_stream_test(
+    request: pytest.FixtureRequest,
+    polars_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
+) -> None:
+    if polars_version < (1, 3):  # pragma: no cover
+        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in Polars"))
+    if pyarrow_version < (16, 0, 0):  # pragma: no cover
+        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in PyArrow"))
     df = nw.from_native(pl.Series([1, 2, 3]).to_frame("a"), eager_only=True)
     result = pa.table(df)
     expected = pa.table({"a": [1, 2, 3]})
     assert pc.all(pc.equal(result["a"], expected["a"])).as_py()
 
 
-@pytest.mark.skipif(
-    parse_version(pl.__version__) < (1, 3), reason="too old for pycapsule in Polars"
-)
-@pytest.mark.skipif(
-    parse_version(pa.__version__) < (16, 0, 0), reason="too old for pycapsule in PyArrow"
-)
-def test_arrow_c_stream_test_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_arrow_c_stream_test_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    polars_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
+) -> None:
+    if polars_version < (1, 3):  # pragma: no cover
+        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in Polars"))
+    if pyarrow_version < (16, 0, 0):  # pragma: no cover
+        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in PyArrow"))
     # "poison" the dunder method to make sure it actually got called above
     monkeypatch.setattr(
         "narwhals.dataframe.DataFrame.__arrow_c_stream__", lambda *_: 1 / 0
@@ -38,13 +42,16 @@ def test_arrow_c_stream_test_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
         pa.table(df)
 
 
-@pytest.mark.skipif(
-    parse_version(pl.__version__) < (1, 3), reason="too old for pycapsule in Polars"
-)
-@pytest.mark.skipif(
-    parse_version(pa.__version__) < (16, 0, 0), reason="too old for pycapsule in PyArrow"
-)
-def test_arrow_c_stream_test_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_arrow_c_stream_test_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    polars_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
+) -> None:
+    if polars_version < (1, 3):  # pragma: no cover
+        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in Polars"))
+    if pyarrow_version < (16, 0, 0):  # pragma: no cover
+        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in PyArrow"))
     # Check that fallback to PyArrow works
     monkeypatch.delattr("polars.DataFrame.__arrow_c_stream__")
     df = nw.from_native(pl.Series([1, 2, 3]).to_frame("a"), eager_only=True)

--- a/tests/frame/drop_test.py
+++ b/tests/frame/drop_test.py
@@ -4,13 +4,11 @@ from contextlib import nullcontext as does_not_raise
 from typing import TYPE_CHECKING
 from typing import Any
 
-import polars as pl
 import pytest
 from polars.exceptions import ColumnNotFoundError as PlColumnNotFoundError
 
 import narwhals.stable.v1 as nw
 from narwhals._exceptions import ColumnNotFoundError
-from narwhals.utils import parse_version
 
 if TYPE_CHECKING:
     from tests.utils import Constructor
@@ -46,14 +44,11 @@ def test_drop_strict(
     request: pytest.FixtureRequest,
     constructor: Constructor,
     context: Any,
+    polars_version: tuple[int, ...],
     *,
     strict: bool,
 ) -> None:
-    if (
-        "polars_lazy" in str(request)
-        and parse_version(pl.__version__) < (1, 0, 0)
-        and strict
-    ):
+    if "polars_lazy" in str(request) and polars_version < (1, 0, 0) and strict:
         request.applymarker(pytest.mark.xfail)
 
     data = {"a": [1, 3, 2], "b": [4, 4, 6]}

--- a/tests/frame/drop_test.py
+++ b/tests/frame/drop_test.py
@@ -9,6 +9,7 @@ from polars.exceptions import ColumnNotFoundError as PlColumnNotFoundError
 
 import narwhals.stable.v1 as nw
 from narwhals._exceptions import ColumnNotFoundError
+from tests.utils import POLARS_VERSION
 
 if TYPE_CHECKING:
     from tests.utils import Constructor
@@ -44,11 +45,10 @@ def test_drop_strict(
     request: pytest.FixtureRequest,
     constructor: Constructor,
     context: Any,
-    polars_version: tuple[int, ...],
     *,
     strict: bool,
 ) -> None:
-    if "polars_lazy" in str(request) and polars_version < (1, 0, 0) and strict:
+    if "polars_lazy" in str(request) and POLARS_VERSION < (1, 0, 0) and strict:
         request.applymarker(pytest.mark.xfail)
 
     data = {"a": [1, 3, 2], "b": [4, 4, 6]}

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -10,7 +10,6 @@ import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 
 def test_interchange_schema() -> None:
@@ -72,7 +71,7 @@ def test_interchange_schema() -> None:
 
 @pytest.mark.filterwarnings("ignore:.*locale specific date formats")
 def test_interchange_schema_ibis(
-    tmpdir: pytest.TempdirFactory,
+    tmpdir: pytest.TempdirFactory, ibis_version: tuple[int, ...]
 ) -> None:  # pragma: no cover
     ibis = pytest.importorskip("ibis")
     df_pl = pl.DataFrame(
@@ -116,7 +115,7 @@ def test_interchange_schema_ibis(
     tbl = ibis.read_parquet(filepath)
     df = nw.from_native(tbl, eager_or_interchange_only=True)
     result = df.schema
-    if parse_version(ibis.__version__) > (6, 0, 0):
+    if ibis_version > (6, 0, 0):
         expected = {
             "a": nw.Int64,
             "b": nw.Int32,

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -10,6 +10,7 @@ import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import IBIS_VERSION
 
 
 def test_interchange_schema() -> None:
@@ -71,7 +72,7 @@ def test_interchange_schema() -> None:
 
 @pytest.mark.filterwarnings("ignore:.*locale specific date formats")
 def test_interchange_schema_ibis(
-    tmpdir: pytest.TempdirFactory, ibis_version: tuple[int, ...]
+    tmpdir: pytest.TempdirFactory,
 ) -> None:  # pragma: no cover
     ibis = pytest.importorskip("ibis")
     df_pl = pl.DataFrame(
@@ -115,7 +116,7 @@ def test_interchange_schema_ibis(
     tbl = ibis.read_parquet(filepath)
     df = nw.from_native(tbl, eager_or_interchange_only=True)
     result = df.schema
-    if ibis_version > (6, 0, 0):
+    if IBIS_VERSION > (6, 0, 0):
         expected = {
             "a": nw.Int64,
             "b": nw.Int32,

--- a/tests/frame/interchange_to_pandas_test.py
+++ b/tests/frame/interchange_to_pandas_test.py
@@ -5,14 +5,13 @@ import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 
 data = {"a": [1, 2, 3], "b": [4.0, 5.0, 6.0], "z": ["x", "y", "z"]}
 
 
-def test_interchange_to_pandas(
-    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
-) -> None:
-    if pandas_version < (1, 5, 0):
+def test_interchange_to_pandas(request: pytest.FixtureRequest) -> None:
+    if PANDAS_VERSION < (1, 5, 0):
         request.applymarker(pytest.mark.xfail)
     df_raw = pd.DataFrame(data)
     df = nw.from_native(df_raw.__dataframe__(), eager_or_interchange_only=True)
@@ -23,9 +22,8 @@ def test_interchange_to_pandas(
 def test_interchange_ibis_to_pandas(
     tmpdir: pytest.TempdirFactory,
     request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
 ) -> None:  # pragma: no cover
-    if pandas_version < (1, 5, 0):
+    if PANDAS_VERSION < (1, 5, 0):
         request.applymarker(pytest.mark.xfail)
 
     ibis = pytest.importorskip("ibis")
@@ -40,10 +38,8 @@ def test_interchange_ibis_to_pandas(
     assert df.to_pandas().equals(df_raw)
 
 
-def test_interchange_duckdb_to_pandas(
-    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
-) -> None:
-    if pandas_version < (1, 0, 0):
+def test_interchange_duckdb_to_pandas(request: pytest.FixtureRequest) -> None:
+    if PANDAS_VERSION < (1, 0, 0):
         request.applymarker(pytest.mark.xfail)
     df_raw = pd.DataFrame(data)
     rel = duckdb.sql("select * from df_raw")

--- a/tests/frame/interchange_to_pandas_test.py
+++ b/tests/frame/interchange_to_pandas_test.py
@@ -5,13 +5,14 @@ import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 data = {"a": [1, 2, 3], "b": [4.0, 5.0, 6.0], "z": ["x", "y", "z"]}
 
 
-def test_interchange_to_pandas(request: pytest.FixtureRequest) -> None:
-    if parse_version(pd.__version__) < parse_version("1.5.0"):
+def test_interchange_to_pandas(
+    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
+) -> None:
+    if pandas_version < (1, 5, 0):
         request.applymarker(pytest.mark.xfail)
     df_raw = pd.DataFrame(data)
     df = nw.from_native(df_raw.__dataframe__(), eager_or_interchange_only=True)
@@ -20,9 +21,11 @@ def test_interchange_to_pandas(request: pytest.FixtureRequest) -> None:
 
 
 def test_interchange_ibis_to_pandas(
-    tmpdir: pytest.TempdirFactory, request: pytest.FixtureRequest
+    tmpdir: pytest.TempdirFactory,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
 ) -> None:  # pragma: no cover
-    if parse_version(pd.__version__) < parse_version("1.5.0"):
+    if pandas_version < (1, 5, 0):
         request.applymarker(pytest.mark.xfail)
 
     ibis = pytest.importorskip("ibis")
@@ -37,8 +40,10 @@ def test_interchange_ibis_to_pandas(
     assert df.to_pandas().equals(df_raw)
 
 
-def test_interchange_duckdb_to_pandas(request: pytest.FixtureRequest) -> None:
-    if parse_version(pd.__version__) < parse_version("1.0.0"):
+def test_interchange_duckdb_to_pandas(
+    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
+) -> None:
+    if pandas_version < (1, 0, 0):
         request.applymarker(pytest.mark.xfail)
     df_raw = pd.DataFrame(data)
     rel = duckdb.sql("select * from df_raw")

--- a/tests/frame/invalid_test.py
+++ b/tests/frame/invalid_test.py
@@ -44,7 +44,7 @@ def test_validate_laziness() -> None:
 
 def test_memmap(request: pytest.FixtureRequest, numpy_version: tuple[int, ...]) -> None:
     if numpy_version < (1, 26, 4):
-        request.applymarker(pytest.mark.skipif(reason="too old"))
+        request.applymarker(pytest.mark.skip(reason="too old"))
     pytest.importorskip("sklearn")
     # the headache this caused me...
     from sklearn.utils import check_X_y

--- a/tests/frame/invalid_test.py
+++ b/tests/frame/invalid_test.py
@@ -6,6 +6,7 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import NUMPY_VERSION
 
 
 def test_invalid() -> None:
@@ -42,9 +43,8 @@ def test_validate_laziness() -> None:
         nw.concat([nw.from_native(df, eager_only=True), nw.from_native(df).lazy()])  # type: ignore[list-item]
 
 
-def test_memmap(request: pytest.FixtureRequest, numpy_version: tuple[int, ...]) -> None:
-    if numpy_version < (1, 26, 4):
-        request.applymarker(pytest.mark.skip(reason="too old"))
+@pytest.mark.skipif(NUMPY_VERSION < (1, 26, 4), reason="too old")
+def test_memmap() -> None:
     pytest.importorskip("sklearn")
     # the headache this caused me...
     from sklearn.utils import check_X_y

--- a/tests/frame/invalid_test.py
+++ b/tests/frame/invalid_test.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import numpy as np
 import pandas as pd
 import polars as pl
 import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 
 def test_invalid() -> None:
@@ -44,10 +42,9 @@ def test_validate_laziness() -> None:
         nw.concat([nw.from_native(df, eager_only=True), nw.from_native(df).lazy()])  # type: ignore[list-item]
 
 
-@pytest.mark.skipif(
-    parse_version(np.__version__) < parse_version("1.26.4"), reason="too old"
-)
-def test_memmap() -> None:
+def test_memmap(request: pytest.FixtureRequest, numpy_version: tuple[int, ...]) -> None:
+    if numpy_version < (1, 26, 4):
+        request.applymarker(pytest.mark.skipif(reason="too old"))
     pytest.importorskip("sklearn")
     # the headache this caused me...
     from sklearn.utils import check_X_y

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -10,7 +10,6 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from narwhals.utils import Implementation
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
@@ -354,11 +353,13 @@ def test_join_keys_exceptions(constructor: Constructor, how: str) -> None:
 
 
 def test_joinasof_numeric(
-    constructor: Constructor, request: pytest.FixtureRequest
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
 ) -> None:
     if "pyarrow_table" in str(constructor) or "cudf" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    if parse_version(pd.__version__) < (2, 1) and (
+    if pandas_version < (2, 1) and (
         ("pandas_pyarrow" in str(constructor)) or ("pandas_nullable" in str(constructor))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -411,10 +412,14 @@ def test_joinasof_numeric(
     assert_equal_data(result_nearest_on, expected_nearest)
 
 
-def test_joinasof_time(constructor: Constructor, request: pytest.FixtureRequest) -> None:
+def test_joinasof_time(
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+) -> None:
     if "pyarrow_table" in str(constructor) or "cudf" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    if parse_version(pd.__version__) < (2, 1) and ("pandas_pyarrow" in str(constructor)):
+    if pandas_version < (2, 1) and ("pandas_pyarrow" in str(constructor)):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(
         constructor(
@@ -489,10 +494,14 @@ def test_joinasof_time(constructor: Constructor, request: pytest.FixtureRequest)
     assert_equal_data(result_nearest_on, expected_nearest)
 
 
-def test_joinasof_by(constructor: Constructor, request: pytest.FixtureRequest) -> None:
+def test_joinasof_by(
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+) -> None:
     if "pyarrow_table" in str(constructor) or "cudf" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    if parse_version(pd.__version__) < (2, 1) and (
+    if pandas_version < (2, 1) and (
         ("pandas_pyarrow" in str(constructor)) or ("pandas_nullable" in str(constructor))
     ):
         request.applymarker(pytest.mark.xfail)

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -10,6 +10,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from narwhals.utils import Implementation
+from tests.utils import PANDAS_VERSION
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
@@ -355,11 +356,10 @@ def test_join_keys_exceptions(constructor: Constructor, how: str) -> None:
 def test_joinasof_numeric(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
 ) -> None:
     if "pyarrow_table" in str(constructor) or "cudf" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    if pandas_version < (2, 1) and (
+    if PANDAS_VERSION < (2, 1) and (
         ("pandas_pyarrow" in str(constructor)) or ("pandas_nullable" in str(constructor))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -415,11 +415,10 @@ def test_joinasof_numeric(
 def test_joinasof_time(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
 ) -> None:
     if "pyarrow_table" in str(constructor) or "cudf" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    if pandas_version < (2, 1) and ("pandas_pyarrow" in str(constructor)):
+    if PANDAS_VERSION < (2, 1) and ("pandas_pyarrow" in str(constructor)):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(
         constructor(
@@ -497,11 +496,10 @@ def test_joinasof_time(
 def test_joinasof_by(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
 ) -> None:
     if "pyarrow_table" in str(constructor) or "cudf" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    if pandas_version < (2, 1) and (
+    if PANDAS_VERSION < (2, 1) and (
         ("pandas_pyarrow" in str(constructor)) or ("pandas_nullable" in str(constructor))
     ):
         request.applymarker(pytest.mark.xfail)

--- a/tests/frame/schema_test.py
+++ b/tests/frame/schema_test.py
@@ -13,6 +13,7 @@ import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 
 if TYPE_CHECKING:
     from tests.utils import Constructor
@@ -80,9 +81,8 @@ def test_actual_object(
     assert result == {"a": nw.Object}
 
 
-def test_dtypes(request: pytest.FixtureRequest, pandas_version: tuple[int, ...]) -> None:
-    if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="too old"))
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="too old")
+def test_dtypes() -> None:
     df_pl = pl.DataFrame(
         {
             "a": [1],
@@ -196,13 +196,11 @@ def test_schema_object(method: str, expected: Any) -> None:
     assert getattr(schema, method)() == expected
 
 
-def test_from_non_hashable_column_name(
-    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
-) -> None:
-    if pandas_version < (2,):
-        request.applymarker(
-            pytest.mark.skip(reason="Before 2.0, pandas would raise on `drop_duplicates`")
-        )
+@pytest.mark.skipif(
+    PANDAS_VERSION < (2,),
+    reason="Before 2.0, pandas would raise on `drop_duplicates`",
+)
+def test_from_non_hashable_column_name() -> None:
     # This is technically super-illegal
     # BUT, it shows up in a scikit-learn test, so...
     df = pd.DataFrame([[1, 2], [3, 4]], columns=["pizza", ["a", "b"]])
@@ -212,11 +210,11 @@ def test_from_non_hashable_column_name(
     assert df["pizza"].dtype == nw.Int64
 
 
-def test_nested_dtypes(
-    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
-) -> None:
-    if pandas_version < (2, 2, 0):
-        request.applymarker(pytest.mark.skip(reason="too old for pyarrow types"))
+@pytest.mark.skipif(
+    PANDAS_VERSION < (2, 2, 0),
+    reason="too old for pyarrow types",
+)
+def test_nested_dtypes() -> None:
     df = pl.DataFrame(
         {"a": [[1, 2]], "b": [[1, 2]], "c": [{"a": 1}]},
         schema_overrides={"b": pl.Array(pl.Int64, 2)},
@@ -268,11 +266,11 @@ def test_nested_dtypes_ibis() -> None:  # pragma: no cover
     assert nwdf.schema == {"a": nw.List(nw.Int64), "c": nw.Struct({"a": nw.Int64})}
 
 
-def test_nested_dtypes_dask(
-    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
-) -> None:
-    if pandas_version < (2, 2, 0):
-        request.applymarker(pytest.mark.skip(reason="too old for pyarrow types"))
+@pytest.mark.skipif(
+    PANDAS_VERSION < (2, 2, 0),
+    reason="too old for pyarrow types",
+)
+def test_nested_dtypes_dask() -> None:
     pytest.importorskip("dask")
     pytest.importorskip("dask_expr", exc_type=ImportError)
     import dask.dataframe as dd

--- a/tests/frame/schema_test.py
+++ b/tests/frame/schema_test.py
@@ -82,7 +82,7 @@ def test_actual_object(
 
 def test_dtypes(request: pytest.FixtureRequest, pandas_version: tuple[int, ...]) -> None:
     if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="too old"))
+        request.applymarker(pytest.mark.skip(reason="too old"))
     df_pl = pl.DataFrame(
         {
             "a": [1],
@@ -201,9 +201,7 @@ def test_from_non_hashable_column_name(
 ) -> None:
     if pandas_version < (2,):
         request.applymarker(
-            pytest.mark.skipif(
-                reason="Before 2.0, pandas would raise on `drop_duplicates`"
-            )
+            pytest.mark.skip(reason="Before 2.0, pandas would raise on `drop_duplicates`")
         )
     # This is technically super-illegal
     # BUT, it shows up in a scikit-learn test, so...
@@ -218,7 +216,7 @@ def test_nested_dtypes(
     request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
 ) -> None:
     if pandas_version < (2, 2, 0):
-        request.applymarker(pytest.mark.skipif(reason="too old for pyarrow types"))
+        request.applymarker(pytest.mark.skip(reason="too old for pyarrow types"))
     df = pl.DataFrame(
         {"a": [[1, 2]], "b": [[1, 2]], "c": [{"a": 1}]},
         schema_overrides={"b": pl.Array(pl.Int64, 2)},
@@ -274,7 +272,7 @@ def test_nested_dtypes_dask(
     request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
 ) -> None:
     if pandas_version < (2, 2, 0):
-        request.applymarker(pytest.mark.skipif(reason="too old for pyarrow types"))
+        request.applymarker(pytest.mark.skip(reason="too old for pyarrow types"))
     pytest.importorskip("dask")
     pytest.importorskip("dask_expr", exc_type=ImportError)
     import dask.dataframe as dd

--- a/tests/frame/to_arrow_test.py
+++ b/tests/frame/to_arrow_test.py
@@ -6,6 +6,7 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
@@ -14,9 +15,8 @@ if TYPE_CHECKING:
 def test_to_arrow(
     request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
-    pandas_version: tuple[int, ...],
 ) -> None:
-    if "pandas" in str(constructor_eager) and pandas_version < (1, 0, 0):
+    if "pandas" in str(constructor_eager) and PANDAS_VERSION < (1, 0, 0):
         # pyarrow requires pandas>=1.0.0
         request.applymarker(pytest.mark.xfail)
 

--- a/tests/frame/to_arrow_test.py
+++ b/tests/frame/to_arrow_test.py
@@ -2,21 +2,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pandas as pd
 import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
 
 
 def test_to_arrow(
-    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
+    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager,
+    pandas_version: tuple[int, ...],
 ) -> None:
-    if "pandas" in str(constructor_eager) and parse_version(pd.__version__) < (1, 0, 0):
+    if "pandas" in str(constructor_eager) and pandas_version < (1, 0, 0):
         # pyarrow requires pandas>=1.0.0
         request.applymarker(pytest.mark.xfail)
 

--- a/tests/frame/to_pandas_test.py
+++ b/tests/frame/to_pandas_test.py
@@ -18,7 +18,7 @@ def test_convert_pandas(
     pandas_version: tuple[int, ...],
 ) -> None:
     if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="too old for pandas-pyarrow"))
+        request.applymarker(pytest.mark.skip(reason="too old for pandas-pyarrow"))
     if "modin" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}

--- a/tests/frame/to_pandas_test.py
+++ b/tests/frame/to_pandas_test.py
@@ -6,20 +6,19 @@ import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
 
 
 @pytest.mark.filterwarnings("ignore:.*Passing a BlockManager.*:DeprecationWarning")
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < parse_version("2.0.0"),
-    reason="too old for pandas-pyarrow",
-)
 def test_convert_pandas(
-    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
+    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
 ) -> None:
+    if pandas_version < (2, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="too old for pandas-pyarrow"))
     if "modin" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}

--- a/tests/frame/to_pandas_test.py
+++ b/tests/frame/to_pandas_test.py
@@ -6,19 +6,21 @@ import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
 
 
 @pytest.mark.filterwarnings("ignore:.*Passing a BlockManager.*:DeprecationWarning")
+@pytest.mark.skipif(
+    PANDAS_VERSION < (2, 0, 0),
+    reason="too old for pandas-pyarrow",
+)
 def test_convert_pandas(
     constructor_eager: ConstructorEager,
     request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
 ) -> None:
-    if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="too old for pandas-pyarrow"))
     if "modin" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}

--- a/tests/frame/unpivot_test.py
+++ b/tests/frame/unpivot_test.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PYARROW_VERSION
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
@@ -92,12 +93,11 @@ def test_unpivot_mixed_types(
     constructor: Constructor,
     data: dict[str, Any],
     expected_dtypes: list[DType],
-    pyarrow_version: tuple[int, ...],
 ) -> None:
     if (
         "dask" in str(constructor)
         or "cudf" in str(constructor)
-        or ("pyarrow_table" in str(constructor) and pyarrow_version < (14, 0, 0))
+        or ("pyarrow_table" in str(constructor) and PYARROW_VERSION < (14, 0, 0))
     ):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))

--- a/tests/frame/unpivot_test.py
+++ b/tests/frame/unpivot_test.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 
-import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
@@ -94,14 +92,12 @@ def test_unpivot_mixed_types(
     constructor: Constructor,
     data: dict[str, Any],
     expected_dtypes: list[DType],
+    pyarrow_version: tuple[int, ...],
 ) -> None:
     if (
         "dask" in str(constructor)
         or "cudf" in str(constructor)
-        or (
-            "pyarrow_table" in str(constructor)
-            and parse_version(pa.__version__) < parse_version("14.0.0")
-        )
+        or ("pyarrow_table" in str(constructor) and pyarrow_version < (14, 0, 0))
     ):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))

--- a/tests/frame/with_columns_test.py
+++ b/tests/frame/with_columns_test.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
-import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
@@ -48,9 +46,11 @@ def test_with_columns_order_single_row(constructor: Constructor) -> None:
 
 
 def test_with_columns_dtypes_single_row(
-    constructor: Constructor, request: pytest.FixtureRequest
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor) and parse_version(pa.__version__) < (15,):
+    if "pyarrow_table" in str(constructor) and pyarrow_version < (15,):
         request.applymarker(pytest.mark.xfail)
     data = {"a": ["foo"]}
     df = nw.from_native(constructor(data)).with_columns(nw.col("a").cast(nw.Categorical))

--- a/tests/frame/with_columns_test.py
+++ b/tests/frame/with_columns_test.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PYARROW_VERSION
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
@@ -48,9 +49,8 @@ def test_with_columns_order_single_row(constructor: Constructor) -> None:
 def test_with_columns_dtypes_single_row(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor) and pyarrow_version < (15,):
+    if "pyarrow_table" in str(constructor) and PYARROW_VERSION < (15,):
         request.applymarker(pytest.mark.xfail)
     data = {"a": ["foo"]}
     df = nw.from_native(constructor(data)).with_columns(nw.col("a").cast(nw.Categorical))

--- a/tests/frame/write_parquet_test.py
+++ b/tests/frame/write_parquet_test.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
@@ -14,12 +12,14 @@ if TYPE_CHECKING:
 data = {"a": [1, 2, 3]}
 
 
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < parse_version("2.0.0"), reason="too old for pyarrow"
-)
 def test_write_parquet(
-    constructor_eager: ConstructorEager, tmpdir: pytest.TempdirFactory
+    constructor_eager: ConstructorEager,
+    tmpdir: pytest.TempdirFactory,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
 ) -> None:
+    if pandas_version < (2, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="too old for pyarrow"))
     path = tmpdir / "foo.parquet"  # type: ignore[operator]
     nw.from_native(constructor_eager(data), eager_only=True).write_parquet(str(path))
     assert path.exists()

--- a/tests/frame/write_parquet_test.py
+++ b/tests/frame/write_parquet_test.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
@@ -12,14 +13,11 @@ if TYPE_CHECKING:
 data = {"a": [1, 2, 3]}
 
 
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="too old for pyarrow")
 def test_write_parquet(
     constructor_eager: ConstructorEager,
     tmpdir: pytest.TempdirFactory,
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
 ) -> None:
-    if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="too old for pyarrow"))
     path = tmpdir / "foo.parquet"  # type: ignore[operator]
     nw.from_native(constructor_eager(data), eager_only=True).write_parquet(str(path))
     assert path.exists()

--- a/tests/frame/write_parquet_test.py
+++ b/tests/frame/write_parquet_test.py
@@ -19,7 +19,7 @@ def test_write_parquet(
     pandas_version: tuple[int, ...],
 ) -> None:
     if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="too old for pyarrow"))
+        request.applymarker(pytest.mark.skip(reason="too old for pyarrow"))
     path = tmpdir / "foo.parquet"  # type: ignore[operator]
     nw.from_native(constructor_eager(data), eager_only=True).write_parquet(str(path))
     assert path.exists()

--- a/tests/from_pycapsule_test.py
+++ b/tests/from_pycapsule_test.py
@@ -8,14 +8,12 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PYARROW_VERSION
 from tests.utils import assert_equal_data
 
 
-def test_from_arrow_to_arrow(
-    request: pytest.FixtureRequest, pyarrow_version: tuple[int, ...]
-) -> None:
-    if pyarrow_version < (14,):
-        request.applymarker(pytest.mark.xfail(reason="too old"))
+@pytest.mark.xfail(PYARROW_VERSION < (14,), reason="too old")
+def test_from_arrow_to_arrow() -> None:
     df = nw.from_native(pl.DataFrame({"ab": [1, 2, 3], "ba": [4, 5, 6]}), eager_only=True)
     result = nw.from_arrow(df, native_namespace=pa)
     assert isinstance(result.to_native(), pa.Table)
@@ -23,13 +21,8 @@ def test_from_arrow_to_arrow(
     assert_equal_data(result, expected)
 
 
-def test_from_arrow_to_polars(
-    request: pytest.FixtureRequest,
-    pyarrow_version: tuple[int, ...],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    if pyarrow_version < (14,):
-        request.applymarker(pytest.mark.xfail(reason="too old"))
+@pytest.mark.xfail(PYARROW_VERSION < (14,), reason="too old")
+def test_from_arrow_to_polars(monkeypatch: pytest.MonkeyPatch) -> None:
     tbl = pa.table({"ab": [1, 2, 3], "ba": [4, 5, 6]})
     monkeypatch.delitem(sys.modules, "pandas")
     df = nw.from_native(tbl, eager_only=True)
@@ -40,11 +33,8 @@ def test_from_arrow_to_polars(
     assert "pandas" not in sys.modules
 
 
-def test_from_arrow_to_pandas(
-    request: pytest.FixtureRequest, pyarrow_version: tuple[int, ...]
-) -> None:
-    if pyarrow_version < (14,):
-        request.applymarker(pytest.mark.xfail(reason="too old"))
+@pytest.mark.xfail(PYARROW_VERSION < (14,), reason="too old")
+def test_from_arrow_to_pandas() -> None:
     df = nw.from_native(pa.table({"ab": [1, 2, 3], "ba": [4, 5, 6]}), eager_only=True)
     result = nw.from_arrow(df, native_namespace=pd)
     assert isinstance(result.to_native(), pd.DataFrame)

--- a/tests/from_pycapsule_test.py
+++ b/tests/from_pycapsule_test.py
@@ -8,12 +8,14 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import assert_equal_data
 
 
-@pytest.mark.xfail(parse_version(pa.__version__) < (14,), reason="too old")
-def test_from_arrow_to_arrow() -> None:
+def test_from_arrow_to_arrow(
+    request: pytest.FixtureRequest, pyarrow_version: tuple[int, ...]
+) -> None:
+    if pyarrow_version < (14,):
+        request.applymarker(pytest.mark.xfail(reason="too old"))
     df = nw.from_native(pl.DataFrame({"ab": [1, 2, 3], "ba": [4, 5, 6]}), eager_only=True)
     result = nw.from_arrow(df, native_namespace=pa)
     assert isinstance(result.to_native(), pa.Table)
@@ -21,8 +23,13 @@ def test_from_arrow_to_arrow() -> None:
     assert_equal_data(result, expected)
 
 
-@pytest.mark.xfail(parse_version(pa.__version__) < (14,), reason="too old")
-def test_from_arrow_to_polars(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_from_arrow_to_polars(
+    request: pytest.FixtureRequest,
+    pyarrow_version: tuple[int, ...],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if pyarrow_version < (14,):
+        request.applymarker(pytest.mark.xfail(reason="too old"))
     tbl = pa.table({"ab": [1, 2, 3], "ba": [4, 5, 6]})
     monkeypatch.delitem(sys.modules, "pandas")
     df = nw.from_native(tbl, eager_only=True)
@@ -33,8 +40,11 @@ def test_from_arrow_to_polars(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "pandas" not in sys.modules
 
 
-@pytest.mark.xfail(parse_version(pa.__version__) < (14,), reason="too old")
-def test_from_arrow_to_pandas() -> None:
+def test_from_arrow_to_pandas(
+    request: pytest.FixtureRequest, pyarrow_version: tuple[int, ...]
+) -> None:
+    if pyarrow_version < (14,):
+        request.applymarker(pytest.mark.xfail(reason="too old"))
     df = nw.from_native(pa.table({"ab": [1, 2, 3], "ba": [4, 5, 6]}), eager_only=True)
     result = nw.from_arrow(df, native_namespace=pd)
     assert isinstance(result.to_native(), pd.DataFrame)

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -8,6 +8,8 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
+from tests.utils import PYARROW_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -232,14 +234,13 @@ def test_group_by_multiple_keys(constructor: Constructor) -> None:
 def test_key_with_nulls(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
 ) -> None:
     if "modin" in str(constructor):
         # TODO(unassigned): Modin flaky here?
         request.applymarker(pytest.mark.skip)
     context = (
         pytest.raises(NotImplementedError, match="null values")
-        if ("pandas_constructor" in str(constructor) and pandas_version < (1, 0, 0))
+        if ("pandas_constructor" in str(constructor) and PANDAS_VERSION < (1, 0, 0))
         else nullcontext()
     )
     data = {"b": [4, 5, None], "a": [1, 2, 3]}
@@ -265,9 +266,8 @@ def test_no_agg(constructor: Constructor) -> None:
 def test_group_by_categorical(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor) and pyarrow_version < (
+    if "pyarrow_table" in str(constructor) and PYARROW_VERSION < (
         15,
         0,
         0,

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -8,7 +8,6 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -230,16 +229,17 @@ def test_group_by_multiple_keys(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
-def test_key_with_nulls(constructor: Constructor, request: pytest.FixtureRequest) -> None:
+def test_key_with_nulls(
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+) -> None:
     if "modin" in str(constructor):
         # TODO(unassigned): Modin flaky here?
         request.applymarker(pytest.mark.skip)
     context = (
         pytest.raises(NotImplementedError, match="null values")
-        if (
-            "pandas_constructor" in str(constructor)
-            and parse_version(pd.__version__) < parse_version("1.0.0")
-        )
+        if ("pandas_constructor" in str(constructor) and pandas_version < (1, 0, 0))
         else nullcontext()
     )
     data = {"b": [4, 5, None], "a": [1, 2, 3]}
@@ -263,9 +263,11 @@ def test_no_agg(constructor: Constructor) -> None:
 
 
 def test_group_by_categorical(
-    constructor: Constructor, request: pytest.FixtureRequest
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor) and parse_version(pa.__version__) < (
+    if "pyarrow_table" in str(constructor) and pyarrow_version < (
         15,
         0,
         0,

--- a/tests/hypothesis/join_test.py
+++ b/tests/hypothesis/join_test.py
@@ -10,6 +10,8 @@ from hypothesis import strategies as st
 from pandas.testing import assert_frame_equal
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
+from tests.utils import POLARS_VERSION
 from tests.utils import assert_equal_data
 
 
@@ -36,20 +38,15 @@ from tests.utils import assert_equal_data
         unique=True,
     ),
 )  # type: ignore[misc]
+@pytest.mark.skipif(POLARS_VERSION < (0, 20, 13), reason="0.0 == -0.0")
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="requires pyarrow")
 @pytest.mark.slow
 def test_join(  # pragma: no cover
     integers: st.SearchStrategy[list[int]],
     other_integers: st.SearchStrategy[list[int]],
     floats: st.SearchStrategy[list[float]],
     cols: st.SearchStrategy[list[str]],
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
-    polars_version: tuple[int, ...],
 ) -> None:
-    if polars_version < (0, 20, 13):
-        request.applymarker(pytest.mark.skip(reason="0.0 == -0.0"))
-    if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="requires pyarrow"))
     data = {"a": integers, "b": other_integers, "c": floats}
 
     df_polars = pl.DataFrame(data)
@@ -89,15 +86,12 @@ def test_join(  # pragma: no cover
         max_size=3,
     ),
 )  # type: ignore[misc]
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="requires pyarrow")
 @pytest.mark.slow
 def test_cross_join(  # pragma: no cover
     integers: st.SearchStrategy[list[int]],
     other_integers: st.SearchStrategy[list[int]],
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
 ) -> None:
-    if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="requires pyarrow"))
     data = {"a": integers, "b": other_integers}
 
     df_polars = pl.DataFrame(data)

--- a/tests/hypothesis/join_test.py
+++ b/tests/hypothesis/join_test.py
@@ -10,11 +10,7 @@ from hypothesis import strategies as st
 from pandas.testing import assert_frame_equal
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import assert_equal_data
-
-pl_version = parse_version(pl.__version__)
-pd_version = parse_version(pd.__version__)
 
 
 @given(
@@ -40,15 +36,20 @@ pd_version = parse_version(pd.__version__)
         unique=True,
     ),
 )  # type: ignore[misc]
-@pytest.mark.skipif(pl_version < parse_version("0.20.13"), reason="0.0 == -0.0")
-@pytest.mark.skipif(pd_version < parse_version("2.0.0"), reason="requires pyarrow")
 @pytest.mark.slow
 def test_join(  # pragma: no cover
     integers: st.SearchStrategy[list[int]],
     other_integers: st.SearchStrategy[list[int]],
     floats: st.SearchStrategy[list[float]],
     cols: st.SearchStrategy[list[str]],
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+    polars_version: tuple[int, ...],
 ) -> None:
+    if polars_version < (0, 20, 13):
+        request.applymarker(pytest.mark.skipif(reason="0.0 == -0.0"))
+    if pandas_version < (2, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="requires pyarrow"))
     data = {"a": integers, "b": other_integers, "c": floats}
 
     df_polars = pl.DataFrame(data)
@@ -89,11 +90,14 @@ def test_join(  # pragma: no cover
     ),
 )  # type: ignore[misc]
 @pytest.mark.slow
-@pytest.mark.skipif(pd_version < parse_version("2.0.0"), reason="requires pyarrow")
 def test_cross_join(  # pragma: no cover
     integers: st.SearchStrategy[list[int]],
     other_integers: st.SearchStrategy[list[int]],
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
 ) -> None:
+    if pandas_version < (2, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="requires pyarrow"))
     data = {"a": integers, "b": other_integers}
 
     df_polars = pl.DataFrame(data)

--- a/tests/hypothesis/join_test.py
+++ b/tests/hypothesis/join_test.py
@@ -47,9 +47,9 @@ def test_join(  # pragma: no cover
     polars_version: tuple[int, ...],
 ) -> None:
     if polars_version < (0, 20, 13):
-        request.applymarker(pytest.mark.skipif(reason="0.0 == -0.0"))
+        request.applymarker(pytest.mark.skip(reason="0.0 == -0.0"))
     if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="requires pyarrow"))
+        request.applymarker(pytest.mark.skip(reason="requires pyarrow"))
     data = {"a": integers, "b": other_integers, "c": floats}
 
     df_polars = pl.DataFrame(data)
@@ -97,7 +97,7 @@ def test_cross_join(  # pragma: no cover
     pandas_version: tuple[int, ...],
 ) -> None:
     if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="requires pyarrow"))
+        request.applymarker(pytest.mark.skip(reason="requires pyarrow"))
     data = {"a": integers, "b": other_integers}
 
     df_polars = pl.DataFrame(data)

--- a/tests/selectors_test.py
+++ b/tests/selectors_test.py
@@ -11,7 +11,6 @@ from narwhals.selectors import by_dtype
 from narwhals.selectors import categorical
 from narwhals.selectors import numeric
 from narwhals.selectors import string
-from narwhals.utils import parse_version
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
@@ -44,8 +43,12 @@ def test_boolean(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
-def test_string(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if "dask" in str(constructor) and parse_version(pa.__version__) < (12,):
+def test_string(
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    pyarrow_version: tuple[int, ...],
+) -> None:
+    if "dask" in str(constructor) and pyarrow_version < (12,):
         # Dask doesn't infer `'b'` as String for old PyArrow versions
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
@@ -54,10 +57,14 @@ def test_string(constructor: Constructor, request: pytest.FixtureRequest) -> Non
     assert_equal_data(result, expected)
 
 
-def test_categorical(request: pytest.FixtureRequest, constructor: Constructor) -> None:
-    if "pyarrow_table_constructor" in str(constructor) and parse_version(
-        pa.__version__
-    ) <= (15,):  # pragma: no cover
+def test_categorical(
+    request: pytest.FixtureRequest,
+    constructor: Constructor,
+    pyarrow_version: tuple[int, ...],
+) -> None:
+    if "pyarrow_table_constructor" in str(constructor) and pyarrow_version <= (
+        15,
+    ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
     expected = {"b": ["a", "b", "c"]}
 

--- a/tests/selectors_test.py
+++ b/tests/selectors_test.py
@@ -11,6 +11,7 @@ from narwhals.selectors import by_dtype
 from narwhals.selectors import categorical
 from narwhals.selectors import numeric
 from narwhals.selectors import string
+from tests.utils import PYARROW_VERSION
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
@@ -46,9 +47,8 @@ def test_boolean(constructor: Constructor) -> None:
 def test_string(
     constructor: Constructor,
     request: pytest.FixtureRequest,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "dask" in str(constructor) and pyarrow_version < (12,):
+    if "dask" in str(constructor) and PYARROW_VERSION < (12,):
         # Dask doesn't infer `'b'` as String for old PyArrow versions
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
@@ -60,9 +60,8 @@ def test_string(
 def test_categorical(
     request: pytest.FixtureRequest,
     constructor: Constructor,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table_constructor" in str(constructor) and pyarrow_version <= (
+    if "pyarrow_table_constructor" in str(constructor) and PYARROW_VERSION <= (
         15,
     ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)

--- a/tests/series_only/array_dunder_test.py
+++ b/tests/series_only/array_dunder_test.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
+from tests.utils import PYARROW_VERSION
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -11,9 +13,8 @@ from tests.utils import assert_equal_data
 def test_array_dunder(
     request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (
+    if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (
         16,
         0,
         0,
@@ -28,9 +29,8 @@ def test_array_dunder(
 def test_array_dunder_with_dtype(
     request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (
+    if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (
         16,
         0,
         0,
@@ -45,10 +45,8 @@ def test_array_dunder_with_dtype(
 def test_array_dunder_with_copy(
     request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
-    pandas_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (
+    if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (
         16,
         0,
         0,
@@ -58,7 +56,7 @@ def test_array_dunder_with_copy(
     s = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)["a"]
     result = s.__array__(copy=True)
     np.testing.assert_array_equal(result, np.array([1, 2, 3], dtype="int64"))
-    if "pandas_constructor" in str(constructor_eager) and pandas_version < (3,):
+    if "pandas_constructor" in str(constructor_eager) and PANDAS_VERSION < (3,):
         # If it's pandas, we know that `copy=False` definitely took effect.
         # So, let's check it!
         result = s.__array__(copy=False)

--- a/tests/series_only/array_dunder_test.py
+++ b/tests/series_only/array_dunder_test.py
@@ -1,22 +1,23 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
-import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
 
 def test_array_dunder(
-    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
+    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager,
+    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and parse_version(
-        pa.__version__
-    ) < parse_version("16.0.0"):  # pragma: no cover
+    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (
+        16,
+        0,
+        0,
+    ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
 
     s = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)["a"]
@@ -25,11 +26,15 @@ def test_array_dunder(
 
 
 def test_array_dunder_with_dtype(
-    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
+    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager,
+    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and parse_version(
-        pa.__version__
-    ) < parse_version("16.0.0"):  # pragma: no cover
+    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (
+        16,
+        0,
+        0,
+    ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
 
     s = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)["a"]
@@ -38,19 +43,22 @@ def test_array_dunder_with_dtype(
 
 
 def test_array_dunder_with_copy(
-    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
+    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager,
+    pandas_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
 ) -> None:
-    if "pyarrow_table" in str(constructor_eager) and parse_version(
-        pa.__version__
-    ) < parse_version("16.0.0"):  # pragma: no cover
+    if "pyarrow_table" in str(constructor_eager) and pyarrow_version < (
+        16,
+        0,
+        0,
+    ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
 
     s = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)["a"]
     result = s.__array__(copy=True)
     np.testing.assert_array_equal(result, np.array([1, 2, 3], dtype="int64"))
-    if "pandas_constructor" in str(constructor_eager) and parse_version(
-        pd.__version__
-    ) < (3,):
+    if "pandas_constructor" in str(constructor_eager) and pandas_version < (3,):
         # If it's pandas, we know that `copy=False` definitely took effect.
         # So, let's check it!
         result = s.__array__(copy=False)

--- a/tests/series_only/arrow_c_stream_test.py
+++ b/tests/series_only/arrow_c_stream_test.py
@@ -6,29 +6,33 @@ import pyarrow.compute as pc
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 
-@pytest.mark.skipif(
-    parse_version(pl.__version__) < (1, 3), reason="too old for pycapsule in Polars"
-)
-@pytest.mark.skipif(
-    parse_version(pa.__version__) < (16, 0, 0), reason="too old for pycapsule in PyArrow"
-)
-def test_arrow_c_stream_test() -> None:
+def test_arrow_c_stream_test(
+    request: pytest.FixtureRequest,
+    polars_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
+) -> None:
+    if polars_version < (1, 3):
+        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in Polars"))
+    if pyarrow_version < (16, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in PyArrow"))
     s = nw.from_native(pl.Series([1, 2, 3]), series_only=True)
     result = pa.chunked_array(s)
     expected = pa.chunked_array([[1, 2, 3]])
     assert pc.all(pc.equal(result, expected)).as_py()
 
 
-@pytest.mark.skipif(
-    parse_version(pl.__version__) < (1, 3), reason="too old for pycapsule in Polars"
-)
-@pytest.mark.skipif(
-    parse_version(pa.__version__) < (16, 0, 0), reason="too old for pycapsule in PyArrow"
-)
-def test_arrow_c_stream_test_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_arrow_c_stream_test_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    polars_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
+) -> None:
+    if polars_version < (1, 3):
+        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in Polars"))
+    if pyarrow_version < (16, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in PyArrow"))
     # "poison" the dunder method to make sure it actually got called above
     monkeypatch.setattr("narwhals.series.Series.__arrow_c_stream__", lambda *_: 1 / 0)
     s = nw.from_native(pl.Series([1, 2, 3]), series_only=True)
@@ -36,13 +40,16 @@ def test_arrow_c_stream_test_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
         pa.chunked_array(s)
 
 
-@pytest.mark.skipif(
-    parse_version(pl.__version__) < (1, 3), reason="too old for pycapsule in Polars"
-)
-@pytest.mark.skipif(
-    parse_version(pa.__version__) < (16, 0, 0), reason="too old for pycapsule in PyArrow"
-)
-def test_arrow_c_stream_test_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_arrow_c_stream_test_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    polars_version: tuple[int, ...],
+    pyarrow_version: tuple[int, ...],
+) -> None:
+    if polars_version < (1, 3):
+        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in Polars"))
+    if pyarrow_version < (16, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in PyArrow"))
     # Check that fallback to PyArrow works
     monkeypatch.delattr("polars.Series.__arrow_c_stream__")
     s = nw.from_native(pl.Series([1, 2, 3]).to_frame("a"), eager_only=True)["a"]

--- a/tests/series_only/arrow_c_stream_test.py
+++ b/tests/series_only/arrow_c_stream_test.py
@@ -14,9 +14,9 @@ def test_arrow_c_stream_test(
     pyarrow_version: tuple[int, ...],
 ) -> None:
     if polars_version < (1, 3):
-        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in Polars"))
+        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in Polars"))
     if pyarrow_version < (16, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in PyArrow"))
+        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in PyArrow"))
     s = nw.from_native(pl.Series([1, 2, 3]), series_only=True)
     result = pa.chunked_array(s)
     expected = pa.chunked_array([[1, 2, 3]])
@@ -30,9 +30,9 @@ def test_arrow_c_stream_test_invalid(
     pyarrow_version: tuple[int, ...],
 ) -> None:
     if polars_version < (1, 3):
-        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in Polars"))
+        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in Polars"))
     if pyarrow_version < (16, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in PyArrow"))
+        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in PyArrow"))
     # "poison" the dunder method to make sure it actually got called above
     monkeypatch.setattr("narwhals.series.Series.__arrow_c_stream__", lambda *_: 1 / 0)
     s = nw.from_native(pl.Series([1, 2, 3]), series_only=True)
@@ -47,9 +47,9 @@ def test_arrow_c_stream_test_fallback(
     pyarrow_version: tuple[int, ...],
 ) -> None:
     if polars_version < (1, 3):
-        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in Polars"))
+        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in Polars"))
     if pyarrow_version < (16, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="too old for pycapsule in PyArrow"))
+        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in PyArrow"))
     # Check that fallback to PyArrow works
     monkeypatch.delattr("polars.Series.__arrow_c_stream__")
     s = nw.from_native(pl.Series([1, 2, 3]).to_frame("a"), eager_only=True)["a"]

--- a/tests/series_only/arrow_c_stream_test.py
+++ b/tests/series_only/arrow_c_stream_test.py
@@ -6,33 +6,26 @@ import pyarrow.compute as pc
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import POLARS_VERSION
+from tests.utils import PYARROW_VERSION
 
 
-def test_arrow_c_stream_test(
-    request: pytest.FixtureRequest,
-    polars_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
-) -> None:
-    if polars_version < (1, 3):
-        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in Polars"))
-    if pyarrow_version < (16, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in PyArrow"))
+@pytest.mark.skipif(POLARS_VERSION < (1, 3), reason="too old for pycapsule in Polars")
+@pytest.mark.skipif(
+    PYARROW_VERSION < (16, 0, 0), reason="too old for pycapsule in PyArrow"
+)
+def test_arrow_c_stream_test() -> None:
     s = nw.from_native(pl.Series([1, 2, 3]), series_only=True)
     result = pa.chunked_array(s)
     expected = pa.chunked_array([[1, 2, 3]])
     assert pc.all(pc.equal(result, expected)).as_py()
 
 
-def test_arrow_c_stream_test_invalid(
-    monkeypatch: pytest.MonkeyPatch,
-    request: pytest.FixtureRequest,
-    polars_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
-) -> None:
-    if polars_version < (1, 3):
-        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in Polars"))
-    if pyarrow_version < (16, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in PyArrow"))
+@pytest.mark.skipif(POLARS_VERSION < (1, 3), reason="too old for pycapsule in Polars")
+@pytest.mark.skipif(
+    PYARROW_VERSION < (16, 0, 0), reason="too old for pycapsule in PyArrow"
+)
+def test_arrow_c_stream_test_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
     # "poison" the dunder method to make sure it actually got called above
     monkeypatch.setattr("narwhals.series.Series.__arrow_c_stream__", lambda *_: 1 / 0)
     s = nw.from_native(pl.Series([1, 2, 3]), series_only=True)
@@ -40,16 +33,11 @@ def test_arrow_c_stream_test_invalid(
         pa.chunked_array(s)
 
 
-def test_arrow_c_stream_test_fallback(
-    monkeypatch: pytest.MonkeyPatch,
-    request: pytest.FixtureRequest,
-    polars_version: tuple[int, ...],
-    pyarrow_version: tuple[int, ...],
-) -> None:
-    if polars_version < (1, 3):
-        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in Polars"))
-    if pyarrow_version < (16, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="too old for pycapsule in PyArrow"))
+@pytest.mark.skipif(POLARS_VERSION < (1, 3), reason="too old for pycapsule in Polars")
+@pytest.mark.skipif(
+    PYARROW_VERSION < (16, 0, 0), reason="too old for pycapsule in PyArrow"
+)
+def test_arrow_c_stream_test_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     # Check that fallback to PyArrow works
     monkeypatch.delattr("polars.Series.__arrow_c_stream__")
     s = nw.from_native(pl.Series([1, 2, 3]).to_frame("a"), eager_only=True)["a"]

--- a/tests/series_only/cast_test.py
+++ b/tests/series_only/cast_test.py
@@ -11,6 +11,7 @@ import pytest
 from polars.testing import assert_frame_equal
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
@@ -66,12 +67,11 @@ def test_cast_date_datetime_pyarrow() -> None:
     assert result == expected
 
 
-def test_cast_date_datetime_pandas(
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
-) -> None:
-    if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="pyarrow dtype not available"))
+@pytest.mark.skipif(
+    PANDAS_VERSION < (2, 0, 0),
+    reason="pyarrow dtype not available",
+)
+def test_cast_date_datetime_pandas() -> None:
     # pandas: pyarrow date to datetime
     dfpd = pd.DataFrame({"a": [date(2020, 1, 1), date(2020, 1, 2)]}).astype(
         {"a": "date32[pyarrow]"}
@@ -98,12 +98,11 @@ def test_cast_date_datetime_pandas(
     assert df.schema == {"a": nw.Date}
 
 
-def test_cast_date_datetime_invalid(
-    request: pytest.FixtureRequest,
-    pandas_version: tuple[int, ...],
-) -> None:
-    if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="pyarrow dtype not available"))
+@pytest.mark.skipif(
+    PANDAS_VERSION < (2, 0, 0),
+    reason="pyarrow dtype not available",
+)
+def test_cast_date_datetime_invalid() -> None:
     # pandas: pyarrow datetime to date
     dfpd = pd.DataFrame({"a": [datetime(2020, 1, 1), datetime(2020, 1, 2)]})
     df = nw.from_native(dfpd)

--- a/tests/series_only/cast_test.py
+++ b/tests/series_only/cast_test.py
@@ -11,7 +11,6 @@ import pytest
 from polars.testing import assert_frame_equal
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
@@ -67,11 +66,12 @@ def test_cast_date_datetime_pyarrow() -> None:
     assert result == expected
 
 
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < parse_version("2.0.0"),
-    reason="pyarrow dtype not available",
-)
-def test_cast_date_datetime_pandas() -> None:
+def test_cast_date_datetime_pandas(
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+) -> None:
+    if pandas_version < (2, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="pyarrow dtype not available"))
     # pandas: pyarrow date to datetime
     dfpd = pd.DataFrame({"a": [date(2020, 1, 1), date(2020, 1, 2)]}).astype(
         {"a": "date32[pyarrow]"}
@@ -98,11 +98,12 @@ def test_cast_date_datetime_pandas() -> None:
     assert df.schema == {"a": nw.Date}
 
 
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < parse_version("2.0.0"),
-    reason="pyarrow dtype not available",
-)
-def test_cast_date_datetime_invalid() -> None:
+def test_cast_date_datetime_invalid(
+    request: pytest.FixtureRequest,
+    pandas_version: tuple[int, ...],
+) -> None:
+    if pandas_version < (2, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="pyarrow dtype not available"))
     # pandas: pyarrow datetime to date
     dfpd = pd.DataFrame({"a": [datetime(2020, 1, 1), datetime(2020, 1, 2)]})
     df = nw.from_native(dfpd)

--- a/tests/series_only/cast_test.py
+++ b/tests/series_only/cast_test.py
@@ -71,7 +71,7 @@ def test_cast_date_datetime_pandas(
     pandas_version: tuple[int, ...],
 ) -> None:
     if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="pyarrow dtype not available"))
+        request.applymarker(pytest.mark.skip(reason="pyarrow dtype not available"))
     # pandas: pyarrow date to datetime
     dfpd = pd.DataFrame({"a": [date(2020, 1, 1), date(2020, 1, 2)]}).astype(
         {"a": "date32[pyarrow]"}
@@ -103,7 +103,7 @@ def test_cast_date_datetime_invalid(
     pandas_version: tuple[int, ...],
 ) -> None:
     if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="pyarrow dtype not available"))
+        request.applymarker(pytest.mark.skip(reason="pyarrow dtype not available"))
     # pandas: pyarrow datetime to date
     dfpd = pd.DataFrame({"a": [datetime(2020, 1, 1), datetime(2020, 1, 2)]})
     df = nw.from_native(dfpd)

--- a/tests/series_only/is_ordered_categorical_test.py
+++ b/tests/series_only/is_ordered_categorical_test.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
@@ -30,11 +31,8 @@ def test_is_ordered_categorical() -> None:
     assert not nw.is_ordered_categorical(nw.from_native(s, series_only=True))
 
 
-def test_is_ordered_categorical_interchange_protocol(
-    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
-) -> None:
-    if pandas_version < (2, 0):
-        request.applymarker(pytest.mark.skip(reason="requires interchange protocol"))
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="requires interchange protocol")
+def test_is_ordered_categorical_interchange_protocol() -> None:
     df = pd.DataFrame(
         {"a": ["a", "b"]}, dtype=pd.CategoricalDtype(ordered=True)
     ).__dataframe__()

--- a/tests/series_only/is_ordered_categorical_test.py
+++ b/tests/series_only/is_ordered_categorical_test.py
@@ -8,7 +8,6 @@ import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
@@ -31,10 +30,11 @@ def test_is_ordered_categorical() -> None:
     assert not nw.is_ordered_categorical(nw.from_native(s, series_only=True))
 
 
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < (2, 0), reason="requires interchange protocol"
-)
-def test_is_ordered_categorical_interchange_protocol() -> None:
+def test_is_ordered_categorical_interchange_protocol(
+    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
+) -> None:
+    if pandas_version < (2, 0):
+        request.applymarker(pytest.mark.skipif(reason="requires interchange protocol"))
     df = pd.DataFrame(
         {"a": ["a", "b"]}, dtype=pd.CategoricalDtype(ordered=True)
     ).__dataframe__()

--- a/tests/series_only/is_ordered_categorical_test.py
+++ b/tests/series_only/is_ordered_categorical_test.py
@@ -34,7 +34,7 @@ def test_is_ordered_categorical_interchange_protocol(
     request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
 ) -> None:
     if pandas_version < (2, 0):
-        request.applymarker(pytest.mark.skipif(reason="requires interchange protocol"))
+        request.applymarker(pytest.mark.skip(reason="requires interchange protocol"))
     df = pd.DataFrame(
         {"a": ["a", "b"]}, dtype=pd.CategoricalDtype(ordered=True)
     ).__dataframe__()

--- a/tests/series_only/to_pandas_test.py
+++ b/tests/series_only/to_pandas_test.py
@@ -7,6 +7,7 @@ import pytest
 from pandas.testing import assert_series_equal
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
@@ -14,13 +15,11 @@ if TYPE_CHECKING:
 data = [1, 3, 2]
 
 
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="too old for pyarrow")
 def test_convert(
     request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
-    pandas_version: tuple[int, ...],
 ) -> None:
-    if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="too old for pyarrow"))
     if any(
         cname in str(constructor_eager)
         for cname in ("pandas_nullable", "pandas_pyarrow", "modin")

--- a/tests/series_only/to_pandas_test.py
+++ b/tests/series_only/to_pandas_test.py
@@ -7,7 +7,6 @@ import pytest
 from pandas.testing import assert_series_equal
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
@@ -15,12 +14,13 @@ if TYPE_CHECKING:
 data = [1, 3, 2]
 
 
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < parse_version("2.0.0"), reason="too old for pyarrow"
-)
 def test_convert(
-    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
+    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager,
+    pandas_version: tuple[int, ...],
 ) -> None:
+    if pandas_version < (2, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="too old for pyarrow"))
     if any(
         cname in str(constructor_eager)
         for cname in ("pandas_nullable", "pandas_pyarrow", "modin")

--- a/tests/series_only/to_pandas_test.py
+++ b/tests/series_only/to_pandas_test.py
@@ -20,7 +20,7 @@ def test_convert(
     pandas_version: tuple[int, ...],
 ) -> None:
     if pandas_version < (2, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="too old for pyarrow"))
+        request.applymarker(pytest.mark.skip(reason="too old for pyarrow"))
     if any(
         cname in str(constructor_eager)
         for cname in ("pandas_nullable", "pandas_pyarrow", "modin")

--- a/tests/series_only/value_counts_test.py
+++ b/tests/series_only/value_counts_test.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -18,12 +16,14 @@ data = [4, 4, 4, 1, 6, 6, 4, 4, 1, 1]
 def test_value_counts(
     request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
+    pandas_version: tuple[int, ...],
     normalize: Any,
     name: str | None,
 ) -> None:
-    if "pandas_nullable_constructor" in str(constructor_eager) and parse_version(
-        pd.__version__
-    ) < (2, 2):
+    if "pandas_nullable_constructor" in str(constructor_eager) and pandas_version < (
+        2,
+        2,
+    ):
         # bug in old pandas
         request.applymarker(pytest.mark.xfail)
 

--- a/tests/series_only/value_counts_test.py
+++ b/tests/series_only/value_counts_test.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -16,11 +17,10 @@ data = [4, 4, 4, 1, 6, 6, 4, 4, 1, 1]
 def test_value_counts(
     request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
-    pandas_version: tuple[int, ...],
     normalize: Any,
     name: str | None,
 ) -> None:
-    if "pandas_nullable_constructor" in str(constructor_eager) and pandas_version < (
+    if "pandas_nullable_constructor" in str(constructor_eager) and PANDAS_VERSION < (
         2,
         2,
     ):

--- a/tests/tpch_q1_test.py
+++ b/tests/tpch_q1_test.py
@@ -10,7 +10,6 @@ import pyarrow.parquet as pq
 import pytest
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 from tests.utils import assert_equal_data
 
 
@@ -19,8 +18,10 @@ from tests.utils import assert_equal_data
     ["pandas", "polars", "pyarrow", "dask"],
 )
 @pytest.mark.filterwarnings("ignore:.*Passing a BlockManager.*:DeprecationWarning")
-def test_q1(library: str, request: pytest.FixtureRequest) -> None:
-    if library == "pandas" and parse_version(pd.__version__) < (1, 5):
+def test_q1(
+    library: str, request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
+) -> None:
+    if library == "pandas" and pandas_version < (1, 5):
         request.applymarker(pytest.mark.xfail)
     elif library == "pandas":
         df_raw = pd.read_parquet("tests/data/lineitem.parquet")
@@ -98,8 +99,10 @@ def test_q1(library: str, request: pytest.FixtureRequest) -> None:
     "ignore:.*Passing a BlockManager.*:DeprecationWarning",
     "ignore:.*Complex.*:UserWarning",
 )
-def test_q1_w_generic_funcs(library: str, request: pytest.FixtureRequest) -> None:
-    if library == "pandas" and parse_version(pd.__version__) < (1, 5):
+def test_q1_w_generic_funcs(
+    library: str, request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
+) -> None:
+    if library == "pandas" and pandas_version < (1, 5):
         request.applymarker(pytest.mark.xfail)
     elif library == "pandas":
         df_raw = pd.read_parquet("tests/data/lineitem.parquet")
@@ -160,10 +163,11 @@ def test_q1_w_generic_funcs(library: str, request: pytest.FixtureRequest) -> Non
 
 @mock.patch.dict(os.environ, {"NARWHALS_FORCE_GENERIC": "1"})
 @pytest.mark.filterwarnings("ignore:.*Passing a BlockManager.*:DeprecationWarning")
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < parse_version("1.0.0"), reason="too old for pyarrow"
-)
-def test_q1_w_pandas_agg_generic_path() -> None:
+def test_q1_w_pandas_agg_generic_path(
+    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
+) -> None:
+    if pandas_version < (1, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="too old for pyarrow"))
     df_raw = pd.read_parquet("tests/data/lineitem.parquet")
     df_raw["l_shipdate"] = pd.to_datetime(df_raw["l_shipdate"])
     var_1 = datetime(1998, 9, 2)

--- a/tests/tpch_q1_test.py
+++ b/tests/tpch_q1_test.py
@@ -10,6 +10,7 @@ import pyarrow.parquet as pq
 import pytest
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 from tests.utils import assert_equal_data
 
 
@@ -18,10 +19,8 @@ from tests.utils import assert_equal_data
     ["pandas", "polars", "pyarrow", "dask"],
 )
 @pytest.mark.filterwarnings("ignore:.*Passing a BlockManager.*:DeprecationWarning")
-def test_q1(
-    library: str, request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
-) -> None:
-    if library == "pandas" and pandas_version < (1, 5):
+def test_q1(library: str, request: pytest.FixtureRequest) -> None:
+    if library == "pandas" and PANDAS_VERSION < (1, 5):
         request.applymarker(pytest.mark.xfail)
     elif library == "pandas":
         df_raw = pd.read_parquet("tests/data/lineitem.parquet")
@@ -99,10 +98,8 @@ def test_q1(
     "ignore:.*Passing a BlockManager.*:DeprecationWarning",
     "ignore:.*Complex.*:UserWarning",
 )
-def test_q1_w_generic_funcs(
-    library: str, request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
-) -> None:
-    if library == "pandas" and pandas_version < (1, 5):
+def test_q1_w_generic_funcs(library: str, request: pytest.FixtureRequest) -> None:
+    if library == "pandas" and PANDAS_VERSION < (1, 5):
         request.applymarker(pytest.mark.xfail)
     elif library == "pandas":
         df_raw = pd.read_parquet("tests/data/lineitem.parquet")
@@ -163,11 +160,8 @@ def test_q1_w_generic_funcs(
 
 @mock.patch.dict(os.environ, {"NARWHALS_FORCE_GENERIC": "1"})
 @pytest.mark.filterwarnings("ignore:.*Passing a BlockManager.*:DeprecationWarning")
-def test_q1_w_pandas_agg_generic_path(
-    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
-) -> None:
-    if pandas_version < (1, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="too old for pyarrow"))
+@pytest.mark.skipif(PANDAS_VERSION < (1, 0, 0), reason="too old for pyarrow")
+def test_q1_w_pandas_agg_generic_path() -> None:
     df_raw = pd.read_parquet("tests/data/lineitem.parquet")
     df_raw["l_shipdate"] = pd.to_datetime(df_raw["l_shipdate"])
     var_1 = datetime(1998, 9, 2)

--- a/tests/tpch_q1_test.py
+++ b/tests/tpch_q1_test.py
@@ -167,7 +167,7 @@ def test_q1_w_pandas_agg_generic_path(
     request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
 ) -> None:
     if pandas_version < (1, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="too old for pyarrow"))
+        request.applymarker(pytest.mark.skip(reason="too old for pyarrow"))
     df_raw = pd.read_parquet("tests/data/lineitem.parquet")
     df_raw["l_shipdate"] = pd.to_datetime(df_raw["l_shipdate"])
     var_1 = datetime(1998, 9, 2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,6 +21,20 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias  # pragma: no cover
 
+
+def get_module_version_as_tuple(module_name: str) -> tuple[int, ...]:
+    try:
+        return parse_version(__import__(module_name).__version__)
+    except ImportError:
+        return (0, 0, 0)
+
+
+IBIS_VERSION: tuple[int, ...] = get_module_version_as_tuple("ibis")
+NUMPY_VERSION: tuple[int, ...] = get_module_version_as_tuple("numpy")
+PANDAS_VERSION: tuple[int, ...] = get_module_version_as_tuple("pandas")
+POLARS_VERSION: tuple[int, ...] = get_module_version_as_tuple("polars")
+PYARROW_VERSION: tuple[int, ...] = get_module_version_as_tuple("pyarrow")
+
 Constructor: TypeAlias = Callable[[Any], IntoFrame]
 ConstructorEager: TypeAlias = Callable[[Any], IntoDataFrame]
 
@@ -80,10 +94,3 @@ def maybe_get_modin_df(df_pandas: pd.DataFrame) -> Any:
 def is_windows() -> bool:
     """Check if the current platform is Windows."""
     return sys.platform in ["win32", "cygwin"]
-
-
-def get_module_version_as_tuple(module_name: str) -> tuple[int, ...]:
-    try:
-        return parse_version(__import__(module_name).__version__)
-    except ImportError:
-        return (0, 0, 0)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,6 +14,7 @@ import narwhals as nw
 from narwhals.typing import IntoDataFrame
 from narwhals.typing import IntoFrame
 from narwhals.utils import Implementation
+from narwhals.utils import parse_version
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias  # pragma: no cover
@@ -79,3 +80,10 @@ def maybe_get_modin_df(df_pandas: pd.DataFrame) -> Any:
 def is_windows() -> bool:
     """Check if the current platform is Windows."""
     return sys.platform in ["win32", "cygwin"]
+
+
+def get_module_version_as_tuple(module_name: str) -> tuple[int, ...]:
+    try:
+        return parse_version(__import__(module_name).__version__)
+    except ImportError:
+        return (0, 0, 0)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -8,7 +8,6 @@ from pandas.testing import assert_index_equal
 from pandas.testing import assert_series_equal
 
 import narwhals.stable.v1 as nw
-from narwhals.utils import parse_version
 
 
 def test_maybe_align_index_pandas() -> None:
@@ -110,13 +109,13 @@ def test_maybe_reset_index_polars() -> None:
     assert result_s is series
 
 
-@pytest.mark.skipif(
-    parse_version(pd.__version__) < parse_version("1.0.0"),
-    reason="too old for convert_dtypes",
-)
-def test_maybe_convert_dtypes_pandas() -> None:
+def test_maybe_convert_dtypes_pandas(
+    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
+) -> None:
     import numpy as np
 
+    if pandas_version < (1, 0, 0):
+        request.applymarker(pytest.mark.skipif(reason="too old for convert_dtypes"))
     df = nw.from_native(
         pd.DataFrame({"a": [1, np.nan]}, dtype=np.dtype("float64")), eager_only=True
     )

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -115,7 +115,7 @@ def test_maybe_convert_dtypes_pandas(
     import numpy as np
 
     if pandas_version < (1, 0, 0):
-        request.applymarker(pytest.mark.skipif(reason="too old for convert_dtypes"))
+        request.applymarker(pytest.mark.skip(reason="too old for convert_dtypes"))
     df = nw.from_native(
         pd.DataFrame({"a": [1, np.nan]}, dtype=np.dtype("float64")), eager_only=True
     )

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -9,6 +9,7 @@ from pandas.testing import assert_series_equal
 
 import narwhals.stable.v1 as nw
 from tests.utils import PANDAS_VERSION
+from tests.utils import get_module_version_as_tuple
 
 
 def test_maybe_align_index_pandas() -> None:
@@ -131,3 +132,8 @@ def test_maybe_convert_dtypes_polars() -> None:
     df = nw.from_native(pl.DataFrame({"a": [1.1, np.nan]}))
     result = nw.maybe_convert_dtypes(df)
     assert result is df
+
+
+def test_get_trivial_version_with_uninstalled_module() -> None:
+    result = get_module_version_as_tuple("non_existent_module")
+    assert result == (0, 0, 0)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -8,6 +8,7 @@ from pandas.testing import assert_index_equal
 from pandas.testing import assert_series_equal
 
 import narwhals.stable.v1 as nw
+from tests.utils import PANDAS_VERSION
 
 
 def test_maybe_align_index_pandas() -> None:
@@ -109,13 +110,10 @@ def test_maybe_reset_index_polars() -> None:
     assert result_s is series
 
 
-def test_maybe_convert_dtypes_pandas(
-    request: pytest.FixtureRequest, pandas_version: tuple[int, ...]
-) -> None:
+@pytest.mark.skipif(PANDAS_VERSION < (1, 0, 0), reason="too old for convert_dtypes")
+def test_maybe_convert_dtypes_pandas() -> None:
     import numpy as np
 
-    if pandas_version < (1, 0, 0):
-        request.applymarker(pytest.mark.skip(reason="too old for convert_dtypes"))
     df = nw.from_native(
         pd.DataFrame({"a": [1, np.nan]}, dtype=np.dtype("float64")), eager_only=True
     )


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [x] 🐳 Other

## Related issues 

- Closes https://github.com/narwhals-dev/narwhals/issues/1219

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
Makes module versions available as ~~fixtures~~ constants (no need to build fixtures out of them) for use in tests (so that we can avoid specifying `parse_version(pd.__version__)` and similar).
