### PR TITLE
fix: np.datetime64 scalar with ns resolution was become int instead of datetime in to_py_scalar

### DIFF
--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -857,6 +857,13 @@ def to_py_scalar(scalar_like: Any) -> Any:
         return scalar_like
 
     np = get_numpy()
+    if (
+        np
+        and isinstance(scalar_like, np.datetime64)
+        and scalar_like.dtype == "datetime64[ns]"
+    ):
+        return datetime(1970, 1, 1) + timedelta(microseconds=scalar_like.item() // 1000)
+
     if np and np.isscalar(scalar_like) and hasattr(scalar_like, "item"):
         return scalar_like.item()
 

--- a/tests/translate/to_py_scalar_test.py
+++ b/tests/translate/to_py_scalar_test.py
@@ -10,6 +10,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from narwhals.dependencies import get_cudf
+from tests.utils import PANDAS_VERSION
 
 
 @pytest.mark.parametrize(
@@ -30,7 +31,6 @@ from narwhals.dependencies import get_cudf
         (np.datetime64("2020-01-01", "ms"), datetime(2020, 1, 1)),
         (np.datetime64("2020-01-01", "us"), datetime(2020, 1, 1)),
         (np.datetime64("2020-01-01", "ns"), datetime(2020, 1, 1)),
-        (pd.NA, None),
     ],
 )
 def test_to_py_scalar(
@@ -41,6 +41,13 @@ def test_to_py_scalar(
     if expected == 1:
         assert not isinstance(output, np.int64)
     assert output == expected
+
+
+@pytest.mark.skipif(
+    PANDAS_VERSION < (1,), reason="there was a (better?) time when there was no pd.NA"
+)
+def test_na_to_py_scalar() -> None:
+    assert nw.to_py_scalar(pd.NA) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/translate/to_py_scalar_test.py
+++ b/tests/translate/to_py_scalar_test.py
@@ -30,6 +30,7 @@ from narwhals.dependencies import get_cudf
         (np.datetime64("2020-01-01", "ms"), datetime(2020, 1, 1)),
         (np.datetime64("2020-01-01", "us"), datetime(2020, 1, 1)),
         (np.datetime64("2020-01-01", "ns"), datetime(2020, 1, 1)),
+        (pd.NA, None),
     ],
 )
 def test_to_py_scalar(


### PR DESCRIPTION


closes #1300 

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

