### PR TITLE
docs: add `Object` dtype docstring example

### DIFF
--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -351,17 +351,14 @@ class Object(DType):
        >>> import polars as pl
        >>> import pyarrow as pa
        >>> import narwhals as nw
-       >>> data = [{"name": "narwhal"}, {"name": "beluga"}, {"name": "orca"}]
-       >>> ser_pd = pd.Series(data)
-       >>> ser_pl = pl.Series(data)
-       >>> ser_pa = pa.chunked_array([data])
+       >>> class Foo: ...
+       >>> ser_pd = pd.Series([Foo(), Foo()])
+       >>> ser_pl = pl.Series([Foo(), Foo()])
 
        >>> nw.from_native(ser_pd, series_only=True).dtype
        Object
        >>> nw.from_native(ser_pl, series_only=True).dtype
-       Struct({'name': String})
-       >>> nw.from_native(ser_pa, series_only=True).dtype
-       Struct({'name': String})
+       Object
     """
 
 


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #1506 
- Closes #1506 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

**Description of changes:**

[Doc] Added a docstring example in narwhals.dtypes for Object, as part of issue https://github.com/narwhals-dev/narwhals/issues/1506.

Given the nuances of Object dtype and Apache Arrow, the example provided for the documentation only shows the use of this for Pandas and Polars.



@BenjaminFraser
