### PR TITLE
BUG: remove cudf from import hooks

### DIFF
--- a/narwhals/dependencies.py
+++ b/narwhals/dependencies.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 # We silently allow these but - given that they claim
 # to be drop-in replacements for pandas - testing is
 # their responsibility.
-IMPORT_HOOKS = frozenset(["cudf", "fireducks"])
+IMPORT_HOOKS = frozenset(["fireducks"])
 
 
 def get_polars() -> Any:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

The cuDF tests for `is_pandas_dataframe` were failing.
