### PR TITLE
fix: remove _dtype_cache for pandas-like so that inplace modification…

### DIFF
--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -54,8 +54,6 @@ class PandasLikeDataFrame:
         self._backend_version = backend_version
         self._dtypes = dtypes
 
-        self._schema_cache: dict[str, DType] | None = None
-
     def __narwhals_dataframe__(self) -> Self:
         return self
 
@@ -305,14 +303,12 @@ class PandasLikeDataFrame:
 
     @property
     def schema(self) -> dict[str, DType]:
-        if self._schema_cache is None:
-            self._schema_cache = {
-                col: native_to_narwhals_dtype(
-                    self._native_frame[col], self._dtypes, self._implementation
-                )
-                for col in self._native_frame.columns
-            }
-        return self._schema_cache
+        return {
+            col: native_to_narwhals_dtype(
+                self._native_frame[col], self._dtypes, self._implementation
+            )
+            for col in self._native_frame.columns
+        }
 
     def collect_schema(self) -> dict[str, DType]:
         return self.schema

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -89,8 +89,6 @@ class PandasLikeSeries:
         self._backend_version = backend_version
         self._dtypes = dtypes
 
-        self._dtype_cache: DType | None = None
-
         # In pandas, copy-on-write becomes the default in version 3.
         # So, before that, we need to explicitly avoid unnecessary
         # copies by using `copy=False` sometimes.
@@ -172,11 +170,9 @@ class PandasLikeSeries:
 
     @property
     def dtype(self: Self) -> DType:
-        if self._dtype_cache is None:
-            self._dtype_cache = native_to_narwhals_dtype(
-                self._native_series, self._dtypes, self._implementation
-            )
-        return self._dtype_cache
+        return native_to_narwhals_dtype(
+            self._native_series, self._dtypes, self._implementation
+        )
 
     def scatter(self, indices: int | Sequence[int], values: Any) -> Self:
         if isinstance(values, self.__class__):

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -168,6 +168,9 @@ def test_pandas_inplace_modification_1267(request: pytest.FixtureRequest) -> Non
     if PANDAS_VERSION >= (3,):
         # pandas 3.0+ won't allow this kind of inplace modification
         request.applymarker(pytest.mark.xfail)
+    if PANDAS_VERSION < (1, 4):
+        # pandas pre 1.4 wouldn't change the type?
+        request.applymarker(pytest.mark.xfail)
     s = pd.Series([1, 2, 3])
     snw = nw.from_native(s, series_only=True)
     assert snw.dtype == nw.Int64

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -161,3 +161,15 @@ def test_second_time_unit() -> None:
     s = pa.chunked_array([pa.array([timedelta(1)], type=pa.duration("s"))])
     result = nw.from_native(s, series_only=True)
     assert result.dtype == nw.Duration("s")
+
+
+@pytest.mark.filterwarnings("ignore:Setting an item of incompatible")
+def test_pandas_inplace_modification_1267(request: pytest.FixtureRequest) -> None:
+    if PANDAS_VERSION >= (3,):
+        # pandas 3.0+ won't allow this kind of inplace modification
+        request.applymarker(pytest.mark.xfail)
+    s = pd.Series([1, 2, 3])
+    snw = nw.from_native(s, series_only=True)
+    assert snw.dtype == nw.Int64
+    s[0] = 999.5
+    assert snw.dtype == nw.Float64


### PR DESCRIPTION
… which modify dtype do not result in incorrect dtype

closes #1267 

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

