### PR TITLE
docs: update null handling page with `is_nan` reference

### DIFF
--- a/docs/pandas_like_concepts/null_handling.md
+++ b/docs/pandas_like_concepts/null_handling.md
@@ -43,3 +43,48 @@ def check_null_behavior(df: IntoFrameT) -> IntoFrameT:
     df = pa.table(data)
     print(check_null_behavior(df))
     ```
+
+Conversely, `is_nan` is consistent across backends. This consistency comes from Narwhals exploiting its native implementations
+in Polars and PyArrow, while ensuring that pandas only identifies the floating-point NaN values and not those encoding the missing value indicator.
+
+```python exec="1" source="above" session="null_handling"
+import narwhals as nw
+from narwhals.typing import IntoFrameT
+
+data = {"a": [0.0, None, 2.0]}
+
+
+def check_nan_behavior(df: IntoFrameT) -> IntoFrameT:
+    return (
+        nw.from_native(df)
+        .with_columns(
+            a_div_a=(nw.col("a") / nw.col("a")),
+            a_div_a_is_nan=(nw.col("a") / nw.col("a")).is_nan(),
+        )
+        .to_native()
+    )
+```
+
+=== "pandas"
+    ```python exec="true" source="material-block" result="python" session="null_handling"
+    import pandas as pd
+
+    df = pd.DataFrame(data).astype({"a": "Float64"})
+    print(check_nan_behavior(df))
+    ```
+
+=== "Polars (eager)"
+    ```python exec="true" source="material-block" result="python" session="null_handling"
+    import polars as pl
+
+    df = pl.DataFrame(data)
+    print(check_nan_behavior(df))
+    ```
+
+=== "PyArrow"
+    ```python exec="true" source="material-block" result="python" session="null_handling"
+    import pyarrow as pa
+
+    df = pa.table(data)
+    print(check_nan_behavior(df))
+    ```


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Iterates on https://github.com/narwhals-dev/narwhals/pull/1624

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Adds reference to the `is_nan` specificity in the null handling page.