### PR TITLE
ci: Remove vegafusion from blocking releases, assert current branch in bump_version

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -7,12 +7,8 @@ on:
 
 
 jobs:
-  slow-downstream-tests:
-    uses: ./.github/workflows/downstream_tests_slow.yml
-
   build:
     name: Build distribution 📦
-    needs: slow-downstream-tests
     runs-on: ubuntu-latest
 
     steps:

--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -13,6 +13,15 @@ if out.returncode != 0:
     sys.exit(1)
 subprocess.run(["git", "reset", "--hard", "upstream/main"])
 
+if (
+    subprocess.run(
+        ["git", "branch", "--show-current"], text=True, capture_output=True
+    ).stdout.strip()
+    != "bump-version"
+):
+    msg = "`bump_version.py` should be run from `bump-version` branch"
+    raise RuntimeError(msg)
+
 # Delete local tags, if present
 try:
     # Get the list of all tags


### PR DESCRIPTION
Like this the job can be run manually, but I'm not sure it should be required for releases - we already have several other downstream libraries we test against, and vegafusion is by far the one with the slowest tests


<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
