### PR TITLE
docs: zen dedicated doc page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ coverage.xml
 # Documentation
 site/
 todo.md
+docs/this.md
 docs/api-completeness/*.md
 !docs/api-completeness/index.md
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
     - api-reference/dtypes.md
     - api-reference/selectors.md
     - api-reference/typing.md
+  - This: this.md
 theme:
   name: material
   font: false
@@ -92,6 +93,7 @@ plugins:
 
 hooks:
 - utils/generate_backend_completeness.py
+- utils/generate_zen_content.py
 
 
 markdown_extensions:

--- a/utils/generate_zen_content.py
+++ b/utils/generate_zen_content.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+from narwhals.this import ZEN
+
+DESTINATION_PATH: Final[Path] = Path("docs") / "this.md"
+
+content = f"""
+# The Zen of Narwhals
+
+The well famous Python easter egg `import this` will reveal The Zen of Python, by Tim Peters.
+
+Narwhals took inspiration from _this_ and created its own Zen.
+
+```py
+import narwhals.this
+```
+
+```terminal
+{ZEN}
+```
+"""
+
+with DESTINATION_PATH.open(mode="w") as destination:
+    destination.write(content)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

Adds dedicated docpage for rendering the ZEN dynamically:

![image](https://github.com/user-attachments/assets/18b88622-8ded-4ee4-b3d6-b27a32c5cc85)
