### PR TITLE
docs: use `IntoDataFrameT`/`IntoFrameT` in docs

### DIFF
--- a/docs/pandas_like_concepts/boolean.md
+++ b/docs/pandas_like_concepts/boolean.md
@@ -8,12 +8,12 @@ For example, if you do `nw.col('a')*2`, then:
 
 ```python exec="1" source="above" session="boolean"
 import narwhals as nw
-from narwhals.typing import FrameT
+from narwhals.typing import IntoFrameT
 
 data = {"a": [1.4, None, 4.2]}
 
 
-def multiplication(df: FrameT) -> FrameT:
+def multiplication(df: IntoFrameT) -> IntoFrameT:
     return nw.from_native(df).with_columns((nw.col("a") * 2).alias("a*2")).to_native()
 ```
 

--- a/docs/pandas_like_concepts/boolean.md
+++ b/docs/pandas_like_concepts/boolean.md
@@ -57,6 +57,9 @@ be a temporary legacy pandas issue which will eventually go
 away anyway.
 
 ```python exec="1" source="above" session="boolean"
+from narwhals.typing import FrameT
+
+
 def comparison(df: FrameT) -> FrameT:
     return nw.from_native(df).with_columns((nw.col("a") > 2).alias("a>2")).to_native()
 ```

--- a/docs/pandas_like_concepts/column_names.md
+++ b/docs/pandas_like_concepts/column_names.md
@@ -2,12 +2,11 @@
 
 Polars and PyArrow only allow for string column names. What about pandas?
 
-```python
->>> import pandas as pd
->>> pd.concat([pd.Series([1, 2], name=0), pd.Series([1, 3], name=0)], axis=1)
-   0  0
-0  1  1
-1  2  3
+```python exec="true" source="above" result="python" session="col_names"
+import pandas as pd
+
+df = pd.concat([pd.Series([1, 2], name=0), pd.Series([1, 3], name=0)], axis=1)
+print(df)
 ```
 
 Oh...not only does it let us create a dataframe with a column named `0` - it lets us

--- a/docs/pandas_like_concepts/pandas_index.md
+++ b/docs/pandas_like_concepts/pandas_index.md
@@ -20,9 +20,10 @@ Let's learn about what Narwhals promises.
 
 ```python exec="1" source="above" session="ex1"
 import narwhals as nw
+from narwhals.typing import IntoFrameT
 
 
-def my_func(df):
+def my_func(df: IntoFrameT) -> IntoFrameT:
     df = nw.from_native(df)
     df = df.with_columns(a_plus_one=nw.col("a") + 1)
     return nw.to_native(df)
@@ -51,13 +52,16 @@ df_pd = pd.DataFrame({"a": [2, 1, 3], "b": [4, 5, 6]})
 s_pd = df_pd["a"].sort_values()
 df_pd["a_sorted"] = s_pd
 ```
+
 Reading the code, you might expect that `'a_sorted'` will contain the
 values `[1, 2, 3]`.
 
 **However**, here's what actually happens:
+
 ```python exec="1" source="material-block" session="ex2" result="python"
 print(df_pd)
 ```
+
 In other words, pandas' index alignment undid the `sort_values` operation!
 
 Narwhals, on the other hand, preserves the index of the left-hand-side argument.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #386 

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

It seems that it was already mostly used except for the pandas concepts section