### PR TITLE
perf: improve `ArrowGroupBy.__iter__` performances

### DIFF
--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -8,6 +8,7 @@ from typing import Iterator
 
 from narwhals._expression_parsing import is_simple_aggregation
 from narwhals._expression_parsing import parse_into_exprs
+from narwhals.utils import generate_temporary_column_name
 from narwhals.utils import remove_prefix
 
 if TYPE_CHECKING:
@@ -79,16 +80,38 @@ class ArrowGroupBy:
         )
 
     def __iter__(self) -> Iterator[tuple[Any, ArrowDataFrame]]:
-        key_values = self._df.select(*self._keys).unique(subset=self._keys, keep="first")
-        nw_namespace = self._df.__narwhals_namespace__()
+        import pyarrow as pa  # ignore-banned-import
+        import pyarrow.compute as pc  # ignore-banned-import
+
+        col_token = generate_temporary_column_name(n_bytes=8, columns=self._df.columns)
+        null_token = "__null_token_value__"  # noqa: S105
+
+        table = self._df._native_frame
+        key_values = pc.binary_join_element_wise(
+            *[pc.cast(table[key], pa.string()) for key in self._keys],
+            "",
+            null_handling="replace",
+            null_replacement=null_token,
+        )
+        table = table.add_column(i=0, field_=col_token, column=key_values)
+
         yield from (
             (
-                key_value,
-                self._df.filter(
-                    *[nw_namespace.col(k) == v for k, v in zip(self._keys, key_value)]
+                next(
+                    (
+                        t := self._df._from_native_frame(
+                            table.filter(pc.equal(table[col_token], v)).drop_columns(
+                                columns=[col_token]
+                            )
+                        )
+                    )
+                    .select(*self._keys)
+                    .head(1)
+                    .iter_rows()
                 ),
+                t,
             )
-            for key_value in key_values.iter_rows()
+            for v in pc.unique(key_values)
         )
 
 

--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -100,9 +100,7 @@ class ArrowGroupBy:
                 next(
                     (
                         t := self._df._from_native_frame(
-                            table.filter(pc.equal(table[col_token], v)).drop(
-                                columns=[col_token]
-                            )
+                            table.filter(pc.equal(table[col_token], v)).drop(col_token)
                         )
                     )
                     .select(*self._keys)

--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -100,7 +100,7 @@ class ArrowGroupBy:
                 next(
                     (
                         t := self._df._from_native_frame(
-                            table.filter(pc.equal(table[col_token], v)).drop(col_token)
+                            table.filter(pc.equal(table[col_token], v)).drop([col_token])
                         )
                     )
                     .select(*self._keys)

--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -100,7 +100,7 @@ class ArrowGroupBy:
                 next(
                     (
                         t := self._df._from_native_frame(
-                            table.filter(pc.equal(table[col_token], v)).drop_columns(
+                            table.filter(pc.equal(table[col_token], v)).drop(
                                 columns=[col_token]
                             )
                         )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

According to Marco's performance benchmarking for plotly, the bottleneck for a few functions seems to be the call we do to `ArrowGroupBy.__iter__`.

Since pyarrow does not natively support iterating over groups, we (actually pointing finger to myself) implemented a (let's say naive) way of still allowing for that - I remember the use case was for scikit-lego to fully support arrow as well.

This PR tries to improve those performances using native arrow methods and no simple shortcuts. Steps are as follow:

- Create an array containing the string concatenation of the key values (after casting to string). Null handling is required.
- Add the column to the original table
- Return the pair of :
  - key values, obtained as first (and unique) value of filtered table for the key names.
  - sliced dataframe, obtained as filtered table, and dropping the temporary column with string concatenation.

