### PR TITLE
docs: Render table of contents members ordered & removed css reference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,9 +76,7 @@ theme:
       toggle:
         icon: material/brightness-4
         name: Switch to system preference
-extra_css:
-  - https://unpkg.com/katex@0/dist/katex.min.css
-  - css/mkdocstrings.css
+
 
 plugins:
 - search
@@ -89,6 +87,8 @@ plugins:
         - https://installer.readthedocs.io/en/stable/objects.inv
         rendering:
           show_signature_annotations: true
+        options:
+          members_order: alphabetical
 
 hooks:
 - utils/generate_backend_completeness.py


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.
I think it's easier to find info on ToC if it's ordered.. but feel free to ignore me :-)
The extra_css is not needed and causes a 404. 
