### PR TITLE
polars `.collect_schema().names()` instead of `.columns`

### DIFF
--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -179,7 +179,7 @@ class PolarsDataFrame:
 
     @property
     def columns(self) -> list[str]:
-        return self._native_frame.columns  # type: ignore[no-any-return]
+        return self._native_frame.collect_schema().names()  # type: ignore[no-any-return]
 
     def lazy(self) -> PolarsLazyFrame:
         return PolarsLazyFrame(

--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -179,7 +179,7 @@ class PolarsDataFrame:
 
     @property
     def columns(self) -> list[str]:
-        return self._native_frame.collect_schema().names()  # type: ignore[no-any-return]
+        return self._native_frame.columns  # type: ignore[no-any-return]
 
     def lazy(self) -> PolarsLazyFrame:
         return PolarsLazyFrame(
@@ -285,7 +285,7 @@ class PolarsLazyFrame:
 
     @property
     def columns(self) -> list[str]:
-        return self._native_frame.columns  # type: ignore[no-any-return]
+        return self._native_frame.collect_schema().names()  # type: ignore[no-any-return]
 
     @property
     def schema(self) -> dict[str, Any]:


### PR DESCRIPTION
otherwise, this line of code produces a warning for polars 1.1+ https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.columns.html


<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

