### PR TITLE
enh modin dtype interoperability

### DIFF
--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -18,7 +18,6 @@ from narwhals._pandas_like.utils import set_columns
 from narwhals.utils import Implementation
 from narwhals.utils import find_stacklevel
 from narwhals.utils import remove_prefix
-from narwhals.utils import tupleify
 
 if TYPE_CHECKING:
     from narwhals._pandas_like.dataframe import PandasLikeDataFrame
@@ -124,20 +123,8 @@ class PandasLikeGroupBy:
         )
 
     def __iter__(self) -> Iterator[tuple[Any, PandasLikeDataFrame]]:
-        indices = self._grouped.indices
-        if (
-            self._df._implementation is Implementation.PANDAS
-            and self._df._backend_version < (2, 2)
-        ) or (
-            self._df._implementation is Implementation.CUDF
-            and self._df._backend_version < (2024, 12)
-        ):  # pragma: no cover
-            for key in indices:
-                yield (key, self._from_native_frame(self._grouped.get_group(key)))
-        else:
-            for key in indices:
-                key = tupleify(key)  # noqa: PLW2901
-                yield (key, self._from_native_frame(self._grouped.get_group(key)))
+        for key, group in self._grouped:
+            yield (key, self._from_native_frame(group))
 
 
 def agg_pandas(  # noqa: PLR0915

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -481,7 +481,7 @@ def native_to_narwhals_dtype(
 
 
 def get_dtype_backend(dtype: Any, implementation: Implementation) -> str:
-    if implementation is Implementation.PANDAS:
+    if implementation in [Implementation.PANDAS, Implementation.MODIN]:
         import pandas as pd
 
         if hasattr(pd, "ArrowDtype") and isinstance(dtype, pd.ArrowDtype):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,11 @@ def pandas_pyarrow_constructor(obj: Any) -> IntoDataFrame:
 
 def modin_constructor(obj: Any) -> IntoDataFrame:  # pragma: no cover
     mpd = get_modin()
+    return mpd.DataFrame(pd.DataFrame(obj))  # type: ignore[no-any-return]
+
+
+def modin_pyarrow_constructor(obj: Any) -> IntoDataFrame:  # pragma: no cover
+    mpd = get_modin()
     return mpd.DataFrame(pd.DataFrame(obj)).convert_dtypes(dtype_backend="pyarrow")  # type: ignore[no-any-return]
 
 
@@ -146,7 +151,7 @@ eager_constructors.extend([polars_eager_constructor, pyarrow_table_constructor])
 lazy_constructors = [polars_lazy_constructor]
 
 if get_modin() is not None:  # pragma: no cover
-    eager_constructors.append(modin_constructor)
+    eager_constructors.extend([modin_constructor, modin_pyarrow_constructor])
 if get_cudf() is not None:
     eager_constructors.append(cudf_constructor)  # pragma: no cover
 if get_dask_dataframe() is not None:  # pragma: no cover

--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -38,7 +38,7 @@ def test_arithmetic_expr(
     request: pytest.FixtureRequest,
 ) -> None:
     if attr == "__mod__" and any(
-        x in str(constructor) for x in ["pandas_pyarrow", "modin"]
+        x in str(constructor) for x in ["pandas_pyarrow", "modin_pyarrow"]
     ):
         request.applymarker(pytest.mark.xfail)
 
@@ -68,7 +68,7 @@ def test_right_arithmetic_expr(
     request: pytest.FixtureRequest,
 ) -> None:
     if attr == "__rmod__" and any(
-        x in str(constructor) for x in ["pandas_pyarrow", "modin"]
+        x in str(constructor) for x in ["pandas_pyarrow", "modin_pyarrow"]
     ):
         request.applymarker(pytest.mark.xfail)
 
@@ -99,7 +99,7 @@ def test_arithmetic_series(
     request: pytest.FixtureRequest,
 ) -> None:
     if attr == "__mod__" and any(
-        x in str(constructor_eager) for x in ["pandas_pyarrow", "modin"]
+        x in str(constructor_eager) for x in ["pandas_pyarrow", "modin_pyarrow"]
     ):
         request.applymarker(pytest.mark.xfail)
 
@@ -129,7 +129,7 @@ def test_right_arithmetic_series(
     request: pytest.FixtureRequest,
 ) -> None:
     if attr == "__rmod__" and any(
-        x in str(constructor_eager) for x in ["pandas_pyarrow", "modin"]
+        x in str(constructor_eager) for x in ["pandas_pyarrow", "modin_pyarrow"]
     ):
         request.applymarker(pytest.mark.xfail)
 
@@ -242,7 +242,7 @@ def test_arithmetic_expr_left_literal(
     request: pytest.FixtureRequest,
 ) -> None:
     if attr == "__mod__" and any(
-        x in str(constructor) for x in ["pandas_pyarrow", "modin"]
+        x in str(constructor) for x in ["pandas_pyarrow", "modin_pyarrow"]
     ):
         request.applymarker(pytest.mark.xfail)
 
@@ -273,7 +273,7 @@ def test_arithmetic_series_left_literal(
     request: pytest.FixtureRequest,
 ) -> None:
     if attr == "__mod__" and any(
-        x in str(constructor_eager) for x in ["pandas_pyarrow", "modin"]
+        x in str(constructor_eager) for x in ["pandas_pyarrow", "modin_pyarrow"]
     ):
         request.applymarker(pytest.mark.xfail)
 

--- a/tests/expr_and_series/cast_test.py
+++ b/tests/expr_and_series/cast_test.py
@@ -63,7 +63,7 @@ def test_cast(
         15,
     ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
-    if "modin" in str(constructor):
+    if "modin_constructor" in str(constructor):
         # TODO(unassigned): in modin, we end up with `'<U0'` dtype
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data)).select(
@@ -116,7 +116,7 @@ def test_cast_series(
         15,
     ):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
-    if "modin" in str(constructor):
+    if "modin_constructor" in str(constructor):
         # TODO(unassigned): in modin, we end up with `'<U0'` dtype
         request.applymarker(pytest.mark.xfail)
     df = (

--- a/tests/expr_and_series/convert_time_zone_test.py
+++ b/tests/expr_and_series/convert_time_zone_test.py
@@ -23,9 +23,10 @@ def test_convert_time_zone(
     request: pytest.FixtureRequest,
 ) -> None:
     if (
-        ("modin_pyarrow" in str(constructor) and is_windows())
+        ("pyarrow" in str(constructor) and is_windows())
         or ("pyarrow_table" in str(constructor) and is_windows())
         or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2, 1))
+        or ("modin_pyarrow" in str(constructor) and PANDAS_VERSION < (2, 1))
         or ("cudf" in str(constructor))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -50,9 +51,10 @@ def test_convert_time_zone_series(
     request: pytest.FixtureRequest,
 ) -> None:
     if (
-        ("modin_pyarrow" in str(constructor_eager) and is_windows())
+        ("pyarrow" in str(constructor_eager) and is_windows())
         or ("pyarrow_table" in str(constructor_eager) and is_windows())
         or ("pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2, 1))
+        or ("modin_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2, 1))
         or ("cudf" in str(constructor_eager))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -76,9 +78,10 @@ def test_convert_time_zone_from_none(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if (
-        ("modin_pyarrow" in str(constructor) and is_windows())
+        ("pyarrow" in str(constructor) and is_windows())
         or ("pyarrow_table" in str(constructor) and is_windows())
         or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2, 1))
+        or ("modin_pyarrow" in str(constructor) and PANDAS_VERSION < (2, 1))
         or ("pyarrow_table" in str(constructor) and PYARROW_VERSION < (12,))
         or ("cudf" in str(constructor))
     ):

--- a/tests/expr_and_series/convert_time_zone_test.py
+++ b/tests/expr_and_series/convert_time_zone_test.py
@@ -23,7 +23,8 @@ def test_convert_time_zone(
     request: pytest.FixtureRequest,
 ) -> None:
     if (
-        (any(x in str(constructor) for x in ("pyarrow", "modin")) and is_windows())
+        ("modin_pyarrow" in str(constructor) and is_windows())
+        or ("pyarrow_table" in str(constructor) and is_windows())
         or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2, 1))
         or ("cudf" in str(constructor))
     ):
@@ -49,7 +50,8 @@ def test_convert_time_zone_series(
     request: pytest.FixtureRequest,
 ) -> None:
     if (
-        (any(x in str(constructor_eager) for x in ("pyarrow", "modin")) and is_windows())
+        ("modin_pyarrow" in str(constructor_eager) and is_windows())
+        or ("pyarrow_table" in str(constructor_eager) and is_windows())
         or ("pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2, 1))
         or ("cudf" in str(constructor_eager))
     ):
@@ -74,7 +76,8 @@ def test_convert_time_zone_from_none(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if (
-        (any(x in str(constructor) for x in ("pyarrow", "modin")) and is_windows())
+        ("modin_pyarrow" in str(constructor) and is_windows())
+        or ("pyarrow_table" in str(constructor) and is_windows())
         or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2, 1))
         or ("pyarrow_table" in str(constructor) and PYARROW_VERSION < (12,))
         or ("cudf" in str(constructor))

--- a/tests/expr_and_series/dt/datetime_attributes_test.py
+++ b/tests/expr_and_series/dt/datetime_attributes_test.py
@@ -95,6 +95,8 @@ def test_datetime_chained_attributes(
 ) -> None:
     if "pandas" in str(constructor_eager) and "pyarrow" not in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
+    if "modin" in str(constructor_eager) and "pyarrow" not in str(constructor_eager):
+        request.applymarker(pytest.mark.xfail)
     if "cudf" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
 
@@ -109,7 +111,12 @@ def test_datetime_chained_attributes(
 def test_to_date(request: pytest.FixtureRequest, constructor: Constructor) -> None:
     if any(
         x in str(constructor)
-        for x in ("pandas_constructor", "pandas_nullable_constructor", "cudf")
+        for x in (
+            "pandas_constructor",
+            "pandas_nullable_constructor",
+            "cudf",
+            "modin_constructor",
+        )
     ):
         request.applymarker(pytest.mark.xfail)
     dates = {"a": [datetime(2001, 1, 1), None, datetime(2001, 1, 3)]}

--- a/tests/expr_and_series/dt/timestamp_test.py
+++ b/tests/expr_and_series/dt/timestamp_test.py
@@ -138,7 +138,12 @@ def test_timestamp_dates(
 ) -> None:
     if any(
         x in str(constructor)
-        for x in ("pandas_constructor", "pandas_nullable_constructor", "cudf")
+        for x in (
+            "pandas_constructor",
+            "pandas_nullable_constructor",
+            "cudf",
+            "modin_constructor",
+        )
     ):
         request.applymarker(pytest.mark.xfail)
 

--- a/tests/expr_and_series/is_finite_test.py
+++ b/tests/expr_and_series/is_finite_test.py
@@ -14,9 +14,13 @@ data = {"a": [float("nan"), float("inf"), 2.0, None]}
 def test_is_finite_expr(constructor: Constructor) -> None:
     if "polars" in str(constructor) or "pyarrow_table" in str(constructor):
         expected = {"a": [False, False, True, None]}
-    elif "pandas_constructor" in str(constructor) or "dask" in str(constructor):
+    elif (
+        "pandas_constructor" in str(constructor)
+        or "dask" in str(constructor)
+        or "modin_constructor" in str(constructor)
+    ):
         expected = {"a": [False, False, True, False]}
-    else:  # pandas_nullable_constructor, pandas_pyarrow_constructor, modin
+    else:  # pandas_nullable_constructor, pandas_pyarrow_constructor, modin_pyarrrow_constructor
         expected = {"a": [None, False, True, None]}
 
     df = nw.from_native(constructor(data))
@@ -28,11 +32,13 @@ def test_is_finite_expr(constructor: Constructor) -> None:
 def test_is_finite_series(constructor_eager: ConstructorEager) -> None:
     if "polars" in str(constructor_eager) or "pyarrow_table" in str(constructor_eager):
         expected = {"a": [False, False, True, None]}
-    elif "pandas_constructor" in str(constructor_eager) or "dask" in str(
-        constructor_eager
+    elif (
+        "pandas_constructor" in str(constructor_eager)
+        or "dask" in str(constructor_eager)
+        or "modin_constructor" in str(constructor_eager)
     ):
         expected = {"a": [False, False, True, False]}
-    else:  # pandas_nullable_constructor, pandas_pyarrow_constructor, modin
+    else:  # pandas_nullable_constructor, pandas_pyarrow_constructor, modin_pyarrrow_constructor
         expected = {"a": [None, False, True, None]}
 
     df = nw.from_native(constructor_eager(data), eager_only=True)

--- a/tests/expr_and_series/replace_time_zone_test.py
+++ b/tests/expr_and_series/replace_time_zone_test.py
@@ -21,8 +21,9 @@ def test_replace_time_zone(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if (
-        ("modin_pyarrow" in str(constructor) and is_windows())
+        ("pyarrow" in str(constructor) and is_windows())
         or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2,))
+        or ("modin_pyarrow" in str(constructor) and PANDAS_VERSION < (2,))
         or ("pyarrow_table" in str(constructor) and PYARROW_VERSION < (12,))
         or ("cudf" in str(constructor))
     ):
@@ -47,8 +48,9 @@ def test_replace_time_zone_none(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if (
-        ("modin_pyarrow" in str(constructor) and is_windows())
+        ("pyarrow" in str(constructor) and is_windows())
         or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2,))
+        or ("modin_pyarrow" in str(constructor) and PANDAS_VERSION < (2,))
         or ("pyarrow_table" in str(constructor) and PYARROW_VERSION < (12,))
     ):
         request.applymarker(pytest.mark.xfail)
@@ -72,8 +74,9 @@ def test_replace_time_zone_series(
     constructor_eager: ConstructorEager, request: pytest.FixtureRequest
 ) -> None:
     if (
-        ("modin_pyarrow" in str(constructor_eager) and is_windows())
+        ("pyarrow" in str(constructor_eager) and is_windows())
         or ("pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2,))
+        or ("modin_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2,))
         or ("pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (12,))
         or ("cudf" in str(constructor_eager))
     ):
@@ -98,8 +101,9 @@ def test_replace_time_zone_none_series(
     constructor_eager: ConstructorEager, request: pytest.FixtureRequest
 ) -> None:
     if (
-        ("modin_pyarrow" in str(constructor_eager) and is_windows())
+        ("pyarrow" in str(constructor_eager) and is_windows())
         or ("pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2,))
+        or ("modin_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2,))
         or ("pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (12,))
     ):
         request.applymarker(pytest.mark.xfail)

--- a/tests/expr_and_series/replace_time_zone_test.py
+++ b/tests/expr_and_series/replace_time_zone_test.py
@@ -21,7 +21,7 @@ def test_replace_time_zone(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if (
-        (any(x in str(constructor) for x in ("pyarrow", "modin")) and is_windows())
+        ("modin_pyarrow" in str(constructor) and is_windows())
         or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2,))
         or ("pyarrow_table" in str(constructor) and PYARROW_VERSION < (12,))
         or ("cudf" in str(constructor))
@@ -47,7 +47,7 @@ def test_replace_time_zone_none(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if (
-        (any(x in str(constructor) for x in ("pyarrow", "modin")) and is_windows())
+        ("modin_pyarrow" in str(constructor) and is_windows())
         or ("pandas_pyarrow" in str(constructor) and PANDAS_VERSION < (2,))
         or ("pyarrow_table" in str(constructor) and PYARROW_VERSION < (12,))
     ):
@@ -72,7 +72,7 @@ def test_replace_time_zone_series(
     constructor_eager: ConstructorEager, request: pytest.FixtureRequest
 ) -> None:
     if (
-        (any(x in str(constructor_eager) for x in ("pyarrow", "modin")) and is_windows())
+        ("modin_pyarrow" in str(constructor_eager) and is_windows())
         or ("pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2,))
         or ("pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (12,))
         or ("cudf" in str(constructor_eager))
@@ -98,7 +98,7 @@ def test_replace_time_zone_none_series(
     constructor_eager: ConstructorEager, request: pytest.FixtureRequest
 ) -> None:
     if (
-        (any(x in str(constructor_eager) for x in ("pyarrow", "modin")) and is_windows())
+        ("modin_pyarrow" in str(constructor_eager) and is_windows())
         or ("pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2,))
         or ("pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (12,))
     ):

--- a/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
+++ b/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
@@ -38,7 +38,7 @@ def test_str_to_uppercase(
         in (
             "pandas_pyarrow_constructor",
             "pyarrow_table_constructor",
-            "modin_constructor",
+            "modin_pyarrow_constructor",
         )
         or ("dask" in str(constructor) and PYARROW_VERSION >= (12,))
     ):
@@ -80,6 +80,7 @@ def test_str_to_uppercase_series(
             "pandas_nullable_constructor",
             "polars_eager_constructor",
             "cudf_constructor",
+            "modin_constructor",
         )
     ):
         # We are marking it xfail for these conditions above

--- a/tests/frame/to_numpy_test.py
+++ b/tests/frame/to_numpy_test.py
@@ -31,10 +31,7 @@ def test_to_numpy_tz_aware(
     if (
         ("pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (12,))
         or ("pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2, 2))
-        or (
-            any(x in str(constructor_eager) for x in ("pyarrow", "modin"))
-            and is_windows()
-        )
+        or ("pyarrow" in str(constructor_eager) and is_windows())
     ):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(

--- a/tests/frame/to_pandas_test.py
+++ b/tests/frame/to_pandas_test.py
@@ -19,16 +19,15 @@ if TYPE_CHECKING:
 )
 def test_convert_pandas(
     constructor_eager: ConstructorEager,
-    request: pytest.FixtureRequest,
 ) -> None:
-    if "modin" in str(constructor_eager):
-        request.applymarker(pytest.mark.xfail)
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df_raw = constructor_eager(data)
     result = nw.from_native(df_raw).to_pandas()  # type: ignore[union-attr]
 
     if constructor_eager.__name__.startswith("pandas"):
         expected = constructor_eager(data)
+    elif "modin_pyarrow" in str(constructor_eager):
+        expected = pd.DataFrame(data).convert_dtypes(dtype_backend="pyarrow")
     else:
         expected = pd.DataFrame(data)
 

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -330,6 +330,7 @@ def test_key_with_nulls_iter(
         .group_by("b", "c", drop_null_keys=True)
         .__iter__()
     )
+
     assert len(result) == 2
     assert_equal_data(result[("4", "4")], {"b": ["4"], "a": [1], "c": ["4"]})
     assert_equal_data(result[("5", "3")], {"b": ["5"], "a": [2], "c": ["3"]})
@@ -415,7 +416,7 @@ def test_double_same_aggregation(
 def test_all_kind_of_aggs(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
-    if any(x in str(constructor) for x in ("dask", "cudf", "modin_constructor")):
+    if any(x in str(constructor) for x in ("dask", "cudf", "modin")):
         # bugged in dask https://github.com/dask/dask/issues/11612
         # and modin lol https://github.com/modin-project/modin/issues/7414
         # and cudf https://github.com/rapidsai/cudf/issues/17649

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -319,7 +319,11 @@ def test_key_with_nulls_ignored(
 
 def test_key_with_nulls_iter(
     constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest,
 ) -> None:
+    if PANDAS_VERSION < (1, 0) and "pandas_constructor" in str(constructor_eager):
+        # Grouping by null values is not supported in pandas < 1.0.0
+        request.applymarker(pytest.mark.xfail)
     data = {"b": ["4", "5", None, "7"], "a": [1, 2, 3, 4], "c": ["4", "3", None, None]}
     result = dict(
         nw.from_native(constructor_eager(data), eager_only=True)

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -319,11 +319,7 @@ def test_key_with_nulls_ignored(
 
 def test_key_with_nulls_iter(
     constructor_eager: ConstructorEager,
-    request: pytest.FixtureRequest,
 ) -> None:
-    if PANDAS_VERSION < (1, 3) and "pandas_constructor" in str(constructor_eager):
-        # bug in old pandas
-        request.applymarker(pytest.mark.xfail)
     data = {"b": ["4", "5", None, "7"], "a": [1, 2, 3, 4], "c": ["4", "3", None, None]}
     result = dict(
         nw.from_native(constructor_eager(data), eager_only=True)

--- a/tests/series_only/to_numpy_test.py
+++ b/tests/series_only/to_numpy_test.py
@@ -42,7 +42,8 @@ def test_to_numpy_tz_aware(
     if (
         ("pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (12,))
         or ("pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2, 2))
-        or ("modin_pyarrow" in str(constructor_eager) and is_windows())
+        or ("modin_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2, 2))
+        or ("pyarrow" in str(constructor_eager) and is_windows())
     ):
         request.applymarker(pytest.mark.xfail)
         request.applymarker(pytest.mark.xfail)

--- a/tests/series_only/to_numpy_test.py
+++ b/tests/series_only/to_numpy_test.py
@@ -42,10 +42,7 @@ def test_to_numpy_tz_aware(
     if (
         ("pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (12,))
         or ("pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2, 2))
-        or (
-            any(x in str(constructor_eager) for x in ("pyarrow", "modin"))
-            and is_windows()
-        )
+        or ("modin_pyarrow" in str(constructor_eager) and is_windows())
     ):
         request.applymarker(pytest.mark.xfail)
         request.applymarker(pytest.mark.xfail)

--- a/tests/series_only/to_pandas_test.py
+++ b/tests/series_only/to_pandas_test.py
@@ -22,7 +22,7 @@ def test_convert(
 ) -> None:
     if any(
         cname in str(constructor_eager)
-        for cname in ("pandas_nullable", "pandas_pyarrow", "modin")
+        for cname in ("pandas_nullable", "pandas_pyarrow", "modin_pyarrow")
     ):
         request.applymarker(pytest.mark.xfail)
 


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Semi-related PR #1625 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Narwhals failed to preserve pyarrow backed datatypes with Modin-native backed DataFrames. This issue was first noticed in the aforementioned PR and subsequent MRE

```python
# modin.pandas Series with pyarrow backed dtype
>>> import modin.pandas as mpd
>>> s = mpd.Series([1.0, None]).convert_dtypes(dtype_backend='pyarrow')
>>> s
0       1
1    <NA>
dtype: int64[pyarrow]

>>> import narwhals as nw
>>> ns = nw.from_native(s, series_only=True)
>>> ns.cast(nw.Float64).to_native() # loses pyarrow backend info
0    1.0
1    NaN
dtype: float64
```

With this PR, we appropriately preserve the dtype back-end

```python
>>> import modin.pandas as mpd
>>> s = mpd.Series([1.0, None]).convert_dtypes(dtype_backend='pyarrow')
>>> s
0       1
1    <NA>
dtype: int64[pyarrow]

>>> import narwhals as nw
>>> ns = nw.from_native(s, series_only=True)
>>> ns.cast(nw.Float64).to_native()
0     1.0
1    <NA>
dtype: double[pyarrow]
```

An edge case was encountered in `narwhals/_pandas_like/group_by.py` where `.get_group(...)` would raise a KeyError if the passed key contained `float("nan")` (as it does in the testing suite). This is likely due to some copying/reconstruction of the nan object which fails to reproduce its original hash since its hash is compute against the object id.