### PR TITLE
ci: add plotly to downstream tests

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -261,7 +261,7 @@ jobs:
       - name: install-deps
         run: |
             cd plotly.py
-            uv pip install -r packages/python/plotly/test_requirements/requirements_312_core.txt -r packages/python/plotly/test_requirements/requirements_312_optional.txt --system
+            uv pip install -r packages/python/plotly/test_requirements/requirements_312_optional.txt --system
       - name: install-narwhals-dev
         run: |
             uv pip uninstall narwhals --system

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -232,3 +232,43 @@ jobs:
         run: |
             cd tubular
             pytest tests --config-file=pyproject.toml
+
+  plotly:
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: "true"
+          cache-suffix: ${{ matrix.python-version }}
+          cache-dependency-glob: "**requirements*.txt"
+      - name: clone-plotly
+        run: |
+            git clone https://github.com/plotly/plotly.py --depth=1
+            cd plotly.py
+            git log
+      - name: install-basics
+        run: uv pip install --upgrade tox virtualenv setuptools --system
+      - name: install-deps
+        run: |
+            cd plotly.py
+            uv pip install -r packages/python/plotly/test_requirements/requirements_312_core.txt -r packages/python/plotly/test_requirements/requirements_312_optional.txt --system
+      - name: install-narwhals-dev
+        run: |
+            uv pip uninstall narwhals --system
+            uv pip install -e . --system
+      - name: show-deps
+        run: uv pip freeze
+      - name: Run pytest on plotly express
+        run: |
+            cd plotly.py
+            pytest packages/python/plotly/plotly/tests/test_optional/test_px


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## If you have comments or can explain your changes, please do so below.

Since yesterday the PR to [narwhalify plotly express](https://github.com/plotly/plotly.py/pull/4790) got merged, we should start to include (some) plotly tests in our ci as promised!

Opening this as draft because it was not fully decided which tests should be run.

@emilykl this is along the lines of how we would test that each commit does not end up breaking plotly via its unit tests

Associated plotly issue: https://github.com/plotly/plotly.py/issues/4864