### PR TITLE
fix: address `lit` broadcasting and output name of right arithmetic ops

### DIFF
--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -163,43 +163,43 @@ class ArrowExpr:
         return reuse_series_implementation(self, "__add__", other)
 
     def __radd__(self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__radd__", other)
+        return reuse_series_implementation(self, "__radd__", other, alias="literal")
 
     def __sub__(self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__sub__", other)
 
     def __rsub__(self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__rsub__", other)
+        return reuse_series_implementation(self, "__rsub__", other, alias="literal")
 
     def __mul__(self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__mul__", other)
 
     def __rmul__(self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__rmul__", other)
+        return reuse_series_implementation(self, "__rmul__", other, alias="literal")
 
     def __pow__(self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__pow__", other)
 
     def __rpow__(self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__rpow__", other)
+        return reuse_series_implementation(self, "__rpow__", other, alias="literal")
 
     def __floordiv__(self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__floordiv__", other)
 
     def __rfloordiv__(self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__rfloordiv__", other)
+        return reuse_series_implementation(self, "__rfloordiv__", other, alias="literal")
 
     def __truediv__(self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__truediv__", other)
 
     def __rtruediv__(self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__rtruediv__", other)
+        return reuse_series_implementation(self, "__rtruediv__", other, alias="literal")
 
     def __mod__(self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__mod__", other)
 
     def __rmod__(self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__rmod__", other)
+        return reuse_series_implementation(self, "__rmod__", other, alias="literal")
 
     def __invert__(self) -> Self:
         return reuse_series_implementation(self, "__invert__")

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -151,55 +151,64 @@ class ArrowExpr:
         return reuse_series_implementation(self, "__and__", other=other)
 
     def __rand__(self: Self, other: ArrowExpr | bool | Any) -> Self:
-        return reuse_series_implementation(self, "__rand__", other=other)
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__and__(self)  # type: ignore[return-value]
 
     def __or__(self: Self, other: ArrowExpr | bool | Any) -> Self:
         return reuse_series_implementation(self, "__or__", other=other)
 
     def __ror__(self: Self, other: ArrowExpr | bool | Any) -> Self:
-        return reuse_series_implementation(self, "__ror__", other=other)
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__or__(self)  # type: ignore[return-value]
 
     def __add__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__add__", other)
 
     def __radd__(self: Self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__radd__", other)
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__add__(self)  # type: ignore[return-value]
 
     def __sub__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__sub__", other)
 
     def __rsub__(self: Self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__rsub__", other)
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__sub__(self)  # type: ignore[return-value]
 
     def __mul__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__mul__", other)
 
     def __rmul__(self: Self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__rmul__", other)
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__mul__(self)  # type: ignore[return-value]
 
     def __pow__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__pow__", other)
 
     def __rpow__(self: Self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__rpow__", other)
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__pow__(self)  # type: ignore[return-value]
 
     def __floordiv__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__floordiv__", other)
 
     def __rfloordiv__(self: Self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__rfloordiv__", other)
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__floordiv__(self)  # type: ignore[return-value]
 
     def __truediv__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__truediv__", other)
 
     def __rtruediv__(self: Self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__rtruediv__", other)
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__truediv__(self)  # type: ignore[return-value]
 
     def __mod__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__mod__", other)
 
     def __rmod__(self: Self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self, "__rmod__", other)
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__mod__(self)  # type: ignore[return-value]
 
     def __invert__(self: Self) -> Self:
         return reuse_series_implementation(self, "__invert__")

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -170,7 +170,7 @@ class ArrowNamespace:
             depth=0,
             function_name="lit",
             root_names=None,
-            output_names=["literal"],
+            output_names=[_lit_arrow_series.__name__],
             backend_version=self._backend_version,
             dtypes=self._dtypes,
         )

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -167,7 +167,7 @@ class ArrowNamespace:
             depth=0,
             function_name="lit",
             root_names=None,
-            output_names=[_lit_arrow_series.__name__],
+            output_names=["literal"],
             backend_version=self._backend_version,
             dtypes=self._dtypes,
         )

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -170,7 +170,7 @@ class ArrowNamespace:
             depth=0,
             function_name="lit",
             root_names=None,
-            output_names=[_lit_arrow_series.__name__],
+            output_names=["literal"],
             backend_version=self._backend_version,
             dtypes=self._dtypes,
         )

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -166,7 +166,7 @@ class ArrowSeries:
         import pyarrow.compute as pc  # ignore-banned-import()
 
         ser, other = validate_column_comparand(self, other)
-        return self._from_native_series(pc.subtract(self._native_series, other))
+        return self._from_native_series(pc.subtract(ser, other))
 
     def __rsub__(self: Self, other: Any) -> Self:
         return (self - other) * (-1)  # type: ignore[no-any-return]
@@ -223,16 +223,16 @@ class ArrowSeries:
     def __mod__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
         floor_div = (self // other)._native_series
+        ser, other = validate_column_comparand(self, other)
         res = pc.subtract(ser, pc.multiply(floor_div, other))
         return self._from_native_series(res)
 
     def __rmod__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
         floor_div = (other // self)._native_series
+        ser, other = validate_column_comparand(self, other)
         res = pc.subtract(other, pc.multiply(floor_div, ser))
         return self._from_native_series(res)
 

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -161,7 +161,9 @@ class ArrowSeries:
         return self._from_native_series(pc.add(ser, other))
 
     def __radd__(self, other: Any) -> Self:
-        return self + other  # type: ignore[no-any-return]
+        res = self + other
+        res._name = "literal"
+        return res  # type: ignore[no-any-return]
 
     def __sub__(self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
@@ -171,7 +173,9 @@ class ArrowSeries:
         return self._from_native_series(pc.subtract(ser, other))
 
     def __rsub__(self, other: Any) -> Self:
-        return (self - other) * (-1)  # type: ignore[no-any-return]
+        res = (self - other) * (-1)
+        res._name = "literal"
+        return res  # type: ignore[no-any-return]
 
     def __mul__(self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
@@ -181,7 +185,9 @@ class ArrowSeries:
         return self._from_native_series(pc.multiply(ser, other))
 
     def __rmul__(self, other: Any) -> Self:
-        return self * other  # type: ignore[no-any-return]
+        res = self * other
+        res._name = "literal"
+        return res  # type: ignore[no-any-return]
 
     def __pow__(self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
@@ -195,7 +201,9 @@ class ArrowSeries:
 
         ser = self._native_series
         other = validate_column_comparand(other)
-        return self._from_native_series(pc.power(other, ser))
+        res = self._from_native_series(pc.power(other, ser))
+        res._name = "literal"
+        return res
 
     def __floordiv__(self, other: Any) -> Self:
         other = validate_column_comparand(other)
@@ -205,7 +213,9 @@ class ArrowSeries:
     def __rfloordiv__(self, other: Any) -> Self:
         ser = self._native_series
         other = validate_column_comparand(other)
-        return self._from_native_series(floordiv_compat(other, ser))
+        res = self._from_native_series(floordiv_compat(other, ser))
+        res._name = "literal"
+        return res
 
     def __truediv__(self, other: Any) -> Self:
         import pyarrow as pa  # ignore-banned-import()
@@ -227,7 +237,9 @@ class ArrowSeries:
         if not isinstance(other, (pa.Array, pa.ChunkedArray)):
             # scalar
             other = pa.scalar(other)
-        return self._from_native_series(pc.divide(*cast_for_truediv(other, ser)))
+        res = self._from_native_series(pc.divide(*cast_for_truediv(other, ser)))
+        res._name = "literal"
+        return res
 
     def __mod__(self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
@@ -244,8 +256,9 @@ class ArrowSeries:
         ser = self._native_series
         other = validate_column_comparand(other)
         floor_div = (other // self)._native_series
-        res = pc.subtract(other, pc.multiply(floor_div, ser))
-        return self._from_native_series(res)
+        res = self._from_native_series(pc.subtract(other, pc.multiply(floor_div, ser)))
+        res._name = "literal"
+        return res
 
     def __invert__(self) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -96,78 +96,68 @@ class ArrowSeries:
     def __eq__(self: Self, other: object) -> Self:  # type: ignore[override]
         import pyarrow.compute as pc
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.equal(ser, other))
 
     def __ne__(self: Self, other: object) -> Self:  # type: ignore[override]
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.not_equal(ser, other))
 
     def __ge__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.greater_equal(ser, other))
 
     def __gt__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.greater(ser, other))
 
     def __le__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.less_equal(ser, other))
 
     def __lt__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.less(ser, other))
 
     def __and__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.and_kleene(ser, other))
 
     def __rand__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.and_kleene(other, ser))
 
     def __or__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.or_kleene(ser, other))
 
     def __ror__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.or_kleene(other, ser))
 
     def __add__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        other = validate_column_comparand(other)
-        return self._from_native_series(pc.add(self._native_series, other))
+        ser, other = validate_column_comparand(self, other)
+        return self._from_native_series(pc.add(ser, other))
 
     def __radd__(self: Self, other: Any) -> Self:
         return self + other  # type: ignore[no-any-return]
@@ -175,7 +165,7 @@ class ArrowSeries:
     def __sub__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.subtract(self._native_series, other))
 
     def __rsub__(self: Self, other: Any) -> Self:
@@ -184,8 +174,8 @@ class ArrowSeries:
     def __mul__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        other = validate_column_comparand(other)
-        return self._from_native_series(pc.multiply(self._native_series, other))
+        ser, other = validate_column_comparand(self, other)
+        return self._from_native_series(pc.multiply(ser, other))
 
     def __rmul__(self: Self, other: Any) -> Self:
         return self * other  # type: ignore[no-any-return]
@@ -193,33 +183,28 @@ class ArrowSeries:
     def __pow__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.power(ser, other))
 
     def __rpow__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(pc.power(other, ser))
 
     def __floordiv__(self: Self, other: Any) -> Self:
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(floordiv_compat(ser, other))
 
     def __rfloordiv__(self: Self, other: Any) -> Self:
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(floordiv_compat(other, ser))
 
     def __truediv__(self: Self, other: Any) -> Self:
         import pyarrow as pa  # ignore-banned-import()
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         if not isinstance(other, (pa.Array, pa.ChunkedArray)):
             # scalar
             other = pa.scalar(other)
@@ -229,8 +214,7 @@ class ArrowSeries:
         import pyarrow as pa  # ignore-banned-import()
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         if not isinstance(other, (pa.Array, pa.ChunkedArray)):
             # scalar
             other = pa.scalar(other)
@@ -239,8 +223,7 @@ class ArrowSeries:
     def __mod__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         floor_div = (self // other)._native_series
         res = pc.subtract(ser, pc.multiply(floor_div, other))
         return self._from_native_series(res)
@@ -248,8 +231,7 @@ class ArrowSeries:
     def __rmod__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser = self._native_series
-        other = validate_column_comparand(other)
+        ser, other = validate_column_comparand(self, other)
         floor_div = (other // self)._native_series
         res = pc.subtract(other, pc.multiply(floor_div, ser))
         return self._from_native_series(res)
@@ -264,8 +246,10 @@ class ArrowSeries:
 
     def filter(self: Self, other: Any) -> Self:
         if not (isinstance(other, list) and all(isinstance(x, bool) for x in other)):
-            other = validate_column_comparand(other)
-        return self._from_native_series(self._native_series.filter(other))
+            ser, other = validate_column_comparand(self, other)
+        else:
+            ser = self._native_series
+        return self._from_native_series(ser.filter(other))
 
     def mean(self: Self) -> int:
         import pyarrow.compute as pc  # ignore-banned-import()
@@ -382,16 +366,17 @@ class ArrowSeries:
         import pyarrow as pa  # ignore-banned-import
         import pyarrow.compute as pc  # ignore-banned-import
 
-        ca = self._native_series
-        mask = np.zeros(len(ca), dtype=bool)
+        mask = np.zeros(self.len(), dtype=bool)
         mask[indices] = True
         if isinstance(values, self.__class__):
-            values = validate_column_comparand(values)
+            ser, values = validate_column_comparand(self, values)
+        else:
+            ser = self._native_series
         if isinstance(values, pa.ChunkedArray):
             values = values.combine_chunks()
         if not isinstance(values, pa.Array):
             values = pa.array(values)
-        result = pc.replace_with_mask(ca, mask, values.take(indices))
+        result = pc.replace_with_mask(ser, mask, values.take(indices))
         return self._from_native_series(result)
 
     def to_list(self: Self) -> list[Any]:

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -96,67 +96,67 @@ class ArrowSeries:
     def __eq__(self: Self, other: object) -> Self:  # type: ignore[override]
         import pyarrow.compute as pc
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.equal(ser, other))
 
     def __ne__(self: Self, other: object) -> Self:  # type: ignore[override]
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.not_equal(ser, other))
 
     def __ge__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.greater_equal(ser, other))
 
     def __gt__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.greater(ser, other))
 
     def __le__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.less_equal(ser, other))
 
     def __lt__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.less(ser, other))
 
     def __and__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.and_kleene(ser, other))
 
     def __rand__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.and_kleene(other, ser))
 
     def __or__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.or_kleene(ser, other))
 
     def __ror__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.or_kleene(other, ser))
 
     def __add__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.add(ser, other))
 
     def __radd__(self: Self, other: Any) -> Self:
@@ -165,7 +165,7 @@ class ArrowSeries:
     def __sub__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.subtract(ser, other))
 
     def __rsub__(self: Self, other: Any) -> Self:
@@ -174,7 +174,7 @@ class ArrowSeries:
     def __mul__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.multiply(ser, other))
 
     def __rmul__(self: Self, other: Any) -> Self:
@@ -183,28 +183,28 @@ class ArrowSeries:
     def __pow__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.power(ser, other))
 
     def __rpow__(self: Self, other: Any) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(pc.power(other, ser))
 
     def __floordiv__(self: Self, other: Any) -> Self:
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(floordiv_compat(ser, other))
 
     def __rfloordiv__(self: Self, other: Any) -> Self:
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         return self._from_native_series(floordiv_compat(other, ser))
 
     def __truediv__(self: Self, other: Any) -> Self:
         import pyarrow as pa  # ignore-banned-import()
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         if not isinstance(other, (pa.Array, pa.ChunkedArray)):
             # scalar
             other = pa.scalar(other)
@@ -214,7 +214,7 @@ class ArrowSeries:
         import pyarrow as pa  # ignore-banned-import()
         import pyarrow.compute as pc  # ignore-banned-import()
 
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         if not isinstance(other, (pa.Array, pa.ChunkedArray)):
             # scalar
             other = pa.scalar(other)
@@ -224,7 +224,7 @@ class ArrowSeries:
         import pyarrow.compute as pc  # ignore-banned-import()
 
         floor_div = (self // other)._native_series
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         res = pc.subtract(ser, pc.multiply(floor_div, other))
         return self._from_native_series(res)
 
@@ -232,7 +232,7 @@ class ArrowSeries:
         import pyarrow.compute as pc  # ignore-banned-import()
 
         floor_div = (other // self)._native_series
-        ser, other = validate_column_comparand(self, other)
+        ser, other = validate_column_comparand(self, other, self._backend_version)
         res = pc.subtract(other, pc.multiply(floor_div, ser))
         return self._from_native_series(res)
 
@@ -246,7 +246,7 @@ class ArrowSeries:
 
     def filter(self: Self, other: Any) -> Self:
         if not (isinstance(other, list) and all(isinstance(x, bool) for x in other)):
-            ser, other = validate_column_comparand(self, other)
+            ser, other = validate_column_comparand(self, other, self._backend_version)
         else:
             ser = self._native_series
         return self._from_native_series(ser.filter(other))
@@ -369,7 +369,7 @@ class ArrowSeries:
         mask = np.zeros(self.len(), dtype=bool)
         mask[indices] = True
         if isinstance(values, self.__class__):
-            ser, values = validate_column_comparand(self, values)
+            ser, values = validate_column_comparand(self, values, self._backend_version)
         else:
             ser = self._native_series
         if isinstance(values, pa.ChunkedArray):

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -173,6 +173,14 @@ def validate_column_comparand(other: Any) -> Any:
     return other
 
 
+def maybe_broadcast_scalar_into_series(series: Any, other: Any) -> Any:
+    import pyarrow as pa  # ignore-banned-import
+
+    if isinstance(other, pa.ChunkedArray) and len(series) == 1 and len(other) > 1:
+        return pa.chunked_array([series.to_pylist() * len(other)])
+    return series
+
+
 def validate_dataframe_comparand(
     length: int, other: Any, backend_version: tuple[int, ...]
 ) -> Any:

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -163,15 +163,6 @@ def validate_column_comparand(other: Any) -> Any:
     return other
 
 
-def maybe_broadcast_scalar_into_series(series: Any, other: Any) -> Any:
-    """Broadcast a single-element `series` into a series that matches the length of `other`."""
-    import pyarrow as pa  # ignore-banned-import
-
-    if isinstance(other, pa.ChunkedArray) and len(series) == 1 and len(other) > 1:
-        return pa.chunked_array([series.to_pylist() * len(other)])
-    return series
-
-
 def validate_dataframe_comparand(
     length: int, other: Any, backend_version: tuple[int, ...]
 ) -> Any:

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -129,8 +129,8 @@ def narwhals_to_native_dtype(dtype: DType | type[DType], dtypes: DTypes) -> pa.D
 
 
 def validate_column_comparand(
-    lhs: Any, rhs: Any, backend_version: tuple[int, ...]
-) -> Any:
+    lhs: ArrowSeries, rhs: Any, backend_version: tuple[int, ...]
+) -> tuple[pa.ChunkedArray, Any]:
     """Validate RHS of binary operation.
 
     If the comparison isn't supported, return `NotImplemented` so that the

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -174,6 +174,7 @@ def validate_column_comparand(other: Any) -> Any:
 
 
 def maybe_broadcast_scalar_into_series(series: Any, other: Any) -> Any:
+    """Broadcast a single-element series into a `series` that matches the length of `other`."""
     import pyarrow as pa  # ignore-banned-import
 
     if isinstance(other, pa.ChunkedArray) and len(series) == 1 and len(other) > 1:

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -174,7 +174,7 @@ def validate_column_comparand(other: Any) -> Any:
 
 
 def maybe_broadcast_scalar_into_series(series: Any, other: Any) -> Any:
-    """Broadcast a single-element series into a `series` that matches the length of `other`."""
+    """Broadcast a single-element `series` into a series that matches the length of `other`."""
     import pyarrow as pa  # ignore-banned-import
 
     if isinstance(other, pa.ChunkedArray) and len(series) == 1 and len(other) > 1:

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -172,14 +172,15 @@ def validate_column_comparand(
             fill_value = lhs[0]
             if backend_version < (13,) and hasattr(fill_value, "as_py"):
                 fill_value = fill_value.as_py()
-            return pa.chunked_array(
+            left_result = pa.chunked_array(
                 [
                     pa.array(
                         np.full(shape=rhs.len(), fill_value=fill_value),
                         type=lhs._native_series.type,
                     )
                 ]
-            ), rhs._native_series
+            )
+            return left_result, rhs._native_series
         return lhs._native_series, rhs._native_series
     return lhs._native_series, rhs
 
@@ -200,7 +201,7 @@ def validate_dataframe_comparand(
             import pyarrow as pa  # ignore-banned-import
 
             value = other._native_series[0]
-            if backend_version < (13,) and hasattr(value, "as_py"):  # pragma: no cover
+            if backend_version < (13,) and hasattr(value, "as_py"):
                 value = value.as_py()
             return pa.array(np.full(shape=length, fill_value=value))
         return other._native_series
@@ -342,7 +343,7 @@ def broadcast_series(series: list[ArrowSeries]) -> list[Any]:
         s_native = s._native_series
         if is_max_length_gt_1 and length == 1:
             value = s_native[0]
-            if s._backend_version < (13,) and hasattr(value, "as_py"):  # pragma: no cover
+            if s._backend_version < (13,) and hasattr(value, "as_py"):
                 value = value.as_py()
             reshaped.append(pa.array([value] * max_length, type=s_native.type))
         else:

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -118,8 +118,12 @@ class DaskExpr:
         expr_name: str,
         *args: Any,
         returns_scalar: bool,
+        alias: str | None = None,
         **kwargs: Any,
     ) -> Self:
+        if alias is not None and self._output_names is not None:
+            self._output_names = [alias]
+
         def func(df: DaskLazyFrame) -> list[dask_expr.Series]:
             results = []
             inputs = self._call(df)
@@ -199,6 +203,7 @@ class DaskExpr:
             "__radd__",
             other,
             returns_scalar=False,
+            alias="literal",
         )
 
     def __sub__(self, other: Any) -> Self:
@@ -215,6 +220,7 @@ class DaskExpr:
             "__rsub__",
             other,
             returns_scalar=False,
+            alias="literal",
         )
 
     def __mul__(self, other: Any) -> Self:
@@ -231,6 +237,7 @@ class DaskExpr:
             "__rmul__",
             other,
             returns_scalar=False,
+            alias="literal",
         )
 
     def __truediv__(self, other: Any) -> Self:
@@ -247,6 +254,7 @@ class DaskExpr:
             "__rtruediv__",
             other,
             returns_scalar=False,
+            alias="literal",
         )
 
     def __floordiv__(self, other: Any) -> Self:
@@ -263,6 +271,7 @@ class DaskExpr:
             "__rfloordiv__",
             other,
             returns_scalar=False,
+            alias="literal",
         )
 
     def __pow__(self, other: Any) -> Self:
@@ -279,6 +288,7 @@ class DaskExpr:
             "__rpow__",
             other,
             returns_scalar=False,
+            alias="literal",
         )
 
     def __mod__(self, other: Any) -> Self:
@@ -295,6 +305,7 @@ class DaskExpr:
             "__rmod__",
             other,
             returns_scalar=False,
+            alias="literal",
         )
 
     def __eq__(self, other: DaskExpr) -> Self:  # type: ignore[override]

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -118,12 +118,8 @@ class DaskExpr:
         expr_name: str,
         *args: Any,
         returns_scalar: bool,
-        alias: str | None = None,
         **kwargs: Any,
     ) -> Self:
-        if alias is not None and self._output_names is not None:
-            self._output_names = [alias]
-
         def func(df: DaskLazyFrame) -> list[dask_expr.Series]:
             results = []
             inputs = self._call(df)
@@ -133,7 +129,7 @@ class DaskExpr:
                 result = call(_input, *_args, **_kwargs)
                 if returns_scalar:
                     result = result.to_series()
-                result = result.rename(alias or _input.name)
+                result = result.rename(_input.name)
                 results.append(result)
             return results
 
@@ -203,7 +199,6 @@ class DaskExpr:
             "__radd__",
             other,
             returns_scalar=False,
-            alias="literal",
         )
 
     def __sub__(self, other: Any) -> Self:
@@ -220,7 +215,6 @@ class DaskExpr:
             "__rsub__",
             other,
             returns_scalar=False,
-            alias="literal",
         )
 
     def __mul__(self, other: Any) -> Self:
@@ -237,7 +231,6 @@ class DaskExpr:
             "__rmul__",
             other,
             returns_scalar=False,
-            alias="literal",
         )
 
     def __truediv__(self, other: Any) -> Self:
@@ -254,7 +247,6 @@ class DaskExpr:
             "__rtruediv__",
             other,
             returns_scalar=False,
-            alias="literal",
         )
 
     def __floordiv__(self, other: Any) -> Self:
@@ -271,7 +263,6 @@ class DaskExpr:
             "__rfloordiv__",
             other,
             returns_scalar=False,
-            alias="literal",
         )
 
     def __pow__(self, other: Any) -> Self:
@@ -288,7 +279,6 @@ class DaskExpr:
             "__rpow__",
             other,
             returns_scalar=False,
-            alias="literal",
         )
 
     def __mod__(self, other: Any) -> Self:
@@ -305,7 +295,6 @@ class DaskExpr:
             "__rmod__",
             other,
             returns_scalar=False,
-            alias="literal",
         )
 
     def __eq__(self, other: DaskExpr) -> Self:  # type: ignore[override]

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -133,7 +133,7 @@ class DaskExpr:
                 result = call(_input, *_args, **_kwargs)
                 if returns_scalar:
                     result = result.to_series()
-                result = result.rename(_input.name)
+                result = result.rename(alias or _input.name)
                 results.append(result)
             return results
 

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -353,7 +353,7 @@ class DaskExpr:
             returns_scalar=False,
         )
 
-    def __rand__(self, other: DaskExpr) -> Self:  # pragma: no cover
+    def __rand__(self, other: DaskExpr) -> Self:
         return self._from_call(
             lambda _input, other: _input.__rand__(other),
             "__rand__",
@@ -369,7 +369,7 @@ class DaskExpr:
             returns_scalar=False,
         )
 
-    def __ror__(self, other: DaskExpr) -> Self:  # pragma: no cover
+    def __ror__(self, other: DaskExpr) -> Self:
         return self._from_call(
             lambda _input, other: _input.__ror__(other),
             "__ror__",

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -199,7 +199,7 @@ class DaskExpr:
             "__radd__",
             other,
             returns_scalar=False,
-        )
+        ).alias("literal")
 
     def __sub__(self, other: Any) -> Self:
         return self._from_call(
@@ -215,7 +215,7 @@ class DaskExpr:
             "__rsub__",
             other,
             returns_scalar=False,
-        )
+        ).alias("literal")
 
     def __mul__(self, other: Any) -> Self:
         return self._from_call(
@@ -231,7 +231,7 @@ class DaskExpr:
             "__rmul__",
             other,
             returns_scalar=False,
-        )
+        ).alias("literal")
 
     def __truediv__(self, other: Any) -> Self:
         return self._from_call(
@@ -247,7 +247,7 @@ class DaskExpr:
             "__rtruediv__",
             other,
             returns_scalar=False,
-        )
+        ).alias("literal")
 
     def __floordiv__(self, other: Any) -> Self:
         return self._from_call(
@@ -263,7 +263,7 @@ class DaskExpr:
             "__rfloordiv__",
             other,
             returns_scalar=False,
-        )
+        ).alias("literal")
 
     def __pow__(self, other: Any) -> Self:
         return self._from_call(
@@ -279,7 +279,7 @@ class DaskExpr:
             "__rpow__",
             other,
             returns_scalar=False,
-        )
+        ).alias("literal")
 
     def __mod__(self, other: Any) -> Self:
         return self._from_call(
@@ -295,7 +295,7 @@ class DaskExpr:
             "__rmod__",
             other,
             returns_scalar=False,
-        )
+        ).alias("literal")
 
     def __eq__(self, other: DaskExpr) -> Self:  # type: ignore[override]
         return self._from_call(
@@ -359,7 +359,7 @@ class DaskExpr:
             "__rand__",
             other,
             returns_scalar=False,
-        )
+        ).alias("literal")
 
     def __or__(self, other: DaskExpr) -> Self:
         return self._from_call(
@@ -375,7 +375,7 @@ class DaskExpr:
             "__ror__",
             other,
             returns_scalar=False,
-        )
+        ).alias("literal")
 
     def __invert__(self: Self) -> Self:
         return self._from_call(

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -199,7 +199,6 @@ def reuse_series_implementation(
     attr: str,
     *args: Any,
     returns_scalar: bool = False,
-    alias: str | None = None,
     **kwargs: Any,
 ) -> CompliantExprT:
     """Reuse Series implementation for expression.
@@ -212,14 +211,10 @@ def reuse_series_implementation(
         attr: name of method.
         returns_scalar: whether the Series version returns a scalar. In this case,
             the expression version should return a 1-row Series.
-        alias: the new name.
         args: arguments to pass to function.
         kwargs: keyword arguments to pass to function.
     """
     plx = expr.__narwhals_namespace__()
-
-    if alias is not None and expr._output_names is not None:
-        expr._output_names = [alias]  # type: ignore[union-attr]
 
     def func(df: CompliantDataFrame) -> list[CompliantSeries]:
         _args = [maybe_evaluate_expr(df, arg) for arg in args]
@@ -240,7 +235,11 @@ def reuse_series_implementation(
         if expr._output_names is not None and (
             [s.name for s in out] != expr._output_names
         ):  # pragma: no cover
-            msg = "Safety assertion failed, please report a bug to https://github.com/narwhals-dev/narwhals/issues"
+            msg = (
+                f"Safety assertion failed, please report a bug to https://github.com/narwhals-dev/narwhals/issues\n"
+                f"Expression output names: {expr._output_names}\n"
+                f"Series names: {[s.name for s in out]}"
+            )
             raise AssertionError(msg)
         return out
 

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -199,6 +199,7 @@ def reuse_series_implementation(
     attr: str,
     *args: Any,
     returns_scalar: bool = False,
+    alias: str | None = None,
     **kwargs: Any,
 ) -> CompliantExprT:
     """Reuse Series implementation for expression.
@@ -211,10 +212,14 @@ def reuse_series_implementation(
         attr: name of method.
         returns_scalar: whether the Series version returns a scalar. In this case,
             the expression version should return a 1-row Series.
+        alias: the new name.
         args: arguments to pass to function.
         kwargs: keyword arguments to pass to function.
     """
     plx = expr.__narwhals_namespace__()
+
+    if alias is not None and expr._output_names is not None:
+        expr._output_names = [alias]  # type: ignore[union-attr]
 
     def func(df: CompliantDataFrame) -> list[CompliantSeries]:
         _args = [maybe_evaluate_expr(df, arg) for arg in args]

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -159,59 +159,64 @@ class PandasLikeExpr:
         return reuse_series_implementation(self, "__and__", other=other)
 
     def __rand__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__rand__", other=other)
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__and__(self)  # type: ignore[no-any-return]
 
     def __or__(self, other: PandasLikeExpr | bool | Any) -> Self:
         return reuse_series_implementation(self, "__or__", other=other)
 
     def __ror__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__ror__", other=other)
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__or__(self)  # type: ignore[no-any-return]
 
     def __add__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__add__", other=other)
 
     def __radd__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__radd__", other=other, alias="literal")
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__add__(self)  # type: ignore[no-any-return]
 
     def __sub__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__sub__", other=other)
 
     def __rsub__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__rsub__", other=other, alias="literal")
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__sub__(self)  # type: ignore[no-any-return]
 
     def __mul__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__mul__", other=other)
 
     def __rmul__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__rmul__", other=other, alias="literal")
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__mul__(self)  # type: ignore[no-any-return]
 
     def __truediv__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__truediv__", other=other)
 
     def __rtruediv__(self, other: Any) -> Self:
-        return reuse_series_implementation(
-            self, "__rtruediv__", other=other, alias="literal"
-        )
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__truediv__(self)  # type: ignore[no-any-return]
 
     def __floordiv__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__floordiv__", other=other)
 
     def __rfloordiv__(self, other: Any) -> Self:
-        return reuse_series_implementation(
-            self, "__rfloordiv__", other=other, alias="literal"
-        )
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__floordiv__(self)  # type: ignore[no-any-return]
 
     def __pow__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__pow__", other=other)
 
     def __rpow__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__rpow__", other=other, alias="literal")
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__pow__(self)  # type: ignore[no-any-return]
 
     def __mod__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__mod__", other=other)
 
     def __rmod__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__rmod__", other=other, alias="literal")
+        other = self.__narwhals_namespace__().lit(other, dtype=None)
+        return other.__mod__(self)  # type: ignore[no-any-return]
 
     # Unary
 

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -171,43 +171,47 @@ class PandasLikeExpr:
         return reuse_series_implementation(self, "__add__", other=other)
 
     def __radd__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__radd__", other=other)
+        return reuse_series_implementation(self, "__radd__", other=other, alias="literal")
 
     def __sub__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__sub__", other=other)
 
     def __rsub__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__rsub__", other=other)
+        return reuse_series_implementation(self, "__rsub__", other=other, alias="literal")
 
     def __mul__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__mul__", other=other)
 
     def __rmul__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__rmul__", other=other)
+        return reuse_series_implementation(self, "__rmul__", other=other, alias="literal")
 
     def __truediv__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__truediv__", other=other)
 
     def __rtruediv__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__rtruediv__", other=other)
+        return reuse_series_implementation(
+            self, "__rtruediv__", other=other, alias="literal"
+        )
 
     def __floordiv__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__floordiv__", other=other)
 
     def __rfloordiv__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__rfloordiv__", other=other)
+        return reuse_series_implementation(
+            self, "__rfloordiv__", other=other, alias="literal"
+        )
 
     def __pow__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__pow__", other=other)
 
     def __rpow__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__rpow__", other=other)
+        return reuse_series_implementation(self, "__rpow__", other=other, alias="literal")
 
     def __mod__(self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__mod__", other=other)
 
     def __rmod__(self, other: Any) -> Self:
-        return reuse_series_implementation(self, "__rmod__", other=other)
+        return reuse_series_implementation(self, "__rmod__", other=other, alias="literal")
 
     # Unary
 

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -154,7 +154,7 @@ class PandasLikeNamespace:
             depth=0,
             function_name="lit",
             root_names=None,
-            output_names=[_lit_pandas_series.__name__],
+            output_names=["literal"],
             implementation=self._implementation,
             backend_version=self._backend_version,
             dtypes=self._dtypes,

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -501,8 +501,9 @@ class PandasWhen:
             )
         value_series = cast(PandasLikeSeries, value_series)
 
-        value_series_native = value_series._native_series
-        condition_native = validate_column_comparand(value_series_native.index, condition)
+        value_series_native, condition_native = validate_column_comparand(
+            value_series, condition
+        )
 
         if self._otherwise_value is None:
             return [

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -339,8 +339,8 @@ class PandasLikeSeries:
 
     def __radd__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
-        return self._from_native_series(ser.__radd__(other).rename(ser.name, copy=False))
+        other = validate_column_comparand(ser.index, other)
+        return self._from_native_series(ser.__radd__(other).rename("literal", copy=False))
 
     def __sub__(self, other: Any) -> PandasLikeSeries:
         other = validate_column_comparand(self._native_series.index, other)
@@ -349,8 +349,8 @@ class PandasLikeSeries:
 
     def __rsub__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
-        return self._from_native_series(ser.__rsub__(other).rename(ser.name, copy=False))
+        other = validate_column_comparand(ser.index, other)
+        return self._from_native_series(ser.__rsub__(other).rename("literal", copy=False))
 
     def __mul__(self, other: Any) -> PandasLikeSeries:
         other = validate_column_comparand(self._native_series.index, other)
@@ -359,8 +359,8 @@ class PandasLikeSeries:
 
     def __rmul__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
-        return self._from_native_series(ser.__rmul__(other).rename(ser.name, copy=False))
+        other = validate_column_comparand(ser.index, other)
+        return self._from_native_series(ser.__rmul__(other).rename("literal", copy=False))
 
     def __truediv__(self, other: Any) -> PandasLikeSeries:
         other = validate_column_comparand(self._native_series.index, other)
@@ -371,9 +371,9 @@ class PandasLikeSeries:
 
     def __rtruediv__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
+        other = validate_column_comparand(ser.index, other)
         return self._from_native_series(
-            ser.__rtruediv__(other).rename(ser.name, copy=False)
+            ser.__rtruediv__(other).rename("literal", copy=False)
         )
 
     def __floordiv__(self, other: Any) -> PandasLikeSeries:
@@ -385,9 +385,9 @@ class PandasLikeSeries:
 
     def __rfloordiv__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
+        other = validate_column_comparand(ser.index, other)
         return self._from_native_series(
-            ser.__rfloordiv__(other).rename(ser.name, copy=False)
+            ser.__rfloordiv__(other).rename("literal", copy=False)
         )
 
     def __pow__(self, other: Any) -> PandasLikeSeries:
@@ -397,8 +397,8 @@ class PandasLikeSeries:
 
     def __rpow__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
-        return self._from_native_series(ser.__rpow__(other).rename(ser.name, copy=False))
+        other = validate_column_comparand(ser.index, other)
+        return self._from_native_series(ser.__rpow__(other).rename("literal", copy=False))
 
     def __mod__(self, other: Any) -> PandasLikeSeries:
         other = validate_column_comparand(self._native_series.index, other)
@@ -407,8 +407,8 @@ class PandasLikeSeries:
 
     def __rmod__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
-        return self._from_native_series(ser.__rmod__(other).rename(ser.name, copy=False))
+        other = validate_column_comparand(ser.index, other)
+        return self._from_native_series(ser.__rmod__(other).rename("literal", copy=False))
 
     # Unary
 

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -738,7 +738,12 @@ class PandasLikeSeries:
         return self._native_series.quantile(q=quantile, interpolation=interpolation)
 
     def zip_with(self: Self, mask: Any, other: Any) -> PandasLikeSeries:
-        # TODO(marco): check that mask and other are same length?
+        if self.len() != mask.len():
+            msg = (
+                "`mask` must have same length as original column.\n"
+                f"Got: original column length {self.len()}, mask length {mask.len()}."
+            )
+            raise ValueError(msg)
         ser, mask = validate_column_comparand(self, mask)
         _, other = validate_column_comparand(self, other)
         res = ser.where(mask, other)

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -11,6 +11,7 @@ from typing import overload
 from narwhals._pandas_like.utils import calculate_timestamp_date
 from narwhals._pandas_like.utils import calculate_timestamp_datetime
 from narwhals._pandas_like.utils import int_dtype_mapper
+from narwhals._pandas_like.utils import maybe_broadcast_scalar_into_series
 from narwhals._pandas_like.utils import narwhals_to_native_dtype
 from narwhals._pandas_like.utils import native_series_from_iterable
 from narwhals._pandas_like.utils import native_to_narwhals_dtype
@@ -332,8 +333,8 @@ class PandasLikeSeries:
         return self._from_native_series(ser.__ror__(other).rename(ser.name, copy=False))
 
     def __add__(self, other: Any) -> PandasLikeSeries:
-        ser = self._native_series
         other = validate_column_comparand(self._native_series.index, other)
+        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
         return self._from_native_series(ser.__add__(other).rename(ser.name, copy=False))
 
     def __radd__(self, other: Any) -> PandasLikeSeries:
@@ -342,8 +343,8 @@ class PandasLikeSeries:
         return self._from_native_series(ser.__radd__(other).rename(ser.name, copy=False))
 
     def __sub__(self, other: Any) -> PandasLikeSeries:
-        ser = self._native_series
         other = validate_column_comparand(self._native_series.index, other)
+        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
         return self._from_native_series(ser.__sub__(other).rename(ser.name, copy=False))
 
     def __rsub__(self, other: Any) -> PandasLikeSeries:
@@ -352,8 +353,8 @@ class PandasLikeSeries:
         return self._from_native_series(ser.__rsub__(other).rename(ser.name, copy=False))
 
     def __mul__(self, other: Any) -> PandasLikeSeries:
-        ser = self._native_series
         other = validate_column_comparand(self._native_series.index, other)
+        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
         return self._from_native_series(ser.__mul__(other).rename(ser.name, copy=False))
 
     def __rmul__(self, other: Any) -> PandasLikeSeries:
@@ -362,8 +363,8 @@ class PandasLikeSeries:
         return self._from_native_series(ser.__rmul__(other).rename(ser.name, copy=False))
 
     def __truediv__(self, other: Any) -> PandasLikeSeries:
-        ser = self._native_series
         other = validate_column_comparand(self._native_series.index, other)
+        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
         return self._from_native_series(
             ser.__truediv__(other).rename(ser.name, copy=False)
         )
@@ -376,8 +377,8 @@ class PandasLikeSeries:
         )
 
     def __floordiv__(self, other: Any) -> PandasLikeSeries:
-        ser = self._native_series
         other = validate_column_comparand(self._native_series.index, other)
+        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
         return self._from_native_series(
             ser.__floordiv__(other).rename(ser.name, copy=False)
         )
@@ -390,8 +391,8 @@ class PandasLikeSeries:
         )
 
     def __pow__(self, other: Any) -> PandasLikeSeries:
-        ser = self._native_series
         other = validate_column_comparand(self._native_series.index, other)
+        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
         return self._from_native_series(ser.__pow__(other).rename(ser.name, copy=False))
 
     def __rpow__(self, other: Any) -> PandasLikeSeries:
@@ -400,8 +401,8 @@ class PandasLikeSeries:
         return self._from_native_series(ser.__rpow__(other).rename(ser.name, copy=False))
 
     def __mod__(self, other: Any) -> PandasLikeSeries:
-        ser = self._native_series
         other = validate_column_comparand(self._native_series.index, other)
+        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
         return self._from_native_series(ser.__mod__(other).rename(ser.name, copy=False))
 
     def __rmod__(self, other: Any) -> PandasLikeSeries:

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -392,7 +392,7 @@ class PandasLikeSeries:
         ser = self._native_series
         ser, other = validate_column_comparand(self, other)
         return self._from_native_series(
-            ser.__rtruediv__(other).rename("literal", copy=False)
+            ser.__rtruediv__(other).rename(ser.name, copy=False)
         )
 
     def __floordiv__(self, other: Any) -> PandasLikeSeries:

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -11,7 +11,6 @@ from typing import overload
 from narwhals._pandas_like.utils import calculate_timestamp_date
 from narwhals._pandas_like.utils import calculate_timestamp_datetime
 from narwhals._pandas_like.utils import int_dtype_mapper
-from narwhals._pandas_like.utils import maybe_broadcast_scalar_into_series
 from narwhals._pandas_like.utils import narwhals_to_native_dtype
 from narwhals._pandas_like.utils import native_series_from_iterable
 from narwhals._pandas_like.utils import native_to_narwhals_dtype
@@ -219,7 +218,7 @@ class PandasLikeSeries:
         if isinstance(values, self.__class__):
             # .copy() is necessary in some pre-2.2 versions of pandas to avoid
             # `values` also getting modified (!)
-            values = validate_column_comparand(self._native_series.index, values).copy()
+            _, values = validate_column_comparand(self, values).copy()
             values = set_axis(
                 values,
                 self._native_series.index[indices],
@@ -299,136 +298,136 @@ class PandasLikeSeries:
     def filter(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
         if not (isinstance(other, list) and all(isinstance(x, bool) for x in other)):
-            other = validate_column_comparand(self._native_series.index, other)
+            ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.loc[other].rename(ser.name, copy=False))
 
     def __eq__(self, other: object) -> PandasLikeSeries:  # type: ignore[override]
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__eq__(other).rename(ser.name, copy=False))
 
     def __ne__(self, other: object) -> PandasLikeSeries:  # type: ignore[override]
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__ne__(other).rename(ser.name, copy=False))
 
     def __ge__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__ge__(other).rename(ser.name, copy=False))
 
     def __gt__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__gt__(other).rename(ser.name, copy=False))
 
     def __le__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__le__(other).rename(ser.name, copy=False))
 
     def __lt__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__lt__(other).rename(ser.name, copy=False))
 
     def __and__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__and__(other).rename(ser.name, copy=False))
 
     def __rand__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__rand__(other).rename(ser.name, copy=False))
 
     def __or__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__or__(other).rename(ser.name, copy=False))
 
     def __ror__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(self._native_series.index, other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__ror__(other).rename(ser.name, copy=False))
 
     def __add__(self, other: Any) -> PandasLikeSeries:
-        other = validate_column_comparand(self._native_series.index, other)
-        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
+        ser = self._native_series
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__add__(other).rename(ser.name, copy=False))
 
     def __radd__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(ser.index, other)
-        return self._from_native_series(ser.__radd__(other).rename("literal", copy=False))
+        ser, other = validate_column_comparand(self, other)
+        return self._from_native_series(ser.__radd__(other).rename(ser.name, copy=False))
 
     def __sub__(self, other: Any) -> PandasLikeSeries:
-        other = validate_column_comparand(self._native_series.index, other)
-        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
+        ser = self._native_series
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__sub__(other).rename(ser.name, copy=False))
 
     def __rsub__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(ser.index, other)
-        return self._from_native_series(ser.__rsub__(other).rename("literal", copy=False))
+        ser, other = validate_column_comparand(self, other)
+        return self._from_native_series(ser.__rsub__(other).rename(ser.name, copy=False))
 
     def __mul__(self, other: Any) -> PandasLikeSeries:
-        other = validate_column_comparand(self._native_series.index, other)
-        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
+        ser = self._native_series
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__mul__(other).rename(ser.name, copy=False))
 
     def __rmul__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(ser.index, other)
-        return self._from_native_series(ser.__rmul__(other).rename("literal", copy=False))
+        ser, other = validate_column_comparand(self, other)
+        return self._from_native_series(ser.__rmul__(other).rename(ser.name, copy=False))
 
     def __truediv__(self, other: Any) -> PandasLikeSeries:
-        other = validate_column_comparand(self._native_series.index, other)
-        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
+        ser = self._native_series
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(
             ser.__truediv__(other).rename(ser.name, copy=False)
         )
 
     def __rtruediv__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(ser.index, other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(
             ser.__rtruediv__(other).rename("literal", copy=False)
         )
 
     def __floordiv__(self, other: Any) -> PandasLikeSeries:
-        other = validate_column_comparand(self._native_series.index, other)
-        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
+        ser = self._native_series
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(
             ser.__floordiv__(other).rename(ser.name, copy=False)
         )
 
     def __rfloordiv__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(ser.index, other)
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(
-            ser.__rfloordiv__(other).rename("literal", copy=False)
+            ser.__rfloordiv__(other).rename(ser.name, copy=False)
         )
 
     def __pow__(self, other: Any) -> PandasLikeSeries:
-        other = validate_column_comparand(self._native_series.index, other)
-        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
+        ser = self._native_series
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__pow__(other).rename(ser.name, copy=False))
 
     def __rpow__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(ser.index, other)
-        return self._from_native_series(ser.__rpow__(other).rename("literal", copy=False))
+        ser, other = validate_column_comparand(self, other)
+        return self._from_native_series(ser.__rpow__(other).rename(ser.name, copy=False))
 
     def __mod__(self, other: Any) -> PandasLikeSeries:
-        other = validate_column_comparand(self._native_series.index, other)
-        ser = maybe_broadcast_scalar_into_series(self._native_series, other)
+        ser = self._native_series
+        ser, other = validate_column_comparand(self, other)
         return self._from_native_series(ser.__mod__(other).rename(ser.name, copy=False))
 
     def __rmod__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
-        other = validate_column_comparand(ser.index, other)
-        return self._from_native_series(ser.__rmod__(other).rename("literal", copy=False))
+        ser, other = validate_column_comparand(self, other)
+        return self._from_native_series(ser.__rmod__(other).rename(ser.name, copy=False))
 
     # Unary
 
@@ -739,9 +738,9 @@ class PandasLikeSeries:
         return self._native_series.quantile(q=quantile, interpolation=interpolation)
 
     def zip_with(self: Self, mask: Any, other: Any) -> PandasLikeSeries:
-        ser = self._native_series
-        mask = validate_column_comparand(ser.index, mask)
-        other = validate_column_comparand(ser.index, other)
+        # TODO(marco): check that mask and other are same length?
+        ser, mask = validate_column_comparand(self, mask)
+        _, other = validate_column_comparand(self, other)
         res = ser.where(mask, other)
         return self._from_native_series(res)
 

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -218,9 +218,9 @@ class PandasLikeSeries:
         if isinstance(values, self.__class__):
             # .copy() is necessary in some pre-2.2 versions of pandas to avoid
             # `values` also getting modified (!)
-            _, values = validate_column_comparand(self, values).copy()
+            _, values = validate_column_comparand(self, values)
             values = set_axis(
-                values,
+                values.copy(),
                 self._native_series.index[indices],
                 implementation=self._implementation,
                 backend_version=self._backend_version,

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -339,7 +339,7 @@ class PandasLikeSeries:
     def __rand__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
         ser, other = validate_column_comparand(self, other)
-        return self._from_native_series(ser.__rand__(other).rename(ser.name, copy=False))
+        return self._from_native_series(ser.__and__(other).rename(ser.name, copy=False))
 
     def __or__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
@@ -349,7 +349,7 @@ class PandasLikeSeries:
     def __ror__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series
         ser, other = validate_column_comparand(self, other)
-        return self._from_native_series(ser.__ror__(other).rename(ser.name, copy=False))
+        return self._from_native_series(ser.__or__(other).rename(ser.name, copy=False))
 
     def __add__(self, other: Any) -> PandasLikeSeries:
         ser = self._native_series

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -738,12 +738,6 @@ class PandasLikeSeries:
         return self._native_series.quantile(q=quantile, interpolation=interpolation)
 
     def zip_with(self: Self, mask: Any, other: Any) -> PandasLikeSeries:
-        if self.len() != mask.len():
-            msg = (
-                "`mask` must have same length as original column.\n"
-                f"Got: original column length {self.len()}, mask length {mask.len()}."
-            )
-            raise ValueError(msg)
         ser, mask = validate_column_comparand(self, mask)
         _, other = validate_column_comparand(self, other)
         res = ser.where(mask, other)

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -112,7 +112,7 @@ def validate_column_comparand(index: Any, other: Any) -> Any:
             # broadcast
             s = other._native_series
             return s.__class__(s.iloc[0], index=index, dtype=s.dtype)
-        if other._native_series.index is not index:
+        if other._native_series.index is not index and len(index) > 1:
             return set_axis(
                 other._native_series,
                 index,
@@ -121,6 +121,18 @@ def validate_column_comparand(index: Any, other: Any) -> Any:
             )
         return other._native_series
     return other
+
+
+def maybe_broadcast_scalar_into_series(series: Any, other: Any) -> Any:
+    import pandas as pd  # ignore-banned-import
+
+    if isinstance(other, pd.Series) and len(series) == 1 and len(other) > 1:
+        return series.__class__(
+            [series.iloc[0]] * len(other),
+            other.index,
+            series.dtype,
+        ).rename(series.name, copy=False)
+    return series
 
 
 def validate_dataframe_comparand(index: Any, other: Any) -> Any:

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -79,7 +79,7 @@ $"""
 PATTERN_PA_DURATION = re.compile(PA_DURATION_RGX, re.VERBOSE)
 
 
-def validate_column_comparand(lhs: Any, rhs: Any) -> Any:
+def validate_column_comparand(lhs: PandasLikeSeries, rhs: Any) -> tuple[pd.Series, Any]:
     """Validate RHS of binary operation.
 
     If the comparison isn't supported, return `NotImplemented` so that the

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -124,7 +124,7 @@ def validate_column_comparand(index: Any, other: Any) -> Any:
 
 
 def maybe_broadcast_scalar_into_series(series: Any, other: Any) -> Any:
-    """Broadcast a single-element series into a `series` that matches the length of `other`."""
+    """Broadcast a single-element `series` into a series that matches the length of `other`."""
     import pandas as pd  # ignore-banned-import
 
     if isinstance(other, pd.Series) and len(series) == 1 and len(other) > 1:

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -124,6 +124,7 @@ def validate_column_comparand(index: Any, other: Any) -> Any:
 
 
 def maybe_broadcast_scalar_into_series(series: Any, other: Any) -> Any:
+    """Broadcast a single-element series into a `series` that matches the length of `other`."""
     import pandas as pd  # ignore-banned-import
 
     if isinstance(other, pd.Series) and len(series) == 1 and len(other) > 1:

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -192,9 +192,11 @@ class PolarsSeries:
         )
 
     def __rpow__(self, other: PolarsSeries | Any) -> Self:
-        return self._from_native_series(
-            self._native_series.__rpow__(extract_native(other))
-        )
+        result = self._native_series.__rpow__(extract_native(other))
+        if self._backend_version < (16, 1):
+            # Explicitly set alias to work around https://github.com/pola-rs/polars/issues/20071
+            result = result.alias(self.name)
+        return self._from_native_series(result)
 
     def __invert__(self) -> Self:
         return self._from_native_series(self._native_series.__invert__())

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -2037,9 +2037,19 @@ class Series(Generic[IntoSeriesT]):
             self._compliant_series.__and__(self._extract_native(other))
         )
 
+    def __rand__(self, other: Any) -> Self:
+        return self._from_compliant_series(
+            self._compliant_series.__rand__(self._extract_native(other))
+        )
+
     def __or__(self, other: Any) -> Self:
         return self._from_compliant_series(
             self._compliant_series.__or__(self._extract_native(other))
+        )
+
+    def __ror__(self, other: Any) -> Self:
+        return self._from_compliant_series(
+            self._compliant_series.__ror__(self._extract_native(other))
         )
 
     # unary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ exclude_also = [
   "if (:?self._)?implementation is Implementation.MODIN",
   "if (:?self._)?implementation is Implementation.CUDF",
   'request.applymarker\(pytest.mark.xfail\)',
-  'if self._backend_version < ',
+  'if \w+._backend_version < ',
   'if backend_version <',
   'if "cudf" in str\(constructor'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,8 @@ exclude_also = [
   "if (:?self._)?implementation is Implementation.CUDF",
   'request.applymarker\(pytest.mark.xfail\)',
   'if self._backend_version < ',
-  'if "cudf" in str\(constructor',
+  'if backend_version <',
+  'if "cudf" in str\(constructor'
 ]
 
 [tool.mypy]

--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -71,8 +71,6 @@ def test_right_arithmetic_expr(
         x in str(constructor) for x in ["pandas_pyarrow", "modin"]
     ):
         request.applymarker(pytest.mark.xfail)
-    if "dask" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
 
     data = {"a": [1, 2, 3]}
     df = nw.from_native(constructor(data))

--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -135,10 +135,11 @@ def test_right_arithmetic_series(
 
     data = {"a": [1, 2, 3]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
-    result = df.select(a=getattr(df["a"], attr)(rhs))
+    result_series = getattr(df["a"], attr)(rhs)
+    assert result_series.name == "a"
     # rarithmetic ops on series in Polars do return an unnamed series: expected?
     # can't assert on col name being "literal"
-    assert_equal_data(result, {"a": expected})
+    assert_equal_data({"a": result_series}, {"a": expected})
 
 
 def test_truediv_same_dims(

--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -71,11 +71,13 @@ def test_right_arithmetic_expr(
         x in str(constructor) for x in ["pandas_pyarrow", "modin"]
     ):
         request.applymarker(pytest.mark.xfail)
+    if "dask" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
 
     data = {"a": [1, 2, 3]}
     df = nw.from_native(constructor(data))
-    result = df.select(a=getattr(nw.col("a"), attr)(rhs))
-    assert_equal_data(result, {"a": expected})
+    result = df.select(getattr(nw.col("a"), attr)(rhs))
+    assert_equal_data(result, {"literal": expected})
 
 
 @pytest.mark.parametrize(
@@ -136,6 +138,8 @@ def test_right_arithmetic_series(
     data = {"a": [1, 2, 3]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(a=getattr(df["a"], attr)(rhs))
+    # rarithmetic ops on series in Polars do return an unnamed series: expected?
+    # can't assert on col name being "literal"
     assert_equal_data(result, {"a": expected})
 
 

--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -137,8 +137,6 @@ def test_right_arithmetic_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result_series = getattr(df["a"], attr)(rhs)
     assert result_series.name == "a"
-    # rarithmetic ops on series in Polars do return an unnamed series: expected?
-    # can't assert on col name being "literal"
     assert_equal_data({"a": result_series}, {"a": expected})
 
 

--- a/tests/expr_and_series/operators_test.py
+++ b/tests/expr_and_series/operators_test.py
@@ -68,6 +68,25 @@ def test_logic_operators_expr(
 @pytest.mark.parametrize(
     ("operator", "expected"),
     [
+        ("__and__", [False, False, False, False]),
+        ("__rand__", [False, False, False, False]),
+        ("__or__", [True, True, False, False]),
+        ("__ror__", [True, True, False, False]),
+    ],
+)
+def test_logic_operators_expr_scalar(
+    constructor: Constructor, operator: str, expected: list[bool]
+) -> None:
+    data = {"a": [True, True, False, False]}
+    df = nw.from_native(constructor(data))
+
+    result = df.select(a=getattr(nw.col("a"), operator)(False))  # noqa: FBT003
+    assert_equal_data(result, {"a": expected})
+
+
+@pytest.mark.parametrize(
+    ("operator", "expected"),
+    [
         ("__eq__", [False, True, False]),
         ("__ne__", [True, False, True]),
         ("__le__", [True, True, False]),

--- a/tests/expr_and_series/operators_test.py
+++ b/tests/expr_and_series/operators_test.py
@@ -129,7 +129,9 @@ def test_comparand_operators_series(
     ("operator", "expected"),
     [
         ("__and__", [True, False, False, False]),
+        ("__rand__", [True, False, False, False]),
         ("__or__", [True, True, True, False]),
+        ("__ror__", [True, True, True, False]),
     ],
 )
 def test_logic_operators_series(

--- a/tests/frame/lit_test.py
+++ b/tests/frame/lit_test.py
@@ -62,3 +62,33 @@ def test_lit_out_name(constructor: Constructor) -> None:
         "literal": [2, 2, 2],
     }
     assert_equal_data(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("col_name", "expr", "expected_result"),
+    [
+        ("left_lit", nw.lit(1) + nw.col("a"), [2, 4, 3]),
+        ("right_lit", nw.col("a") + nw.lit(1), [2, 4, 3]),
+        ("left_lit_with_agg", nw.lit(1) + nw.col("a").mean(), [3]),
+        ("right_lit_with_agg", nw.col("a").mean() - nw.lit(1), [1]),
+        ("left_scalar", 1 + nw.col("a"), [2, 4, 3]),
+        ("right_scalar", nw.col("a") + 1, [2, 4, 3]),
+        ("left_scalar_with_agg", 1 + nw.col("a").mean(), [3]),
+        ("right_scalar_with_agg", nw.col("a").mean() - 1, [1]),
+    ],
+)
+def test_lit_operation(
+    constructor: Constructor,
+    col_name: str,
+    expr: nw.Expr,
+    expected_result: list[int],
+    request: pytest.FixtureRequest,
+) -> None:
+    if "dask_lazy_p2" in str(constructor) and "lit_with_agg" in col_name:
+        request.applymarker(pytest.mark.xfail)
+    data = {"a": [1, 3, 2]}
+    df_raw = constructor(data)
+    df = nw.from_native(df_raw).lazy()
+    result = df.select(expr.alias(col_name))
+    expected = {col_name: expected_result}
+    assert_equal_data(result, expected)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -62,7 +62,7 @@ def assert_equal_data(result: Any, expected: dict[str, Any]) -> None:
         result = result.collect()
     if hasattr(result, "columns"):
         for key in result.columns:
-            assert key in expected
+            assert key in expected, (key, expected)
     result = {key: _to_comparable_list(result[key]) for key in expected}
     for key in expected:
         result_key = result[key]


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Resolves #853, resolves #509

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

Opening as draft to get comments/guidance on the approach. Also, (1) `Dask` behaviour, (2) column name resulting from right arithmetics _on Series_ in `Polars`, (3) leftover _binary dunder methods_ need more thourough exploration on my side.

Another point, this PR should solve both of the issues in principle. I combined the two fixes because I originally thought that the second (#509) could naturally be resolved as a consequence of the first, but at the end that's not really the case (at least via the approach I followed). Perhaps I should separate the two?

### Key points:

#853:
    - Tweak `validate_column_comparand` in `_pandas_like` so as to reindex `other` via the lhs series only when possible (which is what the error message was complaining about when outputting _ValueError: Length mismatch: Expected axis has 3 elements, new values have 1 elements_)
    - Broadcast the lhs series via `maybe_broadcast_scalar_into_series` when relevant (i.e. when of different length wrt the previously validated/broadcasted rhs `other`)

#509:
    - Add optional `alias` parameter to `reuse_series_implementation` and assign it to `expr._output_names` (basically, the approach Marco was showing in last week's livestream) and pass it all along to be able to rename the output of rarithmetic ops as `"literal"` without incurring into _safety assertion_ errors.

### Points that need - for sure - further exploration:
- `Dask` behaviour related to ~~both~~ #853 ~~and #509~~ (I had to `xfail` `tests/frame/lit_test.py::test_lit_operation` ~~and `tests/expr_and_series/arithmetic_test.py::test_right_arithmetic_expr`~~); what happens here is that `Dask`'s `lit` reasonably aligns the index with the native frame, but here a reduction takes place, which shrinks the index of the resulting frame causing a mismatch.
- Right arithmetic operations _on Series_ in `Polars` return an unnamed column. So, while
```
@nw.narwhalify
def func(df):
    return df.select(1 + nw.col('a'))
```
outputs `"literal"` as col name as reported in #509, `1 + pl.Series([1, 2, 3])` returns an unnamed series. This does prevent `tests/expr_and_series/arithmetic_test.py::test_right_arithmetic_series` from testing for the output column name being `"literal"`. Point is that, as we're generally _reusing series implementation_ in expressions, this might need to be taken into consideration as on other backends we're kind of imposing output name to be `"literal"`.
- Analyse behaviour of the binary dunder methods that were momentaneously left apart.