### PR TITLE
chroe: refactor `ArrowDataFrame.with_columns`

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -305,35 +305,30 @@ class ArrowDataFrame:
         *exprs: IntoArrowExpr,
         **named_exprs: IntoArrowExpr,
     ) -> Self:
+        native_frame = self._native_frame
         new_columns = evaluate_into_exprs(self, *exprs, **named_exprs)
-        new_column_name_to_new_column_map = {s.name: s for s in new_columns}
-        to_concat = []
-        output_names = []
-        # Make sure to preserve column order
+
         length = len(self)
-        for name in self.columns:
-            if name in new_column_name_to_new_column_map:
-                to_concat.append(
-                    validate_dataframe_comparand(
-                        length=length,
-                        other=new_column_name_to_new_column_map.pop(name),
-                        backend_version=self._backend_version,
-                    )
-                )
-            else:
-                to_concat.append(self._native_frame[name])
-            output_names.append(name)
-        for s in new_column_name_to_new_column_map:
-            to_concat.append(
-                validate_dataframe_comparand(
-                    length=length,
-                    other=new_column_name_to_new_column_map[s],
-                    backend_version=self._backend_version,
-                )
+        columns = self.columns
+
+        for col_value in new_columns:
+            col_name = col_value.name
+
+            column = validate_dataframe_comparand(
+                length=length,
+                other=col_value,
+                backend_version=self._backend_version,
             )
-            output_names.append(s)
-        df = self._native_frame.__class__.from_arrays(to_concat, names=output_names)
-        return self._from_native_frame(df)
+
+            native_frame = (
+                native_frame.set_column(
+                    columns.index(col_name), field_=col_name, column=column
+                )
+                if col_name in columns
+                else native_frame.append_column(field_=col_name, column=column)
+            )
+
+        return self._from_native_frame(native_frame)
 
     def group_by(self, *keys: str, drop_null_keys: bool) -> ArrowGroupBy:
         from narwhals._arrow.group_by import ArrowGroupBy

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -184,9 +184,7 @@ def validate_dataframe_comparand(
             value = other[0]
             if backend_version < (13,) and hasattr(value, "as_py"):  # pragma: no cover
                 value = value.as_py()
-            return pa.chunked_array(
-                [np.full(shape=length, fill_value=value, dtype=type(value))]
-            )
+            return pa.array(np.full(shape=length, fill_value=value, dtype=type(value)))
         return other._native_series
 
     from narwhals._arrow.dataframe import ArrowDataFrame  # pragma: no cover

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -181,10 +181,10 @@ def validate_dataframe_comparand(
             import numpy as np  # ignore-banned-import
             import pyarrow as pa  # ignore-banned-import
 
-            value = other[0]
+            value = other._native_series[0]
             if backend_version < (13,) and hasattr(value, "as_py"):  # pragma: no cover
                 value = value.as_py()
-            return pa.array(np.full(shape=length, fill_value=value, dtype=type(value)))
+            return pa.array(np.full(shape=length, fill_value=value))
         return other._native_series
 
     from narwhals._arrow.dataframe import ArrowDataFrame  # pragma: no cover

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -5203,8 +5203,8 @@ def lit(value: Any, dtype: DType | None = None) -> Expr:
 
         >>> func(df_pd)
            a  literal
-        0  1  3
-        1  2  3
+        0  1        3
+        1  2        3
         >>> func(df_pl)
         shape: (2, 2)
         ┌─────┬─────────┐

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -1453,8 +1453,8 @@ def lit(value: Any, dtype: DType | None = None) -> Expr:
 
         >>> func(df_pd)
            a  literal
-        0  1  3
-        1  2  3
+        0  1        3
+        1  2        3
         >>> func(df_pl)
         shape: (2, 2)
         ┌─────┬─────────┐


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added 
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below.

While profiling for plotly, py-spy indicates that we spend a lot of time in `validate_dataframe_comparand` for pyarrow case. This is called only in `with_columns` methods.

This PR proposed two changes:

- Creates constant array via `np.full` in `validate_dataframe_comparand` instead of `[const] * length`
- Changes the logic in `with_columns` to use pyarrow native methods to insert a column value. I expect this to be faster than the current approach of concatenating the already existing columns with the new ones - caveat is if the number of new columns is order(s) of magnitude greater than the existing ones. In _majority_ of scenarios I would expect this to not be the case, but this is the reason I am opening this as **RFC**
