### PR TITLE
test: fix docstrings tests in CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -86,9 +86,9 @@ jobs:
         run: uv pip install ibis-framework[duckdb]>=6.0.0 --system
         # Ibis puts upper bounds on dependencies, and requires Python3.10+,
         # which messes with other dependencies on lower Python versions
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.11'
       - name: Run pytest
         run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=100 --runslow
       - name: Run doctests
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         run: pytest narwhals --doctest-modules

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -5272,8 +5272,8 @@ def lit(value: Any, dtype: DType | None = None) -> Expr:
 
         >>> func(df_pd)
            a  literal
-        0  1  3
-        1  2  3
+        0  1        3
+        1  2        3
         >>> func(df_pl)
         shape: (2, 2)
         ┌─────┬─────────┐

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -1453,8 +1453,8 @@ def lit(value: Any, dtype: DType | None = None) -> Expr:
 
         >>> func(df_pd)
            a  literal
-        0  1  3
-        1  2  3
+        0  1        3
+        1  2        3
         >>> func(df_pl)
         shape: (2, 2)
         ┌─────┬─────────┐


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

The docstring tests didn't run in CI. The Python version for testing docstrings is changed to 3.13 whereas for ibis tests it is changed to 3.11. The outputs are fixed.