### PR TITLE
ci: Check docstrings don't have unused imports in docstring examples

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -186,8 +186,6 @@ jobs:
         run: |
             uv pip uninstall narwhals --system
             uv pip install -e . --system
-            # temporarily pin ollama to get CI green
-            uv pip install "ollama<0.4.0" --system
       - name: show-deps
         run: uv pip freeze
       - name: Run `make narwhals-test-integration`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,13 +33,14 @@ repos:
             (?x)^(
                 tests/.*|
                 # TODO: gradually enable
-                narwhals/series\.py$|
+                narwhals/series\.py|
                 # TODO: gradually enable
-                narwhals/dataframe\.py$|
+                narwhals/dataframe\.py|
                 # TODO: gradually enable
-                narwhals/dependencies\.py$|
+                narwhals/dependencies\.py|
                 # private, so less urgent to document too well
-                narwhals/_.*
+                narwhals/_.*|
+                ^utils/.*
             )$
 - repo: local
   hooks:
@@ -55,6 +56,11 @@ repos:
       language: python
       files: ^narwhals/
       exclude: ^narwhals/dependencies\.py
+    - id: check-docstrings-execute
+      name: check docstrings execute
+      entry: python utils/check_docstrings.py
+      language: python
+      files: ^narwhals/
 - repo: https://github.com/kynan/nbstripout
   rev: 0.8.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,9 @@ repos:
     # Run the linter.
     - id: ruff
       args: [--fix]
+    - id: ruff
+      alias: check-docstrings
+      entry: python utils/check_docstrings.py
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: 'v1.13.0'
   hooks:
@@ -56,11 +59,6 @@ repos:
       language: python
       files: ^narwhals/
       exclude: ^narwhals/dependencies\.py
-    - id: check-docstrings-execute
-      name: check docstrings execute
-      entry: python utils/check_docstrings.py
-      language: python
-      files: ^narwhals/
 - repo: https://github.com/kynan/nbstripout
   rev: 0.8.0
   hooks:

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -1773,7 +1773,7 @@ def narwhalify(
         Instead of writing
 
         >>> import narwhals as nw
-        >>> def func(df):
+        >>> def agnostic_group_by_sum(df):
         ...     df = nw.from_native(df, pass_through=True)
         ...     df = df.group_by("a").agg(nw.col("b").sum())
         ...     return nw.to_native(df)
@@ -1781,7 +1781,7 @@ def narwhalify(
         you can just write
 
         >>> @nw.narwhalify
-        ... def func(df):
+        ... def agnostic_group_by_sum(df):
         ...     return df.group_by("a").agg(nw.col("b").sum())
     """
     pass_through = validate_strict_and_pass_though(

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -816,7 +816,7 @@ def narwhalify(
         Instead of writing
 
         >>> import narwhals as nw
-        >>> def func(df):
+        >>> def agnostic_group_by_sum(df):
         ...     df = nw.from_native(df, pass_through=True)
         ...     df = df.group_by("a").agg(nw.col("b").sum())
         ...     return nw.to_native(df)
@@ -824,7 +824,7 @@ def narwhalify(
         you can just write
 
         >>> @nw.narwhalify
-        ... def func(df):
+        ... def agnostic_group_by_sum(df):
         ...     return df.group_by("a").agg(nw.col("b").sum())
     """
     from narwhals.utils import validate_strict_and_pass_though

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ pytest
 pytest-cov
 pytest-randomly
 pytest-env
+ruff
 hypothesis
 hypothesis[numpy]
 scikit-learn

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,6 @@ pytest
 pytest-cov
 pytest-randomly
 pytest-env
-ruff
 hypothesis
 hypothesis[numpy]
 scikit-learn

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import ast
+import doctest
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def extract_docstring_examples(files: list[Path]) -> list[tuple[Path, str, str]]:
+    """Extract examples from docstrings in Python files."""
+    examples: list[tuple[Path, str, str]] = []
+
+    for file in files:
+        with open(file, encoding="utf-8") as f:
+            tree = ast.parse(f.read())
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.ClassDef)):
+                docstring = ast.get_docstring(node)
+                if docstring:
+                    parsed_examples = doctest.DocTestParser().get_examples(docstring)
+                    example_code = "\n".join(
+                        example.source for example in parsed_examples
+                    )
+                    if example_code.strip():
+                        examples.append((file, node.name, example_code))
+
+    return examples
+
+
+def create_temp_files(examples: list[tuple[Path, str, str]]) -> list[tuple[Path, str]]:
+    """Create temporary files for all examples and return their paths."""
+    temp_files: list[tuple[Path, str]] = []
+
+    for file, name, example in examples:
+        temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False)  # noqa: SIM115
+        temp_file.write(example)
+        temp_file_path = temp_file.name
+        temp_file.close()
+        temp_files.append((Path(temp_file_path), f"{file}:{name}"))
+
+    return temp_files
+
+
+def run_ruff_on_temp_files(temp_files: list[tuple[Path, str]]) -> list[str]:
+    """Run ruff on all temporary files and collect error messages."""
+    temp_file_paths = [str(temp_file[0]) for temp_file in temp_files]
+
+    result = subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "python",
+            "-m",
+            "ruff",
+            "check",
+            "--select=F",
+            "--ignore=F811",
+            *temp_file_paths,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if result.returncode == 0:
+        return []  # No issues found
+    return result.stdout.splitlines()  # Return ruff errors as a list of lines
+
+
+def report_errors(errors: list[str], temp_files: list[tuple[Path, str]]) -> None:
+    """Map errors back to original examples and report them."""
+    if not errors:
+        return
+
+    print("❌ Ruff issues found in examples:\n")  # noqa: T201
+    for line in errors:
+        for temp_file, original_context in temp_files:
+            if str(temp_file) in line:
+                print(f"{original_context}{line.replace(str(temp_file), '')}")  # noqa: T201
+                break
+
+
+def cleanup_temp_files(temp_files: list[tuple[Path, str]]) -> None:
+    """Remove all temporary files."""
+    for temp_file, _ in temp_files:
+        temp_file.unlink()
+
+
+def main(python_files: list[str]) -> None:
+    docstring_examples = extract_docstring_examples(python_files)
+
+    if not docstring_examples:
+        sys.exit(0)
+
+    temp_files = create_temp_files(docstring_examples)
+
+    try:
+        errors = run_ruff_on_temp_files(temp_files)
+        report_errors(errors, temp_files)
+    finally:
+        cleanup_temp_files(temp_files)
+
+    if errors:
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -1,3 +1,5 @@
+"""Run ruff on Python examples in docstrings."""
+
 from __future__ import annotations
 
 import ast


### PR DESCRIPTION
It looks like other linters don't pick this up, so we need to roll our own script

inspired by @LiamConnors 's work in https://github.com/narwhals-dev/narwhals/pull/1448 - this at least picks up unused imports

also:
closes #1344 

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
