### PR TITLE
fix: return Python scalar for Series.__getitem__ when pyarrow-backed (like Polars does)

### DIFF
--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -372,7 +372,9 @@ class ArrowSeries:
 
     def __getitem__(self: Self, idx: int | slice | Sequence[int]) -> Any | Self:
         if isinstance(idx, int):
-            return self._native_series[idx]
+            return maybe_extract_py_scalar(
+                self._native_series[idx], return_py_scalar=True
+            )
         if isinstance(idx, Sequence):
             return self._from_native_series(self._native_series.take(idx))
         return self._from_native_series(self._native_series[idx])

--- a/tests/series_only/slice_test.py
+++ b/tests/series_only/slice_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pyarrow as pa
+
 import narwhals.stable.v1 as nw
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -32,3 +34,8 @@ def test_slice(constructor_eager: ConstructorEager) -> None:
     result = {"b": df[[], 1]}
     expected = {"b": []}
     assert_equal_data(result, expected)
+
+
+def test_getitem_arrow_scalar() -> None:
+    result = nw.from_native(pa.chunked_array([[1]]), series_only=True)[0]
+    assert isinstance(result, int)


### PR DESCRIPTION



<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
