### PR TITLE
docs: fix parameters table rendering in `quantile` docs

### DIFF
--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -1827,15 +1827,13 @@ class Expr:
         r"""Get quantile value.
 
         Note:
-            * pandas and Polars may have implementation differences for a given interpolation method.
-            * [dask](https://docs.dask.org/en/stable/generated/dask.dataframe.Series.quantile.html) has its own method to approximate quantile and it doesn't implement 'nearest', 'higher', 'lower', 'midpoint'
+            - pandas and Polars may have implementation differences for a given interpolation method.
+            - [dask](https://docs.dask.org/en/stable/generated/dask.dataframe.Series.quantile.html) has its own method to approximate quantile and it doesn't implement 'nearest', 'higher', 'lower', 'midpoint'
             as interpolation method - use 'linear' which is closest to the native 'dask' - method.
 
         Arguments:
-            quantile : float
-                Quantile between 0.0 and 1.0.
-            interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
-                Interpolation method.
+            quantile: Quantile between 0.0 and 1.0.
+            interpolation: Interpolation method.
 
         Examples:
             >>> import narwhals as nw

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2060,10 +2060,8 @@ class Series:
             pandas and Polars may have implementation differences for a given interpolation method.
 
         Arguments:
-            quantile : float
-                Quantile between 0.0 and 1.0.
-            interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
-                Interpolation method.
+            quantile: Quantile between 0.0 and 1.0.
+            interpolation: Interpolation method.
 
         Examples:
             >>> import narwhals as nw


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 
N/A

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
Fixes rendering of parameters table at https://narwhals-dev.github.io/narwhals/api-reference/expr/#narwhals.Expr.quantile and https://narwhals-dev.github.io/narwhals/api-reference/series/#narwhals.series.Series.quantile.

From 
<img width="509" alt="image" src="https://github.com/user-attachments/assets/b458bebf-6f93-4945-af6f-e61cc3ba8270">

to
<img width="500" alt="image" src="https://github.com/user-attachments/assets/7634ca8b-9f09-4be0-acb8-b313fb4bea5e">

