### PR TITLE
ci: remove pull_request_target, sanitise github.ref_name

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,52 +6,7 @@ name-template: 'Narwhals unreleased'
 version-template: unreleased
 
 change-template: '- $TITLE (#$NUMBER)' 
-    
-autolabeler:
-  - label: breaking
-    title:
-      # Example: feat!: ...
-      - '/^([Bb]uild|[Cc]hore|CI|ci|[Dd]epr|[Dd]oc|DOC|[Ff]eat|[Ff]ix|[Pp]erf|[Rr]efactor|[Rr]elease|[Tt]est)\! /'
-  - label: build
-    title:
-      - '/^([Bb]uild)/'
-  - label: internal
-    title:
-      - '/^(chore|ci|refactor|test|template|bench|Chore|CI|Refactor|Test|Template|Bench)/'
-  - label: deprecation
-    title:
-      - '/^([Dd]epr)/'
-  - label: documentation
-    title:
-      - '/^([Dd]oc|DOC)/'
-  - label: enhancement
-    title:
-      - '/^(feat|enh|Feat|ENH|Enh)/'
-  - label: fix
-    title:
-      - '/^([Ff]ix)/'
-  - label: performance
-    title:
-      - '/^([Pp]erf)/'
-  - label: release
-    title:
-      - '/^([Rr]elease)/'
-  - label: ignore
-    title:
-      - '/^\[pre-commit.ci\]/'
-      
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-  
+
 categories:
   - title: 🏆 Highlights
     labels: highlight

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,4 +1,11 @@
-name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+# This is taken from
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#the-whole-ci-cd-workflow
+# but with the following differences
+# - removed the TestPyPI part
+# - sanitise the `github.ref_name` part
+# - instead of `on: push`, we have `tags` in there too
+
+name: Publish Python 🐍 distribution 📦 to PyPI
 
 on: 
   push:
@@ -32,13 +39,15 @@ jobs:
         path: dist/
 
   publish-to-pypi:
-    name: Publish Python 🐍 distribution 📦 to PyPI
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/narwhals  # Replace <package-name> with your PyPI project name
+      url: https://pypi.org/p/narwhals
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
@@ -76,18 +85,38 @@ jobs:
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        '${{ github.ref_name }}'
-        --repo '${{ github.repository }}'
-        --notes ""
+      run: |
+        # Sanitize ref_name by removing unsafe characters
+        SAFE_REF_NAME=$(echo '${{ github.ref_name }}' | tr -cd '[:alnum:]-_')
+
+        # Validate that the sanitized name is not empty (to avoid invalid input)
+        if [ -z "$SAFE_REF_NAME" ]; then
+          echo "Sanitized reference name is empty. Exiting."
+          exit 1
+        fi
+
+        # Use the sanitized name in the gh command
+        gh release create \
+          "$SAFE_REF_NAME" \
+          --repo '${{ github.repository }}' \
+          --notes ""
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
       # Upload to GitHub Release using the `gh` CLI.
       # `dist/` contains the built packages, and the
       # sigstore-produced signatures and certificates.
-      run: >-
-        gh release upload
-        '${{ github.ref_name }}' dist/**
+      run: |
+        # Sanitize ref_name by removing unsafe characters
+        SAFE_REF_NAME=$(echo '${{ github.ref_name }}' | tr -cd '[:alnum:]-_')
+
+        # Validate that the sanitized name is not empty (to avoid invalid input)
+        if [ -z "$SAFE_REF_NAME" ]; then
+          echo "Sanitized reference name is empty. Exiting."
+          exit 1
+        fi
+
+        # Use the sanitized name in the gh command
+        gh release upload \
+        "$SAFE_REF_NAME" dist/** \
         --repo '${{ github.repository }}'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize, edited]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,6 +79,11 @@ repos:
             narwhals/.*__init__.py|
             narwhals/.*typing\.py
           )
+    - id: pull-request-target
+      name: don't use `pull_request_target`
+      entry: pull_request_target
+      language: pygrep
+      files: ^\.github/workflows/
 - repo: https://github.com/adamchainz/blacken-docs
   rev: "1.19.1"  # replace with latest tag on GitHub
   hooks:


### PR DESCRIPTION
`pull_request_target` is flagged as unsafe by [zizmor](https://github.com/woodruffw/zizmor)

in wake of https://blog.pypi.org/posts/2024-12-11-ultralytics-attack-analysis/, i think it might be best to just remove it

we'll just have to remember to set labels before merging, but i think we can get into that habit - else we just fixup the release notes before publishing, no big deal

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
