### PR TITLE
docs: add example to Unknown dtype

### DIFF
--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -363,7 +363,17 @@ class Object(DType):
 
 
 class Unknown(DType):
-    """Type representing DataType values that could not be determined statically."""
+    """Type representing DataType values that could not be determined statically.
+
+    Examples:
+       >>> import pandas as pd
+       >>> import narwhals as nw
+       >>> data = pd.period_range("2000-01", periods=4, freq="M")
+       >>> ser_pd = pd.Series(data)
+
+       >>> nw.from_native(ser_pd, series_only=True).dtype
+       Unknown
+    """
 
 
 class Datetime(TemporalType):


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #1507 

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

Documentation for `dtypes.Unknown` was missing examples for when users might encounter this particular datatype. This PR adds an example converting from `pandas` input. Since this is only a change to documentation, no tests were added/required.
