### PR TITLE
feat: add `Series|Expr.rolling_sum` method

### DIFF
--- a/docs/api-reference/exceptions.md
+++ b/docs/api-reference/exceptions.md
@@ -7,5 +7,6 @@
         - ColumnNotFoundError
         - InvalidIntoExprError
         - InvalidOperationError
+        - NarwhalsUnstableWarning
       show_source: false
       show_bases: false

--- a/docs/api-reference/expr.md
+++ b/docs/api-reference/expr.md
@@ -43,6 +43,7 @@
         - pipe
         - quantile
         - replace_strict
+        - rolling_sum
         - round
         - sample
         - shift

--- a/docs/api-reference/series.md
+++ b/docs/api-reference/series.md
@@ -50,6 +50,7 @@
         - quantile
         - rename
         - replace_strict
+        - rolling_sum
         - round
         - sample
         - scatter

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -450,6 +450,21 @@ class ArrowExpr:
     def cum_prod(self: Self, *, reverse: bool) -> Self:
         return reuse_series_implementation(self, "cum_prod", reverse=reverse)
 
+    def rolling_sum(
+        self: Self,
+        window_size: int,
+        *,
+        min_periods: int | None,
+        center: bool,
+    ) -> Self:
+        return reuse_series_implementation(
+            self,
+            "rolling_sum",
+            window_size=window_size,
+            min_periods=min_periods,
+            center=center,
+        )
+
     @property
     def dt(self: Self) -> ArrowExprDateTimeNamespace:
         return ArrowExprDateTimeNamespace(self)

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -831,6 +831,32 @@ class DaskExpr:
             returns_scalar=False,
         )
 
+    def rolling_sum(
+        self: Self,
+        window_size: int,
+        *,
+        min_periods: int | None,
+        center: bool,
+    ) -> Self:
+        def func(
+            _input: dask_expr.Series,
+            _window: int,
+            _min_periods: int | None,
+            _center: bool,  # noqa: FBT001
+        ) -> dask_expr.Series:
+            return _input.rolling(
+                window=_window, min_periods=_min_periods, center=_center
+            ).sum()
+
+        return self._from_call(
+            func,
+            "rolling_sum",
+            window_size,
+            min_periods,
+            center,
+            returns_scalar=False,
+        )
+
 
 class DaskExprStringNamespace:
     def __init__(self, expr: DaskExpr) -> None:

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -461,6 +461,21 @@ class PandasLikeExpr:
     def cum_prod(self: Self, *, reverse: bool) -> Self:
         return reuse_series_implementation(self, "cum_prod", reverse=reverse)
 
+    def rolling_sum(
+        self: Self,
+        window_size: int,
+        *,
+        min_periods: int | None,
+        center: bool,
+    ) -> Self:
+        return reuse_series_implementation(
+            self,
+            "rolling_sum",
+            window_size=window_size,
+            min_periods=min_periods,
+            center=center,
+        )
+
     @property
     def str(self: Self) -> PandasLikeExprStringNamespace:
         return PandasLikeExprStringNamespace(self)

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -798,6 +798,18 @@ class PandasLikeSeries:
         )
         return self._from_native_series(result)
 
+    def rolling_sum(
+        self: Self,
+        window_size: int,
+        *,
+        min_periods: int | None,
+        center: bool,
+    ) -> Self:
+        result = self._native_series.rolling(
+            window=window_size, min_periods=min_periods, center=center
+        ).sum()
+        return self._from_native_series(result)
+
     def __iter__(self: Self) -> Iterator[Any]:
         yield from self._native_series.__iter__()
 

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -805,9 +805,6 @@ class PandasLikeSeries:
         min_periods: int | None,
         center: bool,
     ) -> Self:
-        if window_size == 0:
-            return self.cum_sum(reverse=False).fill_null(strategy="forward")
-
         result = self._native_series.rolling(
             window=window_size, min_periods=min_periods, center=center
         ).sum()

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -457,7 +457,7 @@ class PandasLikeSeries:
         value: Any | None = None,
         strategy: Literal["forward", "backward"] | None = None,
         limit: int | None = None,
-    ) -> PandasLikeSeries:
+    ) -> Self:
         ser = self._native_series
         if value is not None:
             res_ser = self._from_native_series(ser.fillna(value=value))
@@ -805,6 +805,9 @@ class PandasLikeSeries:
         min_periods: int | None,
         center: bool,
     ) -> Self:
+        if window_size == 0:
+            return self.cum_sum(reverse=False).fill_null(strategy="forward")
+
         result = self._native_series.rolling(
             window=window_size, min_periods=min_periods, center=center
         ).sum()

--- a/narwhals/exceptions.py
+++ b/narwhals/exceptions.py
@@ -55,3 +55,7 @@ class InvalidIntoExprError(TypeError):
             "named `0`."
         )
         return InvalidIntoExprError(message)
+
+
+class NarwhalsUnstableWarning(UserWarning):
+    """Warning issued when a method or function is considered unstable in the stable api."""

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -11,6 +11,7 @@ from typing import Sequence
 from typing import TypeVar
 
 from narwhals.dependencies import is_numpy_array
+from narwhals.exceptions import InvalidOperationError
 from narwhals.utils import flatten
 
 if TYPE_CHECKING:
@@ -3014,6 +3015,36 @@ class Expr:
             a: [[1,2,null,4]]
             b: [[1,3,3,6]]
         """
+        if window_size < 0:
+            msg = "window_size should be greater or equal than 0"
+            raise ValueError(msg)
+
+        if not isinstance(window_size, int):
+            _type = window_size.__class__.__name__
+            msg = (
+                f"argument 'window_size': '{_type}' object cannot be "
+                "interpreted as an integer"
+            )
+            raise TypeError(msg)
+
+        if min_periods is not None:
+            if min_periods < 0:
+                msg = "min_periods should be greater or equal than 0"
+                raise ValueError(msg)
+
+            if not isinstance(min_periods, int):
+                _type = min_periods.__class__.__name__
+                msg = (
+                    f"argument 'min_periods': '{_type}' object cannot be "
+                    "interpreted as an integer"
+                )
+                raise TypeError(msg)
+            if min_periods > window_size:
+                msg = "`min_periods` should be less or equal than `window_size`"
+                raise InvalidOperationError(msg)
+        else:
+            min_periods = window_size
+
         return self.__class__(
             lambda plx: self._call(plx).rolling_sum(
                 window_size=window_size,

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -2937,6 +2937,91 @@ class Expr:
         """
         return self.__class__(lambda plx: self._call(plx).cum_prod(reverse=reverse))
 
+    def rolling_sum(
+        self: Self,
+        window_size: int,
+        *,
+        min_periods: int | None = None,
+        center: bool = False,
+    ) -> Self:
+        """Apply a rolling sum (moving sum) over the values.
+
+        !!! warning
+            This functionality is considered **unstable**. It may be changed at any point
+            without it being considered a breaking change.
+
+        A window of length `window_size` will traverse the values. The resulting values
+        will be aggregated to their sum.
+
+        The window at a given row will include the row itself and the `window_size - 1`
+        elements before it.
+
+        Arguments:
+            window_size: The length of the window in number of elements.
+            min_periods: The number of values in the window that should be non-null before
+                computing a result. If set to `None` (default), it will be set equal to
+                `window_size`.
+            center: Set the labels at the center of the window.
+
+        Returns:
+            A new expression.
+
+        Examples:
+            >>> import narwhals as nw
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import pyarrow as pa
+            >>> data = {"a": [1.0, 2.0, None, 4.0]}
+            >>> df_pd = pd.DataFrame(data)
+            >>> df_pl = pl.DataFrame(data)
+            >>> df_pa = pa.table(data)
+
+            We define a library agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     return df.with_columns(
+            ...         b=nw.col("a").rolling_sum(window_size=3, min_periods=1)
+            ...     )
+
+            We can then pass any supported library such as Pandas, Polars, or PyArrow to `func`:
+
+            >>> func(df_pd)
+                 a    b
+            0  1.0  1.0
+            1  2.0  3.0
+            2  NaN  3.0
+            3  4.0  6.0
+
+            >>> func(df_pl)
+            shape: (4, 2)
+            ┌──────┬─────┐
+            │ a    ┆ b   │
+            │ ---  ┆ --- │
+            │ f64  ┆ f64 │
+            ╞══════╪═════╡
+            │ 1.0  ┆ 1.0 │
+            │ 2.0  ┆ 3.0 │
+            │ null ┆ 3.0 │
+            │ 4.0  ┆ 6.0 │
+            └──────┴─────┘
+
+            >>> func(df_pa)  #  doctest:+ELLIPSIS
+            pyarrow.Table
+            a: double
+            b: double
+            ----
+            a: [[1,2,null,4]]
+            b: [[1,3,3,6]]
+        """
+        return self.__class__(
+            lambda plx: self._call(plx).rolling_sum(
+                window_size=window_size,
+                min_periods=min_periods,
+                center=center,
+            )
+        )
+
     @property
     def str(self: Self) -> ExprStringNamespace[Self]:
         return ExprStringNamespace(self)

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -3015,8 +3015,8 @@ class Expr:
             a: [[1,2,null,4]]
             b: [[1,3,3,6]]
         """
-        if window_size < 0:
-            msg = "window_size should be greater or equal than 0"
+        if window_size < 1:
+            msg = "window_size must be greater or equal than 1"
             raise ValueError(msg)
 
         if not isinstance(window_size, int):
@@ -3028,8 +3028,8 @@ class Expr:
             raise TypeError(msg)
 
         if min_periods is not None:
-            if min_periods < 0:
-                msg = "min_periods should be greater or equal than 0"
+            if min_periods < 1:
+                msg = "min_periods must be greater or equal than 1"
                 raise ValueError(msg)
 
             if not isinstance(min_periods, int):
@@ -3040,7 +3040,7 @@ class Expr:
                 )
                 raise TypeError(msg)
             if min_periods > window_size:
-                msg = "`min_periods` should be less or equal than `window_size`"
+                msg = "`min_periods` must be less or equal than `window_size`"
                 raise InvalidOperationError(msg)
         else:
             min_periods = window_size

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -3011,10 +3011,12 @@ class Expr:
         elements before it.
 
         Arguments:
-            window_size: The length of the window in number of elements.
+            window_size: The length of the window in number of elements. It must be a
+                strictly positive integer.
             min_periods: The number of values in the window that should be non-null before
                 computing a result. If set to `None` (default), it will be set equal to
-                `window_size`.
+                `window_size`. If provided, it must be a strictly positive integer, and
+                less than or equal to `window_size`
             center: Set the labels at the center of the window.
 
         Returns:

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2842,6 +2842,89 @@ class Series:
             self._compliant_series.cum_prod(reverse=reverse)
         )
 
+    def rolling_sum(
+        self: Self,
+        window_size: int,
+        *,
+        min_periods: int | None = None,
+        center: bool = False,
+    ) -> Self:
+        """Apply a rolling sum (moving sum) over the values.
+
+        !!! warning
+            This functionality is considered **unstable**. It may be changed at any point
+            without it being considered a breaking change.
+
+        A window of length `window_size` will traverse the values. The resulting values
+        will be aggregated to their sum.
+
+        The window at a given row will include the row itself and the `window_size - 1`
+        elements before it.
+
+        Arguments:
+            window_size: The length of the window in number of elements.
+            min_periods: The number of values in the window that should be non-null before
+                computing a result. If set to `None` (default), it will be set equal to
+                `window_size`.
+            center: Set the labels at the center of the window.
+
+        Returns:
+            A new expression.
+
+        Examples:
+            >>> import narwhals as nw
+            >>> import pandas as pd
+            >>> import polars as pl
+            >>> import pyarrow as pa
+            >>> data = [1.0, 2.0, 3.0, 4.0]
+            >>> s_pd = pd.Series(data)
+            >>> s_pl = pl.Series(data)
+            >>> s_pa = pa.chunked_array([data])
+
+            We define a library agnostic function:
+
+            >>> @nw.narwhalify
+            ... def func(df):
+            ...     return df.rolling_sum(window_size=2)
+
+            We can then pass any supported library such as Pandas, Polars, or PyArrow to `func`:
+
+            >>> func(s_pd)
+            0    NaN
+            1    3.0
+            2    5.0
+            3    7.0
+            dtype: float64
+
+            >>> func(s_pl)  # doctest:+NORMALIZE_WHITESPACE
+            shape: (4,)
+            Series: '' [f64]
+            [
+               null
+               3.0
+               5.0
+               7.0
+            ]
+
+            >>> func(s_pa)  # doctest:+ELLIPSIS
+            <pyarrow.lib.ChunkedArray object at ...>
+            [
+              [
+                null,
+                3,
+                5,
+                7
+              ]
+            ]
+        """
+        return self._from_compliant_series(
+            self._compliant_series.rolling_sum(
+                window_size=window_size,
+                min_periods=min_periods,
+                center=center,
+            )
+        )
+
     def __iter__(self: Self) -> Iterator[Any]:
         yield from self._compliant_series.__iter__()
 

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -11,6 +11,7 @@ from typing import Sequence
 from typing import TypeVar
 from typing import overload
 
+from narwhals.exceptions import InvalidOperationError
 from narwhals.utils import parse_version
 
 if TYPE_CHECKING:
@@ -2917,6 +2918,39 @@ class Series:
               ]
             ]
         """
+        if window_size < 0:
+            msg = "window_size should be greater or equal than 0"
+            raise ValueError(msg)
+
+        if not isinstance(window_size, int):
+            _type = window_size.__class__.__name__
+            msg = (
+                f"argument 'window_size': '{_type}' object cannot be "
+                "interpreted as an integer"
+            )
+            raise TypeError(msg)
+
+        if min_periods is not None:
+            if min_periods < 0:
+                msg = "min_periods should be greater or equal than 0"
+                raise ValueError(msg)
+
+            if not isinstance(min_periods, int):
+                _type = min_periods.__class__.__name__
+                msg = (
+                    f"argument 'min_periods': '{_type}' object cannot be "
+                    "interpreted as an integer"
+                )
+                raise TypeError(msg)
+            if min_periods > window_size:
+                msg = "`min_periods` should be less or equal than `window_size`"
+                raise InvalidOperationError(msg)
+        else:
+            min_periods = window_size
+
+        if len(self) == 0:  # pragma: no cover
+            return self
+
         return self._from_compliant_series(
             self._compliant_series.rolling_sum(
                 window_size=window_size,

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2918,8 +2918,8 @@ class Series:
               ]
             ]
         """
-        if window_size < 0:
-            msg = "window_size should be greater or equal than 0"
+        if window_size < 1:
+            msg = "window_size must be greater or equal than 1"
             raise ValueError(msg)
 
         if not isinstance(window_size, int):
@@ -2931,8 +2931,8 @@ class Series:
             raise TypeError(msg)
 
         if min_periods is not None:
-            if min_periods < 0:
-                msg = "min_periods should be greater or equal than 0"
+            if min_periods < 1:
+                msg = "min_periods must be greater or equal than 1"
                 raise ValueError(msg)
 
             if not isinstance(min_periods, int):
@@ -2943,7 +2943,7 @@ class Series:
                 )
                 raise TypeError(msg)
             if min_periods > window_size:
-                msg = "`min_periods` should be less or equal than `window_size`"
+                msg = "`min_periods` must be less or equal than `window_size`"
                 raise InvalidOperationError(msg)
         else:
             min_periods = window_size

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2919,10 +2919,12 @@ class Series:
         elements before it.
 
         Arguments:
-            window_size: The length of the window in number of elements.
+            window_size: The length of the window in number of elements. It must be a
+                strictly positive integer.
             min_periods: The number of values in the window that should be non-null before
                 computing a result. If set to `None` (default), it will be set equal to
-                `window_size`.
+                `window_size`. If provided, it must be a strictly positive integer, and
+                less than or equal to `window_size`
             center: Set the labels at the center of the window.
 
         Returns:

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -513,10 +513,12 @@ class Series(NwSeries):
         elements before it.
 
         Arguments:
-            window_size: The length of the window in number of elements.
+            window_size: The length of the window in number of elements. It must be a
+                strictly positive integer.
             min_periods: The number of values in the window that should be non-null before
                 computing a result. If set to `None` (default), it will be set equal to
-                `window_size`.
+                `window_size`. If provided, it must be a strictly positive integer, and
+                less than or equal to `window_size`
             center: Set the labels at the center of the window.
 
         Returns:
@@ -607,10 +609,12 @@ class Expr(NwExpr):
         elements before it.
 
         Arguments:
-            window_size: The length of the window in number of elements.
+            window_size: The length of the window in number of elements. It must be a
+                strictly positive integer.
             min_periods: The number of values in the window that should be non-null before
                 computing a result. If set to `None` (default), it will be set equal to
-                `window_size`.
+                `window_size`. If provided, it must be a strictly positive integer, and
+                less than or equal to `window_size`
             center: Set the labels at the center of the window.
 
         Returns:

--- a/tests/expr_and_series/rolling_sum_test.py
+++ b/tests/expr_and_series/rolling_sum_test.py
@@ -13,6 +13,7 @@ expected = {
     "x2": [float("nan"), 1.0, 3.0, 3.0, 6.0, 10.0, 21.0],
     "x3": [float("nan"), 1.0, 3.0, 2.0, 4.0, 10.0, 17.0],
     "x4": [3.0, 3.0, 7.0, 13.0, 23.0, 21.0, 21.0],
+    "x5": [1.0, 3.0, 3.0, 7.0, 12.0, 21.0, 21.0],
 }
 
 
@@ -34,6 +35,7 @@ def test_rolling_sum_expr(
         x2=nw.col("a").rolling_sum(window_size=3, min_periods=1),
         x3=nw.col("a").rolling_sum(window_size=2, min_periods=1),
         x4=nw.col("a").rolling_sum(window_size=5, min_periods=1, center=True),
+        x5=nw.col("a").rolling_sum(window_size=4, min_periods=1, center=True),
     )
 
     assert_equal_data(result, expected)
@@ -50,5 +52,6 @@ def test_rolling_sum_series(constructor_eager: ConstructorEager) -> None:
         x2=df["a"].rolling_sum(window_size=3, min_periods=1),
         x3=df["a"].rolling_sum(window_size=2, min_periods=1),
         x4=df["a"].rolling_sum(window_size=5, min_periods=1, center=True),
+        x5=df["a"].rolling_sum(window_size=4, min_periods=1, center=True),
     )
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/rolling_sum_test.py
+++ b/tests/expr_and_series/rolling_sum_test.py
@@ -11,6 +11,7 @@ from hypothesis import given
 
 import narwhals.stable.v1 as nw
 from narwhals.exceptions import InvalidOperationError
+from tests.utils import PANDAS_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -197,6 +198,7 @@ def test_rolling_sum_series_invalid_params(
     center=st.booleans(),
     values=st.lists(st.floats(-10, 10), min_size=3, max_size=10),
 )
+@pytest.mark.skipif(PANDAS_VERSION < (1,), reason="too old for pyarrow")
 @pytest.mark.filterwarnings("ignore:.*:narwhals.exceptions.NarwhalsUnstableWarning")
 def test_rolling_sum_hypothesis(center: bool, values: list[float]) -> None:  # noqa: FBT001
     s = pd.Series(values)

--- a/tests/expr_and_series/rolling_sum_test.py
+++ b/tests/expr_and_series/rolling_sum_test.py
@@ -1,19 +1,44 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 import narwhals.stable.v1 as nw
+from narwhals.exceptions import InvalidOperationError
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
 data = {"a": [None, 1, 2, None, 4, 6, 11]}
-expected = {
-    "x1": [float("nan")] * 6 + [21],
-    "x2": [float("nan"), 1.0, 3.0, 3.0, 6.0, 10.0, 21.0],
-    "x3": [float("nan"), 1.0, 3.0, 2.0, 4.0, 10.0, 17.0],
-    "x4": [3.0, 3.0, 7.0, 13.0, 23.0, 21.0, 21.0],
-    "x5": [1.0, 3.0, 3.0, 7.0, 12.0, 21.0, 21.0],
+
+kwargs_and_expected = {
+    "x1": {"kwargs": {"window_size": 3}, "expected": [float("nan")] * 6 + [21]},
+    "x2": {
+        "kwargs": {"window_size": 3, "min_periods": 1},
+        "expected": [float("nan"), 1.0, 3.0, 3.0, 6.0, 10.0, 21.0],
+    },
+    "x3": {
+        "kwargs": {"window_size": 2, "min_periods": 1},
+        "expected": [float("nan"), 1.0, 3.0, 2.0, 4.0, 10.0, 17.0],
+    },
+    "x4": {
+        "kwargs": {"window_size": 5, "min_periods": 1, "center": True},
+        "expected": [3.0, 3.0, 7.0, 13.0, 23.0, 21.0, 21.0],
+    },
+    "x5": {
+        "kwargs": {"window_size": 4, "min_periods": 1, "center": True},
+        "expected": [1.0, 3.0, 3.0, 7.0, 12.0, 21.0, 21.0],
+    },
+    "x6": {
+        "kwargs": {"window_size": 0},
+        "expected": [float("nan"), 1.0, 3.0, 3.0, 7.0, 13.0, 24.0],
+    },
+    # There are still some edge cases to take care of with nulls and min_periods=0:
+    # "x7": {  # noqa: ERA001
+    #     "kwargs": {"window_size": 2, "min_periods": 0},  # noqa: ERA001
+    #     "expected": [float("nan"), 1.0, 3.0, 2.0, 4.0, 10.0, 17.0],  # noqa: ERA001
+    # },
 }
 
 
@@ -31,12 +56,12 @@ def test_rolling_sum_expr(
 
     df = nw.from_native(constructor(data))
     result = df.select(
-        x1=nw.col("a").rolling_sum(window_size=3),
-        x2=nw.col("a").rolling_sum(window_size=3, min_periods=1),
-        x3=nw.col("a").rolling_sum(window_size=2, min_periods=1),
-        x4=nw.col("a").rolling_sum(window_size=5, min_periods=1, center=True),
-        x5=nw.col("a").rolling_sum(window_size=4, min_periods=1, center=True),
+        **{
+            name: nw.col("a").rolling_sum(**values["kwargs"])  # type: ignore[arg-type]
+            for name, values in kwargs_and_expected.items()
+        }
     )
+    expected = {name: values["expected"] for name, values in kwargs_and_expected.items()}
 
     assert_equal_data(result, expected)
 
@@ -48,10 +73,125 @@ def test_rolling_sum_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
     result = df.select(
-        x1=df["a"].rolling_sum(window_size=3),
-        x2=df["a"].rolling_sum(window_size=3, min_periods=1),
-        x3=df["a"].rolling_sum(window_size=2, min_periods=1),
-        x4=df["a"].rolling_sum(window_size=5, min_periods=1, center=True),
-        x5=df["a"].rolling_sum(window_size=4, min_periods=1, center=True),
+        **{
+            name: df["a"].rolling_sum(**values["kwargs"])  # type: ignore[arg-type]
+            for name, values in kwargs_and_expected.items()
+        }
     )
+    expected = {name: values["expected"] for name, values in kwargs_and_expected.items()}
     assert_equal_data(result, expected)
+
+
+@pytest.mark.filterwarnings(
+    "ignore:`Expr.rolling_sum` is being called from the stable API although considered an unstable feature."
+)
+@pytest.mark.parametrize(
+    ("window_size", "min_periods", "context"),
+    [
+        (
+            -1,
+            None,
+            pytest.raises(
+                ValueError, match="window_size should be greater or equal than 0"
+            ),
+        ),
+        (
+            4.2,
+            None,
+            pytest.raises(
+                TypeError,
+                match="argument 'window_size': 'float' object cannot be interpreted as an integer",
+            ),
+        ),
+        (
+            2,
+            -1,
+            pytest.raises(
+                ValueError, match="min_periods should be greater or equal than 0"
+            ),
+        ),
+        (
+            2,
+            4.2,
+            pytest.raises(
+                TypeError,
+                match="argument 'min_periods': 'float' object cannot be interpreted as an integer",
+            ),
+        ),
+        (
+            1,
+            2,
+            pytest.raises(
+                InvalidOperationError,
+                match="`min_periods` should be less or equal than `window_size`",
+            ),
+        ),
+    ],
+)
+def test_rolling_sum_expr_invalid_params(
+    constructor: Constructor, window_size: int, min_periods: int | None, context: Any
+) -> None:
+    df = nw.from_native(constructor(data))
+
+    with context:
+        df.select(
+            nw.col("a").rolling_sum(window_size=window_size, min_periods=min_periods)
+        )
+
+
+@pytest.mark.filterwarnings(
+    "ignore:`Series.rolling_sum` is being called from the stable API although considered an unstable feature."
+)
+@pytest.mark.parametrize(
+    ("window_size", "min_periods", "context"),
+    [
+        (
+            -1,
+            None,
+            pytest.raises(
+                ValueError, match="window_size should be greater or equal than 0"
+            ),
+        ),
+        (
+            4.2,
+            None,
+            pytest.raises(
+                TypeError,
+                match="argument 'window_size': 'float' object cannot be interpreted as an integer",
+            ),
+        ),
+        (
+            2,
+            -1,
+            pytest.raises(
+                ValueError, match="min_periods should be greater or equal than 0"
+            ),
+        ),
+        (
+            2,
+            4.2,
+            pytest.raises(
+                TypeError,
+                match="argument 'min_periods': 'float' object cannot be interpreted as an integer",
+            ),
+        ),
+        (
+            1,
+            2,
+            pytest.raises(
+                InvalidOperationError,
+                match="`min_periods` should be less or equal than `window_size`",
+            ),
+        ),
+    ],
+)
+def test_rolling_sum_series_invalid_params(
+    constructor_eager: ConstructorEager,
+    window_size: int,
+    min_periods: int | None,
+    context: Any,
+) -> None:
+    df = nw.from_native(constructor_eager(data))
+
+    with context:
+        df["a"].rolling_sum(window_size=window_size, min_periods=min_periods)

--- a/tests/expr_and_series/rolling_sum_test.py
+++ b/tests/expr_and_series/rolling_sum_test.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+import narwhals.stable.v1 as nw
+from tests.utils import Constructor
+from tests.utils import ConstructorEager
+from tests.utils import assert_equal_data
+
+data = {"a": [None, 1, 2, None, 4, 6, 11]}
+expected = {
+    "x1": [float("nan")] * 6 + [21],
+    "x2": [float("nan"), 1.0, 3.0, 3.0, 6.0, 10.0, 21.0],
+    "x3": [float("nan"), 1.0, 3.0, 2.0, 4.0, 10.0, 17.0],
+    "x4": [3.0, 3.0, 7.0, 13.0, 23.0, 21.0, 21.0],
+}
+
+
+@pytest.mark.filterwarnings(
+    "ignore:`Expr.rolling_sum` is being called from the stable API although considered an unstable feature."
+)
+def test_rolling_sum_expr(
+    request: pytest.FixtureRequest, constructor: Constructor
+) -> None:
+    if "dask" in str(constructor):
+        # TODO(FBruzzesi): Dask is raising the following error:
+        # NotImplementedError: Partition size is less than overlapping window size.
+        # Try using ``df.repartition`` to increase the partition size.
+        request.applymarker(pytest.mark.xfail)
+
+    df = nw.from_native(constructor(data))
+    result = df.select(
+        x1=nw.col("a").rolling_sum(window_size=3),
+        x2=nw.col("a").rolling_sum(window_size=3, min_periods=1),
+        x3=nw.col("a").rolling_sum(window_size=2, min_periods=1),
+        x4=nw.col("a").rolling_sum(window_size=5, min_periods=1, center=True),
+    )
+
+    assert_equal_data(result, expected)
+
+
+@pytest.mark.filterwarnings(
+    "ignore:`Series.rolling_sum` is being called from the stable API although considered an unstable feature."
+)
+def test_rolling_sum_series(constructor_eager: ConstructorEager) -> None:
+    df = nw.from_native(constructor_eager(data), eager_only=True)
+
+    result = df.select(
+        x1=df["a"].rolling_sum(window_size=3),
+        x2=df["a"].rolling_sum(window_size=3, min_periods=1),
+        x3=df["a"].rolling_sum(window_size=2, min_periods=1),
+        x4=df["a"].rolling_sum(window_size=5, min_periods=1, center=True),
+    )
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/rolling_sum_test.py
+++ b/tests/expr_and_series/rolling_sum_test.py
@@ -30,15 +30,6 @@ kwargs_and_expected = {
         "kwargs": {"window_size": 4, "min_periods": 1, "center": True},
         "expected": [1.0, 3.0, 3.0, 7.0, 12.0, 21.0, 21.0],
     },
-    "x6": {
-        "kwargs": {"window_size": 0},
-        "expected": [float("nan"), 1.0, 3.0, 3.0, 7.0, 13.0, 24.0],
-    },
-    # There are still some edge cases to take care of with nulls and min_periods=0:
-    # "x7": {  # noqa: ERA001
-    #     "kwargs": {"window_size": 2, "min_periods": 0},  # noqa: ERA001
-    #     "expected": [float("nan"), 1.0, 3.0, 2.0, 4.0, 10.0, 17.0],  # noqa: ERA001
-    # },
 }
 
 
@@ -92,7 +83,7 @@ def test_rolling_sum_series(constructor_eager: ConstructorEager) -> None:
             -1,
             None,
             pytest.raises(
-                ValueError, match="window_size should be greater or equal than 0"
+                ValueError, match="window_size must be greater or equal than 1"
             ),
         ),
         (
@@ -107,7 +98,7 @@ def test_rolling_sum_series(constructor_eager: ConstructorEager) -> None:
             2,
             -1,
             pytest.raises(
-                ValueError, match="min_periods should be greater or equal than 0"
+                ValueError, match="min_periods must be greater or equal than 1"
             ),
         ),
         (
@@ -123,7 +114,7 @@ def test_rolling_sum_series(constructor_eager: ConstructorEager) -> None:
             2,
             pytest.raises(
                 InvalidOperationError,
-                match="`min_periods` should be less or equal than `window_size`",
+                match="`min_periods` must be less or equal than `window_size`",
             ),
         ),
     ],
@@ -149,7 +140,7 @@ def test_rolling_sum_expr_invalid_params(
             -1,
             None,
             pytest.raises(
-                ValueError, match="window_size should be greater or equal than 0"
+                ValueError, match="window_size must be greater or equal than 1"
             ),
         ),
         (
@@ -164,7 +155,7 @@ def test_rolling_sum_expr_invalid_params(
             2,
             -1,
             pytest.raises(
-                ValueError, match="min_periods should be greater or equal than 0"
+                ValueError, match="min_periods must be greater or equal than 1"
             ),
         ),
         (
@@ -180,7 +171,7 @@ def test_rolling_sum_expr_invalid_params(
             2,
             pytest.raises(
                 InvalidOperationError,
-                match="`min_periods` should be less or equal than `window_size`",
+                match="`min_periods` must be less or equal than `window_size`",
             ),
         ),
     ],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #1254
- Closes #1367 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

So I wanted to start with `sum`, assuming it would have been simpler for arrow to implement in a way which is not naive.

Running some benchmarks, performances of this with 1M rows is in the same ballpark of pandas, while the naive way in #1290 is orders of magnitude slower. I would consider this the way to go forward.
