### PR TITLE
chore: flatten `subset` in `unique` one level up

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -641,7 +641,7 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
 
     def unique(
         self: Self,
-        subset: str | list[str] | None,
+        subset: list[str] | None,
         *,
         keep: Literal["any", "first", "last", "none"],
         maintain_order: bool,
@@ -653,9 +653,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         import pyarrow.compute as pc
 
         df = self._native_frame
-
-        if isinstance(subset, str):
-            subset = [subset]
         subset = subset or self.columns
 
         if keep in {"any", "first", "last"}:

--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -198,14 +198,13 @@ class DaskLazyFrame(CompliantLazyFrame):
 
     def unique(
         self: Self,
-        subset: str | list[str] | None,
+        subset: list[str] | None,
         *,
         keep: Literal["any", "first", "last", "none"] = "any",
         maintain_order: bool = False,
     ) -> Self:
         # The param `maintain_order` is only here for compatibility with the Polars API
         # and has no effect on the output.
-        subset = flatten(subset) if subset else None
         native_frame = self._native_frame
         if keep == "none":
             subset = subset or self.columns

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -684,7 +684,7 @@ class PandasLikeDataFrame:
 
     def unique(
         self: Self,
-        subset: str | list[str] | None,
+        subset: list[str] | None,
         *,
         keep: Literal["any", "first", "last", "none"] = "any",
         maintain_order: bool = False,
@@ -692,7 +692,6 @@ class PandasLikeDataFrame:
         # The param `maintain_order` is only here for compatibility with the Polars API
         # and has no effect on the output.
         mapped_keep = {"none": False, "any": "first"}.get(keep, keep)
-        subset = flatten(subset) if subset else None
         return self._from_native_frame(
             self._native_frame.drop_duplicates(subset=subset, keep=mapped_keep)
         )

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -153,6 +153,8 @@ class BaseFrame(Generic[FrameT]):
         keep: Literal["any", "first", "last", "none"] = "any",
         maintain_order: bool = False,
     ) -> Self:
+        if isinstance(subset, str):
+            subset = [subset]
         return self._from_compliant_dataframe(
             self._compliant_frame.unique(
                 subset=subset, keep=keep, maintain_order=maintain_order


### PR DESCRIPTION
In general, it's probably good if we simplify the implementation of `CompliantFrame`s by doing these kinds of operations at the Narwhals level

If we want to encourage people to extend Narwhals, it'll be easier if they just have to worry about `subset: list[str] | None` rather than `subset: str | list[str] | None`

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
