### PR TITLE
feat: support passing index object directly into maybe_set_index

### DIFF
--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -322,7 +322,7 @@ def maybe_set_index(
                 )
             )
 
-        if index is not None:
+        if index is not None:  # pragma: no cover
             from narwhals.series import Series
 
             if _is_iterable(index):

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -307,11 +307,11 @@ def maybe_set_index(
     native_frame = to_native(df_any)
 
     if column_names is not None and index is not None:
-        msg = "Only one of `column_names` or `keys` should be provided"
+        msg = "Only one of `column_names` or `index` should be provided"
         raise ValueError(msg)
 
     if not column_names and not index:
-        msg = "Either `column_names` or `keys` should be provided"
+        msg = "Either `column_names` or `index` should be provided"
         raise ValueError(msg)
 
     if is_pandas_like_dataframe(native_frame):
@@ -327,7 +327,7 @@ def maybe_set_index(
 
             if _is_iterable(index):
                 index = [
-                    key.to_native() if isinstance(key, Series) else key for key in index
+                    idx.to_native() if isinstance(idx, Series) else idx for idx in index
                 ]
             if isinstance(index, Series):
                 index = index.to_native()

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -333,9 +333,8 @@ def maybe_set_index(
         if column_names:
             msg = "Cannot set index using column names on a Series"
             raise ValueError(msg)
-        native_obj.index = keys
         return df_any._from_compliant_series(  # type: ignore[no-any-return]
-            df_any._compliant_series._from_native_series(native_obj)
+            df_any._compliant_series._from_native_series(native_obj.set_axis(keys))
         )
     else:
         return df_any  # type: ignore[no-any-return]

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -333,9 +333,9 @@ def maybe_set_index(
         if column_names:
             msg = "Cannot set index using column names on a Series"
             raise ValueError(msg)
-
+        native_obj.index = keys
         return df_any._from_compliant_series(  # type: ignore[no-any-return]
-            df_any._compliant_series._from_native_series(native_obj.set_axis(keys))
+            df_any._compliant_series._from_native_series(native_obj)
         )
     else:
         return df_any  # type: ignore[no-any-return]

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -275,16 +275,16 @@ def maybe_get_index(obj: T) -> Any | None:
 
 
 def maybe_set_index(
-    df: T,
+    obj: T,
     column_names: str | list[str] | None = None,
     *,
     index: Series | list[Series] | None = None,
 ) -> T:
     """
-    Set the index of `df`, if `df` is pandas-like, otherwise this is a no-op.
+    Set the index of a DataFrame or a Series, if it's pandas-like.
 
     Arguments:
-        df: object for which maybe set the index (can be either a Narwhals `DataFrame`
+        obj: object for which maybe set the index (can be either a Narwhals `DataFrame`
             or `Series`).
         column_names: name or list of names of the columns to set as index.
             For dataframes, only one of `column_names` and `index` can be specified but
@@ -320,7 +320,7 @@ def maybe_set_index(
         5  2
     """
 
-    df_any = cast(Any, df)
+    df_any = cast(Any, obj)
     native_obj = to_native(df_any)
 
     if column_names is not None and index is not None:

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -348,8 +348,17 @@ def maybe_set_index(
         if column_names:
             msg = "Cannot set index using column names on a Series"
             raise ValueError(msg)
+
+        if (
+            df_any._compliant_series._implementation is Implementation.PANDAS
+            and df_any._compliant_series._backend_version < (1,)
+        ):  # pragma: no cover
+            native_obj = native_obj.set_axis(keys, inplace=False)
+        else:
+            native_obj = native_obj.set_axis(keys)
+
         return df_any._from_compliant_series(  # type: ignore[no-any-return]
-            df_any._compliant_series._from_native_series(native_obj.set_axis(keys))
+            df_any._compliant_series._from_native_series(native_obj)
         )
     else:
         return df_any  # type: ignore[no-any-return]

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -332,6 +332,11 @@ def maybe_set_index(
             if isinstance(index, Series):
                 index = index.to_native()
 
+            if is_pandas_like_series(df_any):
+                native_frame.index = index
+            else:
+                native_frame = native_frame.set_index(index)
+
             return df_any._from_compliant_dataframe(  # type: ignore[no-any-return]
                 df_any._compliant_frame._from_native_frame(native_frame.set_index(index))
             )

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -276,7 +276,8 @@ def maybe_get_index(obj: T) -> Any | None:
 
 def maybe_set_index(df: T, keys: str | Series | list[Series | str]) -> T:
     """
-    Set columns `columns` to be the index of `df`, if `df` is pandas-like.
+    Set columns `keys` to be the index of `df`, if `df` is pandas-like. 'keys' should be
+    a name of an existing column, a Series, or a list of column names and/or Series.
     Notes:
         This is only really intended for backwards-compatibility purposes,
         for example if your library already aligns indices for users.
@@ -296,12 +297,13 @@ def maybe_set_index(df: T, keys: str | Series | list[Series | str]) -> T:
         4  1
         5  2
     """
-    from narwhals.series import Series
 
     df_any = cast(Any, df)
     native_frame = to_native(df_any)
 
     if is_pandas_like_dataframe(native_frame):
+        from narwhals.series import Series
+
         if _is_iterable(keys):
             keys = [key.to_native() if isinstance(key, Series) else key for key in keys]
         if isinstance(keys, Series):

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -281,15 +281,30 @@ def maybe_set_index(
     index: Series | list[Series] | None = None,
 ) -> T:
     """
-    Set the index of `df`, if `df` is pandas-like. The index can either be specified as
-    a existing column name or list of column names with `column_names`, or set directly
-    with a Series or list of Series with `index`.
+    Set the index of `df`, if `df` is pandas-like, otherwise this is a no-op.
+
+    Arguments:
+        df: object for which maybe set the index (can be either a Narwhals `DataFrame`
+            or `Series`).
+        column_names: name or list of names of the columns to set as index.
+            For dataframes, only one of `column_names` and `index` can be specified but
+            not both. If `column_names` is passed and `df` is a Series, then a
+            `ValueError` is raised.
+        index: series or list of series to set as index.
+
+    Raises:
+        ValueError: If one of the following condition happens:
+
+            - none of `column_names` and `index` are provided
+            - both `column_names` and `index` are provided
+            - `column_names` is provided and `df` is a Series
 
     Notes:
         This is only really intended for backwards-compatibility purposes, for example if
         your library already aligns indices for users.
         If you're designing a new library, we highly encourage you to not
         rely on the Index.
+
         For non-pandas-like inputs, this is a no-op.
 
     Examples:

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -320,7 +320,7 @@ def maybe_set_index(
         keys = (
             [to_native(idx, pass_through=True) for idx in index]
             if _is_iterable(index)
-            else [to_native(index, pass_through=True)]
+            else to_native(index, pass_through=True)
         )
     else:
         keys = column_names

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -139,11 +139,11 @@ def test_maybe_set_index_pandas_either_index_or_column_names() -> None:
     column_names = ["a", "b"]
     index = nw.from_native(pd.Series([0, 1, 2]), series_only=True)
     with pytest.raises(
-        ValueError, match="Only one of `column_names` or `keys` should be provided"
+        ValueError, match="Only one of `column_names` or `index` should be provided"
     ):
         nw.maybe_set_index(df, column_names=column_names, index=index)
     with pytest.raises(
-        ValueError, match="Either `column_names` or `keys` should be provided"
+        ValueError, match="Either `column_names` or `index` should be provided"
     ):
         nw.maybe_set_index(df)
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -143,6 +143,14 @@ def test_maybe_set_index_polars_direct_index(
     assert result is df
 
 
+def test_maybe_set_index_pandas_series_column_names() -> None:
+    df = nw.from_native(pd.Series([0, 1, 2]), allow_series=True)
+    with pytest.raises(
+        ValueError, match="Cannot set index using column names on a Series"
+    ):
+        nw.maybe_set_index(df, column_names=["a"])
+
+
 def test_maybe_set_index_pandas_either_index_or_column_names() -> None:
     df = nw.from_native(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}))
     column_names = ["a", "b"]


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue #1239
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.
[Pandas set_index docs](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.set_index.html#pandas-dataframe-set-index)
[Pandas set_index test cases](https://github.com/pandas-dev/pandas/blob/9a015d19514597ad5d1c31f566a0a2bdb17d4cc5/pandas/tests/frame/methods/test_set_index.py#L309)
I've renamed the `column_names: str | list[str]` parameter to `keys: str | Series | list[Series | str]`. I referenced the Pandas docs where which have `keys: label or array-like or list of labels/arrays`. Since this is a backwards-compatability function, I figured it is good for it to be close to the Pandas spec, and the original param name `column` doesn't cover all cases anymore.
