### PR TITLE
ci: get cudf tests passing again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,8 @@ exclude_also = [
   "if (:?self._)?implementation is Implementation.MODIN",
   "if (:?self._)?implementation is Implementation.CUDF",
   'request.applymarker\(pytest.mark.xfail\)',
-  'if self._backend_version < '
+  'if self._backend_version < ',
+  'if "cudf" in str\(constructor',
 ]
 
 [tool.mypy]

--- a/tests/expr_and_series/ewm_test.py
+++ b/tests/expr_and_series/ewm_test.py
@@ -16,9 +16,9 @@ data = {"a": [1, 1, 2], "b": [1, 2, 3]}
     "ignore:`Expr.ewm_mean` is being called from the stable API although considered an unstable feature."
 )
 def test_ewm_mean_expr(request: pytest.FixtureRequest, constructor: Constructor) -> None:
-    if any(x in str(constructor) for x in ("pyarrow_table_", "dask", "modin")) or (
-        "polars" in str(constructor) and POLARS_VERSION < (1,)
-    ):
+    if any(
+        x in str(constructor) for x in ("pyarrow_table_", "dask", "modin", "cudf")
+    ) or ("polars" in str(constructor) and POLARS_VERSION < (1,)):
         request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor(data))
@@ -36,7 +36,7 @@ def test_ewm_mean_expr(request: pytest.FixtureRequest, constructor: Constructor)
 def test_ewm_mean_series(
     request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
-    if any(x in str(constructor_eager) for x in ("pyarrow_table_", "modin")) or (
+    if any(x in str(constructor_eager) for x in ("pyarrow_table_", "modin", "cudf")) or (
         "polars" in str(constructor_eager) and POLARS_VERSION < (1,)
     ):
         request.applymarker(pytest.mark.xfail)
@@ -75,9 +75,9 @@ def test_ewm_mean_expr_adjust(
     adjust: bool,  # noqa: FBT001
     expected: dict[str, list[float]],
 ) -> None:
-    if any(x in str(constructor) for x in ("pyarrow_table_", "dask", "modin")) or (
-        "polars" in str(constructor) and POLARS_VERSION < (1,)
-    ):
+    if any(
+        x in str(constructor) for x in ("pyarrow_table_", "dask", "modin", "cudf")
+    ) or ("polars" in str(constructor) and POLARS_VERSION < (1,)):
         request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor(data))
@@ -137,9 +137,9 @@ def test_ewm_mean_nulls(
     expected: dict[str, list[float]],
     constructor: Constructor,
 ) -> None:
-    if any(x in str(constructor) for x in ("pyarrow_table_", "dask", "modin")) or (
-        "polars" in str(constructor) and POLARS_VERSION < (1,)
-    ):
+    if any(
+        x in str(constructor) for x in ("pyarrow_table_", "dask", "modin", "cudf")
+    ) or ("polars" in str(constructor) and POLARS_VERSION < (1,)):
         request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor({"a": [2.0, 4.0, None, 3.0]}))
@@ -154,9 +154,9 @@ def test_ewm_mean_params(
     request: pytest.FixtureRequest,
     constructor: Constructor,
 ) -> None:
-    if any(x in str(constructor) for x in ("pyarrow_table_", "dask", "modin")) or (
-        "polars" in str(constructor) and POLARS_VERSION < (1,)
-    ):
+    if any(
+        x in str(constructor) for x in ("pyarrow_table_", "dask", "modin", "cudf")
+    ) or ("polars" in str(constructor) and POLARS_VERSION < (1,)):
         request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor({"a": [2, 5, 3]}))

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -18,7 +18,7 @@ data = {"a": ["2020-01-01T12:34:56"]}
 
 
 def test_to_datetime(constructor: Constructor) -> None:
-    if "cudf" in str(constructor):  # pragma: no cover
+    if "cudf" in str(constructor):
         expected = "2020-01-01T12:34:56.000000000"
     else:
         expected = "2020-01-01 12:34:56"
@@ -34,7 +34,7 @@ def test_to_datetime(constructor: Constructor) -> None:
 
 
 def test_to_datetime_series(constructor_eager: ConstructorEager) -> None:
-    if "cudf" in str(constructor_eager):  # pragma: no cover
+    if "cudf" in str(constructor_eager):
         expected = "2020-01-01T12:34:56.000000000"
     else:
         expected = "2020-01-01 12:34:56"
@@ -76,7 +76,7 @@ def test_to_datetime_infer_fmt(
 ) -> None:
     if "polars" in str(constructor) and str(data["a"][0]).isdigit():
         request.applymarker(pytest.mark.xfail)
-    if "cudf" in str(constructor):  # pragma: no cover
+    if "cudf" in str(constructor):
         expected = expected_cudf
     result = (
         nw.from_native(constructor(data))
@@ -117,7 +117,7 @@ def test_to_datetime_series_infer_fmt(
 ) -> None:
     if "polars" in str(constructor_eager) and str(data["a"][0]).isdigit():
         request.applymarker(pytest.mark.xfail)
-    if "cudf" in str(constructor_eager):  # pragma: no cover
+    if "cudf" in str(constructor_eager):
         expected = expected_cudf
 
     result = (

--- a/tests/frame/pivot_test.py
+++ b/tests/frame/pivot_test.py
@@ -122,7 +122,7 @@ def test_pivot(
     index: str | list[str],
     request: pytest.FixtureRequest,
 ) -> None:
-    if any(x in str(constructor_eager) for x in ("pyarrow_table", "modin")):
+    if any(x in str(constructor_eager) for x in ("pyarrow_table", "modin", "cudf")):
         request.applymarker(pytest.mark.xfail)
     if ("polars" in str(constructor_eager) and POLARS_VERSION < (1, 0)) or (
         "pandas" in str(constructor_eager) and PANDAS_VERSION < (1, 1)
@@ -153,6 +153,11 @@ def test_pivot_no_agg(
 ) -> None:
     if any(x in str(constructor_eager) for x in ("pyarrow_table", "modin")):
         request.applymarker(pytest.mark.xfail)
+    if "cudf" in str(constructor_eager):
+        # The first one fails, the second one passes. Let's just skip
+        # the test until they address their pivot shortcomings in the next
+        # release https://github.com/rapidsai/cudf/pull/17373.
+        request.applymarker(pytest.mark.skip)
     if ("polars" in str(constructor_eager) and POLARS_VERSION < (1, 0)) or (
         "pandas" in str(constructor_eager) and PANDAS_VERSION < (1, 1)
     ):
@@ -174,7 +179,7 @@ def test_pivot_no_agg(
 def test_pivot_sort_columns(
     request: Any, constructor_eager: Any, sort_columns: Any, expected: list[str]
 ) -> None:
-    if any(x in str(constructor_eager) for x in ("pyarrow_table", "modin")):
+    if any(x in str(constructor_eager) for x in ("pyarrow_table", "modin", "cudf")):
         request.applymarker(pytest.mark.xfail)
     if ("polars" in str(constructor_eager) and POLARS_VERSION < (1, 0)) or (
         "pandas" in str(constructor_eager) and PANDAS_VERSION < (1, 1)
@@ -224,7 +229,7 @@ def test_pivot_sort_columns(
 def test_pivot_names_out(
     request: Any, constructor_eager: Any, kwargs: Any, expected: list[str]
 ) -> None:
-    if any(x in str(constructor_eager) for x in ("pyarrow_table", "modin")):
+    if any(x in str(constructor_eager) for x in ("pyarrow_table", "modin", "cudf")):
         request.applymarker(pytest.mark.xfail)
     if ("polars" in str(constructor_eager) and POLARS_VERSION < (1, 0)) or (
         "pandas" in str(constructor_eager) and PANDAS_VERSION < (1, 1)

--- a/tests/frame/pivot_test.py
+++ b/tests/frame/pivot_test.py
@@ -157,7 +157,7 @@ def test_pivot_no_agg(
         # The first one fails, the second one passes. Let's just skip
         # the test until they address their pivot shortcomings in the next
         # release https://github.com/rapidsai/cudf/pull/17373.
-        request.applymarker(pytest.mark.skip)
+        return
     if ("polars" in str(constructor_eager) and POLARS_VERSION < (1, 0)) or (
         "pandas" in str(constructor_eager) and PANDAS_VERSION < (1, 1)
     ):


### PR DESCRIPTION
For pivot, they have a fix in place, so we can remove the xfail once they make a new release: https://github.com/rapidsai/cudf/pull/17373

In the meantime, let's make sure to have the test suite passing so we can include it in the release process (for now, manually)

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
