### PR TITLE
chore: avoid unnecessary branching on pl version in `pln.mean`

### DIFF
--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -132,14 +132,8 @@ class PolarsNamespace:
 
         from narwhals._polars.expr import PolarsExpr
 
-        if self._backend_version < (0, 20, 4):
-            return PolarsExpr(
-                pl.mean([*column_names]),  # type: ignore[arg-type]
-                version=self._version,
-                backend_version=self._backend_version,
-            )
         return PolarsExpr(
-            pl.mean(*column_names),
+            pl.mean([*column_names]),  # type: ignore[arg-type]
             version=self._version,
             backend_version=self._backend_version,
         )


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

NA, addresses https://github.com/narwhals-dev/narwhals/pull/1212#discussion_r1806719080 for `mean` as well.

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Avoids unnecessary branching based on `polars` version.
Stumbled upon the above comment by chance, I _think_ we might do the same on `mean` for coherence.

Perhaps I might also take the opportunity to work on unifying exceptions for strings handling in reduction methods that might need it (and _where_ feasible), leveraging the takeaways of the referenced PR and in the spirit of https://github.com/narwhals-dev/narwhals/issues/1373? Might it be useful/reasonable (though not particularly urgent ofc)?