### PR TITLE
feat: add `Series|Expr.cum_count` method

### DIFF
--- a/docs/api-reference/expr.md
+++ b/docs/api-reference/expr.md
@@ -11,6 +11,7 @@
         - arg_true
         - cast
         - count
+        - cum_count
         - cum_sum
         - diff
         - drop_nulls

--- a/docs/api-reference/series.md
+++ b/docs/api-reference/series.md
@@ -15,6 +15,7 @@
         - cast
         - clip
         - count
+        - cum_count
         - cum_sum
         - diff
         - drop_nulls

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -430,6 +430,9 @@ class ArrowExpr:
             dtypes=self._dtypes,
         )
 
+    def cum_count(self: Self, *, reverse: bool) -> Self:
+        return reuse_series_implementation(self, "cum_count", reverse=reverse)
+
     @property
     def dt(self: Self) -> ArrowExprDateTimeNamespace:
         return ArrowExprDateTimeNamespace(self)

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -394,7 +394,9 @@ class ArrowSeries:
     def cum_sum(self) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        return self._from_native_series(pc.cumulative_sum(self._native_series))
+        return self._from_native_series(
+            pc.cumulative_sum(self._native_series, skip_nulls=True)
+        )
 
     def round(self, decimals: int) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
@@ -814,6 +816,14 @@ class ArrowSeries:
         return self.value_counts(name=col_token, normalize=False).filter(
             plx.col(col_token) == plx.col(col_token).max()
         )[self.name]
+
+    def cum_count(self: Self, *, reverse: bool) -> Self:
+        not_na_series = (~self.is_null()).cast(self._dtypes.UInt32())
+        return (
+            not_na_series.cum_sum()
+            if not reverse
+            else len(self) - not_na_series.cum_sum() + not_na_series - 1
+        )
 
     def __iter__(self: Self) -> Iterator[Any]:
         yield from self._native_series.__iter__()

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -749,6 +749,10 @@ class DaskExpr:
         msg = "`Expr.mode` is not supported for the Dask backend."
         raise NotImplementedError(msg)
 
+    def cum_count(self: Self, *, reverse: bool) -> Self:
+        msg = "`Expr.cum_count` is not supported for the Dask backend."
+        raise NotImplementedError(msg)
+
     @property
     def str(self: Self) -> DaskExprStringNamespace:
         return DaskExprStringNamespace(self)

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -441,6 +441,9 @@ class PandasLikeExpr:
             dtypes=self._dtypes,
         )
 
+    def cum_count(self: Self, *, reverse: bool) -> Self:
+        return reuse_series_implementation(self, "cum_count", reverse=reverse)
+
     @property
     def str(self: Self) -> PandasLikeExprStringNamespace:
         return PandasLikeExprStringNamespace(self)

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -759,6 +759,15 @@ class PandasLikeSeries:
         result.name = native_series.name
         return self._from_native_series(result)
 
+    def cum_count(self: Self, *, reverse: bool) -> Self:
+        not_na_series = ~self._native_series.isna()
+        result = (
+            not_na_series.cumsum()
+            if not reverse
+            else len(self) - not_na_series.cumsum() + not_na_series - 1
+        )
+        return self._from_native_series(result)
+
     def __iter__(self: Self) -> Iterator[Any]:
         yield from self._native_series.__iter__()
 

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -127,6 +127,15 @@ class PolarsExpr:
     def __invert__(self) -> Self:
         return self._from_native_expr(self._native_expr.__invert__())
 
+    def cum_count(self: Self, *, reverse: bool = False) -> Self:
+        if self._backend_version < (0, 20, 4):
+            not_null = ~self._native_expr.is_null()
+            result = not_null.cum_sum(reverse=reverse)
+        else:
+            result = self._native_expr.cum_count(reverse=reverse)
+
+        return self._from_native_expr(result)
+
     @property
     def dt(self) -> PolarsExprDateTimeNamespace:
         return PolarsExprDateTimeNamespace(self)

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -127,7 +127,7 @@ class PolarsExpr:
     def __invert__(self) -> Self:
         return self._from_native_expr(self._native_expr.__invert__())
 
-    def cum_count(self: Self, *, reverse: bool = False) -> Self:
+    def cum_count(self: Self, *, reverse: bool) -> Self:
         if self._backend_version < (0, 20, 4):
             not_null = ~self._native_expr.is_null()
             result = not_null.cum_sum(reverse=reverse)

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -281,6 +281,15 @@ class PolarsSeries:
             result, backend_version=self._backend_version, dtypes=self._dtypes
         )
 
+    def cum_count(self: Self, *, reverse: bool = False) -> Self:
+        if self._backend_version < (0, 20, 4):
+            not_null_series = ~self._native_series.is_null()
+            result = not_null_series.cum_sum(reverse=reverse)
+        else:
+            result = self._native_series.cum_count(reverse=reverse)
+
+        return self._from_native_series(result)
+
     @property
     def dt(self) -> PolarsSeriesDateTimeNamespace:
         return PolarsSeriesDateTimeNamespace(self)

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -281,7 +281,7 @@ class PolarsSeries:
             result, backend_version=self._backend_version, dtypes=self._dtypes
         )
 
-    def cum_count(self: Self, *, reverse: bool = False) -> Self:
+    def cum_count(self: Self, *, reverse: bool) -> Self:
         if self._backend_version < (0, 20, 4):
             not_null_series = ~self._native_series.is_null()
             result = not_null_series.cum_sum(reverse=reverse)

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -2599,6 +2599,63 @@ class Expr:
         """
         return self.__class__(lambda plx: self._call(plx).mode())
 
+    def cum_count(self: Self, *, reverse: bool = False) -> Self:
+        r"""
+        Return the cumulative count of the non-null values in the column.
+
+        Arguments:
+            reverse: reverse the operation
+
+        Examples:
+            >>> import narwhals as nw
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import pyarrow as pa
+            >>> data = {"a": ["x", "k", None, "d"]}
+
+            We define a library agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     return df.with_columns(
+            ...         nw.col("a").cum_count().alias("cum_count"),
+            ...         nw.col("a").cum_count(reverse=True).alias("cum_count_reverse"),
+            ...     )
+
+            We can then pass any supported library such as Pandas, Polars, or PyArrow to `func`:
+
+            >>> func(pd.DataFrame(data))
+                  a  cum_count  cum_count_reverse
+            0     x          1                  3
+            1     k          2                  2
+            2  None          2                  1
+            3     d          3                  1
+
+            >>> func(pl.DataFrame(data))
+            shape: (4, 3)
+            ┌──────┬───────────┬───────────────────┐
+            │ a    ┆ cum_count ┆ cum_count_reverse │
+            │ ---  ┆ ---       ┆ ---               │
+            │ str  ┆ u32       ┆ u32               │
+            ╞══════╪═══════════╪═══════════════════╡
+            │ x    ┆ 1         ┆ 3                 │
+            │ k    ┆ 2         ┆ 2                 │
+            │ null ┆ 2         ┆ 1                 │
+            │ d    ┆ 3         ┆ 1                 │
+            └──────┴───────────┴───────────────────┘
+
+            >>> func(pa.table(data))
+            pyarrow.Table
+            a: string
+            cum_count: uint32
+            cum_count_reverse: int64
+            ----
+            a: [["x","k",null,"d"]]
+            cum_count: [[1,2,2,3]]
+            cum_count_reverse: [[3,2,1,1]]
+        """
+        return self.__class__(lambda plx: self._call(plx).cum_count(reverse=reverse))
+
     @property
     def str(self: Self) -> ExprStringNamespace[Self]:
         return ExprStringNamespace(self)

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2689,6 +2689,59 @@ class Series:
         """
         return self._from_compliant_series(self._compliant_series.mode())
 
+    def cum_count(self: Self, *, reverse: bool = False) -> Self:
+        r"""
+        Return the cumulative count of the non-null values in the series.
+
+        Arguments:
+            reverse: reverse the operation
+
+        Examples:
+            >>> import narwhals as nw
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import pyarrow as pa
+            >>> data = ["x", "k", None, "d"]
+
+            We define a library agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(s):
+            ...     return s.cum_count(reverse=True)
+
+            We can then pass any supported library such as Pandas, Polars, or PyArrow to `func`:
+
+            >>> func(pd.Series(data))
+            0    3
+            1    2
+            2    1
+            3    1
+            dtype: int64
+            >>> func(pl.Series(data))  # doctest:+NORMALIZE_WHITESPACE
+            shape: (4,)
+            Series: '' [u32]
+            [
+                3
+                2
+                1
+                1
+            ]
+            >>> func(pa.chunked_array([data]))  # doctest:+ELLIPSIS
+            <pyarrow.lib.ChunkedArray object at ...>
+            [
+              [
+                3,
+                2,
+                1,
+                1
+              ]
+            ]
+
+        """
+        return self._from_compliant_series(
+            self._compliant_series.cum_count(reverse=reverse)
+        )
+
     def __iter__(self: Self) -> Iterator[Any]:
         yield from self._compliant_series.__iter__()
 

--- a/tests/expr_and_series/cum_count_test.py
+++ b/tests/expr_and_series/cum_count_test.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+import narwhals.stable.v1 as nw
+from tests.utils import Constructor
+from tests.utils import ConstructorEager
+from tests.utils import assert_equal_data
+
+data = {
+    "a": ["x", "y", None, "z"],
+}
+
+
+def test_cum_count_expr(request: pytest.FixtureRequest, constructor: Constructor) -> None:
+    if "dask" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
+
+    df = nw.from_native(constructor(data))
+    result = df.select(
+        cum_count=nw.col("a").cum_count(),
+        reverse_cum_count=nw.col("a").cum_count(reverse=True),
+    )
+    expected = {
+        "cum_count": [1, 2, 2, 3],
+        "reverse_cum_count": [3, 2, 1, 1],
+    }
+    assert_equal_data(result, expected)
+
+
+def test_cum_count_series(constructor_eager: ConstructorEager) -> None:
+    df = nw.from_native(constructor_eager(data), eager_only=True)
+    result = df.select(
+        cum_count=df["a"].cum_count(),
+        reverse_cum_count=df["a"].cum_count(reverse=True),
+    )
+    expected = {
+        "cum_count": [1, 2, 2, 3],
+        "reverse_cum_count": [3, 2, 1, 1],
+    }
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/cum_sum_test.py
+++ b/tests/expr_and_series/cum_sum_test.py
@@ -6,7 +6,7 @@ from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
 data = {
-    "a": [0, 1, 2, 3, 4],
+    "a": [0, 1, 2, None, 4],
     "b": [1, 2, 3, 5, 3],
     "c": [5, 4, 3, 2, 1],
 }
@@ -16,7 +16,7 @@ def test_cum_sum_simple(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a", "b", "c").cum_sum())
     expected = {
-        "a": [0, 1, 3, 6, 10],
+        "a": [0, 1, 3, None, 7],
         "b": [1, 3, 6, 11, 14],
         "c": [5, 9, 12, 14, 15],
     }
@@ -26,7 +26,7 @@ def test_cum_sum_simple(constructor: Constructor) -> None:
 def test_cum_sum_simple_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     expected = {
-        "a": [0, 1, 3, 6, 10],
+        "a": [0, 1, 3, None, 7],
         "b": [1, 3, 6, 11, 14],
         "c": [5, 9, 12, 14, 15],
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #1371

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

I have dask skill issues. Replicating what works for pandas raises an error:

>     def _divisions(self):
>        # This is an issue.  In normal Dask we re-divide everything in a step
>        # which combines divisions and graph.
>        # We either have to create a new Align layer (ok) or combine divisions
>        # and graph into a single operation.
>        dependencies = self.dependencies()
>        for arg in dependencies:
>            if not self._broadcast_dep(arg):
>               assert arg.divisions == dependencies[0].divisions
> E               AssertionError

Code:

```py
def cum_count(self, reverse):
    def func(_input: dask_expr.Series, _reverse: bool) -> dask_expr.Series:
        not_na_series = (~_input.isna()).astype(int)
        return (
            not_na_series.cumsum()
            if not _reverse
            else _input.size - not_na_series.cumsum() + not_na_series - 1
       )

return self._from_call(
    func,
    "cum_count",
    reverse,
    returns_scalar=False,
)
```