### PR TITLE
fix: Catch cuDF warning for concat with empty elements, and ComputeError for non-float is_nan

### DIFF
--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from functools import lru_cache
 from typing import TYPE_CHECKING
 from typing import Any
@@ -211,7 +212,16 @@ def horizontal_concat(
 
     Should be in namespace.
     """
-    if implementation in PANDAS_LIKE_IMPLEMENTATION:
+    if implementation is Implementation.CUDF:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="The behavior of array concatenation with empty entries is deprecated",
+                category=FutureWarning,
+            )
+            return implementation.to_native_namespace().concat(dfs, axis=1)
+
+    if implementation.is_pandas_like():
         extra_kwargs = (
             {"copy": False}
             if implementation is Implementation.PANDAS and backend_version < (3,)

--- a/tests/expr_and_series/is_nan_test.py
+++ b/tests/expr_and_series/is_nan_test.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from contextlib import nullcontext as does_not_raise
 from typing import Any
 
 import pytest
+from polars.exceptions import ComputeError
 
 import narwhals.stable.v1 as nw
 from tests.conftest import dask_lazy_p1_constructor
@@ -48,7 +50,15 @@ def test_nan(constructor: Constructor) -> None:
             "float_na": [True, False, None],
         }
 
-    assert_equal_data(result, expected)
+    context = (
+        pytest.raises(
+            ComputeError, match="NAN is not supported in a Non-floating point type column"
+        )
+        if "cudf" in str(constructor)
+        else does_not_raise()
+    )
+    with context:
+        assert_equal_data(result, expected)
 
 
 def test_nan_series(constructor_eager: ConstructorEager) -> None:

--- a/tests/expr_and_series/is_nan_test.py
+++ b/tests/expr_and_series/is_nan_test.py
@@ -55,11 +55,8 @@ def test_nan(constructor: Constructor) -> None:
         pytest.raises(
             ComputeError, match="NAN is not supported in a Non-floating point type column"
         )
-        if ("cudf" in str(constructor))
-        or (
-            "polars_lazy" in str(constructor)
-            and os.environ.get("NARWHALS_POLARS_GPU", False)
-        )
+        if "polars_lazy" in str(constructor)
+        and os.environ.get("NARWHALS_POLARS_GPU", False)
         else does_not_raise()
     )
     with context:

--- a/tests/expr_and_series/is_nan_test.py
+++ b/tests/expr_and_series/is_nan_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from contextlib import nullcontext as does_not_raise
 from typing import Any
 
@@ -54,7 +55,11 @@ def test_nan(constructor: Constructor) -> None:
         pytest.raises(
             ComputeError, match="NAN is not supported in a Non-floating point type column"
         )
-        if "cudf" in str(constructor)
+        if ("cudf" in str(constructor))
+        or (
+            "polars_lazy" in str(constructor)
+            and os.environ.get("NARWHALS_POLARS_GPU", False)
+        )
         else does_not_raise()
     )
     with context:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
