### PR TITLE
feat: raise `NotImplementedError` for not supported parameters in `ewm_mean` for cuDF

### DIFF
--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -188,9 +188,15 @@ class PandasLikeSeries:
     ) -> PandasLikeSeries:
         ser = self._native_series
         mask_na = ser.isna()
-        if self._implementation is Implementation.CUDF and sum(mask_na) > 0:
-            msg = "`ewm_mean` with null values is not yet implemented for cuDF"
-            raise NotImplementedError(msg)
+        if self._implementation is Implementation.CUDF:
+            if min_periods == 0 and not ignore_nulls:
+                result = ser.ewm(com, span, half_life, alpha, adjust).mean()
+            elif min_periods != 0:
+                msg = "`min_periods != 0` is not yet implemented for cuDF"
+                raise NotImplementedError(msg)
+            else:
+                msg = "`ignore_nulls=True` is not yet implemented for cuDF"
+                raise NotImplementedError(msg)
         result = ser.ewm(
             com, span, half_life, alpha, min_periods, adjust, ignore_na=ignore_nulls
         ).mean()

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -188,6 +188,9 @@ class PandasLikeSeries:
     ) -> PandasLikeSeries:
         ser = self._native_series
         mask_na = ser.isna()
+        if self._implementation is Implementation.CUDF and sum(mask_na) > 0:
+            msg = "`ewm_mean` with null values is not yet implemented for cuDF"
+            raise NotImplementedError(msg)
         result = ser.ewm(
             com, span, half_life, alpha, min_periods, adjust, ignore_na=ignore_nulls
         ).mean()

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -190,7 +190,9 @@ class PandasLikeSeries:
         mask_na = ser.isna()
         if self._implementation is Implementation.CUDF:
             if (min_periods == 0 and not ignore_nulls) or (not mask_na.any()):
-                result = ser.ewm(com, span, half_life, alpha, adjust).mean()
+                result = ser.ewm(
+                    com=com, span=span, halflife=half_life, alpha=alpha, adjust=adjust
+                ).mean()
             else:
                 msg = (
                     "cuDF only supports `ewm_mean` when there are no missing values "

--- a/tests/expr_and_series/ewm_test.py
+++ b/tests/expr_and_series/ewm_test.py
@@ -137,9 +137,9 @@ def test_ewm_mean_nulls(
     expected: dict[str, list[float]],
     constructor: Constructor,
 ) -> None:
-    if any(x in str(constructor) for x in ("pyarrow_table_", "dask", "modin")) or (
-        "polars" in str(constructor) and POLARS_VERSION < (1,)
-    ):
+    if any(
+        x in str(constructor) for x in ("pyarrow_table_", "dask", "modin", "cudf")
+    ) or ("polars" in str(constructor) and POLARS_VERSION < (1,)):
         request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor({"a": [2.0, 4.0, None, 3.0]}))

--- a/tests/expr_and_series/ewm_test.py
+++ b/tests/expr_and_series/ewm_test.py
@@ -196,17 +196,9 @@ def test_ewm_mean_cudf_raise() -> None:  # pragma: no cover
     pytest.importorskip("cudf")
     import cudf
 
-    df_with_nulls = nw.from_native(cudf.DataFrame({"a": [2.0, 4.0, None, 3.0]}))
-    df_ignore_nulls = nw.from_native(cudf.DataFrame(data))
+    df = nw.from_native(cudf.DataFrame({"a": [2.0, 4.0, None, 3.0]}))
     with pytest.raises(
         NotImplementedError,
         match="cuDF only supports `ewm_mean` when there are no missing values",
     ):
-        df_with_nulls.select(nw.col("a").ewm_mean(com=1))
-    with pytest.raises(
-        NotImplementedError,
-        match="cuDF only supports `ewm_mean` when there are no missing values",
-    ):
-        df_ignore_nulls.select(
-            nw.col("a").ewm_mean(com=1, min_periods=0, ignore_nulls=True)
-        )
+        df.select(nw.col("a").ewm_mean(com=1))

--- a/tests/expr_and_series/ewm_test.py
+++ b/tests/expr_and_series/ewm_test.py
@@ -211,7 +211,7 @@ def test_ewm_mean_cudf_default_params(
 @pytest.mark.filterwarnings(
     "ignore:`Expr.ewm_mean` is being called from the stable API although considered an unstable feature."
 )
-def test_ewm_mean_cudf_raise() -> None:
+def test_ewm_mean_cudf_raise() -> None:  # pragma: no cover
     pytest.importorskip("cudf")
     import cudf
 


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
cuDF tests were failing for `ewm_mean`.
