### PR TITLE
fix: `.list` namespace should preserve pandas index

### DIFF
--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -1170,7 +1170,11 @@ class PandasLikeSeriesListNamespace:
         from narwhals.utils import import_dtypes_module
 
         native_series = self._compliant_series._native_series
-        native_result = native_series.list.len().rename(native_series.name, copy=False)
+        native_result = (
+            native_series.list.len()
+            .rename(native_series.name, copy=False)
+            .set_axis(native_series.index)
+        )
         dtype = narwhals_to_native_dtype(
             dtype=import_dtypes_module(self._compliant_series._version).UInt32(),
             starting_dtype=native_result.dtype,

--- a/tests/expr_and_series/list/len_test.py
+++ b/tests/expr_and_series/list/len_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pandas as pd
 import pytest
 
 import narwhals.stable.v1 as nw
@@ -43,3 +44,15 @@ def test_len_series(
 
     result = df["a"].cast(nw.List(nw.Int32())).list.len()
     assert_equal_data({"a": result}, expected)
+
+
+def test_pandas_preserve_index(request: pytest.FixtureRequest) -> None:
+    if PANDAS_VERSION < (2, 2):
+        request.applymarker(pytest.mark.xfail)
+
+    index = pd.Index(["a", "b", "c", "d", "e"])
+    df = nw.from_native(pd.DataFrame(data, index=index), eager_only=True)
+
+    result = df["a"].cast(nw.List(nw.Int32())).list.len()
+    assert_equal_data({"a": result}, expected)
+    assert (result.to_native().index == index).all()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Noticed while opening the PR in pandas itself for the name preserving issue. The fix will come in pandas 3.0