### PR TITLE
fix: Dask was raising for scalar vs Series binary operations

### DIFF
--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -9,6 +9,7 @@ from typing import NoReturn
 from typing import Sequence
 
 from narwhals._dask.utils import add_row_index
+from narwhals._dask.utils import binary_operation_returns_scalar
 from narwhals._dask.utils import maybe_evaluate
 from narwhals._dask.utils import narwhals_to_native_dtype
 from narwhals._pandas_like.utils import calculate_timestamp_date
@@ -205,8 +206,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__add__(other),
             "__add__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __radd__(self, other: Any) -> Self:
@@ -214,8 +214,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__radd__(other),
             "__radd__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         ).alias("literal")
 
     def __sub__(self, other: Any) -> Self:
@@ -223,8 +222,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__sub__(other),
             "__sub__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __rsub__(self, other: Any) -> Self:
@@ -232,8 +230,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__rsub__(other),
             "__rsub__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         ).alias("literal")
 
     def __mul__(self, other: Any) -> Self:
@@ -241,8 +238,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__mul__(other),
             "__mul__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __rmul__(self, other: Any) -> Self:
@@ -250,8 +246,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__rmul__(other),
             "__rmul__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         ).alias("literal")
 
     def __truediv__(self, other: Any) -> Self:
@@ -259,8 +254,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__truediv__(other),
             "__truediv__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __rtruediv__(self, other: Any) -> Self:
@@ -268,8 +262,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__rtruediv__(other),
             "__rtruediv__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         ).alias("literal")
 
     def __floordiv__(self, other: Any) -> Self:
@@ -277,8 +270,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__floordiv__(other),
             "__floordiv__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __rfloordiv__(self, other: Any) -> Self:
@@ -286,8 +278,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__rfloordiv__(other),
             "__rfloordiv__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         ).alias("literal")
 
     def __pow__(self, other: Any) -> Self:
@@ -295,8 +286,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__pow__(other),
             "__pow__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __rpow__(self, other: Any) -> Self:
@@ -304,8 +294,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__rpow__(other),
             "__rpow__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         ).alias("literal")
 
     def __mod__(self, other: Any) -> Self:
@@ -313,8 +302,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__mod__(other),
             "__mod__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __rmod__(self, other: Any) -> Self:
@@ -322,8 +310,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__rmod__(other),
             "__rmod__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         ).alias("literal")
 
     def __eq__(self, other: DaskExpr) -> Self:  # type: ignore[override]
@@ -331,8 +318,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__eq__(other),
             "__eq__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __ne__(self, other: DaskExpr) -> Self:  # type: ignore[override]
@@ -340,8 +326,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__ne__(other),
             "__ne__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __ge__(self, other: DaskExpr) -> Self:
@@ -349,8 +334,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__ge__(other),
             "__ge__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __gt__(self, other: DaskExpr) -> Self:
@@ -358,8 +342,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__gt__(other),
             "__gt__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __le__(self, other: DaskExpr) -> Self:
@@ -367,8 +350,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__le__(other),
             "__le__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __lt__(self, other: DaskExpr) -> Self:
@@ -376,8 +358,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__lt__(other),
             "__lt__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __and__(self, other: DaskExpr) -> Self:
@@ -385,8 +366,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__and__(other),
             "__and__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __rand__(self, other: DaskExpr) -> Self:
@@ -394,8 +374,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__rand__(other),
             "__rand__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         ).alias("literal")
 
     def __or__(self, other: DaskExpr) -> Self:
@@ -403,8 +382,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__or__(other),
             "__or__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
     def __ror__(self, other: DaskExpr) -> Self:
@@ -412,8 +390,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             lambda _input, other: _input.__ror__(other),
             "__ror__",
             other=other,
-            returns_scalar=self._returns_scalar
-            and getattr(other, "_returns_scalar", True),
+            returns_scalar=binary_operation_returns_scalar(self, other),
         ).alias("literal")
 
     def __invert__(self: Self) -> Self:

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -140,7 +140,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
                 if self._returns_scalar:
                     _input = _input[0]
                 result = call(_input, **_kwargs)
-                if returns_scalar and hasattr(result, "to_series"):
+                if returns_scalar:
                     result = result.to_series()
                 result = result.rename(name)
                 results.append(result)

--- a/narwhals/_dask/utils.py
+++ b/narwhals/_dask/utils.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     import dask_expr
 
     from narwhals._dask.dataframe import DaskLazyFrame
+    from narwhals._dask.expr import DaskExpr
     from narwhals.dtypes import DType
     from narwhals.utils import Version
 
@@ -143,3 +144,10 @@ def name_preserving_sum(s1: dask_expr.Series, s2: dask_expr.Series) -> dask_expr
 
 def name_preserving_div(s1: dask_expr.Series, s2: dask_expr.Series) -> dask_expr.Series:
     return (s1 / s2).rename(s1.name)
+
+
+def binary_operation_returns_scalar(lhs: DaskExpr, rhs: DaskExpr | Any) -> bool:
+    # If `rhs` is a DaskExpr, we look at `_returns_scalar`. If it isn't,
+    # it means that it was a scalar (e.g. nw.col('a') + 1), and so we default
+    # to `True`.
+    return lhs._returns_scalar and getattr(rhs, "_returns_scalar", True)

--- a/tests/frame/select_test.py
+++ b/tests/frame/select_test.py
@@ -112,3 +112,16 @@ def test_missing_columns(constructor: Constructor) -> None:
             df.drop(selected_columns, strict=True)
         with pytest.raises(ColumnNotFoundError, match=msg):
             df.select(nw.col("fdfa"))
+
+
+def test_left_to_right_broadcasting(constructor: Constructor) -> None:
+    df = nw.from_native(constructor({"a": [1, 1, 2], "b": [4, 5, 6]}))
+    result = df.select(nw.col("a") + nw.col("b").sum())
+    expected = {"a": [16, 16, 17]}
+    assert_equal_data(result, expected)
+    result = df.select(nw.col("b").sum() + nw.col("a"))
+    expected = {"b": [16, 16, 17]}
+    assert_equal_data(result, expected)
+    result = df.select(nw.col("b").sum() + nw.col("a").sum())
+    expected = {"b": [19]}
+    assert_equal_data(result, expected)

--- a/tests/frame/select_test.py
+++ b/tests/frame/select_test.py
@@ -9,6 +9,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from narwhals.exceptions import ColumnNotFoundError
 from narwhals.exceptions import InvalidIntoExprError
+from tests.utils import DASK_VERSION
 from tests.utils import PANDAS_VERSION
 from tests.utils import POLARS_VERSION
 from tests.utils import Constructor
@@ -114,7 +115,11 @@ def test_missing_columns(constructor: Constructor) -> None:
             df.select(nw.col("fdfa"))
 
 
-def test_left_to_right_broadcasting(constructor: Constructor) -> None:
+def test_left_to_right_broadcasting(
+    constructor: Constructor, request: pytest.FixtureRequest
+) -> None:
+    if "dask" in str(constructor) and DASK_VERSION < (2024, 9):
+        request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor({"a": [1, 1, 2], "b": [4, 5, 6]}))
     result = df.select(nw.col("a") + nw.col("b").sum())
     expected = {"a": [16, 16, 17]}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,6 +32,7 @@ IBIS_VERSION: tuple[int, ...] = get_module_version_as_tuple("ibis")
 NUMPY_VERSION: tuple[int, ...] = get_module_version_as_tuple("numpy")
 PANDAS_VERSION: tuple[int, ...] = get_module_version_as_tuple("pandas")
 POLARS_VERSION: tuple[int, ...] = get_module_version_as_tuple("polars")
+DASK_VERSION: tuple[int, ...] = get_module_version_as_tuple("dask")
 PYARROW_VERSION: tuple[int, ...] = get_module_version_as_tuple("pyarrow")
 PYSPARK_VERSION: tuple[int, ...] = get_module_version_as_tuple("pyspark")
 


### PR DESCRIPTION
closes #1685 

We may need to update the PySpark `returns_scalar` bits based on this refactor

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
