### PR TITLE
docs: use boolean columns in any/all horizontal docstrings

### DIFF
--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -5983,9 +5983,6 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     Returns:
         A new expression.
 
-    Notes:
-        pandas and Polars handle null values differently.
-
     Examples:
         >>> import pandas as pd
         >>> import polars as pl
@@ -5996,7 +5993,7 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         ...     "b": [False, True, True, None, None, None],
         ... }
         >>> df_pl = pl.DataFrame(data)
-        >>> df_pd = pd.DataFrame(data)
+        >>> df_pd = pd.DataFrame(data).convert_dtypes(dtype_backend="pyarrow")
         >>> df_pa = pa.table(data)
 
         We define a dataframe-agnostic function:
@@ -6012,9 +6009,9 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         0  False  False  False
         1  False   True  False
         2   True   True   True
-        3   True   None  False
-        4  False   None  False
-        5   None   None  False
+        3   True   <NA>   <NA>
+        4  False   <NA>  False
+        5   <NA>   <NA>   <NA>
 
         >>> func(df_pl)
         shape: (6, 3)

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -2146,9 +2146,6 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     Returns:
         A new expression.
 
-    Notes:
-        pandas and Polars handle null values differently.
-
     Examples:
         >>> import pandas as pd
         >>> import polars as pl
@@ -2159,7 +2156,7 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         ...     "b": [False, True, True, None, None, None],
         ... }
         >>> df_pl = pl.DataFrame(data)
-        >>> df_pd = pd.DataFrame(data)
+        >>> df_pd = pd.DataFrame(data).convert_dtypes(dtype_backend="pyarrow")
         >>> df_pa = pa.table(data)
 
         We define a dataframe-agnostic function:
@@ -2175,9 +2172,9 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         0  False  False  False
         1  False   True  False
         2   True   True   True
-        3   True   None  False
-        4  False   None  False
-        5   None   None  False
+        3   True   <NA>   <NA>
+        4  False   <NA>  False
+        5   <NA>   <NA>   <NA>
 
         >>> func(df_pl)
         shape: (6, 3)
@@ -2216,9 +2213,6 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     Returns:
         A new expression.
 
-    Notes:
-        pandas and Polars handle null values differently.
-
     Examples:
         >>> import pandas as pd
         >>> import polars as pl
@@ -2229,7 +2223,7 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         ...     "b": [False, True, True, None, None, None],
         ... }
         >>> df_pl = pl.DataFrame(data)
-        >>> df_pd = pd.DataFrame(data)
+        >>> df_pd = pd.DataFrame(data).convert_dtypes(dtype_backend="pyarrow")
         >>> df_pa = pa.table(data)
 
         We define a dataframe-agnostic function:
@@ -2245,9 +2239,9 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         0  False  False  False
         1  False   True   True
         2   True   True   True
-        3   True   None   True
-        4  False   None  False
-        5   None   None  False
+        3   True   <NA>   True
+        4  False   <NA>   <NA>
+        5   <NA>   <NA>   <NA>
 
         >>> func(df_pl)
         shape: (6, 3)


### PR DESCRIPTION
related to #1401 

Making a pandas series from `[True, False, None]` would result in object dtype, and isn't something users would typically run into, as boolean operations would typically return `False` for pandas' classical types https://narwhals-dev.github.io/narwhals/pandas_like_concepts/boolean/

I think it's better if we just showcase a proper boolean column in this example

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
