### PR TITLE
fix: correct minimum Polars version for ewm_mean

### DIFF
--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -9,7 +9,6 @@ from narwhals._polars.utils import extract_args_kwargs
 from narwhals._polars.utils import extract_native
 from narwhals._polars.utils import narwhals_to_native_dtype
 from narwhals.utils import Implementation
-from narwhals.utils import parse_version
 
 if TYPE_CHECKING:
     import polars as pl
@@ -61,10 +60,8 @@ class PolarsExpr:
         min_periods: int = 1,
         ignore_nulls: bool = False,
     ) -> Self:
-        import polars as pl  # ignore-banned-import()
-
-        if parse_version(pl.__version__) <= (0, 20, 31):  # pragma: no cover
-            msg = "`ewm_mean` not implemented for polars older than 0.20.31"
+        if self._backend_version < (1,):  # pragma: no cover
+            msg = "`ewm_mean` not implemented for polars older than 1.0"
             raise NotImplementedError(msg)
         expr = self._native_expr
         return self._from_native_expr(

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -236,8 +236,8 @@ class PolarsSeries:
         min_periods: int = 1,
         ignore_nulls: bool = False,
     ) -> Self:
-        if self._backend_version < (0, 20, 31):  # pragma: no cover
-            msg = "`ewm_mean` not implemented for polars older than 0.20.31"
+        if self._backend_version < (1,):  # pragma: no cover
+            msg = "`ewm_mean` not implemented for polars older than 1.0"
             raise NotImplementedError(msg)
         expr = self._native_series
         return self._from_native_series(

--- a/tests/expr_and_series/ewm_test.py
+++ b/tests/expr_and_series/ewm_test.py
@@ -36,9 +36,7 @@ def test_ewm_mean_expr(request: pytest.FixtureRequest, constructor: Constructor)
 def test_ewm_mean_series(
     request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
-    if any(x in str(constructor_eager) for x in ("pyarrow_table_", "modin")) or (
-        "polars" in str(constructor_eager) and POLARS_VERSION <= (0, 20, 31)
-    ):
+    if any(x in str(constructor_eager) for x in ("pyarrow_table_", "modin")):
         request.applymarker(pytest.mark.xfail)
 
     series = nw.from_native(constructor_eager(data), eager_only=True)["a"]

--- a/tests/expr_and_series/ewm_test.py
+++ b/tests/expr_and_series/ewm_test.py
@@ -36,7 +36,9 @@ def test_ewm_mean_expr(request: pytest.FixtureRequest, constructor: Constructor)
 def test_ewm_mean_series(
     request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
-    if any(x in str(constructor_eager) for x in ("pyarrow_table_", "modin")):
+    if any(x in str(constructor_eager) for x in ("pyarrow_table_", "modin")) or (
+        "polars" in str(constructor_eager) and POLARS_VERSION <= (0, 20, 3)
+    ):
         request.applymarker(pytest.mark.xfail)
 
     series = nw.from_native(constructor_eager(data), eager_only=True)["a"]

--- a/tests/expr_and_series/ewm_test.py
+++ b/tests/expr_and_series/ewm_test.py
@@ -17,7 +17,7 @@ data = {"a": [1, 1, 2], "b": [1, 2, 3]}
 )
 def test_ewm_mean_expr(request: pytest.FixtureRequest, constructor: Constructor) -> None:
     if any(x in str(constructor) for x in ("pyarrow_table_", "dask", "modin")) or (
-        "polars" in str(constructor) and POLARS_VERSION <= (0, 20, 31)
+        "polars" in str(constructor) and POLARS_VERSION < (1,)
     ):
         request.applymarker(pytest.mark.xfail)
 
@@ -37,7 +37,7 @@ def test_ewm_mean_series(
     request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
     if any(x in str(constructor_eager) for x in ("pyarrow_table_", "modin")) or (
-        "polars" in str(constructor_eager) and POLARS_VERSION <= (0, 20, 3)
+        "polars" in str(constructor_eager) and POLARS_VERSION < (1,)
     ):
         request.applymarker(pytest.mark.xfail)
 
@@ -76,7 +76,7 @@ def test_ewm_mean_expr_adjust(
     expected: dict[str, list[float]],
 ) -> None:
     if any(x in str(constructor) for x in ("pyarrow_table_", "dask", "modin")) or (
-        "polars" in str(constructor) and POLARS_VERSION <= (0, 20, 31)
+        "polars" in str(constructor) and POLARS_VERSION < (1,)
     ):
         request.applymarker(pytest.mark.xfail)
 
@@ -138,7 +138,7 @@ def test_ewm_mean_nulls(
     constructor: Constructor,
 ) -> None:
     if any(x in str(constructor) for x in ("pyarrow_table_", "dask", "modin")) or (
-        "polars" in str(constructor) and POLARS_VERSION <= (0, 20, 31)
+        "polars" in str(constructor) and POLARS_VERSION < (1,)
     ):
         request.applymarker(pytest.mark.xfail)
 
@@ -155,7 +155,7 @@ def test_ewm_mean_params(
     constructor: Constructor,
 ) -> None:
     if any(x in str(constructor) for x in ("pyarrow_table_", "dask", "modin")) or (
-        "polars" in str(constructor) and POLARS_VERSION <= (0, 20, 31)
+        "polars" in str(constructor) and POLARS_VERSION < (1,)
     ):
         request.applymarker(pytest.mark.xfail)
 


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #1414

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Trying to close that issue,  ~~but I haven't checked with older polars versions than that.~~
**Not ready for review**