### PR TITLE
DataFrame conversion tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Join the party!
 - [scikit-playtime](https://github.com/koaning/scikit-playtime)
 - [timebasedcv](https://github.com/FBruzzesi/timebasedcv)
 - [marimo](https://github.com/marimo-team/marimo)
+- [pymarginaleffects](https://github.com/vincentarelbundock/pymarginaleffects)
 
 Feel free to add your project to the list if it's missing, and/or
 [chat with us on Discord](https://discord.gg/V3PqtB4VA4) if you'd like any support.

--- a/docs/basics/dataframe_conversion.md
+++ b/docs/basics/dataframe_conversion.md
@@ -1,0 +1,29 @@
+# Lightweight DataFrame conversion
+
+Some library maintainers must apply complex data frame operations, using methods and functions that may not (yet) be implemented in Narwhals. In such cases, Narwhals can still be highly beneficial, by allowing easy data frame conversion.
+
+Imagine that you maintain a library with a function that operates on Pandas data frames to produce automated reports. You want to allow users to supply data frames in any format to that function (Pandas, Polars, DuckDB, CuDF, Modin, etc.) without adding all those dependencies to your own project.
+
+One solution is to use Narwhals as a thin "DataFrame ingestion" layer, to convert user-supplied data frames to the format that your library uses internally. Since Narwhals is 0-dependency, this is a much more lightweight solution than including all the data frame libraries as dependencies.
+
+For example, this function can ingest any data frame type supported by Narwhals, and convert it to a Pandas DataFrame for internal use:
+
+```python
+import narwhals as nw
+def df_to_pandas(df):
+  out = nw.from_native(df)
+  out = out.to_pandas()
+  return out
+```
+
+Similarly, if your library uses Polars internally, you can convert any user-supplied data frames to Polars format using Narwhals.
+
+```python
+import narwhals as nw
+import polars as pl
+def df_to_polars(df):
+  out = nw.from_native(df)  
+  out = out.to_arrow()
+  return pl.DataFrame(out)
+```
+

--- a/docs/basics/dataframe_conversion.md
+++ b/docs/basics/dataframe_conversion.md
@@ -6,28 +6,45 @@ Imagine that you maintain a library with a function that operates on Pandas data
 
 One solution is to use Narwhals as a thin "DataFrame ingestion" layer, to convert user-supplied data frames to the format that your library uses internally. Since Narwhals is 0-dependency, this is a much more lightweight solution than including all the data frame libraries as dependencies.
 
-For example, this function can ingest any data frame type supported by Narwhals, and convert it to a Pandas DataFrame for internal use:
+To illustrate, we create data frames in various formats:
 
-```python
+```python exec="1" source="above"
 import narwhals as nw
+from narwhals.typing import IntoDataFrame
 
+import duckdb
+import polars as pl
+import pandas as pd
 
-def df_to_pandas(df):
+df_polars = pl.DataFrame( {
+        "A": [1, 2, 3, 4, 5],
+        "fruits": ["banana", "banana", "apple", "apple", "banana"],
+        "B": [5, 4, 3, 2, 1],
+        "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
+} )
+df_pandas = df_polars.to_pandas()
+df_duckdb = duckdb.sql("SELECT * FROM df")
+```
+
+Now, we define a function that can ingest any data frame type supported by Narwhals, and convert it to a Pandas DataFrame for internal use:
+
+```python exec="1" source="above"
+def df_to_pandas(df: IntoDataFrame) -> pd.DataFrame:
     out = nw.from_native(df)
     out = out.to_pandas()
     return out
+
+df_to_pandas(df_duckdb)
 ```
 
-Similarly, if your library uses Polars internally, you can convert any user-supplied data frames to Polars format using Narwhals.
+Similarly, if your library uses Polars internally, you can convert any user-supplied data frame to Polars format using Narwhals.
 
-```python
-import narwhals as nw
-import polars as pl
-
-
-def df_to_polars(df):
+```python exec="1" source="above"
+def df_to_polars(df: IntoDataFrame) -> pl.DataFrame:
     out = nw.from_native(df)
     out = out.to_arrow()
     return pl.DataFrame(out)
+
+df_to_polars(df_pandas)
 ```
 

--- a/docs/basics/dataframe_conversion.md
+++ b/docs/basics/dataframe_conversion.md
@@ -1,14 +1,17 @@
-# Lightweight DataFrame conversion
+# Conversion between libraries
 
-Some library maintainers must apply complex data frame operations, using methods and functions that may not (yet) be implemented in Narwhals. In such cases, Narwhals can still be highly beneficial, by allowing easy data frame conversion.
+Some library maintainers must apply complex dataframe operations, using methods and functions that may not (yet) be implemented in Narwhals. In such cases, Narwhals can still be highly beneficial, by allowing easy dataframe conversion.
 
-Imagine that you maintain a library with a function that operates on Pandas data frames to produce automated reports. You want to allow users to supply data frames in any format to that function (Pandas, Polars, DuckDB, CuDF, Modin, etc.) without adding all those dependencies to your own project.
+## Dataframe X in, pandas out
 
-One solution is to use Narwhals as a thin "DataFrame ingestion" layer, to convert user-supplied data frames to the format that your library uses internally. Since Narwhals is 0-dependency, this is a much more lightweight solution than including all the data frame libraries as dependencies.
+Imagine that you maintain a library with a function that operates on pandas dataframes to produce automated reports. You want to allow users to supply a dataframe in any format to that function (pandas, Polars, DuckDB, cuDF, Modin, etc.) without adding all those dependencies to your own project and without special-casing each input library's variation of `to_pandas` / `toPandas` / `to_pandas_df` / `df` ...
 
-To illustrate, we create data frames in various formats:
+One solution is to use Narwhals as a thin Dataframe ingestion layer, to convert user-supplied dataframe to the format that your library uses internally. Since Narwhals is zero-dependency, this is a much more lightweight solution than including all the dataframe libraries as dependencies,
+and easier to write than special casing each input library's `to_pandas` method (if it even exists!).
 
-```python exec="1" source="above"
+To illustrate, we create dataframes in various formats:
+
+```python exec="1" source="above" session="conversion"
 import narwhals as nw
 from narwhals.typing import IntoDataFrame
 
@@ -28,34 +31,46 @@ df_pandas = df_polars.to_pandas()
 df_duckdb = duckdb.sql("SELECT * FROM df_polars")
 ```
 
-Now, we define a function that can ingest any data frame type supported by Narwhals, and convert it to a Pandas DataFrame for internal use:
+Now, we define a function that can ingest any dataframe type supported by Narwhals, and convert it to a pandas DataFrame for internal use:
 
-```python exec="1" source="above"
+```python exec="1" source="above" session="conversion" result="python"
 def df_to_pandas(df: IntoDataFrame) -> pd.DataFrame:
     return nw.from_native(df).to_pandas()
 
 
-df_to_pandas(df_polars)
+print(df_to_pandas(df_polars))
 ```
 
-Similarly, if your library uses Polars internally, you can convert any user-supplied data frame to Polars format using Narwhals.
+## Dataframe X in, Polars out
 
-```python exec="1" source="above"
+### Via PyCapsule Interface
+
+Similarly, if your library uses Polars internally, you can convert any user-supplied dataframe to Polars format using Narwhals.
+
+```python exec="1" source="above" session="conversion" result="python"
 def df_to_polars(df: IntoDataFrame) -> pl.DataFrame:
     return nw.from_arrow(nw.from_native(df), native_namespace=pl).to_native()
 
 
-df_to_polars(df_duckdb)
+print(df_to_polars(df_duckdb))  # You can only execute this line of code once.
 ```
 
-Note that the `df_to_polars` function defined above uses PyCapsule. This strategy does not guarantee that we can call the Arrow stream repeatedly. If you need to ingest the same data frame several times, you may want to go through PyArrow, which may be less efficient, but is more forgiving:
+It works to pass Polars to `native_namespace` here because Polars supports the [PyCapsule Interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html) for import.
 
-```python exec="1" source="above"
+Note that the PyCapsule Interface makes no guarantee that you can call it repeatedly, so the approach above only works if you
+only expect to perform the conversion a single time on each input object.
+
+### Via PyArrow
+
+If you need to ingest the same dataframe multiple times, then you may want to go via PyArrow instead.
+This may be less efficient than the PyCapsule approach above (and always requires PyArrow!), but is more forgiving:
+
+```python exec="1" source="above" session="conversion" result="python"
 def df_to_polars(df: IntoDataFrame) -> pl.DataFrame:
     return pl.DataFrame(nw.from_native(df).to_arrow())
 
 
 df_duckdb = duckdb.sql("SELECT * FROM df_polars")
-df_to_polars(df_duckdb)
+print(df_to_polars(df_duckdb))  # We can execute this...
+print(df_to_polars(df_duckdb))  # ...as many times as we like!
 ```
-

--- a/docs/basics/dataframe_conversion.md
+++ b/docs/basics/dataframe_conversion.md
@@ -10,10 +10,12 @@ For example, this function can ingest any data frame type supported by Narwhals,
 
 ```python
 import narwhals as nw
+
+
 def df_to_pandas(df):
-  out = nw.from_native(df)
-  out = out.to_pandas()
-  return out
+    out = nw.from_native(df)
+    out = out.to_pandas()
+    return out
 ```
 
 Similarly, if your library uses Polars internally, you can convert any user-supplied data frames to Polars format using Narwhals.
@@ -21,9 +23,11 @@ Similarly, if your library uses Polars internally, you can convert any user-supp
 ```python
 import narwhals as nw
 import polars as pl
+
+
 def df_to_polars(df):
-  out = nw.from_native(df)  
-  out = out.to_arrow()
-  return pl.DataFrame(out)
+    out = nw.from_native(df)
+    out = out.to_arrow()
+    return pl.DataFrame(out)
 ```
 

--- a/docs/basics/dataframe_conversion.md
+++ b/docs/basics/dataframe_conversion.md
@@ -16,12 +16,14 @@ import duckdb
 import polars as pl
 import pandas as pd
 
-df_polars = pl.DataFrame( {
+df_polars = pl.DataFrame(
+    {
         "A": [1, 2, 3, 4, 5],
         "fruits": ["banana", "banana", "apple", "apple", "banana"],
         "B": [5, 4, 3, 2, 1],
         "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
-} )
+    }
+)
 df_pandas = df_polars.to_pandas()
 df_duckdb = duckdb.sql("SELECT * FROM df")
 ```
@@ -34,6 +36,7 @@ def df_to_pandas(df: IntoDataFrame) -> pd.DataFrame:
     out = out.to_pandas()
     return out
 
+
 df_to_pandas(df_duckdb)
 ```
 
@@ -44,6 +47,7 @@ def df_to_polars(df: IntoDataFrame) -> pl.DataFrame:
     out = nw.from_native(df)
     out = out.to_arrow()
     return pl.DataFrame(out)
+
 
 df_to_polars(df_pandas)
 ```

--- a/docs/basics/dataframe_conversion.md
+++ b/docs/basics/dataframe_conversion.md
@@ -25,30 +25,34 @@ df_polars = pl.DataFrame(
     }
 )
 df_pandas = df_polars.to_pandas()
-df_duckdb = duckdb.sql("SELECT * FROM df")
+df_duckdb = duckdb.sql("SELECT * FROM df_polars")
 ```
 
 Now, we define a function that can ingest any data frame type supported by Narwhals, and convert it to a Pandas DataFrame for internal use:
 
 ```python exec="1" source="above"
 def df_to_pandas(df: IntoDataFrame) -> pd.DataFrame:
-    out = nw.from_native(df)
-    out = out.to_pandas()
-    return out
+    return nw.from_native(df).to_pandas()
 
-
-df_to_pandas(df_duckdb)
+df_to_pandas(df_polars)
 ```
 
 Similarly, if your library uses Polars internally, you can convert any user-supplied data frame to Polars format using Narwhals.
 
 ```python exec="1" source="above"
 def df_to_polars(df: IntoDataFrame) -> pl.DataFrame:
-    out = nw.from_native(df)
-    out = out.to_arrow()
-    return pl.DataFrame(out)
+    return nw.from_arrow(nw.from_native(df), native_namespace=pl).to_native()
 
+df_to_polars(df_duckdb)
+```
 
-df_to_polars(df_pandas)
+Note that the `df_to_polars` function defined above uses PyCapsule. This strategy does not guarantee that we can call the Arrow stream repeatedly. If you need to ingest the same data frame several times, you may want to go through PyArrow, which may be less efficient, but is more forgiving:
+
+```python exec="1" source="above"
+def df_to_polars(df: IntoDataFrame) -> pl.DataFrame:
+    return pl.DataFrame(nw.from_native(df).to_arrow())
+
+df_duckdb = duckdb.sql("SELECT * FROM df_polars")
+df_to_polars(df_duckdb)
 ```
 

--- a/docs/basics/dataframe_conversion.md
+++ b/docs/basics/dataframe_conversion.md
@@ -34,6 +34,7 @@ Now, we define a function that can ingest any data frame type supported by Narwh
 def df_to_pandas(df: IntoDataFrame) -> pd.DataFrame:
     return nw.from_native(df).to_pandas()
 
+
 df_to_pandas(df_polars)
 ```
 
@@ -43,6 +44,7 @@ Similarly, if your library uses Polars internally, you can convert any user-supp
 def df_to_polars(df: IntoDataFrame) -> pl.DataFrame:
     return nw.from_arrow(nw.from_native(df), native_namespace=pl).to_native()
 
+
 df_to_polars(df_duckdb)
 ```
 
@@ -51,6 +53,7 @@ Note that the `df_to_polars` function defined above uses PyCapsule. This strateg
 ```python exec="1" source="above"
 def df_to_polars(df: IntoDataFrame) -> pl.DataFrame:
     return pl.DataFrame(nw.from_native(df).to_arrow())
+
 
 df_duckdb = duckdb.sql("SELECT * FROM df_polars")
 df_to_polars(df_duckdb)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - basics/dataframe.md
     - basics/series.md
     - basics/complete_example.md
+    - basics/dataframe_conversion.md
   - Pandas-like concepts:
     - other/pandas_index.md
     - other/user_warning.md

--- a/tests/expr_and_series/dt/timestamp_test.py
+++ b/tests/expr_and_series/dt/timestamp_test.py
@@ -11,6 +11,7 @@ from hypothesis import given
 
 import narwhals.stable.v1 as nw
 from tests.utils import PANDAS_VERSION
+from tests.utils import POLARS_VERSION
 from tests.utils import PYARROW_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
@@ -198,6 +199,7 @@ def test_timestamp_invalid_unit_series(constructor_eager: ConstructorEager) -> N
     starting_time_unit=st.sampled_from(["us", "ns"]),
 )
 @pytest.mark.skipif(PANDAS_VERSION < (2, 2), reason="bug in old pandas")
+@pytest.mark.skipif(POLARS_VERSION < (0, 20, 7), reason="bug in old Polars")
 def test_timestamp_hypothesis(
     inputs: datetime,
     time_unit: Literal["ms", "us", "ns"],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## What is this?

A new tutorial with ultra-simple examples of DataFrame conversion functions using Narwhals.

## Motivation

I maintain a library which uses Polars internally. I want to allow my users to supply any DataFrame format, but I don't want to re-write my library's code, and not all the methods I use are already implemented in Narwhals.

For me, the most attractive application of Narwhals is to use it to "ingest" any DataFrame, and convert them to Polars for internal use. This is the lowest barrier to entry approach to Narwhals, and my guess is that *many* users would like this.

Given the likely popularity of this workflow, I think it deserves its own page and tutorial on the website.

