### PR TITLE
fix: always pass Column to pandas.spark.functions

### DIFF
--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -121,7 +121,7 @@ def maybe_evaluate(df: SparkLikeLazyFrame, obj: Any) -> Any:
 
 
 def _std(
-    _input: Column,
+    _input: Column | str,
     ddof: int,
     backend_version: tuple[int, ...],
     np_version: tuple[int, ...],
@@ -136,12 +136,14 @@ def _std(
         return F.stddev_samp(_input) * F.sqrt((n_rows - 1) / (n_rows - ddof))
 
     from pyspark.pandas.spark.functions import stddev
+    from pyspark.sql import functions as F  # noqa: N812
 
-    return stddev(_input, ddof=ddof)
+    input_col = F.col(_input) if isinstance(_input, str) else _input
+    return stddev(input_col, ddof=ddof)
 
 
 def _var(
-    _input: Column,
+    _input: Column | str,
     ddof: int,
     backend_version: tuple[int, ...],
     np_version: tuple[int, ...],
@@ -156,5 +158,7 @@ def _var(
         return F.var_samp(_input) * (n_rows - 1) / (n_rows - ddof)
 
     from pyspark.pandas.spark.functions import var
+    from pyspark.sql import functions as F  # noqa: N812
 
-    return var(_input, ddof=ddof)
+    input_col = F.col(_input) if isinstance(_input, str) else _input
+    return var(input_col, ddof=ddof)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues


## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

I guess it was not picked up in the CI because `numpy` version is > 2.0.
Should we have an extra test session with `numpy<2.0` and pyspark? 