### PR TITLE
fix: fix pyarrow `len` aggregation behaviour for depth-1 exprs

### DIFF
--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -172,7 +172,10 @@ def agg_arrow(
             function_name = remove_prefix(expr._function_name, "col->")
             function_name = POLARS_TO_ARROW_AGGREGATIONS.get(function_name, function_name)
 
-            option = get_function_name_option(function_name)
+            if expr._function_name != "col->len":
+                option = get_function_name_option(function_name)
+            else:
+                option = pc.CountOptions(mode="all")
             for root_name, output_name in zip(expr._root_names, expr._output_names):
                 simple_aggregations[output_name] = (
                     (root_name, function_name, option),

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -97,11 +97,26 @@ def test_group_by_iter(constructor_eager: ConstructorEager) -> None:
     assert sorted(keys) == sorted(expected_keys)
 
 
-def test_group_by_len(constructor: Constructor) -> None:
-    result = (
-        nw.from_native(constructor(data)).group_by("a").agg(nw.col("b").len()).sort("a")
-    )
-    expected = {"a": [1, 3], "b": [2, 1]}
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        (nw.col("b").sum(), {"a": [1, 2], "b": [3, 3]}),
+        (nw.col("b").mean(), {"a": [1, 2], "b": [1.5, 3]}),
+        (nw.col("b").max(), {"a": [1, 2], "b": [2, 3]}),
+        (nw.col("b").min(), {"a": [1, 2], "b": [1, 3]}),
+        (nw.col("b").std(), {"a": [1, 2], "b": [0.707107, None]}),
+        (nw.col("b").len(), {"a": [1, 2], "b": [3, 1]}),
+        (nw.col("b").n_unique(), {"a": [1, 2], "b": [3, 1]}),
+        (nw.col("b").count(), {"a": [1, 2], "b": [2, 1]}),
+    ],
+)
+def test_group_by_depth_1_agg(
+    constructor: Constructor,
+    expr: nw.Expr,
+    expected: dict[str, list[int | float]],
+) -> None:
+    data = {"a": [1, 1, 1, 2], "b": [1, None, 2, 3]}
+    result = nw.from_native(constructor(data)).group_by("a").agg(expr).sort("a")
     assert_equal_data(result, expected)
 
 
@@ -114,26 +129,6 @@ def test_group_by_median(constructor: Constructor) -> None:
         .sort("a")
     )
     expected = {"a": [1, 2], "b": [5, 3]}
-    assert_equal_data(result, expected)
-
-
-def test_group_by_n_unique(constructor: Constructor) -> None:
-    result = (
-        nw.from_native(constructor(data))
-        .group_by("a")
-        .agg(nw.col("b").n_unique())
-        .sort("a")
-    )
-    expected = {"a": [1, 3], "b": [1, 1]}
-    assert_equal_data(result, expected)
-
-
-def test_group_by_std(constructor: Constructor) -> None:
-    data = {"a": [1, 1, 2, 2], "b": [5, 4, 3, 2]}
-    result = (
-        nw.from_native(constructor(data)).group_by("a").agg(nw.col("b").std()).sort("a")
-    )
-    expected = {"a": [1, 2], "b": [0.707107] * 2}
     assert_equal_data(result, expected)
 
 
@@ -357,11 +352,3 @@ def test_group_by_shift_raises(
         ValueError, match=".*(failed to aggregate|Non-trivial complex aggregation found)"
     ):
         df.group_by("b").agg(nw.col("a").shift(1))
-
-
-def test_group_by_count(constructor: Constructor) -> None:
-    data = {"a": [1, 1, 1, 2], "b": [1, None, 2, 3]}
-    df = nw.from_native(constructor(data))
-    result = df.group_by("a").agg(nw.col("b").count()).sort("a")
-    expected = {"a": [1, 2], "b": [2, 1]}
-    assert_equal_data(result, expected)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Addresses https://github.com/narwhals-dev/narwhals/pull/1584#discussion_r1884565419

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Adds a specific condition for dealing with pyarrow depth-1 `len` expressions in group-by contexts.