### PR TITLE
test: allow to run tests for Polars[gpu]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ If you add code that should be tested, please add tests.
   - To run tests using `cudf.pandas`, run `NARWHALS_DEFAULT_CONSTRUCTORS=pandas python -m cudf.pandas -m pytest`
   - To run tests using `polars[gpu]`, run `NARWHALS_POLARS_GPU=1 pytest --constructors=polars[lazy]`
 
-If you want to have less surprises when opening a PR, you can take advantage of [](https://nox.thea.codes/en/stable/index.html) to run the entire CI/CD test suite locally in your operating system.
+If you want to have less surprises when opening a PR, you can take advantage of [nox](https://nox.thea.codes/en/stable/index.html) to run the entire CI/CD test suite locally in your operating system.
 
 To do so, you will first need to install nox and then run the `nox` command in the root of the repository:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,11 +133,13 @@ If you add code that should be tested, please add tests.
 - To run unit tests and doctests at the same time, run `pytest tests narwhals --cov=narwhals --doctest-modules`
 - To run tests multiprocessed, you may also want to use [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) (optional)
 - To choose which backends to run tests with you, you can use the `--constructors` flag:
-  - to only run tests for pandas, Polars, and PyArrow, use `pytest --constructors=pandas,pyarrow,polars`
-  - to run tests for all CPU constructors, use `pytest --all-cpu-constructors`
-  - by default, tests run for pandas, pandas (PyArrow dtypes), PyArrow, and Polars.
+  - To only run tests for pandas, Polars, and PyArrow, use `pytest --constructors=pandas,pyarrow,polars`
+  - To run tests for all CPU constructors, use `pytest --all-cpu-constructors`
+  - By default, tests run for pandas, pandas (PyArrow dtypes), PyArrow, and Polars.
+  - To run tests using `cudf.pandas`, run `NARWHALS_DEFAULT_CONSTRUCTORS=pandas python -m cudf.pandas -m pytest`
+  - To run tests using `polars[gpu]`, run `NARWHALS_POLARS_GPU=1 pytest --constructors=polars[lazy]`
 
-If you want to have less surprises when opening a PR, you can take advantage of [nox](https://nox.thea.codes/en/stable/index.html) to run the entire CI/CD test suite locally in your operating system.
+If you want to have less surprises when opening a PR, you can take advantage of [](https://nox.thea.codes/en/stable/index.html) to run the entire CI/CD test suite locally in your operating system.
 
 To do so, you will first need to install nox and then run the `nox` command in the root of the repository:
 

--- a/tests/expr_and_series/sample_test.py
+++ b/tests/expr_and_series/sample_test.py
@@ -46,17 +46,13 @@ def test_sample_with_seed(
     size, n = 100, 10
     df = nw.from_native(constructor({"a": list(range(size))})).lazy()
     expected = {"res1": [True], "res2": [False]}
-    result = (
-        df.select(
-            seed1=nw.col("a").sample(n=n, seed=123),
-            seed2=nw.col("a").sample(n=n, seed=123),
-            seed3=nw.col("a").sample(n=n, seed=42),
-        )
-        .select(
-            res1=(nw.col("seed1") == nw.col("seed2")).all(),
-            res2=(nw.col("seed1") == nw.col("seed3")).all(),
-        )
-        .collect()
+    result = df.select(
+        seed1=nw.col("a").sample(n=n, seed=123),
+        seed2=nw.col("a").sample(n=n, seed=123),
+        seed3=nw.col("a").sample(n=n, seed=42),
+    ).select(
+        res1=(nw.col("seed1") == nw.col("seed2")).all(),
+        res2=(nw.col("seed1") == nw.col("seed3")).all(),
     )
 
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -130,10 +130,7 @@ def test_to_datetime_infer_fmt_from_date(constructor: Constructor) -> None:
     data = {"z": ["2020-01-01", "2020-01-02", None]}
     expected = [datetime(2020, 1, 1), datetime(2020, 1, 2), None]
     result = (
-        nw.from_native(constructor(data))
-        .lazy()
-        .select(nw.col("z").str.to_datetime())
-        .collect()
+        nw.from_native(constructor(data)).lazy().select(nw.col("z").str.to_datetime())
     )
     assert_equal_data(result, {"z": expected})
 

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -31,9 +31,7 @@ def test_group_by_complex() -> None:
     assert_equal_data(result, expected)
 
     lf = nw.from_native(df_lazy).lazy()
-    result = nw.to_native(
-        lf.group_by("a").agg((nw.col("b") - nw.col("c").mean()).mean()).sort("a")
-    )
+    result = lf.group_by("a").agg((nw.col("b") - nw.col("c").mean()).mean()).sort("a")
     assert_equal_data(result, expected)
 
 
@@ -220,7 +218,6 @@ def test_group_by_simple_named(constructor: Constructor) -> None:
             b_min=nw.col("b").min(),
             b_max=nw.col("b").max(),
         )
-        .collect()
         .sort("a")
     )
     expected = {
@@ -240,7 +237,6 @@ def test_group_by_simple_unnamed(constructor: Constructor) -> None:
             nw.col("b").min(),
             nw.col("c").max(),
         )
-        .collect()
         .sort("a")
     )
     expected = {
@@ -260,7 +256,6 @@ def test_group_by_multiple_keys(constructor: Constructor) -> None:
             c_min=nw.col("c").min(),
             c_max=nw.col("c").max(),
         )
-        .collect()
         .sort("a")
     )
     expected = {

--- a/tests/read_scan_test.py
+++ b/tests/read_scan_test.py
@@ -60,7 +60,7 @@ def test_scan_csv(
     df = nw.from_native(constructor(data))
     native_namespace = nw.get_native_namespace(df)
     result = nw.scan_csv(filepath, native_namespace=native_namespace)
-    assert_equal_data(result.collect(), data)
+    assert_equal_data(result, data)
     assert isinstance(result, nw.LazyFrame)
 
 
@@ -74,7 +74,7 @@ def test_scan_csv_v1(
     df = nw_v1.from_native(constructor(data))
     native_namespace = nw_v1.get_native_namespace(df)
     result = nw_v1.scan_csv(filepath, native_namespace=native_namespace)
-    assert_equal_data(result.collect(), data)
+    assert_equal_data(result, data)
     assert isinstance(result, nw_v1.LazyFrame)
 
 
@@ -136,7 +136,7 @@ def test_scan_parquet(
     df = nw.from_native(constructor(data))
     native_namespace = nw.get_native_namespace(df)
     result = nw.scan_parquet(filepath, native_namespace=native_namespace)
-    assert_equal_data(result.collect(), data)
+    assert_equal_data(result, data)
     assert isinstance(result, nw.LazyFrame)
 
 
@@ -151,7 +151,7 @@ def test_scan_parquet_v1(
     df = nw_v1.from_native(constructor(data))
     native_namespace = nw_v1.get_native_namespace(df)
     result = nw_v1.scan_parquet(filepath, native_namespace=native_namespace)
-    assert_equal_data(result.collect(), data)
+    assert_equal_data(result, data)
     assert isinstance(result, nw_v1.LazyFrame)
 
 

--- a/tests/spark_like_test.py
+++ b/tests/spark_like_test.py
@@ -150,7 +150,7 @@ def test_collect_schema(pyspark_constructor: Constructor) -> None:
 
     result = df.collect_schema()
     assert result == expected
-    result = df.lazy().collect().collect_schema()
+    result = df.lazy().collect_schema()
     assert result == expected
 
 
@@ -548,34 +548,35 @@ def test_rename(pyspark_constructor: Constructor) -> None:
         ("none", {"a": [2], "b": [6], "z": [9]}),
     ],
 )
+@pytest.mark.filterwarnings("ignore:Argument `maintain_order=True` is unused")
 def test_unique(
     pyspark_constructor: Constructor,
     subset: str | list[str] | None,
     keep: str,
     expected: dict[str, list[float]],
 ) -> None:
-    if keep == "any":
-        context: Any = does_not_raise()
-    elif keep == "none":
-        context = pytest.raises(
+    context = (
+        does_not_raise()
+        if keep == "any"
+        else pytest.raises(
             ValueError,
             match=r"`LazyFrame.unique` with PySpark backend only supports `keep='any'`.",
         )
-    else:
-        context = pytest.raises(ValueError, match=f": {keep}")
+    )
 
     with context:
         data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
         df = nw.from_native(pyspark_constructor(data))
 
-        result = df.unique(subset, keep=keep).sort("z")  # type: ignore[arg-type]
+        result = df.unique(subset, keep=keep, maintain_order=True)  # type: ignore[arg-type]
         assert_equal_data(result, expected)
 
 
+@pytest.mark.filterwarnings("ignore:Argument `maintain_order=True` is unused")
 def test_unique_none(pyspark_constructor: Constructor) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df = nw.from_native(pyspark_constructor(data))
-    result = df.unique().sort("z")
+    result = df.unique(maintain_order=True)
     assert_equal_data(result, data)
 
 

--- a/tests/spark_like_test.py
+++ b/tests/spark_like_test.py
@@ -150,7 +150,7 @@ def test_collect_schema(pyspark_constructor: Constructor) -> None:
 
     result = df.collect_schema()
     assert result == expected
-    result = df.lazy().collect_schema()
+    result = df.lazy().collect().collect_schema()
     assert result == expected
 
 
@@ -548,35 +548,34 @@ def test_rename(pyspark_constructor: Constructor) -> None:
         ("none", {"a": [2], "b": [6], "z": [9]}),
     ],
 )
-@pytest.mark.filterwarnings("ignore:Argument `maintain_order=True` is unused")
 def test_unique(
     pyspark_constructor: Constructor,
     subset: str | list[str] | None,
     keep: str,
     expected: dict[str, list[float]],
 ) -> None:
-    context = (
-        does_not_raise()
-        if keep == "any"
-        else pytest.raises(
+    if keep == "any":
+        context: Any = does_not_raise()
+    elif keep == "none":
+        context = pytest.raises(
             ValueError,
             match=r"`LazyFrame.unique` with PySpark backend only supports `keep='any'`.",
         )
-    )
+    else:
+        context = pytest.raises(ValueError, match=f": {keep}")
 
     with context:
         data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
         df = nw.from_native(pyspark_constructor(data))
 
-        result = df.unique(subset, keep=keep, maintain_order=True)  # type: ignore[arg-type]
+        result = df.unique(subset, keep=keep).sort("z")  # type: ignore[arg-type]
         assert_equal_data(result, expected)
 
 
-@pytest.mark.filterwarnings("ignore:Argument `maintain_order=True` is unused")
 def test_unique_none(pyspark_constructor: Constructor) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df = nw.from_native(pyspark_constructor(data))
-    result = df.unique(maintain_order=True)
+    result = df.unique().sort("z")
     assert_equal_data(result, data)
 
 

--- a/tests/tpch_q1_test.py
+++ b/tests/tpch_q1_test.py
@@ -66,7 +66,6 @@ def test_q1(library: str, request: pytest.FixtureRequest) -> None:
         )
         .sort(["l_returnflag", "l_linestatus"])
     )
-    result = query_result.collect().to_dict(as_series=False)
     expected = {
         "l_returnflag": ["A", "N", "N", "R"],
         "l_linestatus": ["F", "F", "O", "F"],
@@ -89,7 +88,7 @@ def test_q1(library: str, request: pytest.FixtureRequest) -> None:
         "avg_disc": [0.05039473684210526, 0.02, 0.05537414965986395, 0.04507042253521127],
         "count_order": [76, 1, 147, 71],
     }
-    assert_equal_data(result, expected)
+    assert_equal_data(query_result, expected)
 
 
 @pytest.mark.parametrize(
@@ -193,7 +192,6 @@ def test_q1_w_pandas_agg_generic_path() -> None:
         )
         .sort(["l_returnflag", "l_linestatus"])
     )
-    result = query_result.collect().to_dict(as_series=False)
     expected = {
         "l_returnflag": ["A", "N", "N", "R"],
         "l_linestatus": ["F", "F", "O", "F"],
@@ -216,4 +214,4 @@ def test_q1_w_pandas_agg_generic_path() -> None:
         "avg_disc": [0.05039473684210526, 0.02, 0.05537414965986395, 0.04507042253521127],
         "count_order": [76, 1, 147, 71],
     }
-    assert_equal_data(result, expected)
+    assert_equal_data(query_result, expected)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -77,7 +77,7 @@ def assert_equal_data(result: Any, expected: dict[str, Any]) -> None:
         if result.implementation is Implementation.POLARS and os.environ.get(
             "NARWHALS_POLARS_GPU", False
         ):
-            result = result.to_native().collect(gpu=True)
+            result = result.to_native().collect(engine="gpu")
         else:
             result = result.collect()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -76,7 +76,7 @@ def assert_equal_data(result: Any, expected: dict[str, Any]) -> None:
     if hasattr(result, "collect"):
         if result.implementation is Implementation.POLARS and os.environ.get(
             "NARWHALS_POLARS_GPU", False
-        ):
+        ):  # pragma: no cover
             result = result.to_native().collect(engine="gpu")
         else:
             result = result.collect()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -77,7 +77,7 @@ def assert_equal_data(result: Any, expected: dict[str, Any]) -> None:
         if result.implementation is Implementation.POLARS and os.environ.get(
             "NARWHALS_POLARS_GPU", False
         ):
-            result = result.collect(gpu=True)
+            result = result.to_native().collect(gpu=True)
         else:
             result = result.collect()
 


### PR DESCRIPTION
i've removed several `collect`s from tests, so it can happen in `assert_data_equal` and there the environment variable can determine the engine

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
