### PR TITLE
perf: concatenate less in pandas-like with_columns

### DIFF
--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -432,7 +432,7 @@ class PandasLikeDataFrame:
                 self._implementation,
             )
             other = [
-                validate_dataframe_comparand(index, value).rename(key, copy=False)
+                validate_dataframe_comparand(index, value)
                 for key, value in new_column_name_to_new_column_map.items()
                 if key not in frame.columns
             ]


### PR DESCRIPTION
It was mentioned [here](https://github.com/Nixtla/hierarchicalforecast/pull/305#issuecomment-2471635374) that they're seeing fragmentation warnings from pandas

I think we can address this by only concatenating less in `with_columns`

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues 

- Related issue # 
- Closes #

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added 
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below.

