### PR TITLE
ci: trigger slow downstream libraries tests suites before release

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,8 +14,12 @@ on:
         - major
 
 jobs:
+  downstream-tests-slow:
+     uses: ./.github/workflows/downstream_tests_slow.yml
+
   bump-version:
     runs-on: ubuntu-latest
+    needs: downstream-tests-slow
     steps:
 
     - uses: actions/checkout@v4

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,12 +14,8 @@ on:
         - major
 
 jobs:
-  downstream-tests-slow:
-     uses: ./.github/workflows/downstream_tests_slow.yml
-
   bump-version:
     runs-on: ubuntu-latest
-    needs: downstream-tests-slow
     steps:
 
     - uses: actions/checkout@v4

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -1,4 +1,4 @@
-name: Test Downstream Libraries
+name: Test Downstream Libraries - Fast
 
 on: 
   pull_request:
@@ -230,60 +230,3 @@ jobs:
         run: |
             cd tubular
             pytest tests --config-file=pyproject.toml
-  
-  # vegafusion:
-  #    env:
-  #      UV_SYSTEM_PYTHON: true
-
-  #    strategy:
-  #      matrix:
-  #        python-version: ["3.11"]
-  #        os: [ubuntu-latest]
-
-  #    runs-on: ${{ matrix.os }}
-  #    steps:
-  #       - uses: actions/checkout@v4
-  #       - uses: actions/setup-python@v5
-  #         with:
-  #           python-version: ${{ matrix.python-version }}
-  #       - name: Install uv
-  #         uses: astral-sh/setup-uv@v3
-  #         with:
-  #           enable-cache: "true"
-  #           cache-suffix: ${{ matrix.python-version }}
-  #           cache-dependency-glob: "**requirements*.txt"
-  #       - name: clone-vegafusion
-  #         run: |
-  #             git clone --single-branch -b v2 https://github.com/vega/vegafusion.git
-  #             cd vegafusion
-  #             git log
-  #       - name: Cache rust dependencies
-  #         uses: Swatinem/rust-cache@v2
-  #         with:
-  #           workspaces: vegafusion
-  #       - name: Build wheels
-  #         uses: PyO3/maturin-action@v1
-  #         with:
-  #           command: build
-  #           manylinux: 2014
-  #           rust-toolchain: stable
-  #           args: --release -m vegafusion/vegafusion-python/Cargo.toml --features=protobuf-src --strip
-  #       - name: Install wheels
-  #         working-directory: vegafusion/target/wheels/
-  #         run: |
-  #           ls -la
-  #           python -m pip install vegafusion-*manylinux*.whl
-
-  #           # Optional dependencies
-  #           python -m pip install pyarrow pandas polars-lts-cpu "duckdb>=1.0" "vl-convert-python>=1.0.1rc1" scikit-image "pandas>=2.2" jupytext voila anywidget ipywidgets chromedriver-binary-auto
-
-  #           # Test dependencies
-  #           python -m pip install pytest altair vega-datasets scikit-image jupytext voila ipykernel anywidget ipywidgets selenium flaky tenacity chromedriver-binary-auto 
-  #       - name: Test lazy imports
-  #         working-directory: vegafusion/vegafusion-python/
-  #         run: python checks/check_lazy_imports.py
-  #       - name: Test vegafusion
-  #         working-directory: vegafusion/vegafusion-python/
-  #         env:
-  #           VEGAFUSION_TEST_HEADLESS: 1
-  #         run: pytest

--- a/.github/workflows/downstream_tests_slow.yml
+++ b/.github/workflows/downstream_tests_slow.yml
@@ -1,0 +1,62 @@
+name: Test Downstream Libraries - Slow
+
+on: 
+  workflow_call:
+
+jobs:
+  vegafusion:
+     env:
+       UV_SYSTEM_PYTHON: true
+
+     strategy:
+       matrix:
+         python-version: ["3.11"]
+         os: [ubuntu-latest]
+
+     runs-on: ${{ matrix.os }}
+     steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-python@v5
+          with:
+            python-version: ${{ matrix.python-version }}
+        - name: Install uv
+          uses: astral-sh/setup-uv@v3
+          with:
+            enable-cache: "true"
+            cache-suffix: ${{ matrix.python-version }}
+            cache-dependency-glob: "**requirements*.txt"
+        - name: clone-vegafusion
+          run: |
+              git clone --single-branch -b v2 https://github.com/vega/vegafusion.git
+              cd vegafusion
+              git log
+        - name: Cache rust dependencies
+          uses: Swatinem/rust-cache@v2
+          with:
+            workspaces: vegafusion
+        - name: Build wheels
+          uses: PyO3/maturin-action@v1
+          with:
+            command: build
+            manylinux: 2014
+            rust-toolchain: stable
+            args: --release -m vegafusion/vegafusion-python/Cargo.toml --features=protobuf-src --strip
+        - name: Install wheels
+          working-directory: vegafusion/target/wheels/
+          run: |
+            ls -la
+            python -m pip install vegafusion-*manylinux*.whl
+
+            # Optional dependencies
+            python -m pip install pyarrow pandas polars-lts-cpu "duckdb>=1.0" "vl-convert-python>=1.0.1rc1" scikit-image "pandas>=2.2" jupytext voila anywidget ipywidgets chromedriver-binary-auto
+
+            # Test dependencies
+            python -m pip install pytest altair vega-datasets scikit-image jupytext voila ipykernel anywidget ipywidgets selenium flaky tenacity chromedriver-binary-auto 
+        - name: Test lazy imports
+          working-directory: vegafusion/vegafusion-python/
+          run: python checks/check_lazy_imports.py
+        - name: Test vegafusion
+          working-directory: vegafusion/vegafusion-python/
+          env:
+            VEGAFUSION_TEST_HEADLESS: 1
+          run: pytest

--- a/.github/workflows/downstream_tests_slow.yml
+++ b/.github/workflows/downstream_tests_slow.yml
@@ -2,6 +2,7 @@ name: Test Downstream Libraries - Slow
 
 on: 
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   vegafusion:

--- a/.github/workflows/downstream_tests_slow.yml
+++ b/.github/workflows/downstream_tests_slow.yml
@@ -1,7 +1,11 @@
 name: Test Downstream Libraries - Slow
 
 on: 
-  workflow_call:
+  push:
+    branches-ignore:
+      - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   vegafusion:

--- a/.github/workflows/downstream_tests_slow.yml
+++ b/.github/workflows/downstream_tests_slow.yml
@@ -1,11 +1,7 @@
 name: Test Downstream Libraries - Slow
 
 on: 
-  push:
-    branches-ignore:
-      - main
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+  workflow_call:
 
 jobs:
   vegafusion:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,6 +1,11 @@
 name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
-on: push
+on: 
+  push:
+    branches:
+      - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 
 jobs:
@@ -29,9 +34,7 @@ jobs:
         path: dist/
 
   publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/v')  # only publish to PyPI on tag pushes
+    name: Publish Python 🐍 distribution 📦 to PyPI
     needs:
     - build
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -2,15 +2,17 @@ name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
 on: 
   push:
-    branches:
-      - main
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 
 
 jobs:
+  slow-downstream-tests:
+    uses: ./.github/workflows/downstream_tests_slow.yml
+
   build:
     name: Build distribution 📦
+    needs: slow-downstream-tests
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues 

- Related PR #1228 

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

EDIT: I changed my mind 😄 I think the "slow tests" and the "publish" workflows should all run in the bump-version PR. So we can see if everything went well before merging.

The flow would be:
1. bump version
2. PR with new tag
3. Publish workflow starts along side all other workflows
4. The publish workflow triggers the "slow tests" workflow and wait for completion
5. Library published
6. merge release PR to main and celebration


~The slow tests are triggered when a tag is pushed to a branch that is _not_ `main`. Since "Bump version" creates a tag on a `bump-version` branch, this should also trigger the slow tests when the bump version PR is made. 
I also changed the "Publish Python" workflow to be triggered on tag pushes on `main`.~

~The flow would be:~
~1. bump version~
~2. PR with new tag~
~3. slow tests running along side all tests~
~4. merge PR to main~
~5. Publish workflow is triggered~
~6. Library published and celebrations~

~Currently the "publish" workflow is triggered in the "bump version" PR though. And you can see the results of the workflow before merging to `main`. Is this something that we need to keep?~