### PR TITLE
chore: remove more trailing commas

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -360,7 +360,7 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
                     join_type="inner",
                     right_suffix=suffix,
                 )
-                .drop([key_token]),
+                .drop([key_token])
             )
 
         return self._from_native_frame(
@@ -370,7 +370,7 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
                 right_keys=right_on,
                 join_type=how_to_join_map[how],
                 right_suffix=suffix,
-            ),
+            )
         )
 
     def join_asof(

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -409,9 +409,7 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
         return reuse_series_implementation(self, "mode")
 
     def map_batches(
-        self: Self,
-        function: Callable[[Any], Any],
-        return_dtype: DType | None,
+        self: Self, function: Callable[[Any], Any], return_dtype: DType | None
     ) -> Self:
         def func(df: ArrowDataFrame) -> list[ArrowSeries]:
             input_series_list = self._call(df)
@@ -463,11 +461,7 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
         return reuse_series_implementation(self, "cum_prod", reverse=reverse)
 
     def rolling_sum(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool
     ) -> Self:
         return reuse_series_implementation(
             self,
@@ -478,11 +472,7 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
         )
 
     def rolling_mean(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool
     ) -> Self:
         return reuse_series_implementation(
             self,
@@ -493,12 +483,7 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
         )
 
     def rolling_var(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
-        ddof: int,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool, ddof: int
     ) -> Self:
         return reuse_series_implementation(
             self,
@@ -510,12 +495,7 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
         )
 
     def rolling_std(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
-        ddof: int,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool, ddof: int
     ) -> Self:
         return reuse_series_implementation(
             self,

--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -50,14 +50,10 @@ class ArrowGroupBy:
         self._grouped = pa.TableGroupBy(self._df._native_frame, list(self._keys))
 
     def agg(
-        self: Self,
-        *aggs: IntoArrowExpr,
-        **named_aggs: IntoArrowExpr,
+        self: Self, *aggs: IntoArrowExpr, **named_aggs: IntoArrowExpr
     ) -> ArrowDataFrame:
         exprs = parse_into_exprs(
-            *aggs,
-            namespace=self._df.__narwhals_namespace__(),
-            **named_aggs,
+            *aggs, namespace=self._df.__narwhals_namespace__(), **named_aggs
         )
         for expr in exprs:
             if expr._output_names is None:

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -354,10 +354,7 @@ class ArrowNamespace(CompliantNamespace[ArrowSeries]):
             backend_version=self._backend_version, version=self._version
         )
 
-    def when(
-        self: Self,
-        *predicates: IntoArrowExpr,
-    ) -> ArrowWhen:
+    def when(self: Self, *predicates: IntoArrowExpr) -> ArrowWhen:
         plx = self.__class__(backend_version=self._backend_version, version=self._version)
         condition = plx.all_horizontal(*predicates)
         return ArrowWhen(condition, self._backend_version, version=self._version)

--- a/narwhals/_arrow/selectors.py
+++ b/narwhals/_arrow/selectors.py
@@ -55,7 +55,7 @@ class ArrowSelectorNamespace:
                 dtypes.UInt8,
                 dtypes.Float64,
                 dtypes.Float32,
-            ],
+            ]
         )
 
     def categorical(self: Self) -> ArrowSelector:

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -956,11 +956,7 @@ class ArrowSeries(CompliantSeries):
         return self._from_native_series(result)
 
     def rolling_sum(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool
     ) -> Self:
         import pyarrow.compute as pc
 
@@ -992,11 +988,7 @@ class ArrowSeries(CompliantSeries):
         return result[offset:]
 
     def rolling_mean(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool
     ) -> Self:
         import pyarrow.compute as pc
 
@@ -1031,12 +1023,7 @@ class ArrowSeries(CompliantSeries):
         return result[offset:]
 
     def rolling_var(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
-        ddof: int,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool, ddof: int
     ) -> Self:
         import pyarrow.compute as pc  # ignore-banned-import
 
@@ -1083,12 +1070,7 @@ class ArrowSeries(CompliantSeries):
         return result[offset:]
 
     def rolling_std(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
-        ddof: int,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool, ddof: int
     ) -> Self:
         return (
             self.rolling_var(
@@ -1149,8 +1131,7 @@ class ArrowSeries(CompliantSeries):
                 else pa.scalar(None, type=native_series.type)
             )
             return maybe_extract_py_scalar(  # type: ignore[no-any-return]
-                pc.is_in(other_, native_series),
-                return_py_scalar=True,
+                pc.is_in(other_, native_series), return_py_scalar=True
             )
         except (ArrowInvalid, ArrowNotImplementedError, ArrowTypeError) as exc:
             from narwhals.exceptions import InvalidOperationError
@@ -1553,7 +1534,7 @@ class ArrowSeriesStringNamespace:
         return self._compliant_series._from_native_series(
             pc.utf8_slice_codeunits(
                 self._compliant_series._native_series, start=offset, stop=stop
-            ),
+            )
         )
 
     def to_datetime(self: Self, format: str | None) -> ArrowSeries:  # noqa: A002

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -630,11 +630,7 @@ class ArrowSeries(CompliantSeries):
 
         mask = mask._native_series.combine_chunks()
         return self._from_native_series(
-            pc.if_else(
-                mask,
-                self._native_series,
-                other._native_series,
-            )
+            pc.if_else(mask, self._native_series, other._native_series)
         )
 
     def sample(
@@ -689,10 +685,7 @@ class ArrowSeries(CompliantSeries):
                 )[::-1]
                 distance = valid_index - indices
             return pc.if_else(
-                pc.and_(
-                    pc.is_null(arr),
-                    pc.less_equal(distance, pa.scalar(limit)),
-                ),
+                pc.and_(pc.is_null(arr), pc.less_equal(distance, pa.scalar(limit))),
                 arr.take(valid_index),
                 arr,
             )
@@ -1499,10 +1492,7 @@ class ArrowSeriesStringNamespace:
 
         whitespace = " \t\n\r\v\f"
         return self._compliant_series._from_native_series(
-            pc.utf8_trim(
-                self._compliant_series._native_series,
-                characters or whitespace,
-            )
+            pc.utf8_trim(self._compliant_series._native_series, characters or whitespace)
         )
 
     def starts_with(self: Self, prefix: str) -> ArrowSeries:
@@ -1551,14 +1541,14 @@ class ArrowSeriesStringNamespace:
         import pyarrow.compute as pc
 
         return self._compliant_series._from_native_series(
-            pc.utf8_upper(self._compliant_series._native_series),
+            pc.utf8_upper(self._compliant_series._native_series)
         )
 
     def to_lowercase(self: Self) -> ArrowSeries:
         import pyarrow.compute as pc
 
         return self._compliant_series._from_native_series(
-            pc.utf8_lower(self._compliant_series._native_series),
+            pc.utf8_lower(self._compliant_series._native_series)
         )
 
 

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -312,8 +312,7 @@ def floordiv_compat(left: Any, right: Any) -> Any:
             # GH 56676
             has_remainder = pc.not_equal(pc.multiply(divided, right), left)
             has_one_negative_operand = pc.less(
-                pc.bit_wise_xor(left, right),
-                pa.scalar(0, type=divided.type),
+                pc.bit_wise_xor(left, right), pa.scalar(0, type=divided.type)
             )
             result = pc.if_else(
                 pc.and_(

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -132,13 +132,7 @@ def narwhals_to_native_dtype(dtype: DType | type[DType], version: Version) -> pa
     if isinstance_or_issubclass(dtype, dtypes.Struct):
         return pa.struct(
             [
-                (
-                    field.name,
-                    narwhals_to_native_dtype(
-                        field.dtype,
-                        version=version,
-                    ),
-                )
+                (field.name, narwhals_to_native_dtype(field.dtype, version=version))
                 for field in dtype.fields  # type: ignore[union-attr]
             ]
         )
@@ -315,10 +309,7 @@ def floordiv_compat(left: Any, right: Any) -> Any:
                 pc.bit_wise_xor(left, right), pa.scalar(0, type=divided.type)
             )
             result = pc.if_else(
-                pc.and_(
-                    has_remainder,
-                    has_one_negative_operand,
-                ),
+                pc.and_(has_remainder, has_one_negative_operand),
                 # GH: 55561 ruff: ignore
                 pc.subtract(divided, pa.scalar(1, type=divided.type)),
                 divided,

--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -304,10 +304,7 @@ class DaskLazyFrame(CompliantLazyFrame):
             )
             return self._from_native_frame(
                 self._native_frame.merge(
-                    other_native,
-                    how="inner",
-                    left_on=left_on,
-                    right_on=left_on,
+                    other_native, how="inner", left_on=left_on, right_on=left_on
                 )
             )
 

--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -105,11 +105,7 @@ class DaskLazyFrame(CompliantLazyFrame):
         mask = expr._call(self)[0]
         return self._from_native_frame(self._native_frame.loc[mask])
 
-    def select(
-        self: Self,
-        *exprs: IntoDaskExpr,
-        **named_exprs: IntoDaskExpr,
-    ) -> Self:
+    def select(self: Self, *exprs: IntoDaskExpr, **named_exprs: IntoDaskExpr) -> Self:
         import dask.dataframe as dd
 
         if exprs and all(isinstance(x, str) for x in exprs) and not named_exprs:
@@ -193,10 +189,7 @@ class DaskLazyFrame(CompliantLazyFrame):
         )
 
     def unique(
-        self: Self,
-        subset: list[str] | None,
-        *,
-        keep: Literal["any", "none"] = "any",
+        self: Self, subset: list[str] | None, *, keep: Literal["any", "none"] = "any"
     ) -> Self:
         if subset is not None and any(x not in self.columns for x in subset):
             msg = f"Column(s) {subset} not found in {self.columns}"
@@ -259,7 +252,7 @@ class DaskLazyFrame(CompliantLazyFrame):
                     right_on=key_token,
                     suffixes=("", suffix),
                 )
-                .drop(columns=key_token),
+                .drop(columns=key_token)
             )
 
         if how == "anti":
@@ -342,7 +335,7 @@ class DaskLazyFrame(CompliantLazyFrame):
                 right_on=right_on,
                 how=how,
                 suffixes=("", suffix),
-            ),
+            )
         )
 
     def join_asof(
@@ -370,7 +363,7 @@ class DaskLazyFrame(CompliantLazyFrame):
                 by=by,
                 direction=strategy,
                 suffixes=("", "_right"),
-            ),
+            )
         )
 
     def group_by(self, *by: str, drop_null_keys: bool) -> DaskLazyGroupBy:

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -84,8 +84,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             except KeyError as e:
                 missing_columns = [x for x in column_names if x not in df.columns]
                 raise ColumnNotFoundError.from_missing_and_available_column_names(
-                    missing_columns=missing_columns,
-                    available_columns=df.columns,
+                    missing_columns=missing_columns, available_columns=df.columns
                 ) from e
 
         return cls(
@@ -360,9 +359,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             raise NotImplementedError(msg)
 
         return self._from_call(
-            lambda _input: _input.cumsum(),
-            "cum_sum",
-            returns_scalar=self._returns_scalar,
+            lambda _input: _input.cumsum(), "cum_sum", returns_scalar=self._returns_scalar
         )
 
     def cum_count(self: Self, *, reverse: bool) -> Self:
@@ -382,9 +379,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             raise NotImplementedError(msg)
 
         return self._from_call(
-            lambda _input: _input.cummin(),
-            "cum_min",
-            returns_scalar=self._returns_scalar,
+            lambda _input: _input.cummin(), "cum_min", returns_scalar=self._returns_scalar
         )
 
     def cum_max(self: Self, *, reverse: bool) -> Self:
@@ -393,9 +388,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
             raise NotImplementedError(msg)
 
         return self._from_call(
-            lambda _input: _input.cummax(),
-            "cum_max",
-            returns_scalar=self._returns_scalar,
+            lambda _input: _input.cummax(), "cum_max", returns_scalar=self._returns_scalar
         )
 
     def cum_prod(self: Self, *, reverse: bool) -> Self:
@@ -410,10 +403,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
         )
 
     def is_between(
-        self,
-        lower_bound: Self | Any,
-        upper_bound: Self | Any,
-        closed: str = "both",
+        self, lower_bound: Self | Any, upper_bound: Self | Any, closed: str = "both"
     ) -> Self:
         if closed == "none":
             closed = "neither"
@@ -537,9 +527,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
         )
 
     def clip(
-        self: Self,
-        lower_bound: Self | Any | None,
-        upper_bound: Self | Any | None,
+        self: Self, lower_bound: Self | Any | None, upper_bound: Self | Any | None
     ) -> Self:
         return self._from_call(
             lambda _input, lower_bound, upper_bound: _input.clip(
@@ -669,9 +657,7 @@ class DaskExpr(CompliantExpr["dask_expr.Series"]):
 
     def null_count(self: Self) -> Self:
         return self._from_call(
-            lambda _input: _input.isna().sum(),
-            "null_count",
-            returns_scalar=True,
+            lambda _input: _input.isna().sum(), "null_count", returns_scalar=True
         )
 
     def tail(self: Self) -> NoReturn:

--- a/narwhals/_dask/group_by.py
+++ b/narwhals/_dask/group_by.py
@@ -29,11 +29,7 @@ def n_unique() -> dd.Aggregation:
     def agg(s0: pd.core.groupby.generic.SeriesGroupBy) -> int:
         return s0.sum()  # type: ignore[no-any-return]
 
-    return dd.Aggregation(
-        name="nunique",
-        chunk=chunk,
-        agg=agg,
-    )
+    return dd.Aggregation(name="nunique", chunk=chunk, agg=agg)
 
 
 def var(
@@ -81,20 +77,12 @@ class DaskLazyGroupBy:
         self._df = df
         self._keys = keys
         self._grouped = self._df._native_frame.groupby(
-            list(self._keys),
-            dropna=drop_null_keys,
-            observed=True,
+            list(self._keys), dropna=drop_null_keys, observed=True
         )
 
-    def agg(
-        self,
-        *aggs: IntoDaskExpr,
-        **named_aggs: IntoDaskExpr,
-    ) -> DaskLazyFrame:
+    def agg(self, *aggs: IntoDaskExpr, **named_aggs: IntoDaskExpr) -> DaskLazyFrame:
         exprs = parse_into_exprs(
-            *aggs,
-            namespace=self._df.__narwhals_namespace__(),
-            **named_aggs,
+            *aggs, namespace=self._df.__narwhals_namespace__(), **named_aggs
         )
         output_names: list[str] = copy(self._keys)
         for expr in exprs:
@@ -109,11 +97,7 @@ class DaskLazyGroupBy:
             output_names.extend(expr._output_names)
 
         return agg_dask(
-            self._df,
-            self._grouped,
-            exprs,
-            self._keys,
-            self._from_native_frame,
+            self._df, self._grouped, exprs, self._keys, self._from_native_frame
         )
 
     def _from_native_frame(self, df: DaskLazyFrame) -> DaskLazyFrame:

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -305,10 +305,7 @@ class DaskNamespace(CompliantNamespace["dask_expr.Series"]):
             kwargs={"exprs": exprs},
         )
 
-    def when(
-        self,
-        *predicates: IntoDaskExpr,
-    ) -> DaskWhen:
+    def when(self, *predicates: IntoDaskExpr) -> DaskWhen:
         plx = self.__class__(backend_version=self._backend_version, version=self._version)
         condition = plx.all_horizontal(*predicates)
         return DaskWhen(

--- a/narwhals/_dask/selectors.py
+++ b/narwhals/_dask/selectors.py
@@ -55,7 +55,7 @@ class DaskSelectorNamespace:
                 dtypes.UInt8,
                 dtypes.Float64,
                 dtypes.Float32,
-            ],
+            ]
         )
 
     def categorical(self: Self) -> DaskSelector:

--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -94,11 +94,7 @@ class DuckDBLazyFrame:
     def head(self, n: int) -> Self:
         return self._from_native_frame(self._native_frame.limit(n))
 
-    def select(
-        self: Self,
-        *exprs: Any,
-        **named_exprs: Any,
-    ) -> Self:
+    def select(self: Self, *exprs: Any, **named_exprs: Any) -> Self:
         new_columns_map = parse_exprs_and_named_exprs(self, *exprs, **named_exprs)
         if not new_columns_map:
             # TODO(marco): return empty relation with 0 columns?
@@ -129,11 +125,7 @@ class DuckDBLazyFrame:
     def lazy(self) -> Self:
         return self
 
-    def with_columns(
-        self: Self,
-        *exprs: Any,
-        **named_exprs: Any,
-    ) -> Self:
+    def with_columns(self: Self, *exprs: Any, **named_exprs: Any) -> Self:
         from duckdb import ColumnExpression
 
         new_columns_map = parse_exprs_and_named_exprs(self, *exprs, **named_exprs)

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -259,9 +259,7 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
 
     def __invert__(self) -> Self:
         return self._from_call(
-            lambda _input: ~_input,
-            "__invert__",
-            returns_scalar=self._returns_scalar,
+            lambda _input: ~_input, "__invert__", returns_scalar=self._returns_scalar
         )
 
     def alias(self, name: str) -> Self:
@@ -295,9 +293,7 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         from duckdb import FunctionExpression
 
         return self._from_call(
-            lambda _input: FunctionExpression("mean", _input),
-            "mean",
-            returns_scalar=True,
+            lambda _input: FunctionExpression("mean", _input), "mean", returns_scalar=True
         )
 
     def skew(self) -> Self:
@@ -352,11 +348,7 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
             msg = "Only linear interpolation methods are supported for DuckDB quantile."
             raise NotImplementedError(msg)
 
-        return self._from_call(
-            func,
-            "quantile",
-            returns_scalar=True,
-        )
+        return self._from_call(func, "quantile", returns_scalar=True)
 
     def clip(self, lower_bound: Any, upper_bound: Any) -> Self:
         from duckdb import FunctionExpression
@@ -510,19 +502,13 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
             returns_scalar=self._returns_scalar,
         )
 
-    def cast(
-        self: Self,
-        dtype: DType | type[DType],
-    ) -> Self:
+    def cast(self: Self, dtype: DType | type[DType]) -> Self:
         def func(_input: Any, dtype: DType | type[DType]) -> Any:
             native_dtype = narwhals_to_native_dtype(dtype, self._version)
             return _input.cast(native_dtype)
 
         return self._from_call(
-            func,
-            "cast",
-            dtype=dtype,
-            returns_scalar=self._returns_scalar,
+            func, "cast", dtype=dtype, returns_scalar=self._returns_scalar
         )
 
     @property

--- a/narwhals/_duckdb/group_by.py
+++ b/narwhals/_duckdb/group_by.py
@@ -20,15 +20,9 @@ class DuckDBGroupBy:
         self._compliant_frame = compliant_frame
         self._keys = keys
 
-    def agg(
-        self,
-        *aggs: IntoDuckDBExpr,
-        **named_aggs: IntoDuckDBExpr,
-    ) -> DuckDBLazyFrame:
+    def agg(self, *aggs: IntoDuckDBExpr, **named_aggs: IntoDuckDBExpr) -> DuckDBLazyFrame:
         exprs = parse_into_exprs(
-            *aggs,
-            namespace=self._compliant_frame.__narwhals_namespace__(),
-            **named_aggs,
+            *aggs, namespace=self._compliant_frame.__narwhals_namespace__(), **named_aggs
         )
         output_names: list[str] = copy(self._keys)
         for expr in exprs:

--- a/narwhals/_duckdb/utils.py
+++ b/narwhals/_duckdb/utils.py
@@ -48,9 +48,7 @@ def maybe_evaluate(df: DuckDBLazyFrame, obj: Any) -> Any:
 
 
 def parse_exprs_and_named_exprs(
-    df: DuckDBLazyFrame,
-    *exprs: IntoDuckDBExpr,
-    **named_exprs: IntoDuckDBExpr,
+    df: DuckDBLazyFrame, *exprs: IntoDuckDBExpr, **named_exprs: IntoDuckDBExpr
 ) -> dict[str, duckdb.Expression]:
     result_columns: dict[str, list[duckdb.Expression]] = {}
     for expr in exprs:
@@ -145,8 +143,7 @@ def native_to_narwhals_dtype(duckdb_dtype: str, version: Version) -> DType:
         return dtypes.List(native_to_narwhals_dtype(match_.group(1), version))
     if match_ := re.match(r"(\w+)\[(\d+)\]", duckdb_dtype):
         return dtypes.Array(
-            native_to_narwhals_dtype(match_.group(1), version),
-            int(match_.group(2)),
+            native_to_narwhals_dtype(match_.group(1), version), int(match_.group(2))
         )
     if duckdb_dtype.startswith("DECIMAL("):
         return dtypes.Decimal()

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -159,21 +159,13 @@ def infer_new_root_output_names(
 
 @overload
 def reuse_series_implementation(
-    expr: PandasLikeExprT,
-    attr: str,
-    *,
-    returns_scalar: bool = False,
-    **kwargs: Any,
+    expr: PandasLikeExprT, attr: str, *, returns_scalar: bool = False, **kwargs: Any
 ) -> PandasLikeExprT: ...
 
 
 @overload
 def reuse_series_implementation(
-    expr: ArrowExprT,
-    attr: str,
-    *,
-    returns_scalar: bool = False,
-    **kwargs: Any,
+    expr: ArrowExprT, attr: str, *, returns_scalar: bool = False, **kwargs: Any
 ) -> ArrowExprT: ...
 
 
@@ -254,10 +246,7 @@ def reuse_series_namespace_implementation(
     expr: PandasLikeExprT, series_namespace: str, attr: str, **kwargs: Any
 ) -> PandasLikeExprT: ...
 def reuse_series_namespace_implementation(
-    expr: ArrowExprT | PandasLikeExprT,
-    series_namespace: str,
-    attr: str,
-    **kwargs: Any,
+    expr: ArrowExprT | PandasLikeExprT, series_namespace: str, attr: str, **kwargs: Any
 ) -> ArrowExprT | PandasLikeExprT:
     """Reuse Series implementation for expression.
 

--- a/narwhals/_ibis/dataframe.py
+++ b/narwhals/_ibis/dataframe.py
@@ -98,11 +98,7 @@ class IbisInterchangeFrame:
     def to_arrow(self: Self) -> pa.Table:
         return self._native_frame.to_pyarrow()
 
-    def select(
-        self: Self,
-        *exprs: Any,
-        **named_exprs: Any,
-    ) -> Self:
+    def select(self: Self, *exprs: Any, **named_exprs: Any) -> Self:
         if named_exprs or not all(isinstance(x, str) for x in exprs):  # pragma: no cover
             msg = (
                 "`select`-ing not by name is not supported for Ibis backend.\n\n"

--- a/narwhals/_ibis/dataframe.py
+++ b/narwhals/_ibis/dataframe.py
@@ -58,8 +58,7 @@ def native_to_narwhals_dtype(ibis_dtype: Any, version: Version) -> DType:
         return dtypes.Struct(
             [
                 dtypes.Field(
-                    ibis_dtype_name,
-                    native_to_narwhals_dtype(ibis_dtype_field, version),
+                    ibis_dtype_name, native_to_narwhals_dtype(ibis_dtype_field, version)
                 )
                 for ibis_dtype_name, ibis_dtype_field in ibis_dtype.items()
             ]

--- a/narwhals/_interchange/dataframe.py
+++ b/narwhals/_interchange/dataframe.py
@@ -148,11 +148,7 @@ class InterchangeFrame:
         )
         raise NotImplementedError(msg)
 
-    def select(
-        self: Self,
-        *exprs: Any,
-        **named_exprs: Any,
-    ) -> Self:
+    def select(self: Self, *exprs: Any, **named_exprs: Any) -> Self:
         if named_exprs or not all(isinstance(x, str) for x in exprs):  # pragma: no cover
             msg = (
                 "`select`-ing not by name is not supported for interchange-only level.\n\n"

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -200,10 +200,7 @@ class PandasLikeDataFrame:
             if all(isinstance(x, int) for x in item[1]):
                 return self._from_native_frame(self._native_frame.iloc[item])
             if all(isinstance(x, str) for x in item[1]):
-                indexer = (
-                    item[0],
-                    self._native_frame.columns.get_indexer(item[1]),
-                )
+                indexer = (item[0], self._native_frame.columns.get_indexer(item[1]))
                 return self._from_native_frame(self._native_frame.iloc[indexer])
             msg = (
                 f"Expected sequence str or int, got: {type(item[1])}"  # pragma: no cover
@@ -279,25 +276,13 @@ class PandasLikeDataFrame:
         return self._native_frame.columns.tolist()  # type: ignore[no-any-return]
 
     @overload
-    def rows(
-        self,
-        *,
-        named: Literal[True],
-    ) -> list[dict[str, Any]]: ...
+    def rows(self, *, named: Literal[True]) -> list[dict[str, Any]]: ...
 
     @overload
-    def rows(
-        self,
-        *,
-        named: Literal[False] = False,
-    ) -> list[tuple[Any, ...]]: ...
+    def rows(self, *, named: Literal[False] = False) -> list[tuple[Any, ...]]: ...
 
     @overload
-    def rows(
-        self,
-        *,
-        named: bool,
-    ) -> list[tuple[Any, ...]] | list[dict[str, Any]]: ...
+    def rows(self, *, named: bool) -> list[tuple[Any, ...]] | list[dict[str, Any]]: ...
 
     def rows(
         self, *, named: bool = False
@@ -313,10 +298,7 @@ class PandasLikeDataFrame:
         return self._native_frame.to_dict(orient="records")  # type: ignore[no-any-return]
 
     def iter_rows(
-        self,
-        *,
-        named: bool = False,
-        buffer_size: int = 512,
+        self, *, named: bool = False, buffer_size: int = 512
     ) -> Iterator[list[tuple[Any, ...]]] | Iterator[list[dict[str, Any]]]:
         # The param ``buffer_size`` is only here for compatibility with the Polars API
         # and has no effect on the output.
@@ -343,9 +325,7 @@ class PandasLikeDataFrame:
 
     # --- reshape ---
     def select(
-        self,
-        *exprs: IntoPandasLikeExpr,
-        **named_exprs: IntoPandasLikeExpr,
+        self, *exprs: IntoPandasLikeExpr, **named_exprs: IntoPandasLikeExpr
     ) -> Self:
         if exprs and all(isinstance(x, str) for x in exprs) and not named_exprs:
             # This is a simple slice => fastpath!
@@ -421,9 +401,7 @@ class PandasLikeDataFrame:
         return self._from_native_frame(self._native_frame.loc[_mask])
 
     def with_columns(
-        self,
-        *exprs: IntoPandasLikeExpr,
-        **named_exprs: IntoPandasLikeExpr,
+        self, *exprs: IntoPandasLikeExpr, **named_exprs: IntoPandasLikeExpr
     ) -> Self:
         index = self._native_frame.index
         new_columns = evaluate_into_exprs(self, *exprs, **named_exprs)
@@ -502,11 +480,7 @@ class PandasLikeDataFrame:
     def group_by(self, *keys: str, drop_null_keys: bool) -> PandasLikeGroupBy:
         from narwhals._pandas_like.group_by import PandasLikeGroupBy
 
-        return PandasLikeGroupBy(
-            self,
-            list(keys),
-            drop_null_keys=drop_null_keys,
-        )
+        return PandasLikeGroupBy(self, list(keys), drop_null_keys=drop_null_keys)
 
     def join(
         self,
@@ -542,7 +516,7 @@ class PandasLikeDataFrame:
                         right_on=key_token,
                         suffixes=("", suffix),
                     )
-                    .drop(columns=key_token),
+                    .drop(columns=key_token)
                 )
             else:
                 return self._from_native_frame(
@@ -550,7 +524,7 @@ class PandasLikeDataFrame:
                         other._native_frame,
                         how="cross",
                         suffixes=("", suffix),
-                    ),
+                    )
                 )
 
         if how == "anti":
@@ -646,7 +620,7 @@ class PandasLikeDataFrame:
                 right_on=right_on,
                 how=how,
                 suffixes=("", suffix),
-            ),
+            )
         )
 
     def join_asof(
@@ -674,7 +648,7 @@ class PandasLikeDataFrame:
                 by=by,
                 direction=strategy,
                 suffixes=("", "_right"),
-            ),
+            )
         )
 
     # --- partial reduction ---

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -521,9 +521,7 @@ class PandasLikeDataFrame:
             else:
                 return self._from_native_frame(
                     self._native_frame.merge(
-                        other._native_frame,
-                        how="cross",
-                        suffixes=("", suffix),
+                        other._native_frame, how="cross", suffixes=("", suffix)
                     )
                 )
 
@@ -589,10 +587,7 @@ class PandasLikeDataFrame:
             )
             return self._from_native_frame(
                 self._native_frame.merge(
-                    other_native,
-                    how="inner",
-                    left_on=left_on,
-                    right_on=left_on,
+                    other_native, how="inner", left_on=left_on, right_on=left_on
                 )
             )
 

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -646,9 +646,7 @@ class PandasLikeExprStringNamespace:
     def __init__(self, expr: PandasLikeExpr) -> None:
         self._compliant_expr = expr
 
-    def len_chars(
-        self,
-    ) -> PandasLikeExpr:
+    def len_chars(self) -> PandasLikeExpr:
         return reuse_series_namespace_implementation(
             self._compliant_expr, "str", "len_chars"
         )

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -106,8 +106,7 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
             except KeyError as e:
                 missing_columns = [x for x in column_names if x not in df.columns]
                 raise ColumnNotFoundError.from_missing_and_available_column_names(
-                    missing_columns=missing_columns,
-                    available_columns=df.columns,
+                    missing_columns=missing_columns, available_columns=df.columns
                 ) from e
 
         return cls(
@@ -153,10 +152,7 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
             kwargs={},
         )
 
-    def cast(
-        self,
-        dtype: Any,
-    ) -> Self:
+    def cast(self, dtype: Any) -> Self:
         return reuse_series_implementation(self, "cast", dtype=dtype)
 
     def __eq__(self, other: PandasLikeExpr | Any) -> Self:  # type: ignore[override]
@@ -513,9 +509,7 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
         return reuse_series_implementation(self, "mode")
 
     def map_batches(
-        self: Self,
-        function: Callable[[Any], Any],
-        return_dtype: DType | None = None,
+        self: Self, function: Callable[[Any], Any], return_dtype: DType | None = None
     ) -> Self:
         def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
             input_series_list = self._call(df)
@@ -562,11 +556,7 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
         return reuse_series_implementation(self, "cum_prod", reverse=reverse)
 
     def rolling_sum(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool
     ) -> Self:
         return reuse_series_implementation(
             self,
@@ -577,11 +567,7 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
         )
 
     def rolling_mean(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool
     ) -> Self:
         return reuse_series_implementation(
             self,
@@ -592,12 +578,7 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
         )
 
     def rolling_var(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
-        ddof: int,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool, ddof: int
     ) -> Self:
         return reuse_series_implementation(
             self,
@@ -609,12 +590,7 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
         )
 
     def rolling_std(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
-        ddof: int,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool, ddof: int
     ) -> Self:
         return reuse_series_implementation(
             self,
@@ -662,9 +638,7 @@ class PandasLikeExprCatNamespace:
 
     def get_categories(self) -> PandasLikeExpr:
         return reuse_series_namespace_implementation(
-            self._compliant_expr,
-            "cat",
-            "get_categories",
+            self._compliant_expr, "cat", "get_categories"
         )
 
 
@@ -680,12 +654,7 @@ class PandasLikeExprStringNamespace:
         )
 
     def replace(
-        self,
-        pattern: str,
-        value: str,
-        *,
-        literal: bool = False,
-        n: int = 1,
+        self, pattern: str, value: str, *, literal: bool = False, n: int = 1
     ) -> PandasLikeExpr:
         return reuse_series_namespace_implementation(
             self._compliant_expr,
@@ -698,11 +667,7 @@ class PandasLikeExprStringNamespace:
         )
 
     def replace_all(
-        self,
-        pattern: str,
-        value: str,
-        *,
-        literal: bool = False,
+        self, pattern: str, value: str, *, literal: bool = False
     ) -> PandasLikeExpr:
         return reuse_series_namespace_implementation(
             self._compliant_expr,
@@ -715,35 +680,22 @@ class PandasLikeExprStringNamespace:
 
     def strip_chars(self, characters: str | None = None) -> PandasLikeExpr:
         return reuse_series_namespace_implementation(
-            self._compliant_expr,
-            "str",
-            "strip_chars",
-            characters=characters,
+            self._compliant_expr, "str", "strip_chars", characters=characters
         )
 
     def starts_with(self, prefix: str) -> PandasLikeExpr:
         return reuse_series_namespace_implementation(
-            self._compliant_expr,
-            "str",
-            "starts_with",
-            prefix=prefix,
+            self._compliant_expr, "str", "starts_with", prefix=prefix
         )
 
     def ends_with(self, suffix: str) -> PandasLikeExpr:
         return reuse_series_namespace_implementation(
-            self._compliant_expr,
-            "str",
-            "ends_with",
-            suffix=suffix,
+            self._compliant_expr, "str", "ends_with", suffix=suffix
         )
 
     def contains(self, pattern: str, *, literal: bool) -> PandasLikeExpr:
         return reuse_series_namespace_implementation(
-            self._compliant_expr,
-            "str",
-            "contains",
-            pattern=pattern,
-            literal=literal,
+            self._compliant_expr, "str", "contains", pattern=pattern, literal=literal
         )
 
     def slice(self, offset: int, length: int | None = None) -> PandasLikeExpr:
@@ -753,24 +705,17 @@ class PandasLikeExprStringNamespace:
 
     def to_datetime(self: Self, format: str | None) -> PandasLikeExpr:  # noqa: A002
         return reuse_series_namespace_implementation(
-            self._compliant_expr,
-            "str",
-            "to_datetime",
-            format=format,
+            self._compliant_expr, "str", "to_datetime", format=format
         )
 
     def to_uppercase(self) -> PandasLikeExpr:
         return reuse_series_namespace_implementation(
-            self._compliant_expr,
-            "str",
-            "to_uppercase",
+            self._compliant_expr, "str", "to_uppercase"
         )
 
     def to_lowercase(self) -> PandasLikeExpr:
         return reuse_series_namespace_implementation(
-            self._compliant_expr,
-            "str",
-            "to_lowercase",
+            self._compliant_expr, "str", "to_lowercase"
         )
 
 
@@ -1041,8 +986,4 @@ class PandasLikeExprListNamespace:
         self._expr = expr
 
     def len(self: Self) -> PandasLikeExpr:
-        return reuse_series_namespace_implementation(
-            self._expr,
-            "list",
-            "len",
-        )
+        return reuse_series_namespace_implementation(self._expr, "list", "len")

--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -64,10 +64,7 @@ class PandasLikeGroupBy:
                 msg = "Grouping by null values is not supported in pandas < 1.0.0"
                 raise NotImplementedError(msg)
             self._grouped = self._df._native_frame.groupby(
-                list(self._keys),
-                sort=False,
-                as_index=True,
-                observed=True,
+                list(self._keys), sort=False, as_index=True, observed=True
             )
         else:
             self._grouped = self._df._native_frame.groupby(
@@ -79,14 +76,10 @@ class PandasLikeGroupBy:
             )
 
     def agg(
-        self,
-        *aggs: IntoPandasLikeExpr,
-        **named_aggs: IntoPandasLikeExpr,
+        self, *aggs: IntoPandasLikeExpr, **named_aggs: IntoPandasLikeExpr
     ) -> PandasLikeDataFrame:
         exprs = parse_into_exprs(
-            *aggs,
-            namespace=self._df.__narwhals_namespace__(),
-            **named_aggs,
+            *aggs, namespace=self._df.__narwhals_namespace__(), **named_aggs
         )
         implementation: Implementation = self._df._implementation
         output_names: list[str] = copy(self._keys)
@@ -355,10 +348,7 @@ def agg_pandas(  # noqa: PLR0915
                 out_group.append(result_keys._native_series.iloc[0])
                 out_names.append(result_keys.name)
         return native_series_from_iterable(
-            out_group,
-            index=out_names,
-            name="",
-            implementation=implementation,
+            out_group, index=out_names, name="", implementation=implementation
         )
 
     if implementation is Implementation.PANDAS and backend_version >= (2, 2):

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -364,10 +364,7 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeSeries]):
             )
         raise NotImplementedError
 
-    def when(
-        self,
-        *predicates: IntoPandasLikeExpr,
-    ) -> PandasWhen:
+    def when(self, *predicates: IntoPandasLikeExpr) -> PandasWhen:
         plx = self.__class__(
             self._implementation, self._backend_version, version=self._version
         )

--- a/narwhals/_pandas_like/selectors.py
+++ b/narwhals/_pandas_like/selectors.py
@@ -57,7 +57,7 @@ class PandasSelectorNamespace:
                 dtypes.UInt8,
                 dtypes.Float64,
                 dtypes.Float32,
-            ],
+            ]
         )
 
     def categorical(self) -> PandasSelector:

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -225,10 +225,7 @@ class PandasLikeSeries(CompliantSeries):
         s.name = self.name
         return self._from_native_series(s)
 
-    def cast(
-        self,
-        dtype: Any,
-    ) -> Self:
+    def cast(self, dtype: Any) -> Self:
         ser = self._native_series
         dtype = narwhals_to_native_dtype(
             dtype, ser.dtype, self._implementation, self._backend_version, self._version
@@ -829,8 +826,7 @@ class PandasLikeSeries(CompliantSeries):
             )
         if not has_missing and str(s.dtype) in PANDAS_TO_NUMPY_DTYPE_NO_MISSING:
             return s.to_numpy(
-                dtype=dtype or PANDAS_TO_NUMPY_DTYPE_NO_MISSING[str(s.dtype)],
-                copy=copy,
+                dtype=dtype or PANDAS_TO_NUMPY_DTYPE_NO_MISSING[str(s.dtype)], copy=copy
             )
         return s.to_numpy(dtype=dtype, copy=copy)
 
@@ -913,9 +909,7 @@ class PandasLikeSeries(CompliantSeries):
         value_name_ = name or ("proportion" if normalize else "count")
 
         val_count = self._native_series.value_counts(
-            dropna=False,
-            sort=False,
-            normalize=normalize,
+            dropna=False, sort=False, normalize=normalize
         ).reset_index()
 
         val_count.columns = [index_name_, value_name_]
@@ -1056,11 +1050,7 @@ class PandasLikeSeries(CompliantSeries):
         return self._from_native_series(result)
 
     def rolling_sum(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool
     ) -> Self:
         result = self._native_series.rolling(
             window=window_size, min_periods=min_periods, center=center
@@ -1068,11 +1058,7 @@ class PandasLikeSeries(CompliantSeries):
         return self._from_native_series(result)
 
     def rolling_mean(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool
     ) -> Self:
         result = self._native_series.rolling(
             window=window_size, min_periods=min_periods, center=center
@@ -1080,12 +1066,7 @@ class PandasLikeSeries(CompliantSeries):
         return self._from_native_series(result)
 
     def rolling_var(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
-        ddof: int,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool, ddof: int
     ) -> Self:
         result = self._native_series.rolling(
             window=window_size, min_periods=min_periods, center=center
@@ -1093,12 +1074,7 @@ class PandasLikeSeries(CompliantSeries):
         return self._from_native_series(result)
 
     def rolling_std(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
-        ddof: int,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool, ddof: int
     ) -> Self:
         result = self._native_series.rolling(
             window=window_size, min_periods=min_periods, center=center
@@ -1161,10 +1137,7 @@ class PandasLikeSeries(CompliantSeries):
 
         else:
             ranked_series = native_series.rank(
-                method=pd_method,
-                na_option="keep",
-                ascending=not descending,
-                pct=False,
+                method=pd_method, na_option="keep", ascending=not descending, pct=False
             )
 
         return self._from_native_series(ranked_series)
@@ -1212,7 +1185,7 @@ class PandasLikeSeriesStringNamespace:
         return self._compliant_series._from_native_series(
             self._compliant_series._native_series.str.replace(
                 pat=pattern, repl=value, n=n, regex=not literal
-            ),
+            )
         )
 
     def replace_all(
@@ -1245,7 +1218,7 @@ class PandasLikeSeriesStringNamespace:
     def slice(self, offset: int, length: int | None = None) -> PandasLikeSeries:
         stop = offset + length if length else None
         return self._compliant_series._from_native_series(
-            self._compliant_series._native_series.str.slice(start=offset, stop=stop),
+            self._compliant_series._native_series.str.slice(start=offset, stop=stop)
         )
 
     def to_datetime(self: Self, format: str | None) -> PandasLikeSeries:  # noqa: A002

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -151,10 +151,7 @@ class PandasLikeSeries(CompliantSeries):
     ) -> Self:
         return cls(
             native_series_from_iterable(
-                data,
-                name=name,
-                index=index,
-                implementation=implementation,
+                data, name=name, index=index, implementation=implementation
             ),
             implementation=implementation,
             backend_version=backend_version,
@@ -1195,17 +1192,17 @@ class PandasLikeSeriesStringNamespace:
 
     def strip_chars(self, characters: str | None) -> PandasLikeSeries:
         return self._compliant_series._from_native_series(
-            self._compliant_series._native_series.str.strip(characters),
+            self._compliant_series._native_series.str.strip(characters)
         )
 
     def starts_with(self, prefix: str) -> PandasLikeSeries:
         return self._compliant_series._from_native_series(
-            self._compliant_series._native_series.str.startswith(prefix),
+            self._compliant_series._native_series.str.startswith(prefix)
         )
 
     def ends_with(self, suffix: str) -> PandasLikeSeries:
         return self._compliant_series._from_native_series(
-            self._compliant_series._native_series.str.endswith(suffix),
+            self._compliant_series._native_series.str.endswith(suffix)
         )
 
     def contains(self, pattern: str, *, literal: bool = False) -> PandasLikeSeries:
@@ -1230,12 +1227,12 @@ class PandasLikeSeriesStringNamespace:
 
     def to_uppercase(self) -> PandasLikeSeries:
         return self._compliant_series._from_native_series(
-            self._compliant_series._native_series.str.upper(),
+            self._compliant_series._native_series.str.upper()
         )
 
     def to_lowercase(self) -> PandasLikeSeries:
         return self._compliant_series._from_native_series(
-            self._compliant_series._native_series.str.lower(),
+            self._compliant_series._native_series.str.lower()
         )
 
 
@@ -1245,7 +1242,7 @@ class PandasLikeSeriesDateTimeNamespace:
 
     def date(self) -> PandasLikeSeries:
         result = self._compliant_series._from_native_series(
-            self._compliant_series._native_series.dt.date,
+            self._compliant_series._native_series.dt.date
         )
         if str(result.dtype).lower() == "object":
             msg = (
@@ -1260,32 +1257,32 @@ class PandasLikeSeriesDateTimeNamespace:
 
     def year(self) -> PandasLikeSeries:
         return self._compliant_series._from_native_series(
-            self._compliant_series._native_series.dt.year,
+            self._compliant_series._native_series.dt.year
         )
 
     def month(self) -> PandasLikeSeries:
         return self._compliant_series._from_native_series(
-            self._compliant_series._native_series.dt.month,
+            self._compliant_series._native_series.dt.month
         )
 
     def day(self) -> PandasLikeSeries:
         return self._compliant_series._from_native_series(
-            self._compliant_series._native_series.dt.day,
+            self._compliant_series._native_series.dt.day
         )
 
     def hour(self) -> PandasLikeSeries:
         return self._compliant_series._from_native_series(
-            self._compliant_series._native_series.dt.hour,
+            self._compliant_series._native_series.dt.hour
         )
 
     def minute(self) -> PandasLikeSeries:
         return self._compliant_series._from_native_series(
-            self._compliant_series._native_series.dt.minute,
+            self._compliant_series._native_series.dt.minute
         )
 
     def second(self) -> PandasLikeSeries:
         return self._compliant_series._from_native_series(
-            self._compliant_series._native_series.dt.second,
+            self._compliant_series._native_series.dt.second
         )
 
     def millisecond(self) -> PandasLikeSeries:
@@ -1335,7 +1332,7 @@ class PandasLikeSeriesDateTimeNamespace:
     def weekday(self) -> PandasLikeSeries:
         return (
             self._compliant_series._from_native_series(
-                self._compliant_series._native_series.dt.weekday,
+                self._compliant_series._native_series.dt.weekday
             )
             + 1  # Pandas is 0-6 while Polars is 1-7
         )

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -295,10 +295,7 @@ def diagonal_concat(
 
 
 def native_series_from_iterable(
-    data: Iterable[Any],
-    name: str,
-    index: Any,
-    implementation: Implementation,
+    data: Iterable[Any], name: str, index: Any, implementation: Implementation
 ) -> Any:
     """Return native series."""
     if implementation in PANDAS_LIKE_IMPLEMENTATION:

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -679,10 +679,7 @@ def narwhals_to_native_dtype(  # noqa: PLR0915
                     [
                         (
                             field.name,
-                            arrow_narwhals_to_native_dtype(
-                                field.dtype,
-                                version=version,
-                            ),
+                            arrow_narwhals_to_native_dtype(field.dtype, version=version),
                         )
                         for field in dtype.fields  # type: ignore[union-attr]
                     ]

--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -434,9 +434,7 @@ class PolarsLazyFrame:
             raise ColumnNotFoundError(str(e)) from e
 
         return PolarsDataFrame(
-            result,
-            backend_version=self._backend_version,
-            version=self._version,
+            result, backend_version=self._backend_version, version=self._version
         )
 
     def group_by(self: Self, *by: str, drop_null_keys: bool) -> PolarsLazyGroupBy:

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -97,10 +97,7 @@ class PolarsExpr:
 
         return self._from_native_expr(
             self._native_expr.rolling_var(
-                window_size=window_size,
-                min_periods=min_periods,
-                center=center,
-                ddof=ddof,
+                window_size=window_size, min_periods=min_periods, center=center, ddof=ddof
             )
         )
 
@@ -113,10 +110,7 @@ class PolarsExpr:
 
         return self._from_native_expr(
             self._native_expr.rolling_std(
-                window_size=window_size,
-                min_periods=min_periods,
-                center=center,
-                ddof=ddof,
+                window_size=window_size, min_periods=min_periods, center=center, ddof=ddof
             )
         )
 

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -89,12 +89,7 @@ class PolarsExpr:
         return self._from_native_expr(self._native_expr.is_nan())
 
     def rolling_var(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
-        ddof: int,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool, ddof: int
     ) -> Self:
         if self._backend_version < (1,):  # pragma: no cover
             msg = "`rolling_var` not implemented for polars older than 1.0"
@@ -110,12 +105,7 @@ class PolarsExpr:
         )
 
     def rolling_std(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
-        ddof: int,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool, ddof: int
     ) -> Self:
         if self._backend_version < (1,):  # pragma: no cover
             msg = "`rolling_std` not implemented for polars older than 1.0"
@@ -131,9 +121,7 @@ class PolarsExpr:
         )
 
     def map_batches(
-        self,
-        function: Callable[..., Self],
-        return_dtype: DType | None,
+        self, function: Callable[..., Self], return_dtype: DType | None
     ) -> Self:
         if return_dtype is not None:
             return_dtype_pl = narwhals_to_native_dtype(return_dtype, self._version)

--- a/narwhals/_polars/group_by.py
+++ b/narwhals/_polars/group_by.py
@@ -27,7 +27,7 @@ class PolarsGroupBy:
     def agg(self: Self, *aggs: PolarsExpr, **named_aggs: PolarsExpr) -> PolarsDataFrame:
         aggs, named_aggs = extract_args_kwargs(aggs, named_aggs)  # type: ignore[assignment]
         return self._compliant_frame._from_native_frame(
-            self._grouped.agg(*aggs, **named_aggs),
+            self._grouped.agg(*aggs, **named_aggs)
         )
 
     def __iter__(self: Self) -> Iterator[tuple[tuple[str, ...], PolarsDataFrame]]:
@@ -49,5 +49,5 @@ class PolarsLazyGroupBy:
     def agg(self: Self, *aggs: PolarsExpr, **named_aggs: PolarsExpr) -> PolarsLazyFrame:
         aggs, named_aggs = extract_args_kwargs(aggs, named_aggs)  # type: ignore[assignment]
         return self._compliant_frame._from_native_frame(
-            self._grouped.agg(*aggs, **named_aggs),
+            self._grouped.agg(*aggs, **named_aggs)
         )

--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -199,11 +199,7 @@ class PolarsNamespace:
             )
 
         return PolarsExpr(
-            pl.concat_str(
-                pl_exprs,
-                separator=separator,
-                ignore_nulls=ignore_nulls,
-            ),
+            pl.concat_str(pl_exprs, separator=separator, ignore_nulls=ignore_nulls),
             version=self._version,
             backend_version=self._backend_version,
         )

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -308,10 +308,7 @@ class PolarsSeries:
 
         return self._from_native_series(
             self._native_series.rolling_var(
-                window_size=window_size,
-                min_periods=min_periods,
-                center=center,
-                ddof=ddof,
+                window_size=window_size, min_periods=min_periods, center=center, ddof=ddof
             )
         )
 
@@ -324,10 +321,7 @@ class PolarsSeries:
 
         return self._from_native_series(
             self._native_series.rolling_std(
-                window_size=window_size,
-                min_periods=min_periods,
-                center=center,
-                ddof=ddof,
+                window_size=window_size, min_periods=min_periods, center=center, ddof=ddof
             )
         )
 

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -300,12 +300,7 @@ class PolarsSeries:
         return self._from_native_series(native_result)
 
     def rolling_var(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
-        ddof: int,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool, ddof: int
     ) -> Self:
         if self._backend_version < (1,):  # pragma: no cover
             msg = "`rolling_var` not implemented for polars older than 1.0"
@@ -321,12 +316,7 @@ class PolarsSeries:
         )
 
     def rolling_std(
-        self: Self,
-        window_size: int,
-        *,
-        min_periods: int | None,
-        center: bool,
-        ddof: int,
+        self: Self, window_size: int, *, min_periods: int | None, center: bool, ddof: int
     ) -> Self:
         if self._backend_version < (1,):  # pragma: no cover
             msg = "`rolling_std` not implemented for polars older than 1.0"
@@ -364,12 +354,7 @@ class PolarsSeries:
         return self._from_native_series(s)
 
     def value_counts(
-        self: Self,
-        *,
-        sort: bool,
-        parallel: bool,
-        name: str | None,
-        normalize: bool,
+        self: Self, *, sort: bool, parallel: bool, name: str | None, normalize: bool
     ) -> PolarsDataFrame:
         from narwhals._polars.dataframe import PolarsDataFrame
 

--- a/narwhals/_polars/utils.py
+++ b/narwhals/_polars/utils.py
@@ -67,9 +67,7 @@ def extract_args_kwargs(args: Any, kwargs: Any) -> tuple[list[Any], dict[str, An
 
 @lru_cache(maxsize=16)
 def native_to_narwhals_dtype(
-    dtype: pl.DataType,
-    version: Version,
-    backend_version: tuple[int, ...],
+    dtype: pl.DataType, version: Version, backend_version: tuple[int, ...]
 ) -> DType:
     import polars as pl
 

--- a/narwhals/_polars/utils.py
+++ b/narwhals/_polars/utils.py
@@ -198,8 +198,7 @@ def narwhals_to_native_dtype(dtype: DType | type[DType], version: Version) -> pl
         return pl.Struct(
             fields=[
                 pl.Field(
-                    name=field.name,
-                    dtype=narwhals_to_native_dtype(field.dtype, version),
+                    name=field.name, dtype=narwhals_to_native_dtype(field.dtype, version)
                 )
                 for field in dtype.fields  # type: ignore[union-attr]
             ]

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -84,9 +84,7 @@ class SparkLikeLazyFrame:
         )
 
     def select(
-        self: Self,
-        *exprs: IntoSparkLikeExpr,
-        **named_exprs: IntoSparkLikeExpr,
+        self: Self, *exprs: IntoSparkLikeExpr, **named_exprs: IntoSparkLikeExpr
     ) -> Self:
         if exprs and all(isinstance(x, str) for x in exprs) and not named_exprs:
             # This is a simple select
@@ -127,9 +125,7 @@ class SparkLikeLazyFrame:
         return self.schema
 
     def with_columns(
-        self: Self,
-        *exprs: IntoSparkLikeExpr,
-        **named_exprs: IntoSparkLikeExpr,
+        self: Self, *exprs: IntoSparkLikeExpr, **named_exprs: IntoSparkLikeExpr
     ) -> Self:
         new_columns_map = parse_exprs_and_named_exprs(self, *exprs, **named_exprs)
         return self._from_native_frame(self._native_frame.withColumns(new_columns_map))
@@ -195,10 +191,7 @@ class SparkLikeLazyFrame:
         )
 
     def unique(
-        self: Self,
-        subset: str | list[str] | None = None,
-        *,
-        keep: Literal["any", "none"],
+        self: Self, subset: str | list[str] | None = None, *, keep: Literal["any", "none"]
     ) -> Self:
         if keep != "any":
             msg = "`LazyFrame.unique` with PySpark backend only supports `keep='any'`."

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -244,9 +244,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         return self._from_call(func, "var", returns_scalar=True, ddof=ddof)
 
     def clip(
-        self,
-        lower_bound: Any | None = None,
-        upper_bound: Any | None = None,
+        self, lower_bound: Any | None = None, upper_bound: Any | None = None
     ) -> Self:
         def _clip(_input: Column, lower_bound: Any, upper_bound: Any) -> Column:
             from pyspark.sql import functions as F  # noqa: N812
@@ -272,12 +270,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             returns_scalar=self._returns_scalar,
         )
 
-    def is_between(
-        self,
-        lower_bound: Any,
-        upper_bound: Any,
-        closed: str,
-    ) -> Self:
+    def is_between(self, lower_bound: Any, upper_bound: Any, closed: str) -> Self:
         def _is_between(_input: Column, lower_bound: Any, upper_bound: Any) -> Column:
             if closed == "both":
                 return (_input >= lower_bound) & (_input <= upper_bound)
@@ -328,10 +321,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             return _input.isin(values)
 
         return self._from_call(
-            _is_in,
-            "is_in",
-            values=values,
-            returns_scalar=self._returns_scalar,
+            _is_in, "is_in", values=values, returns_scalar=self._returns_scalar
         )
 
     def is_unique(self) -> Self:
@@ -362,10 +352,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             return F.round(_input, decimals)
 
         return self._from_call(
-            _round,
-            "round",
-            decimals=decimals,
-            returns_scalar=self._returns_scalar,
+            _round, "round", decimals=decimals, returns_scalar=self._returns_scalar
         )
 
     def skew(self) -> Self:

--- a/narwhals/_spark_like/group_by.py
+++ b/narwhals/_spark_like/group_by.py
@@ -43,14 +43,10 @@ class SparkLikeLazyGroupBy:
             self._grouped = self._df._native_frame.groupBy(*self._keys)
 
     def agg(
-        self,
-        *aggs: IntoSparkLikeExpr,
-        **named_aggs: IntoSparkLikeExpr,
+        self, *aggs: IntoSparkLikeExpr, **named_aggs: IntoSparkLikeExpr
     ) -> SparkLikeLazyFrame:
         exprs = parse_into_exprs(
-            *aggs,
-            namespace=self._df.__narwhals_namespace__(),
-            **named_aggs,
+            *aggs, namespace=self._df.__narwhals_namespace__(), **named_aggs
         )
         output_names: list[str] = copy(self._keys)
         for expr in exprs:
@@ -64,12 +60,7 @@ class SparkLikeLazyGroupBy:
 
             output_names.extend(expr._output_names)
 
-        return agg_pyspark(
-            self._grouped,
-            exprs,
-            self._keys,
-            self._from_native_frame,
-        )
+        return agg_pyspark(self._grouped, exprs, self._keys, self._from_native_frame)
 
     def _from_native_frame(self, df: SparkLikeLazyFrame) -> SparkLikeLazyFrame:
         from narwhals._spark_like.dataframe import SparkLikeLazyFrame

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -76,10 +76,9 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             cols = [c for _expr in parsed_exprs for c in _expr(df)]
             col_name = get_column_name(df, cols[0])
             return [
-                reduce(
-                    operator.add,
-                    (F.coalesce(col, F.lit(0)) for col in cols),
-                ).alias(col_name)
+                reduce(operator.add, (F.coalesce(col, F.lit(0)) for col in cols)).alias(
+                    col_name
+                )
             ]
 
         return SparkLikeExpr(  # type: ignore[abstract]

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -19,8 +19,7 @@ if TYPE_CHECKING:
 
 @lru_cache(maxsize=16)
 def native_to_narwhals_dtype(
-    dtype: pyspark_types.DataType,
-    version: Version,
+    dtype: pyspark_types.DataType, version: Version
 ) -> DType:  # pragma: no cover
     dtypes = import_dtypes_module(version=version)
     from pyspark.sql import types as pyspark_types

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -45,10 +45,7 @@ def native_to_narwhals_dtype(
         return dtypes.Boolean()
     if isinstance(dtype, pyspark_types.DateType):
         return dtypes.Date()
-    datetime_types = [
-        pyspark_types.TimestampType,
-        pyspark_types.TimestampNTZType,
-    ]
+    datetime_types = [pyspark_types.TimestampType, pyspark_types.TimestampNTZType]
     if any(isinstance(dtype, t) for t in datetime_types):
         return dtypes.Datetime()
     if isinstance(dtype, pyspark_types.DecimalType):  # pragma: no cover

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -101,13 +101,11 @@ class BaseFrame(Generic[FrameT]):
         return function(self, *args, **kwargs)
 
     def with_row_index(self, name: str = "index") -> Self:
-        return self._from_compliant_dataframe(
-            self._compliant_frame.with_row_index(name),
-        )
+        return self._from_compliant_dataframe(self._compliant_frame.with_row_index(name))
 
     def drop_nulls(self: Self, subset: str | list[str] | None = None) -> Self:
         return self._from_compliant_dataframe(
-            self._compliant_frame.drop_nulls(subset=subset),
+            self._compliant_frame.drop_nulls(subset=subset)
         )
 
     @property
@@ -293,10 +291,7 @@ class BaseFrame(Generic[FrameT]):
     ) -> Self:
         return self._from_compliant_dataframe(
             self._compliant_frame.unpivot(
-                on=on,
-                index=index,
-                variable_name=variable_name,
-                value_name=value_name,
+                on=on, index=index, variable_name=variable_name, value_name=value_name
             )
         )
 
@@ -324,10 +319,7 @@ class BaseFrame(Generic[FrameT]):
 
     def explode(self: Self, columns: str | Sequence[str], *more_columns: str) -> Self:
         return self._from_compliant_dataframe(
-            self._compliant_frame.explode(
-                columns,
-                *more_columns,
-            )
+            self._compliant_frame.explode(columns, *more_columns)
         )
 
 
@@ -816,11 +808,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import pyarrow as pa
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoDataFrameT
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6.0, 7.0, 8.0],
-            ...     "ham": ["a", "b", "c"],
-            ... }
+            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
@@ -1304,11 +1292,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import narwhals as nw
             >>> from narwhals.schema import Schema
             >>> from narwhals.typing import IntoFrame
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6.0, 7.0, 8.0],
-            ...     "ham": ["a", "b", "c"],
-            ... }
+            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
@@ -1344,11 +1328,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import narwhals as nw
             >>> from narwhals.schema import Schema
             >>> from narwhals.typing import IntoFrame
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6.0, 7.0, 8.0],
-            ...     "ham": ["a", "b", "c"],
-            ... }
+            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
@@ -1635,11 +1615,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import pyarrow as pa
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6, 7, 8],
-            ...     "ham": ["a", "b", "c"],
-            ... }
+            >>> data = {"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]}
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
@@ -2137,11 +2113,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import pyarrow as pa
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6, 7, 8],
-            ...     "ham": ["a", "b", "c"],
-            ... }
+            >>> data = {"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]}
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
@@ -2242,8 +2214,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> def agnostic_filter(df_native: IntoFrameT) -> IntoFrameT:
             ...     df = nw.from_native(df_native)
             ...     dframe = df.filter(
-            ...         nw.col("foo") <= 2,
-            ...         ~nw.col("ham").is_in(["b", "c"]),
+            ...         nw.col("foo") <= 2, ~nw.col("ham").is_in(["b", "c"])
             ...     ).to_native()
             ...     return dframe
             >>> agnostic_filter(df_pd)
@@ -2436,11 +2407,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import pyarrow as pa
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "a": [1, 2, None],
-            ...     "b": [6.0, 5.0, 4.0],
-            ...     "c": ["a", "c", "b"],
-            ... }
+            >>> data = {"a": [1, 2, None], "b": [6.0, 5.0, 4.0], "c": ["a", "c", "b"]}
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
@@ -2519,15 +2486,8 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import pyarrow as pa
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6.0, 7.0, 8.0],
-            ...     "ham": ["a", "b", "c"],
-            ... }
-            >>> data_other = {
-            ...     "apple": ["x", "y", "z"],
-            ...     "ham": ["a", "b", "d"],
-            ... }
+            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
+            >>> data_other = {"apple": ["x", "y", "z"], "ham": ["a", "b", "d"]}
 
             >>> df_pd = pd.DataFrame(data)
             >>> other_pd = pd.DataFrame(data_other)
@@ -2784,10 +2744,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoDataFrame
             >>> from narwhals.typing import IntoSeries
-            >>> data = {
-            ...     "a": [1, 2, 3, 1],
-            ...     "b": ["x", "y", "z", "x"],
-            ... }
+            >>> data = {"a": [1, 2, 3, 1], "b": ["x", "y", "z", "x"]}
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
@@ -2882,10 +2839,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoDataFrame
             >>> from narwhals.typing import IntoSeries
-            >>> data = {
-            ...     "a": [1, 2, 3, 1],
-            ...     "b": ["x", "y", "z", "x"],
-            ... }
+            >>> data = {"a": [1, 2, 3, 1], "b": ["x", "y", "z", "x"]}
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
@@ -2945,11 +2899,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import pyarrow as pa
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "foo": [1, None, 3],
-            ...     "bar": [6, 7, None],
-            ...     "ham": ["a", "b", "c"],
-            ... }
+            >>> data = {"foo": [1, None, 3], "bar": [6, 7, None], "ham": ["a", "b", "c"]}
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
@@ -3399,11 +3349,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import pyarrow as pa
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "a": ["x", "y", "z"],
-            ...     "b": [1, 3, 5],
-            ...     "c": [2, 4, 6],
-            ... }
+            >>> data = {"a": ["x", "y", "z"], "b": [1, 3, 5], "c": [2, 4, 6]}
 
             We define a library agnostic function:
 
@@ -3831,11 +3777,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import polars as pl
             >>> import dask.dataframe as dd
             >>> import narwhals as nw
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6.0, 7.0, 8.0],
-            ...     "ham": ["a", "b", "c"],
-            ... }
+            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
             >>> lf_pl = pl.LazyFrame(data)
             >>> lf_dask = dd.from_dict(data, npartitions=2)
 
@@ -3859,11 +3801,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import polars as pl
             >>> import dask.dataframe as dd
             >>> import narwhals as nw
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6.0, 7.0, 8.0],
-            ...     "ham": ["a", "b", "c"],
-            ... }
+            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
             >>> lf_pl = pl.LazyFrame(data)
             >>> lf_dask = dd.from_dict(data, npartitions=2)
 
@@ -4003,11 +3941,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoFrameT
             >>>
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6, 7, 8],
-            ...     "ham": ["a", "b", "c"],
-            ... }
+            >>> data = {"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]}
             >>> lf_pl = pl.LazyFrame(data)
             >>> lf_dask = dd.from_dict(data, npartitions=2)
 
@@ -4172,10 +4106,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import dask.dataframe as dd
             >>> from narwhals.typing import IntoFrameT
             >>>
-            >>> data = {
-            ...     "a": [1, 2, 3, 4, 5, 6],
-            ...     "b": [7, 8, 9, 10, 11, 12],
-            ... }
+            >>> data = {"a": [1, 2, 3, 4, 5, 6], "b": [7, 8, 9, 10, 11, 12]}
             >>> lf_pl = pl.LazyFrame(data)
             >>> lf_dask = dd.from_dict(data, npartitions=2)
 
@@ -4225,10 +4156,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import dask.dataframe as dd
             >>> from narwhals.typing import IntoFrameT
             >>>
-            >>> data = {
-            ...     "a": [1, 2, 3, 4, 5, 6],
-            ...     "b": [7, 8, 9, 10, 11, 12],
-            ... }
+            >>> data = {"a": [1, 2, 3, 4, 5, 6], "b": [7, 8, 9, 10, 11, 12]}
             >>> lf_pl = pl.LazyFrame(data)
             >>> lf_dask = dd.from_dict(data, npartitions=1)
 
@@ -4437,11 +4365,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoFrameT
             >>>
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6, 7, 8],
-            ...     "ham": ["a", "b", "c"],
-            ... }
+            >>> data = {"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]}
             >>> lf_pl = pl.LazyFrame(data)
             >>> lf_dask = dd.from_dict(data, npartitions=2)
 
@@ -4497,10 +4421,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> def agnostic_filter(df_native: IntoFrameT) -> IntoFrameT:
             ...     df = nw.from_native(df_native)
             ...     return (
-            ...         df.filter(
-            ...             nw.col("foo") == 1,
-            ...             nw.col("ham") == "a",
-            ...         )
+            ...         df.filter(nw.col("foo") == 1, nw.col("ham") == "a")
             ...         .collect()
             ...         .to_native()
             ...     )
@@ -4712,11 +4633,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import dask.dataframe as dd
             >>> from narwhals.typing import IntoFrameT
             >>>
-            >>> data = {
-            ...     "a": [1, 2, None],
-            ...     "b": [6.0, 5.0, 4.0],
-            ...     "c": ["a", "c", "b"],
-            ... }
+            >>> data = {"a": [1, 2, None], "b": [6.0, 5.0, 4.0], "c": ["a", "c", "b"]}
             >>> lf_pl = pl.LazyFrame(data)
             >>> lf_dask = dd.from_dict(data, npartitions=2)
 
@@ -4784,15 +4701,8 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import dask.dataframe as dd
             >>> from narwhals.typing import IntoFrameT
             >>>
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6.0, 7.0, 8.0],
-            ...     "ham": ["a", "b", "c"],
-            ... }
-            >>> data_other = {
-            ...     "apple": ["x", "y", "z"],
-            ...     "ham": ["a", "b", "d"],
-            ... }
+            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
+            >>> data_other = {"apple": ["x", "y", "z"], "ham": ["a", "b", "d"]}
 
             >>> lf_pl = pl.LazyFrame(data)
             >>> other_pl = pl.LazyFrame(data_other)
@@ -4802,8 +4712,7 @@ class LazyFrame(BaseFrame[FrameT]):
             Let's define a dataframe-agnostic function in which we join over "ham" column:
 
             >>> def agnostic_join_on_ham(
-            ...     df_native: IntoFrameT,
-            ...     other_native: IntoFrameT,
+            ...     df_native: IntoFrameT, other_native: IntoFrameT
             ... ) -> IntoFrameT:
             ...     df = nw.from_native(df_native)
             ...     other = nw.from_native(other_native)
@@ -4995,8 +4904,7 @@ class LazyFrame(BaseFrame[FrameT]):
             Let's define a dataframe-agnostic function in which we join over "datetime" and by "ticker" columns:
 
             >>> def agnostic_join_asof_datetime_by_ticker(
-            ...     df_native: IntoFrameT,
-            ...     other_native: IntoFrameT,
+            ...     df_native: IntoFrameT, other_native: IntoFrameT
             ... ) -> IntoFrameT:
             ...     df = nw.from_native(df_native)
             ...     other = nw.from_native(other_native)
@@ -5199,11 +5107,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import dask.dataframe as dd
             >>> from narwhals.typing import IntoFrameT
             >>>
-            >>> data = {
-            ...     "a": ["x", "y", "z"],
-            ...     "b": [1, 3, 5],
-            ...     "c": [2, 4, 6],
-            ... }
+            >>> data = {"a": ["x", "y", "z"], "b": [1, 3, 5], "c": [2, 4, 6]}
             >>> lf_pl = pl.LazyFrame(data)
             >>> lf_dask = dd.from_dict(data, npartitions=2)
 

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -59,8 +59,7 @@ class BaseFrame(Generic[FrameT]):
     def _from_compliant_dataframe(self, df: Any) -> Self:
         # construct, preserving properties
         return self.__class__(  # type: ignore[call-arg]
-            df,
-            level=self._level,
+            df, level=self._level
         )
 
     def _flatten_and_extract(self, *args: Any, **kwargs: Any) -> Any:
@@ -120,17 +119,15 @@ class BaseFrame(Generic[FrameT]):
     ) -> Self:
         exprs, named_exprs = self._flatten_and_extract(*exprs, **named_exprs)
         return self._from_compliant_dataframe(
-            self._compliant_frame.with_columns(*exprs, **named_exprs),
+            self._compliant_frame.with_columns(*exprs, **named_exprs)
         )
 
     def select(
-        self,
-        *exprs: IntoExpr | Iterable[IntoExpr],
-        **named_exprs: IntoExpr,
+        self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
     ) -> Self:
         exprs, named_exprs = self._flatten_and_extract(*exprs, **named_exprs)
         return self._from_compliant_dataframe(
-            self._compliant_frame.select(*exprs, **named_exprs),
+            self._compliant_frame.select(*exprs, **named_exprs)
         )
 
     def rename(self, mapping: dict[str, str]) -> Self:
@@ -159,7 +156,7 @@ class BaseFrame(Generic[FrameT]):
                 *predicates, **constraints
             )
         return self._from_compliant_dataframe(
-            self._compliant_frame.filter(*predicates, **constraints),
+            self._compliant_frame.filter(*predicates, **constraints)
         )
 
     def sort(
@@ -369,12 +366,7 @@ class DataFrame(BaseFrame[DataFrameT]):
     def _lazyframe(self) -> type[LazyFrame[Any]]:
         return LazyFrame
 
-    def __init__(
-        self,
-        df: Any,
-        *,
-        level: Literal["full", "lazy", "interchange"],
-    ) -> None:
+    def __init__(self, df: Any, *, level: Literal["full", "lazy", "interchange"]) -> None:
         self._level: Literal["full", "lazy", "interchange"] = level
         if hasattr(df, "__narwhals_dataframe__"):
             self._compliant_frame: Any = df.__narwhals_dataframe__()
@@ -804,10 +796,7 @@ class DataFrame(BaseFrame[DataFrameT]):
               ]
             ]
         """
-        return self._series(
-            self._compliant_frame.get_column(name),
-            level=self._level,
-        )
+        return self._series(self._compliant_frame.get_column(name), level=self._level)
 
     def estimated_size(self, unit: SizeUnit = "b") -> int | float:
         """Return an estimation of the total (heap) allocated size of the `DataFrame`.
@@ -1002,10 +991,7 @@ class DataFrame(BaseFrame[DataFrameT]):
                 return self
             return self._from_compliant_dataframe(self._compliant_frame[item])
         if isinstance(item, str) or (isinstance(item, tuple) and len(item) == 2):
-            return self._series(
-                self._compliant_frame[item],
-                level=self._level,
-            )
+            return self._series(self._compliant_frame[item], level=self._level)
 
         elif (
             is_sequence_but_not_str(item)
@@ -1077,10 +1063,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         """
         if as_series:
             return {
-                key: self._series(
-                    value,
-                    level=self._level,
-                )
+                key: self._series(value, level=self._level)
                 for key, value in self._compliant_frame.to_dict(
                     as_series=as_series
                 ).items()
@@ -1631,9 +1614,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         return super().with_columns(*exprs, **named_exprs)
 
     def select(
-        self,
-        *exprs: IntoExpr | Iterable[IntoExpr],
-        **named_exprs: IntoExpr,
+        self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
     ) -> Self:
         r"""Select columns from this DataFrame.
 
@@ -2847,10 +2828,7 @@ class DataFrame(BaseFrame[DataFrameT]):
               ]
             ]
         """
-        return self._series(
-            self._compliant_frame.is_duplicated(),
-            level=self._level,
-        )
+        return self._series(self._compliant_frame.is_duplicated(), level=self._level)
 
     def is_empty(self: Self) -> bool:
         r"""Check if the dataframe is empty.
@@ -2948,10 +2926,7 @@ class DataFrame(BaseFrame[DataFrameT]):
               ]
             ]
         """
-        return self._series(
-            self._compliant_frame.is_unique(),
-            level=self._level,
-        )
+        return self._series(self._compliant_frame.is_unique(), level=self._level)
 
     def null_count(self: Self) -> Self:
         r"""Create a new DataFrame that shows the null counts per column.
@@ -3557,12 +3532,7 @@ class LazyFrame(BaseFrame[FrameT]):
     def _dataframe(self) -> type[DataFrame[Any]]:
         return DataFrame
 
-    def __init__(
-        self,
-        df: Any,
-        *,
-        level: Literal["full", "lazy", "interchange"],
-    ) -> None:
+    def __init__(self, df: Any, *, level: Literal["full", "lazy", "interchange"]) -> None:
         self._level = level
         if hasattr(df, "__narwhals_lazyframe__"):
             self._compliant_frame: Any = df.__narwhals_lazyframe__()
@@ -3669,10 +3639,7 @@ class LazyFrame(BaseFrame[FrameT]):
             1  b  11  10
             2  c   6   1
         """
-        return self._dataframe(
-            self._compliant_frame.collect(),
-            level="full",
-        )
+        return self._dataframe(self._compliant_frame.collect(), level="full")
 
     def to_native(self) -> FrameT:
         """Convert Narwhals LazyFrame to native one.
@@ -4011,9 +3978,7 @@ class LazyFrame(BaseFrame[FrameT]):
         return super().with_columns(*exprs, **named_exprs)
 
     def select(
-        self,
-        *exprs: IntoExpr | Iterable[IntoExpr],
-        **named_exprs: IntoExpr,
+        self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
     ) -> Self:
         r"""Select columns from this LazyFrame.
 

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -498,10 +498,7 @@ class Duration(TemporalType):
         Duration(time_unit='ms')
     """
 
-    def __init__(
-        self: Self,
-        time_unit: Literal["us", "ns", "ms", "s"] = "us",
-    ) -> None:
+    def __init__(self: Self, time_unit: Literal["us", "ns", "ms", "s"] = "us") -> None:
         if time_unit not in ("s", "ms", "us", "ns"):
             msg = (
                 "invalid `time_unit`"

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -811,9 +811,7 @@ class Expr:
         return self.__class__(lambda plx: self._to_compliant_expr(plx).var(ddof=ddof))
 
     def map_batches(
-        self,
-        function: Callable[[Any], Self],
-        return_dtype: DType | None = None,
+        self, function: Callable[[Any], Self], return_dtype: DType | None = None
     ) -> Self:
         """Apply a custom python function to a whole Series or sequence of Series.
 

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -220,9 +220,7 @@ class Expr:
             bar: [[6,7,8]]
         """
         _validate_dtype(dtype)
-        return self.__class__(
-            lambda plx: self._to_compliant_expr(plx).cast(dtype),
-        )
+        return self.__class__(lambda plx: self._to_compliant_expr(plx).cast(dtype))
 
     # --- binary ---
     def __eq__(self, other: object) -> Self:  # type: ignore[override]
@@ -1991,7 +1989,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).filter(
-                *[extract_compliant(plx, pred) for pred in flatten(predicates)],
+                *[extract_compliant(plx, pred) for pred in flatten(predicates)]
             )
         )
 
@@ -2014,15 +2012,9 @@ class Expr:
             >>> from narwhals.typing import IntoFrameT
             >>>
             >>> df_pd = pd.DataFrame(
-            ...     {
-            ...         "a": [2, 4, None, 3, 5],
-            ...         "b": [2.0, 4.0, float("nan"), 3.0, 5.0],
-            ...     }
+            ...     {"a": [2, 4, None, 3, 5], "b": [2.0, 4.0, float("nan"), 3.0, 5.0]}
             ... )
-            >>> data = {
-            ...     "a": [2, 4, None, 3, 5],
-            ...     "b": [2.0, 4.0, None, 3.0, 5.0],
-            ... }
+            >>> data = {"a": [2, 4, None, 3, 5], "b": [2.0, 4.0, None, 3.0, 5.0]}
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
 
@@ -2223,10 +2215,7 @@ class Expr:
             ...         "b": [2.0, 4.0, float("nan"), float("nan"), 3.0, 5.0],
             ...     }
             ... )
-            >>> data = {
-            ...     "a": [2, 4, None, None, 3, 5],
-            ...     "b": [2.0, 4.0, None, None, 3.0, 5.0],
-            ... }
+            >>> data = {"a": [2, 4, None, None, 3, 5], "b": [2.0, 4.0, None, None, 3.0, 5.0]}
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
 
@@ -3346,8 +3335,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).clip(
-                extract_compliant(plx, lower_bound),
-                extract_compliant(plx, upper_bound),
+                extract_compliant(plx, lower_bound), extract_compliant(plx, upper_bound)
             )
         )
 
@@ -3366,10 +3354,7 @@ class Expr:
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoFrameT
             >>>
-            >>> data = {
-            ...     "a": [1, 1, 2, 3],
-            ...     "b": [1, 1, 2, 2],
-            ... }
+            >>> data = {"a": [1, 1, 2, 3], "b": [1, 1, 2, 2]}
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
@@ -3821,9 +3806,7 @@ class Expr:
 
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).rolling_sum(
-                window_size=window_size,
-                min_periods=min_periods,
-                center=center,
+                window_size=window_size, min_periods=min_periods, center=center
             )
         )
 
@@ -3915,9 +3898,7 @@ class Expr:
 
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).rolling_mean(
-                window_size=window_size,
-                min_periods=min_periods,
-                center=center,
+                window_size=window_size, min_periods=min_periods, center=center
             )
         )
 
@@ -4105,10 +4086,7 @@ class Expr:
 
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).rolling_std(
-                window_size=window_size,
-                min_periods=min_periods,
-                center=center,
-                ddof=ddof,
+                window_size=window_size, min_periods=min_periods, center=center, ddof=ddof
             )
         )
 
@@ -5327,7 +5305,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             >>> def agnostic_dt_month(df_native: IntoFrameT) -> IntoFrameT:
             ...     df = nw.from_native(df_native)
             ...     return df.with_columns(
-            ...         nw.col("datetime").dt.month().alias("month"),
+            ...         nw.col("datetime").dt.month().alias("month")
             ...     ).to_native()
 
             We can then pass any supported library such as pandas, Polars, or
@@ -5395,7 +5373,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             >>> def agnostic_dt_day(df_native: IntoFrameT) -> IntoFrameT:
             ...     df = nw.from_native(df_native)
             ...     return df.with_columns(
-            ...         nw.col("datetime").dt.day().alias("day"),
+            ...         nw.col("datetime").dt.day().alias("day")
             ...     ).to_native()
 
             We can then pass any supported library such as pandas, Polars, or
@@ -5531,7 +5509,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             >>> def agnostic_dt_minute(df_native: IntoFrameT) -> IntoFrameT:
             ...     df = nw.from_native(df_native)
             ...     return df.with_columns(
-            ...         nw.col("datetime").dt.minute().alias("minute"),
+            ...         nw.col("datetime").dt.minute().alias("minute")
             ...     ).to_native()
 
             We can then pass any supported library such as pandas, Polars, or
@@ -5597,7 +5575,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             >>> def agnostic_dt_second(df_native: IntoFrameT) -> IntoFrameT:
             ...     df = nw.from_native(df_native)
             ...     return df.with_columns(
-            ...         nw.col("datetime").dt.second().alias("second"),
+            ...         nw.col("datetime").dt.second().alias("second")
             ...     ).to_native()
 
             We can then pass any supported library such as pandas, Polars, or
@@ -5663,7 +5641,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             >>> def agnostic_dt_millisecond(df_native: IntoFrameT) -> IntoFrameT:
             ...     df = nw.from_native(df_native)
             ...     return df.with_columns(
-            ...         nw.col("datetime").dt.millisecond().alias("millisecond"),
+            ...         nw.col("datetime").dt.millisecond().alias("millisecond")
             ...     ).to_native()
 
             We can then pass any supported library such as pandas, Polars, or
@@ -5729,7 +5707,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             >>> def agnostic_dt_microsecond(df_native: IntoFrameT) -> IntoFrameT:
             ...     df = nw.from_native(df_native)
             ...     return df.with_columns(
-            ...         nw.col("datetime").dt.microsecond().alias("microsecond"),
+            ...         nw.col("datetime").dt.microsecond().alias("microsecond")
             ...     ).to_native()
 
             We can then pass any supported library such as pandas, Polars, or
@@ -5795,7 +5773,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             >>> def agnostic_dt_nanosecond(df_native: IntoFrameT) -> IntoFrameT:
             ...     df = nw.from_native(df_native)
             ...     return df.with_columns(
-            ...         nw.col("datetime").dt.nanosecond().alias("nanosecond"),
+            ...         nw.col("datetime").dt.nanosecond().alias("nanosecond")
             ...     ).to_native()
 
             We can then pass any supported library such as pandas, Polars, or
@@ -6311,11 +6289,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             >>> from narwhals.typing import IntoFrameT
             >>>
             >>> data = {
-            ...     "a": [
-            ...         datetime(2020, 3, 1),
-            ...         datetime(2020, 4, 1),
-            ...         datetime(2020, 5, 1),
-            ...     ]
+            ...     "a": [datetime(2020, 3, 1), datetime(2020, 4, 1), datetime(2020, 5, 1)]
             ... }
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
@@ -7518,11 +7492,7 @@ def min_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         >>> import narwhals as nw
         >>> from narwhals.typing import IntoFrameT
         >>>
-        >>> data = {
-        ...     "a": [1, 8, 3],
-        ...     "b": [4, 5, None],
-        ...     "c": ["x", "y", "z"],
-        ... }
+        >>> data = {"a": [1, 8, 3], "b": [4, 5, None], "c": ["x", "y", "z"]}
 
         We define a dataframe-agnostic function that computes the horizontal min of "a"
         and "b" columns:
@@ -7588,11 +7558,7 @@ def max_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         >>> import narwhals as nw
         >>> from narwhals.typing import IntoFrameT
         >>>
-        >>> data = {
-        ...     "a": [1, 8, 3],
-        ...     "b": [4, 5, None],
-        ...     "c": ["x", "y", "z"],
-        ... }
+        >>> data = {"a": [1, 8, 3], "b": [4, 5, None], "c": ["x", "y", "z"]}
 
         We define a dataframe-agnostic function that computes the horizontal max of "a"
         and "b" columns:
@@ -7983,11 +7949,7 @@ def mean_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         >>> import narwhals as nw
         >>> from narwhals.typing import IntoFrameT
         >>>
-        >>> data = {
-        ...     "a": [1, 8, 3],
-        ...     "b": [4, 5, None],
-        ...     "c": ["x", "y", "z"],
-        ... }
+        >>> data = {"a": [1, 8, 3], "b": [4, 5, None], "c": ["x", "y", "z"]}
         >>> df_pl = pl.DataFrame(data)
         >>> df_pd = pd.DataFrame(data)
         >>> df_pa = pa.table(data)
@@ -8078,12 +8040,7 @@ def concat_str(
         ...     df = nw.from_native(df_native)
         ...     return df.select(
         ...         nw.concat_str(
-        ...             [
-        ...                 nw.col("a") * 2,
-        ...                 nw.col("b"),
-        ...                 nw.col("c"),
-        ...             ],
-        ...             separator=" ",
+        ...             [nw.col("a") * 2, nw.col("b"), nw.col("c")], separator=" "
         ...         ).alias("full_sentence")
         ...     ).to_native()
 
@@ -8124,6 +8081,4 @@ def concat_str(
     )
 
 
-__all__ = [
-    "Expr",
-]
+__all__ = ["Expr"]

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -229,10 +229,7 @@ def new_series(
         ...     values = [4, 1, 2, 3]
         ...     native_namespace = nw.get_native_namespace(df_native)
         ...     return nw.new_series(
-        ...         name="a",
-        ...         values=values,
-        ...         dtype=nw.Int32,
-        ...         native_namespace=native_namespace,
+        ...         name="a", values=values, dtype=nw.Int32, native_namespace=native_namespace
         ...     ).to_native()
 
         We can then pass any supported eager library, such as pandas / Polars / PyArrow:
@@ -882,9 +879,7 @@ def _get_deps_info() -> dict[str, str]:
 
     from . import __version__
 
-    deps_info = {
-        "narwhals": __version__,
-    }
+    deps_info = {"narwhals": __version__}
 
     from importlib.metadata import PackageNotFoundError
     from importlib.metadata import version

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -192,7 +192,7 @@ def concat(
     first_item = items[0]
     plx = first_item.__narwhals_namespace__()
     return first_item._from_compliant_dataframe(  # type: ignore[return-value]
-        plx.concat([df._compliant_frame for df in items], how=how),
+        plx.concat([df._compliant_frame for df in items], how=how)
     )
 
 
@@ -264,11 +264,7 @@ def new_series(
         ]
     """
     return _new_series_impl(
-        name,
-        values,
-        dtype,
-        native_namespace=native_namespace,
-        version=Version.MAIN,
+        name, values, dtype, native_namespace=native_namespace, version=Version.MAIN
     )
 
 
@@ -396,10 +392,7 @@ def from_dict(
         d: [[1,4]]
     """
     return _from_dict_impl(
-        data,
-        schema,
-        native_namespace=native_namespace,
-        version=Version.MAIN,
+        data, schema, native_namespace=native_namespace, version=Version.MAIN
     )
 
 
@@ -643,10 +636,7 @@ def from_numpy(
         e: [[1,3]]
     """
     return _from_numpy_impl(
-        data,
-        schema,
-        native_namespace=native_namespace,
-        version=Version.MAIN,
+        data, schema, native_namespace=native_namespace, version=Version.MAIN
     )
 
 
@@ -888,14 +878,7 @@ def _get_deps_info() -> dict[str, str]:
     Returns:
         Mapping from dependency to version.
     """
-    deps = (
-        "pandas",
-        "polars",
-        "cudf",
-        "modin",
-        "pyarrow",
-        "numpy",
-    )
+    deps = ("pandas", "polars", "cudf", "modin", "pyarrow", "numpy")
 
     from . import __version__
 
@@ -953,10 +936,7 @@ def get_level(
 
 
 def read_csv(
-    source: str,
-    *,
-    native_namespace: ModuleType,
-    **kwargs: Any,
+    source: str, *, native_namespace: ModuleType, **kwargs: Any
 ) -> DataFrame[Any]:
     """Read a CSV file into a DataFrame.
 
@@ -1121,10 +1101,7 @@ def _scan_csv_impl(
 
 
 def read_parquet(
-    source: str,
-    *,
-    native_namespace: ModuleType,
-    **kwargs: Any,
+    source: str, *, native_namespace: ModuleType, **kwargs: Any
 ) -> DataFrame[Any]:
     """Read into a DataFrame from a parquet file.
 

--- a/narwhals/group_by.py
+++ b/narwhals/group_by.py
@@ -111,7 +111,7 @@ class GroupBy(Generic[DataFrameT]):
         """
         aggs, named_aggs = self._df._flatten_and_extract(*aggs, **named_aggs)
         return self._df._from_compliant_dataframe(  # type: ignore[return-value]
-            self._grouped.agg(*aggs, **named_aggs),
+            self._grouped.agg(*aggs, **named_aggs)
         )
 
     def __iter__(self) -> Iterator[tuple[Any, DataFrameT]]:
@@ -197,5 +197,5 @@ class LazyGroupBy(Generic[LazyFrameT]):
         """
         aggs, named_aggs = self._df._flatten_and_extract(*aggs, **named_aggs)
         return self._df._from_compliant_dataframe(  # type: ignore[return-value]
-            self._grouped.agg(*aggs, **named_aggs),
+            self._grouped.agg(*aggs, **named_aggs)
         )

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -270,11 +270,4 @@ def all() -> Expr:
     return Selector(lambda plx: plx.selectors.all())
 
 
-__all__ = [
-    "all",
-    "boolean",
-    "by_dtype",
-    "categorical",
-    "numeric",
-    "string",
-]
+__all__ = ["all", "boolean", "by_dtype", "categorical", "numeric", "string"]

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -4432,9 +4432,7 @@ class Series(Generic[IntoSeriesT]):
 
         return self._from_compliant_series(
             self._compliant_series.rolling_sum(
-                window_size=window_size,
-                min_periods=min_periods,
-                center=center,
+                window_size=window_size, min_periods=min_periods, center=center
             )
         )
 
@@ -4527,9 +4525,7 @@ class Series(Generic[IntoSeriesT]):
 
         return self._from_compliant_series(
             self._compliant_series.rolling_mean(
-                window_size=window_size,
-                min_periods=min_periods,
-                center=center,
+                window_size=window_size, min_periods=min_periods, center=center
             )
         )
 
@@ -6783,11 +6779,7 @@ class SeriesDateTimeNamespace(Generic[SeriesT]):
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoSeriesT
 
-            >>> data = [
-            ...     datetime(2020, 3, 1),
-            ...     datetime(2020, 4, 1),
-            ...     datetime(2020, 5, 1),
-            ... ]
+            >>> data = [datetime(2020, 3, 1), datetime(2020, 4, 1), datetime(2020, 5, 1)]
             >>> s_pd = pd.Series(data)
             >>> s_pl = pl.Series(data)
             >>> s_pa = pa.chunked_array([data])

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -63,10 +63,7 @@ class Series(Generic[IntoSeriesT]):
         return DataFrame
 
     def __init__(
-        self: Self,
-        series: Any,
-        *,
-        level: Literal["full", "lazy", "interchange"],
+        self: Self, series: Any, *, level: Literal["full", "lazy", "interchange"]
     ) -> None:
         self._level = level
         if hasattr(series, "__narwhals_series__"):
@@ -404,10 +401,7 @@ class Series(Generic[IntoSeriesT]):
         return arg
 
     def _from_compliant_series(self, series: Any) -> Self:
-        return self.__class__(
-            series,
-            level=self._level,
-        )
+        return self.__class__(series, level=self._level)
 
     def pipe(self, function: Callable[[Any], Self], *args: Any, **kwargs: Any) -> Self:
         """Pipe function call.
@@ -789,10 +783,7 @@ class Series(Generic[IntoSeriesT]):
             ----
             : [[1,2]]
         """
-        return self._dataframe(
-            self._compliant_series.to_frame(),
-            level=self._level,
-        )
+        return self._dataframe(self._compliant_series.to_frame(), level=self._level)
 
     def to_list(self) -> list[Any]:
         """Convert to list.

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -835,9 +835,7 @@ class Series(NwSeries[Any]):
         )
         warn(message=msg, category=NarwhalsUnstableWarning, stacklevel=find_stacklevel())
         return super().rolling_sum(
-            window_size=window_size,
-            min_periods=min_periods,
-            center=center,
+            window_size=window_size, min_periods=min_periods, center=center
         )
 
     def rolling_mean(
@@ -929,9 +927,7 @@ class Series(NwSeries[Any]):
         )
         warn(message=msg, category=NarwhalsUnstableWarning, stacklevel=find_stacklevel())
         return super().rolling_mean(
-            window_size=window_size,
-            min_periods=min_periods,
-            center=center,
+            window_size=window_size, min_periods=min_periods, center=center
         )
 
     def rolling_var(
@@ -1025,10 +1021,7 @@ class Series(NwSeries[Any]):
         )
         warn(message=msg, category=NarwhalsUnstableWarning, stacklevel=find_stacklevel())
         return super().rolling_var(
-            window_size=window_size,
-            min_periods=min_periods,
-            center=center,
-            ddof=ddof,
+            window_size=window_size, min_periods=min_periods, center=center, ddof=ddof
         )
 
     def rolling_std(
@@ -1122,10 +1115,7 @@ class Series(NwSeries[Any]):
         )
         warn(message=msg, category=NarwhalsUnstableWarning, stacklevel=find_stacklevel())
         return super().rolling_std(
-            window_size=window_size,
-            min_periods=min_periods,
-            center=center,
-            ddof=ddof,
+            window_size=window_size, min_periods=min_periods, center=center, ddof=ddof
         )
 
 
@@ -1328,9 +1318,7 @@ class Expr(NwExpr):
         )
         warn(message=msg, category=NarwhalsUnstableWarning, stacklevel=find_stacklevel())
         return super().rolling_sum(
-            window_size=window_size,
-            min_periods=min_periods,
-            center=center,
+            window_size=window_size, min_periods=min_periods, center=center
         )
 
     def rolling_mean(
@@ -1421,9 +1409,7 @@ class Expr(NwExpr):
         )
         warn(message=msg, category=NarwhalsUnstableWarning, stacklevel=find_stacklevel())
         return super().rolling_mean(
-            window_size=window_size,
-            min_periods=min_periods,
-            center=center,
+            window_size=window_size, min_periods=min_periods, center=center
         )
 
     def rolling_var(
@@ -1611,10 +1597,7 @@ class Expr(NwExpr):
         )
         warn(message=msg, category=NarwhalsUnstableWarning, stacklevel=find_stacklevel())
         return super().rolling_std(
-            window_size=window_size,
-            min_periods=min_periods,
-            center=center,
-            ddof=ddof,
+            window_size=window_size, min_periods=min_periods, center=center, ddof=ddof
         )
 
 
@@ -1667,19 +1650,14 @@ def _stableify(
 ) -> DataFrame[IntoFrameT] | LazyFrame[IntoFrameT] | Series | Expr | Any:
     if isinstance(obj, NwDataFrame):
         return DataFrame(
-            obj._compliant_frame._change_version(Version.V1),
-            level=obj._level,
+            obj._compliant_frame._change_version(Version.V1), level=obj._level
         )
     if isinstance(obj, NwLazyFrame):
         return LazyFrame(
-            obj._compliant_frame._change_version(Version.V1),
-            level=obj._level,
+            obj._compliant_frame._change_version(Version.V1), level=obj._level
         )
     if isinstance(obj, NwSeries):
-        return Series(
-            obj._compliant_series._change_version(Version.V1),
-            level=obj._level,
-        )
+        return Series(obj._compliant_series._change_version(Version.V1), level=obj._level)
     if isinstance(obj, NwExpr):
         return Expr(obj._to_compliant_expr)
     return obj

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -282,10 +282,7 @@ class DataFrame(NwDataFrame[IntoDataFrameT]):
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoDataFrame
             >>> from narwhals.typing import IntoSeries
-            >>> data = {
-            ...     "a": [1, 2, 3, 1],
-            ...     "b": ["x", "y", "z", "x"],
-            ... }
+            >>> data = {"a": [1, 2, 3, 1], "b": ["x", "y", "z", "x"]}
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
@@ -341,10 +338,7 @@ class DataFrame(NwDataFrame[IntoDataFrameT]):
             >>> import narwhals as nw
             >>> from narwhals.typing import IntoDataFrame
             >>> from narwhals.typing import IntoSeries
-            >>> data = {
-            ...     "a": [1, 2, 3, 1],
-            ...     "b": ["x", "y", "z", "x"],
-            ... }
+            >>> data = {"a": [1, 2, 3, 1], "b": ["x", "y", "z", "x"]}
             >>> df_pd = pd.DataFrame(data)
             >>> df_pl = pl.DataFrame(data)
             >>> df_pa = pa.table(data)
@@ -3096,11 +3090,7 @@ def mean_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         >>> import narwhals as nw
         >>> from narwhals.typing import IntoFrameT
         >>>
-        >>> data = {
-        ...     "a": [1, 8, 3],
-        ...     "b": [4, 5, None],
-        ...     "c": ["x", "y", "z"],
-        ... }
+        >>> data = {"a": [1, 8, 3], "b": [4, 5, None], "c": ["x", "y", "z"]}
         >>> df_pl = pl.DataFrame(data)
         >>> df_pd = pd.DataFrame(data)
         >>> df_pa = pa.table(data)
@@ -3162,11 +3152,7 @@ def min_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         >>> import narwhals as nw
         >>> from narwhals.typing import IntoFrameT
         >>>
-        >>> data = {
-        ...     "a": [1, 8, 3],
-        ...     "b": [4, 5, None],
-        ...     "c": ["x", "y", "z"],
-        ... }
+        >>> data = {"a": [1, 8, 3], "b": [4, 5, None], "c": ["x", "y", "z"]}
 
         We define a dataframe-agnostic function that computes the horizontal min of "a"
         and "b" columns:
@@ -3225,11 +3211,7 @@ def max_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         >>> import narwhals as nw
         >>> from narwhals.typing import IntoFrameT
         >>>
-        >>> data = {
-        ...     "a": [1, 8, 3],
-        ...     "b": [4, 5, None],
-        ...     "c": ["x", "y", "z"],
-        ... }
+        >>> data = {"a": [1, 8, 3], "b": [4, 5, None], "c": ["x", "y", "z"]}
 
         We define a dataframe-agnostic function that computes the horizontal max of "a"
         and "b" columns:
@@ -3469,12 +3451,7 @@ def concat_str(
         ...     df = nw.from_native(df_native)
         ...     return df.select(
         ...         nw.concat_str(
-        ...             [
-        ...                 nw.col("a") * 2,
-        ...                 nw.col("b"),
-        ...                 nw.col("c"),
-        ...             ],
-        ...             separator=" ",
+        ...             [nw.col("a") * 2, nw.col("b"), nw.col("c")], separator=" "
         ...         ).alias("full_sentence")
         ...     ).to_native()
 
@@ -3636,10 +3613,7 @@ def new_series(
         ...     values = [4, 1, 2, 3]
         ...     native_namespace = nw.get_native_namespace(df_native)
         ...     return nw.new_series(
-        ...         name="a",
-        ...         values=values,
-        ...         dtype=nw.Int32,
-        ...         native_namespace=native_namespace,
+        ...         name="a", values=values, dtype=nw.Int32, native_namespace=native_namespace
         ...     ).to_native()
 
         We can then pass any supported eager library, such as pandas / Polars / PyArrow:
@@ -3672,11 +3646,7 @@ def new_series(
     """
     return _stableify(  # type: ignore[no-any-return]
         _new_series_impl(
-            name,
-            values,
-            dtype,
-            native_namespace=native_namespace,
-            version=Version.V1,
+            name, values, dtype, native_namespace=native_namespace, version=Version.V1
         )
     )
 
@@ -3795,10 +3765,7 @@ def from_dict(
     """
     return _stableify(  # type: ignore[no-any-return]
         _from_dict_impl(
-            data,
-            schema,
-            native_namespace=native_namespace,
-            version=Version.V1,
+            data, schema, native_namespace=native_namespace, version=Version.V1
         )
     )
 
@@ -3944,10 +3911,7 @@ def from_numpy(
     """
     return _stableify(  # type: ignore[no-any-return]
         _from_numpy_impl(
-            data,
-            schema,
-            native_namespace=native_namespace,
-            version=Version.V1,
+            data, schema, native_namespace=native_namespace, version=Version.V1
         )
     )
 

--- a/narwhals/stable/v1/selectors.py
+++ b/narwhals/stable/v1/selectors.py
@@ -7,11 +7,4 @@ from narwhals.selectors import categorical
 from narwhals.selectors import numeric
 from narwhals.selectors import string
 
-__all__ = [
-    "all",
-    "boolean",
-    "by_dtype",
-    "categorical",
-    "numeric",
-    "string",
-]
+__all__ = ["all", "boolean", "by_dtype", "categorical", "numeric", "string"]

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -1031,9 +1031,4 @@ def to_py_scalar(scalar_like: Any) -> Any:
     raise ValueError(msg)
 
 
-__all__ = [
-    "get_native_namespace",
-    "narwhalify",
-    "to_native",
-    "to_py_scalar",
-]
+__all__ = ["get_native_namespace", "narwhalify", "to_native", "to_py_scalar"]

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -52,14 +52,7 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
-NON_TEMPORAL_SCALAR_TYPES = (
-    bool,
-    bytes,
-    str,
-    int,
-    float,
-    complex,
-)
+NON_TEMPORAL_SCALAR_TYPES = (bool, bytes, str, int, float, complex)
 
 
 @overload
@@ -431,10 +424,7 @@ def _from_native_impl(  # noqa: PLR0915
                 msg = "Cannot only use `series_only` with dataframe"
                 raise TypeError(msg)
             return native_object
-        return DataFrame(
-            native_object.__narwhals_dataframe__(),
-            level="full",
-        )
+        return DataFrame(native_object.__narwhals_dataframe__(), level="full")
     elif hasattr(native_object, "__narwhals_lazyframe__"):
         if series_only:
             if not pass_through:
@@ -446,20 +436,14 @@ def _from_native_impl(  # noqa: PLR0915
                 msg = "Cannot only use `eager_only` or `eager_or_interchange_only` with lazyframe"
                 raise TypeError(msg)
             return native_object
-        return LazyFrame(
-            native_object.__narwhals_lazyframe__(),
-            level="full",
-        )
+        return LazyFrame(native_object.__narwhals_lazyframe__(), level="full")
     elif hasattr(native_object, "__narwhals_series__"):
         if not allow_series:
             if not pass_through:
                 msg = "Please set `allow_series=True` or `series_only=True`"
                 raise TypeError(msg)
             return native_object
-        return Series(
-            native_object.__narwhals_series__(),
-            level="full",
-        )
+        return Series(native_object.__narwhals_series__(), level="full")
 
     # Polars
     elif is_polars_dataframe(native_object):
@@ -780,8 +764,7 @@ def _from_native_impl(  # noqa: PLR0915
                 raise TypeError(msg)
             return native_object
         return DataFrame(
-            InterchangeFrame(native_object, version=version),
-            level="interchange",
+            InterchangeFrame(native_object, version=version), level="interchange"
         )
 
     elif not pass_through:

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -155,11 +155,7 @@ class Implementation(Enum):
             >>> df.implementation.is_pandas_like()
             True
         """
-        return self in {
-            Implementation.PANDAS,
-            Implementation.MODIN,
-            Implementation.CUDF,
-        }
+        return self in {Implementation.PANDAS, Implementation.MODIN, Implementation.CUDF}
 
     def is_polars(self) -> bool:
         """Return whether implementation is Polars.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.format]
 docstring-code-format = true
+skip-magic-trailing-comma = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/expr_and_series/all_horizontal_test.py
+++ b/tests/expr_and_series/all_horizontal_test.py
@@ -14,10 +14,7 @@ from tests.utils import assert_equal_data
 @pytest.mark.parametrize("expr1", ["a", nw.col("a")])
 @pytest.mark.parametrize("expr2", ["b", nw.col("b")])
 def test_allh(constructor: Constructor, expr1: Any, expr2: Any) -> None:
-    data = {
-        "a": [False, False, True],
-        "b": [False, True, True],
-    }
+    data = {"a": [False, False, True], "b": [False, True, True]}
     df = nw.from_native(constructor(data))
     result = df.select(all=nw.all_horizontal(expr1, expr2))
 
@@ -26,10 +23,7 @@ def test_allh(constructor: Constructor, expr1: Any, expr2: Any) -> None:
 
 
 def test_allh_series(constructor_eager: ConstructorEager) -> None:
-    data = {
-        "a": [False, False, True],
-        "b": [False, True, True],
-    }
+    data = {"a": [False, False, True], "b": [False, True, True]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(all=nw.all_horizontal(df["a"], df["b"]))
 
@@ -38,10 +32,7 @@ def test_allh_series(constructor_eager: ConstructorEager) -> None:
 
 
 def test_allh_all(constructor: Constructor) -> None:
-    data = {
-        "a": [False, False, True],
-        "b": [False, True, True],
-    }
+    data = {"a": [False, False, True], "b": [False, True, True]}
     df = nw.from_native(constructor(data))
     result = df.select(all=nw.all_horizontal(nw.all()))
     expected = {"all": [False, False, True]}
@@ -51,18 +42,12 @@ def test_allh_all(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
-def test_allh_nth(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
-) -> None:
+def test_allh_nth(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if "polars" in str(constructor) and POLARS_VERSION < (1, 0):
         request.applymarker(pytest.mark.xfail)
     if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    data = {
-        "a": [False, False, True],
-        "b": [False, True, True],
-    }
+    data = {"a": [False, False, True], "b": [False, True, True]}
     df = nw.from_native(constructor(data))
     result = df.select(nw.all_horizontal(nw.nth(0, 1)))
     expected = {"a": [False, False, True]}
@@ -73,10 +58,7 @@ def test_allh_nth(
 
 
 def test_horizontal_expressions_empty(constructor: Constructor) -> None:
-    data = {
-        "a": [False, False, True],
-        "b": [False, True, True],
-    }
+    data = {"a": [False, False, True], "b": [False, True, True]}
     df = nw.from_native(constructor(data))
     with pytest.raises(
         ValueError, match=r"At least one expression must be passed.*all_horizontal"

--- a/tests/expr_and_series/any_horizontal_test.py
+++ b/tests/expr_and_series/any_horizontal_test.py
@@ -12,10 +12,7 @@ from tests.utils import assert_equal_data
 @pytest.mark.parametrize("expr1", ["a", nw.col("a")])
 @pytest.mark.parametrize("expr2", ["b", nw.col("b")])
 def test_anyh(constructor: Constructor, expr1: Any, expr2: Any) -> None:
-    data = {
-        "a": [False, False, True],
-        "b": [False, True, True],
-    }
+    data = {"a": [False, False, True], "b": [False, True, True]}
     df = nw.from_native(constructor(data))
     result = df.select(any=nw.any_horizontal(expr1, expr2))
 
@@ -24,10 +21,7 @@ def test_anyh(constructor: Constructor, expr1: Any, expr2: Any) -> None:
 
 
 def test_anyh_all(constructor: Constructor) -> None:
-    data = {
-        "a": [False, False, True],
-        "b": [False, True, True],
-    }
+    data = {"a": [False, False, True], "b": [False, True, True]}
     df = nw.from_native(constructor(data))
     result = df.select(any=nw.any_horizontal(nw.all()))
     expected = {"any": [False, True, True]}

--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -161,8 +161,7 @@ def test_truediv_same_dims(
 
 @pytest.mark.slow
 @given(  # type: ignore[misc]
-    left=st.integers(-100, 100),
-    right=st.integers(-100, 100),
+    left=st.integers(-100, 100), right=st.integers(-100, 100)
 )
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
 def test_floordiv(left: int, right: int) -> None:
@@ -199,8 +198,7 @@ def test_floordiv(left: int, right: int) -> None:
 
 @pytest.mark.slow
 @given(  # type: ignore[misc]
-    left=st.integers(-100, 100),
-    right=st.integers(-100, 100),
+    left=st.integers(-100, 100), right=st.integers(-100, 100)
 )
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
 def test_mod(left: int, right: int) -> None:

--- a/tests/expr_and_series/cast_test.py
+++ b/tests/expr_and_series/cast_test.py
@@ -56,10 +56,7 @@ schema = {
 
 
 @pytest.mark.filterwarnings("ignore:casting period[M] values to int64:FutureWarning")
-def test_cast(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
-) -> None:
+def test_cast(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     if "pyarrow_table_constructor" in str(constructor) and PYARROW_VERSION <= (
@@ -112,8 +109,7 @@ def test_cast(
 
 
 def test_cast_series(
-    constructor_eager: ConstructorEager,
-    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
 ) -> None:
     if "pyarrow_table_constructor" in str(constructor_eager) and PYARROW_VERSION <= (
         15,
@@ -237,10 +233,7 @@ def test_cast_struct(request: pytest.FixtureRequest, constructor: Constructor) -
         request.applymarker(pytest.mark.xfail)
 
     data = {
-        "a": [
-            {"movie": "Cars", "rating": 4.5},
-            {"movie": "Toy Story", "rating": 4.9},
-        ]
+        "a": [{"movie": "Cars", "rating": 4.5}, {"movie": "Toy Story", "rating": 4.9}]
     }
 
     dtype = nw.Struct([nw.Field("movie", nw.String()), nw.Field("rating", nw.Float64())])

--- a/tests/expr_and_series/cat/get_categories_test.py
+++ b/tests/expr_and_series/cat/get_categories_test.py
@@ -12,8 +12,7 @@ data = {"a": ["one", "two", "two"]}
 
 
 def test_get_categories(
-    request: pytest.FixtureRequest,
-    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
     if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (15, 0, 0):
         request.applymarker(pytest.mark.xfail)

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -6,11 +6,7 @@ import narwhals.stable.v1 as nw
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
-data = {
-    "a": [1, 2, 3],
-    "b": ["dogs", "cats", None],
-    "c": ["play", "swim", "walk"],
-}
+data = {"a": [1, 2, 3], "b": ["dogs", "cats", None], "c": ["play", "swim", "walk"]}
 
 
 @pytest.mark.parametrize(
@@ -34,11 +30,7 @@ def test_concat_str(
         df.select(
             "a",
             nw.concat_str(
-                [
-                    nw.col("a") * 2,
-                    nw.col("b"),
-                    nw.col("c"),
-                ],
+                [nw.col("a") * 2, nw.col("b"), nw.col("c")],
                 separator=" ",
                 ignore_nulls=ignore_nulls,  # default behavior is False
             ).alias("full_sentence"),

--- a/tests/expr_and_series/convert_time_zone_test.py
+++ b/tests/expr_and_series/convert_time_zone_test.py
@@ -19,8 +19,7 @@ if TYPE_CHECKING:
 
 
 def test_convert_time_zone(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
+    constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if (
         ("pyarrow" in str(constructor) and is_windows())
@@ -48,8 +47,7 @@ def test_convert_time_zone(
 
 
 def test_convert_time_zone_series(
-    constructor_eager: ConstructorEager,
-    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
 ) -> None:
     if (
         ("pyarrow" in str(constructor_eager) and is_windows())

--- a/tests/expr_and_series/cum_count_test.py
+++ b/tests/expr_and_series/cum_count_test.py
@@ -9,10 +9,7 @@ from tests.utils import assert_equal_data
 
 data = {"a": ["x", "y", None, "z"]}
 
-expected = {
-    "cum_count": [1, 2, 2, 3],
-    "reverse_cum_count": [3, 2, 1, 1],
-}
+expected = {"cum_count": [1, 2, 2, 3], "reverse_cum_count": [3, 2, 1, 1]}
 
 
 @pytest.mark.parametrize("reverse", [True, False])
@@ -26,9 +23,7 @@ def test_cum_count_expr(
 
     name = "reverse_cum_count" if reverse else "cum_count"
     df = nw.from_native(constructor(data))
-    result = df.select(
-        nw.col("a").cum_count(reverse=reverse).alias(name),
-    )
+    result = df.select(nw.col("a").cum_count(reverse=reverse).alias(name))
 
     assert_equal_data(result, {name: expected[name]})
 
@@ -36,11 +31,7 @@ def test_cum_count_expr(
 def test_cum_count_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(
-        cum_count=df["a"].cum_count(),
-        reverse_cum_count=df["a"].cum_count(reverse=True),
+        cum_count=df["a"].cum_count(), reverse_cum_count=df["a"].cum_count(reverse=True)
     )
-    expected = {
-        "cum_count": [1, 2, 2, 3],
-        "reverse_cum_count": [3, 2, 1, 1],
-    }
+    expected = {"cum_count": [1, 2, 2, 3], "reverse_cum_count": [3, 2, 1, 1]}
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/cum_max_test.py
+++ b/tests/expr_and_series/cum_max_test.py
@@ -11,10 +11,7 @@ from tests.utils import assert_equal_data
 
 data = {"a": [1, 3, None, 2]}
 
-expected = {
-    "cum_max": [1, 3, None, 3],
-    "reverse_cum_max": [3, 3, None, 2],
-}
+expected = {"cum_max": [1, 3, None, 3], "reverse_cum_max": [3, 3, None, 2]}
 
 
 @pytest.mark.parametrize("reverse", [True, False])
@@ -36,9 +33,7 @@ def test_cum_max_expr(
 
     name = "reverse_cum_max" if reverse else "cum_max"
     df = nw.from_native(constructor(data))
-    result = df.select(
-        nw.col("a").cum_max(reverse=reverse).alias(name),
-    )
+    result = df.select(nw.col("a").cum_max(reverse=reverse).alias(name))
 
     assert_equal_data(result, {name: expected[name]})
 
@@ -56,7 +51,6 @@ def test_cum_max_series(
 
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(
-        cum_max=df["a"].cum_max(),
-        reverse_cum_max=df["a"].cum_max(reverse=True),
+        cum_max=df["a"].cum_max(), reverse_cum_max=df["a"].cum_max(reverse=True)
     )
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/cum_min_test.py
+++ b/tests/expr_and_series/cum_min_test.py
@@ -11,10 +11,7 @@ from tests.utils import assert_equal_data
 
 data = {"a": [3, 1, None, 2]}
 
-expected = {
-    "cum_min": [3, 1, None, 1],
-    "reverse_cum_min": [1, 1, None, 2],
-}
+expected = {"cum_min": [3, 1, None, 1], "reverse_cum_min": [1, 1, None, 2]}
 
 
 @pytest.mark.parametrize("reverse", [True, False])
@@ -36,9 +33,7 @@ def test_cum_min_expr(
 
     name = "reverse_cum_min" if reverse else "cum_min"
     df = nw.from_native(constructor(data))
-    result = df.select(
-        nw.col("a").cum_min(reverse=reverse).alias(name),
-    )
+    result = df.select(nw.col("a").cum_min(reverse=reverse).alias(name))
 
     assert_equal_data(result, {name: expected[name]})
 
@@ -56,7 +51,6 @@ def test_cum_min_series(
 
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(
-        cum_min=df["a"].cum_min(),
-        reverse_cum_min=df["a"].cum_min(reverse=True),
+        cum_min=df["a"].cum_min(), reverse_cum_min=df["a"].cum_min(reverse=True)
     )
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/cum_prod_test.py
+++ b/tests/expr_and_series/cum_prod_test.py
@@ -11,10 +11,7 @@ from tests.utils import assert_equal_data
 
 data = {"a": [1, 2, None, 3]}
 
-expected = {
-    "cum_prod": [1, 2, None, 6],
-    "reverse_cum_prod": [6, 6, None, 3],
-}
+expected = {"cum_prod": [1, 2, None, 6], "reverse_cum_prod": [6, 6, None, 3]}
 
 
 @pytest.mark.parametrize("reverse", [True, False])
@@ -36,9 +33,7 @@ def test_cum_prod_expr(
 
     name = "reverse_cum_prod" if reverse else "cum_prod"
     df = nw.from_native(constructor(data))
-    result = df.select(
-        nw.col("a").cum_prod(reverse=reverse).alias(name),
-    )
+    result = df.select(nw.col("a").cum_prod(reverse=reverse).alias(name))
 
     assert_equal_data(result, {name: expected[name]})
 
@@ -56,7 +51,6 @@ def test_cum_prod_series(
 
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(
-        cum_prod=df["a"].cum_prod(),
-        reverse_cum_prod=df["a"].cum_prod(reverse=True),
+        cum_prod=df["a"].cum_prod(), reverse_cum_prod=df["a"].cum_prod(reverse=True)
     )
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/cum_sum_test.py
+++ b/tests/expr_and_series/cum_sum_test.py
@@ -8,10 +8,7 @@ from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
 data = {"a": [1, 2, None, 4]}
-expected = {
-    "cum_sum": [1, 3, None, 7],
-    "reverse_cum_sum": [7, 6, None, 4],
-}
+expected = {"cum_sum": [1, 3, None, 7], "reverse_cum_sum": [7, 6, None, 4]}
 
 
 @pytest.mark.parametrize("reverse", [True, False])
@@ -25,9 +22,7 @@ def test_cum_sum_expr(
 
     name = "reverse_cum_sum" if reverse else "cum_sum"
     df = nw.from_native(constructor(data))
-    result = df.select(
-        nw.col("a").cum_sum(reverse=reverse).alias(name),
-    )
+    result = df.select(nw.col("a").cum_sum(reverse=reverse).alias(name))
 
     assert_equal_data(result, {name: expected[name]})
 
@@ -35,7 +30,6 @@ def test_cum_sum_expr(
 def test_cum_sum_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(
-        cum_sum=df["a"].cum_sum(),
-        reverse_cum_sum=df["a"].cum_sum(reverse=True),
+        cum_sum=df["a"].cum_sum(), reverse_cum_sum=df["a"].cum_sum(reverse=True)
     )
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/diff_test.py
+++ b/tests/expr_and_series/diff_test.py
@@ -8,17 +8,10 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {
-    "i": [0, 1, 2, 3, 4],
-    "b": [1, 2, 3, 5, 3],
-    "c": [5, 4, 3, 2, 1],
-}
+data = {"i": [0, 1, 2, 3, 4], "b": [1, 2, 3, 5, 3], "c": [5, 4, 3, 2, 1]}
 
 
-def test_diff(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
-) -> None:
+def test_diff(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if "pyarrow_table_constructor" in str(constructor) and PYARROW_VERSION < (13,):
         # pc.pairwisediff is available since pyarrow 13.0.0
         request.applymarker(pytest.mark.xfail)
@@ -36,8 +29,7 @@ def test_diff(
 
 
 def test_diff_series(
-    constructor_eager: ConstructorEager,
-    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
 ) -> None:
     if "pyarrow_table_constructor" in str(constructor_eager) and PYARROW_VERSION < (13,):
         # pc.pairwisediff is available since pyarrow 13.0.0

--- a/tests/expr_and_series/double_test.py
+++ b/tests/expr_and_series/double_test.py
@@ -17,10 +17,5 @@ def test_double_alias(constructor: Constructor) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df = nw.from_native(constructor(data))
     result = df.with_columns(nw.col("a").alias("o"), nw.all() * 2)
-    expected = {
-        "a": [2, 6, 4],
-        "b": [8, 8, 12],
-        "z": [14.0, 16.0, 18.0],
-        "o": [1, 3, 2],
-    }
+    expected = {"a": [2, 6, 4], "b": [8, 8, 12], "z": [14.0, 16.0, 18.0], "o": [1, 3, 2]}
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/dt/datetime_attributes_test.py
+++ b/tests/expr_and_series/dt/datetime_attributes_test.py
@@ -11,10 +11,7 @@ from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
 data = {
-    "a": [
-        datetime(2021, 3, 1, 12, 34, 56, 49000),
-        datetime(2020, 1, 2, 2, 4, 14, 715000),
-    ],
+    "a": [datetime(2021, 3, 1, 12, 34, 56, 49000), datetime(2020, 1, 2, 2, 4, 14, 715000)]
 }
 
 

--- a/tests/expr_and_series/dt/datetime_duration_test.py
+++ b/tests/expr_and_series/dt/datetime_duration_test.py
@@ -14,14 +14,8 @@ from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
 data = {
-    "a": [
-        None,
-        timedelta(minutes=1, seconds=1, milliseconds=1, microseconds=1),
-    ],
-    "b": [
-        timedelta(milliseconds=2),
-        timedelta(milliseconds=1, microseconds=300),
-    ],
+    "a": [None, timedelta(minutes=1, seconds=1, milliseconds=1, microseconds=1)],
+    "b": [timedelta(milliseconds=2), timedelta(milliseconds=1, microseconds=300)],
     "c": np.array([None, 20], dtype="timedelta64[ns]"),
 }
 

--- a/tests/expr_and_series/dt/ordinal_day_test.py
+++ b/tests/expr_and_series/dt/ordinal_day_test.py
@@ -13,10 +13,7 @@ from tests.utils import PANDAS_VERSION
 
 
 @given(dates=st.datetimes(min_value=datetime(1960, 1, 1), max_value=datetime(1980, 1, 1)))  # type: ignore[misc]
-@pytest.mark.skipif(
-    PANDAS_VERSION < (2, 0, 0),
-    reason="pyarrow dtype not available",
-)
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="pyarrow dtype not available")
 @pytest.mark.slow
 def test_ordinal_day(dates: datetime) -> None:
     result_pd = nw.from_native(pd.Series([dates]), series_only=True).dt.ordinal_day()[0]

--- a/tests/expr_and_series/dt/timestamp_test.py
+++ b/tests/expr_and_series/dt/timestamp_test.py
@@ -19,10 +19,7 @@ from tests.utils import assert_equal_data
 from tests.utils import is_windows
 
 data = {
-    "a": [
-        datetime(2021, 3, 1, 12, 34, 56, 49000),
-        datetime(2020, 1, 2, 2, 4, 14, 715000),
-    ],
+    "a": [datetime(2021, 3, 1, 12, 34, 56, 49000), datetime(2020, 1, 2, 2, 4, 14, 715000)]
 }
 
 
@@ -106,10 +103,7 @@ def test_timestamp_datetimes_tz_aware(
     ):  # pragma: no cover
         # pyarrow-backed timestamps were too inconsistent and unreliable before 2.2
         request.applymarker(pytest.mark.xfail(strict=False))
-    if "dask" in str(constructor) and PANDAS_VERSION < (
-        2,
-        1,
-    ):  # pragma: no cover
+    if "dask" in str(constructor) and PANDAS_VERSION < (2, 1):  # pragma: no cover
         request.applymarker(pytest.mark.xfail)
 
     if original_time_unit == "s" and "polars" in str(constructor):

--- a/tests/expr_and_series/dt/to_string_test.py
+++ b/tests/expr_and_series/dt/to_string_test.py
@@ -12,22 +12,12 @@ from tests.utils import assert_equal_data
 from tests.utils import is_windows
 
 data = {
-    "a": [
-        datetime(2021, 3, 1, 12, 34, 56, 49000),
-        datetime(2020, 1, 2, 2, 4, 14, 715000),
-    ],
+    "a": [datetime(2021, 3, 1, 12, 34, 56, 49000), datetime(2020, 1, 2, 2, 4, 14, 715000)]
 }
 
 
 @pytest.mark.parametrize(
-    "fmt",
-    [
-        "%Y-%m-%d",
-        "%Y-%m-%d %H:%M:%S",
-        "%Y/%m/%d %H:%M:%S",
-        "%G-W%V-%u",
-        "%G-W%V",
-    ],
+    "fmt", ["%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%Y/%m/%d %H:%M:%S", "%G-W%V-%u", "%G-W%V"]
 )
 @pytest.mark.skipif(is_windows(), reason="pyarrow breaking on windows")
 def test_dt_to_string_series(constructor_eager: ConstructorEager, fmt: str) -> None:
@@ -49,14 +39,7 @@ def test_dt_to_string_series(constructor_eager: ConstructorEager, fmt: str) -> N
 
 
 @pytest.mark.parametrize(
-    "fmt",
-    [
-        "%Y-%m-%d",
-        "%Y-%m-%d %H:%M:%S",
-        "%Y/%m/%d %H:%M:%S",
-        "%G-W%V-%u",
-        "%G-W%V",
-    ],
+    "fmt", ["%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%Y/%m/%d %H:%M:%S", "%G-W%V-%u", "%G-W%V"]
 )
 @pytest.mark.skipif(is_windows(), reason="pyarrow breaking on windows")
 def test_dt_to_string_expr(
@@ -97,10 +80,7 @@ def _clean_string_expr(e: Any) -> Any:
         (datetime(2020, 1, 9), "2020-01-09T00:00:00.000000"),
         (datetime(2020, 1, 9, 12, 34, 56), "2020-01-09T12:34:56.000000"),
         (datetime(2020, 1, 9, 12, 34, 56, 123), "2020-01-09T12:34:56.000123"),
-        (
-            datetime(2020, 1, 9, 12, 34, 56, 123456),
-            "2020-01-09T12:34:56.123456",
-        ),
+        (datetime(2020, 1, 9, 12, 34, 56, 123456), "2020-01-09T12:34:56.123456"),
     ],
 )
 @pytest.mark.skipif(is_windows(), reason="pyarrow breaking on windows")
@@ -128,10 +108,7 @@ def test_dt_to_string_iso_local_datetime_series(
     [
         (datetime(2020, 1, 9, 12, 34, 56), "2020-01-09T12:34:56.000000"),
         (datetime(2020, 1, 9, 12, 34, 56, 123), "2020-01-09T12:34:56.000123"),
-        (
-            datetime(2020, 1, 9, 12, 34, 56, 123456),
-            "2020-01-09T12:34:56.123456",
-        ),
+        (datetime(2020, 1, 9, 12, 34, 56, 123456), "2020-01-09T12:34:56.123456"),
     ],
 )
 @pytest.mark.skipif(is_windows(), reason="pyarrow breaking on windows")
@@ -156,10 +133,7 @@ def test_dt_to_string_iso_local_datetime_expr(
     assert_equal_data(result, {"a": [data], "b": [_clean_string(expected)]})
 
 
-@pytest.mark.parametrize(
-    ("data", "expected"),
-    [(datetime(2020, 1, 9), "2020-01-09")],
-)
+@pytest.mark.parametrize(("data", "expected"), [(datetime(2020, 1, 9), "2020-01-09")])
 @pytest.mark.skipif(is_windows(), reason="pyarrow breaking on windows")
 def test_dt_to_string_iso_local_date_series(
     constructor_eager: ConstructorEager, data: datetime, expected: str
@@ -169,10 +143,7 @@ def test_dt_to_string_iso_local_date_series(
     assert str(result) == expected
 
 
-@pytest.mark.parametrize(
-    ("data", "expected"),
-    [(datetime(2020, 1, 9), "2020-01-09")],
-)
+@pytest.mark.parametrize(("data", "expected"), [(datetime(2020, 1, 9), "2020-01-09")])
 @pytest.mark.skipif(is_windows(), reason="pyarrow breaking on windows")
 def test_dt_to_string_iso_local_date_expr(
     constructor: Constructor,

--- a/tests/expr_and_series/dt/total_minutes_test.py
+++ b/tests/expr_and_series/dt/total_minutes_test.py
@@ -18,10 +18,7 @@ from tests.utils import PANDAS_VERSION
         max_value=timedelta(days=3, minutes=90, seconds=60),
     )
 )  # type: ignore[misc]
-@pytest.mark.skipif(
-    PANDAS_VERSION < (2, 2, 0),
-    reason="pyarrow dtype not available",
-)
+@pytest.mark.skipif(PANDAS_VERSION < (2, 2, 0), reason="pyarrow dtype not available")
 @pytest.mark.slow
 def test_total_minutes(timedeltas: timedelta) -> None:
     result_pd = nw.from_native(

--- a/tests/expr_and_series/ewm_test.py
+++ b/tests/expr_and_series/ewm_test.py
@@ -55,13 +55,7 @@ def test_ewm_mean_series(
                 "b": [1.0, 1.6666666666666667, 2.4285714285714284],
             },
         ),
-        (
-            False,
-            {
-                "a": [1.0, 1.0, 1.5],
-                "b": [1.0, 1.5, 2.25],
-            },
-        ),
+        (False, {"a": [1.0, 1.0, 1.5], "b": [1.0, 1.5, 2.25]}),
     ],
 )
 def test_ewm_mean_expr_adjust(
@@ -84,28 +78,8 @@ def test_ewm_mean_expr_adjust(
 @pytest.mark.parametrize(
     ("ignore_nulls", "expected"),
     [
-        (
-            True,
-            {
-                "a": [
-                    2.0,
-                    3.3333333333333335,
-                    None,
-                    3.142857142857143,
-                ]
-            },
-        ),
-        (
-            False,
-            {
-                "a": [
-                    2.0,
-                    3.3333333333333335,
-                    None,
-                    3.090909090909091,
-                ]
-            },
-        ),
+        (True, {"a": [2.0, 3.3333333333333335, None, 3.142857142857143]}),
+        (False, {"a": [2.0, 3.3333333333333335, None, 3.090909090909091]}),
     ],
 )
 def test_ewm_mean_nulls(
@@ -126,8 +100,7 @@ def test_ewm_mean_nulls(
     "ignore:`Expr.ewm_mean` is being called from the stable API although considered an unstable feature."
 )
 def test_ewm_mean_params(
-    request: pytest.FixtureRequest,
-    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
     if any(x in str(constructor_eager) for x in ("pyarrow_table_", "modin", "cudf")):
         request.applymarker(pytest.mark.xfail)

--- a/tests/expr_and_series/fill_null_test.py
+++ b/tests/expr_and_series/fill_null_test.py
@@ -30,9 +30,7 @@ def test_fill_null(constructor: Constructor) -> None:
 
 
 def test_fill_null_exceptions(constructor: Constructor) -> None:
-    data = {
-        "a": [0.0, None, 2, 3, 4],
-    }
+    data = {"a": [0.0, None, 2, 3, 4]}
     df = nw.from_native(constructor(data))
 
     with pytest.raises(ValueError, match="cannot specify both `value` and `strategy`"):
@@ -161,32 +159,20 @@ def test_fill_null_limits(
 
 
 def test_fill_null_series(constructor_eager: ConstructorEager) -> None:
-    data_series_float = {
-        "a": [0.0, 1, None, 2, None, 3],
-    }
+    data_series_float = {"a": [0.0, 1, None, 2, None, 3]}
     df_float = nw.from_native(constructor_eager(data_series_float), eager_only=True)
 
-    expected_float = {
-        "a_zero_digit": [0.0, 1, 0, 2, 0, 3],
-    }
-    result_float = df_float.select(
-        a_zero_digit=df_float["a"].fill_null(value=0),
-    )
+    expected_float = {"a_zero_digit": [0.0, 1, 0, 2, 0, 3]}
+    result_float = df_float.select(a_zero_digit=df_float["a"].fill_null(value=0))
 
     assert_equal_data(result_float, expected_float)
 
-    data_series_str = {
-        "a": ["a", None, "c", None, "e"],
-    }
+    data_series_str = {"a": ["a", None, "c", None, "e"]}
     df_str = nw.from_native(constructor_eager(data_series_str), eager_only=True)
 
-    expected_str = {
-        "a_z_str": ["a", "z", "c", "z", "e"],
-    }
+    expected_str = {"a_z_str": ["a", "z", "c", "z", "e"]}
 
-    result_str = df_str.select(
-        a_z_str=df_str["a"].fill_null(value="z"),
-    )
+    result_str = df_str.select(a_z_str=df_str["a"].fill_null(value="z"))
 
     assert_equal_data(result_str, expected_str)
 
@@ -235,9 +221,7 @@ def test_fill_null_series_limits(constructor_eager: ConstructorEager) -> None:
 
 
 def test_fill_null_series_limit_as_none(constructor_eager: ConstructorEager) -> None:
-    data_series = {
-        "a": [1, None, None, None, 5, 6, None, None, None, 10],
-    }
+    data_series = {"a": [1, None, None, None, 5, 6, None, None, None, 10]}
     df = nw.from_native(constructor_eager(data_series), eager_only=True)
 
     expected_forward = {
@@ -271,9 +255,7 @@ def test_fill_null_series_limit_as_none(constructor_eager: ConstructorEager) -> 
 
         assert_equal_data(result_forward, expected_forward)
 
-    data_series_str = {
-        "a": ["a", None, None, None, "b", "c", None, None, None, "d"],
-    }
+    data_series_str = {"a": ["a", None, None, None, "b", "c", None, None, None, "d"]}
 
     df_str = nw.from_native(constructor_eager(data_series_str), eager_only=True)
 
@@ -310,24 +292,18 @@ def test_fill_null_series_limit_as_none(constructor_eager: ConstructorEager) -> 
 
 
 def test_fill_null_series_exceptions(constructor_eager: ConstructorEager) -> None:
-    data_series_float = {
-        "a": [0.0, 1, None, 2, None, 3],
-    }
+    data_series_float = {"a": [0.0, 1, None, 2, None, 3]}
     df_float = nw.from_native(constructor_eager(data_series_float), eager_only=True)
 
     with pytest.raises(ValueError, match="cannot specify both `value` and `strategy`"):
-        df_float.select(
-            a_zero_digit=df_float["a"].fill_null(value=0, strategy="forward"),
-        )
+        df_float.select(a_zero_digit=df_float["a"].fill_null(value=0, strategy="forward"))
 
     with pytest.raises(
         ValueError, match="must specify either a fill `value` or `strategy`"
     ):
-        df_float.select(
-            a_zero_digit=df_float["a"].fill_null(),
-        )
+        df_float.select(a_zero_digit=df_float["a"].fill_null())
 
     with pytest.raises(ValueError, match="strategy not supported:"):
         df_float.select(
-            a_zero_digit=df_float["a"].fill_null(strategy="invalid"),  # type: ignore  # noqa: PGH003
+            a_zero_digit=df_float["a"].fill_null(strategy="invalid")  # type: ignore  # noqa: PGH003
         )

--- a/tests/expr_and_series/is_first_distinct_test.py
+++ b/tests/expr_and_series/is_first_distinct_test.py
@@ -7,10 +7,7 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {
-    "a": [1, 1, 2, 3, 2],
-    "b": [1, 2, 3, 2, 1],
-}
+data = {"a": [1, 1, 2, 3, 2], "b": [1, 2, 3, 2, 1]}
 
 
 def test_is_first_distinct_expr(
@@ -30,7 +27,5 @@ def test_is_first_distinct_expr(
 def test_is_first_distinct_series(constructor_eager: ConstructorEager) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)["a"]
     result = series.is_first_distinct()
-    expected = {
-        "a": [True, False, True, True, False],
-    }
+    expected = {"a": [True, False, True, True, False]}
     assert_equal_data({"a": result}, expected)

--- a/tests/expr_and_series/is_last_distinct_test.py
+++ b/tests/expr_and_series/is_last_distinct_test.py
@@ -7,10 +7,7 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {
-    "a": [1, 1, 2, 3, 2],
-    "b": [1, 2, 3, 2, 1],
-}
+data = {"a": [1, 1, 2, 3, 2], "b": [1, 2, 3, 2, 1]}
 
 
 def test_is_last_distinct_expr(
@@ -30,7 +27,5 @@ def test_is_last_distinct_expr(
 def test_is_last_distinct_series(constructor_eager: ConstructorEager) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)["a"]
     result = series.is_last_distinct()
-    expected = {
-        "a": [False, True, False, True, True],
-    }
+    expected = {"a": [False, True, False, True, True]}
     assert_equal_data({"a": result}, expected)

--- a/tests/expr_and_series/is_unique_test.py
+++ b/tests/expr_and_series/is_unique_test.py
@@ -11,18 +11,10 @@ from tests.utils import assert_equal_data
 def test_is_unique_expr(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    data = {
-        "a": [1, 1, 2],
-        "b": [1, 2, 3],
-        "index": [0, 1, 2],
-    }
+    data = {"a": [1, 1, 2], "b": [1, 2, 3], "index": [0, 1, 2]}
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a", "b").is_unique(), "index").sort("index")
-    expected = {
-        "a": [False, False, True],
-        "b": [True, True, True],
-        "index": [0, 1, 2],
-    }
+    expected = {"a": [False, False, True], "b": [True, True, True], "index": [0, 1, 2]}
     assert_equal_data(result, expected)
 
 
@@ -31,30 +23,16 @@ def test_is_unique_w_nulls_expr(
 ) -> None:
     if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    data = {
-        "a": [None, 1, 2],
-        "b": [None, 2, None],
-        "index": [0, 1, 2],
-    }
+    data = {"a": [None, 1, 2], "b": [None, 2, None], "index": [0, 1, 2]}
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a", "b").is_unique(), "index").sort("index")
-    expected = {
-        "a": [True, True, True],
-        "b": [False, True, False],
-        "index": [0, 1, 2],
-    }
+    expected = {"a": [True, True, True], "b": [False, True, False], "index": [0, 1, 2]}
     assert_equal_data(result, expected)
 
 
 def test_is_unique_series(constructor_eager: ConstructorEager) -> None:
-    data = {
-        "a": [1, 1, 2],
-        "b": [1, 2, 3],
-        "index": [0, 1, 2],
-    }
+    data = {"a": [1, 1, 2], "b": [1, 2, 3], "index": [0, 1, 2]}
     series = nw.from_native(constructor_eager(data), eager_only=True)["a"]
     result = series.is_unique()
-    expected = {
-        "a": [False, False, True],
-    }
+    expected = {"a": [False, False, True]}
     assert_equal_data({"a": result}, expected)

--- a/tests/expr_and_series/len_test.py
+++ b/tests/expr_and_series/len_test.py
@@ -12,8 +12,7 @@ def test_len_no_filter(constructor: Constructor) -> None:
     data = {"a": list("xyz"), "b": [1, 2, 1]}
     expected = {"l": [3], "l2": [6]}
     df = nw.from_native(constructor(data)).select(
-        nw.col("a").len().alias("l"),
-        (nw.col("a").len() * 2).alias("l2"),
+        nw.col("a").len().alias("l"), (nw.col("a").len() * 2).alias("l2")
     )
 
     assert_equal_data(df, expected)

--- a/tests/expr_and_series/list/len_test.py
+++ b/tests/expr_and_series/list/len_test.py
@@ -13,10 +13,7 @@ data = {"a": [[1, 2], [3, 4, None], None, [], [None]]}
 expected = {"a": [2, 3, None, 0, 1]}
 
 
-def test_len_expr(
-    request: pytest.FixtureRequest,
-    constructor: Constructor,
-) -> None:
+def test_len_expr(request: pytest.FixtureRequest, constructor: Constructor) -> None:
     if any(backend in str(constructor) for backend in ("dask", "modin", "cudf")):
         request.applymarker(pytest.mark.xfail)
 
@@ -31,8 +28,7 @@ def test_len_expr(
 
 
 def test_len_series(
-    request: pytest.FixtureRequest,
-    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
     if any(backend in str(constructor_eager) for backend in ("modin", "cudf")):
         request.applymarker(pytest.mark.xfail)

--- a/tests/expr_and_series/lit_test.py
+++ b/tests/expr_and_series/lit_test.py
@@ -28,12 +28,7 @@ def test_lit(
     df_raw = constructor(data)
     df = nw.from_native(df_raw).lazy()
     result = df.with_columns(nw.lit(2, dtype).alias("lit"))
-    expected = {
-        "a": [1, 3, 2],
-        "b": [4, 4, 6],
-        "z": [7.0, 8.0, 9.0],
-        "lit": expected_lit,
-    }
+    expected = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0], "lit": expected_lit}
     assert_equal_data(result, expected)
 
 
@@ -60,10 +55,7 @@ def test_lit_out_name(constructor: Constructor) -> None:
     df_raw = constructor(data)
     df = nw.from_native(df_raw).lazy()
     result = df.with_columns(nw.lit(2))
-    expected = {
-        "a": [1, 3, 2],
-        "literal": [2, 2, 2],
-    }
+    expected = {"a": [1, 3, 2], "literal": [2, 2, 2]}
     assert_equal_data(result, expected)
 
 

--- a/tests/expr_and_series/mean_horizontal_test.py
+++ b/tests/expr_and_series/mean_horizontal_test.py
@@ -28,12 +28,8 @@ def test_meanh_all(constructor: Constructor, request: pytest.FixtureRequest) -> 
     data = {"a": [2, 4, 6], "b": [10, 20, 30]}
     df = nw.from_native(constructor(data))
     result = df.select(nw.mean_horizontal(nw.all()))
-    expected = {
-        "a": [6, 12, 18],
-    }
+    expected = {"a": [6, 12, 18]}
     assert_equal_data(result, expected)
     result = df.select(c=nw.mean_horizontal(nw.all()))
-    expected = {
-        "c": [6, 12, 18],
-    }
+    expected = {"c": [6, 12, 18]}
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/mode_test.py
+++ b/tests/expr_and_series/mode_test.py
@@ -8,10 +8,7 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {
-    "a": [1, 1, 2, 2, 3],
-    "b": [1, 2, 3, 3, 4],
-}
+data = {"a": [1, 1, 2, 2, 3], "b": [1, 2, 3, 3, 4]}
 
 
 def test_mode_single_expr(constructor_eager: Constructor) -> None:
@@ -22,8 +19,7 @@ def test_mode_single_expr(constructor_eager: Constructor) -> None:
 
 
 def test_mode_multi_expr(
-    constructor_eager: ConstructorEager,
-    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
 ) -> None:
     if "polars" in str(constructor_eager) and POLARS_VERSION >= (1, 7, 0):
         request.applymarker(pytest.mark.xfail)

--- a/tests/expr_and_series/n_unique_test.py
+++ b/tests/expr_and_series/n_unique_test.py
@@ -7,10 +7,7 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {
-    "a": [1.0, None, None, 3.0],
-    "b": [1.0, None, 4, 5.0],
-}
+data = {"a": [1.0, None, None, 3.0], "b": [1.0, None, 4, 5.0]}
 
 
 def test_n_unique(constructor: Constructor, request: pytest.FixtureRequest) -> None:

--- a/tests/expr_and_series/name/keep_test.py
+++ b/tests/expr_and_series/name/keep_test.py
@@ -34,8 +34,7 @@ def test_keep_raise_anonymous(constructor: Constructor) -> None:
         does_not_raise()
         if isinstance(df_raw, (pl.LazyFrame, pl.DataFrame))
         else pytest.raises(
-            ValueError,
-            match="Anonymous expressions are not supported in `.name.keep`.",
+            ValueError, match="Anonymous expressions are not supported in `.name.keep`."
         )
     )
 

--- a/tests/expr_and_series/name/map_test.py
+++ b/tests/expr_and_series/name/map_test.py
@@ -38,8 +38,7 @@ def test_map_raise_anonymous(constructor: Constructor) -> None:
         does_not_raise()
         if isinstance(df_raw, (pl.LazyFrame, pl.DataFrame))
         else pytest.raises(
-            ValueError,
-            match="Anonymous expressions are not supported in `.name.map`.",
+            ValueError, match="Anonymous expressions are not supported in `.name.map`."
         )
     )
 

--- a/tests/expr_and_series/name/prefix_test.py
+++ b/tests/expr_and_series/name/prefix_test.py
@@ -35,8 +35,7 @@ def test_prefix_raise_anonymous(constructor: Constructor) -> None:
         does_not_raise()
         if isinstance(df_raw, (pl.LazyFrame, pl.DataFrame))
         else pytest.raises(
-            ValueError,
-            match="Anonymous expressions are not supported in `.name.prefix`.",
+            ValueError, match="Anonymous expressions are not supported in `.name.prefix`."
         )
     )
 

--- a/tests/expr_and_series/name/suffix_test.py
+++ b/tests/expr_and_series/name/suffix_test.py
@@ -35,8 +35,7 @@ def test_suffix_raise_anonymous(constructor: Constructor) -> None:
         does_not_raise()
         if isinstance(df_raw, (pl.LazyFrame, pl.DataFrame))
         else pytest.raises(
-            ValueError,
-            match="Anonymous expressions are not supported in `.name.suffix`.",
+            ValueError, match="Anonymous expressions are not supported in `.name.suffix`."
         )
     )
 

--- a/tests/expr_and_series/nth_test.py
+++ b/tests/expr_and_series/nth_test.py
@@ -34,10 +34,7 @@ def test_nth(
     assert_equal_data(result, expected)
 
 
-@pytest.mark.skipif(
-    POLARS_VERSION >= (1, 0, 0),
-    reason="1.0.0",
-)
+@pytest.mark.skipif(POLARS_VERSION >= (1, 0, 0), reason="1.0.0")
 def test_nth_not_supported() -> None:  # pragma: no cover
     df = nw.from_native(pl.DataFrame(data))
     with pytest.raises(

--- a/tests/expr_and_series/null_count_test.py
+++ b/tests/expr_and_series/null_count_test.py
@@ -7,10 +7,7 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {
-    "a": [1.0, None, None, 3.0],
-    "b": [1.0, None, 4, 5.0],
-}
+data = {"a": [1.0, None, None, 3.0], "b": [1.0, None, 4, 5.0]}
 
 
 def test_null_count_expr(
@@ -20,10 +17,7 @@ def test_null_count_expr(
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     result = df.select(nw.all().null_count())
-    expected = {
-        "a": [2],
-        "b": [1],
-    }
+    expected = {"a": [2], "b": [1]}
     assert_equal_data(result, expected)
 
 

--- a/tests/expr_and_series/operators_test.py
+++ b/tests/expr_and_series/operators_test.py
@@ -51,10 +51,7 @@ def test_comparand_operators_expr(
 
 @pytest.mark.parametrize(
     ("operator", "expected"),
-    [
-        ("__and__", [True, False, False, False]),
-        ("__or__", [True, True, True, False]),
-    ],
+    [("__and__", [True, False, False, False]), ("__or__", [True, True, True, False])],
 )
 def test_logic_operators_expr(
     constructor: Constructor, operator: str, expected: list[bool]

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -8,17 +8,9 @@ from tests.utils import PANDAS_VERSION
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
-data = {
-    "a": ["a", "a", "b", "b", "b"],
-    "b": [1, 2, 3, 5, 3],
-    "c": [5, 4, 3, 2, 1],
-}
+data = {"a": ["a", "a", "b", "b", "b"], "b": [1, 2, 3, 5, 3], "c": [5, 4, 3, 2, 1]}
 
-data_cum = {
-    "a": ["a", "a", "b", "b", "b"],
-    "b": [1, 2, None, 5, 3],
-    "c": [5, 4, 3, 2, 1],
-}
+data_cum = {"a": ["a", "a", "b", "b", "b"], "b": [1, 2, None, 5, 3], "c": [5, 4, 3, 2, 1]}
 
 
 def test_over_single(request: pytest.FixtureRequest, constructor: Constructor) -> None:

--- a/tests/expr_and_series/pipe_test.py
+++ b/tests/expr_and_series/pipe_test.py
@@ -15,9 +15,7 @@ def test_pipe_expr(constructor: Constructor) -> None:
     assert_equal_data(e, {"a": expected})
 
 
-def test_pipe_series(
-    constructor_eager: ConstructorEager,
-) -> None:
+def test_pipe_series(constructor_eager: ConstructorEager) -> None:
     s = nw.from_native(constructor_eager(input_list), eager_only=True)["a"]
     result = s.pipe(lambda x: x**2)
     assert_equal_data({"a": result}, {"a": expected})

--- a/tests/expr_and_series/rolling_mean_test.py
+++ b/tests/expr_and_series/rolling_mean_test.py
@@ -70,8 +70,7 @@ def test_rolling_mean_series(constructor_eager: ConstructorEager) -> None:
 
 
 @given(  # type: ignore[misc]
-    center=st.booleans(),
-    values=st.lists(st.floats(-10, 10), min_size=3, max_size=10),
+    center=st.booleans(), values=st.lists(st.floats(-10, 10), min_size=3, max_size=10)
 )
 @pytest.mark.skipif(PANDAS_VERSION < (1,), reason="too old for pyarrow")
 @pytest.mark.slow

--- a/tests/expr_and_series/rolling_sum_test.py
+++ b/tests/expr_and_series/rolling_sum_test.py
@@ -189,8 +189,7 @@ def test_rolling_sum_series_invalid_params(
 
 
 @given(  # type: ignore[misc]
-    center=st.booleans(),
-    values=st.lists(st.floats(-10, 10), min_size=3, max_size=10),
+    center=st.booleans(), values=st.lists(st.floats(-10, 10), min_size=3, max_size=10)
 )
 @pytest.mark.skipif(PANDAS_VERSION < (1,), reason="too old for pyarrow")
 @pytest.mark.filterwarnings("ignore:.*:narwhals.exceptions.NarwhalsUnstableWarning")

--- a/tests/expr_and_series/rolling_var_test.py
+++ b/tests/expr_and_series/rolling_var_test.py
@@ -100,8 +100,7 @@ def test_rolling_var_series(
 
 
 @given(  # type: ignore[misc]
-    center=st.booleans(),
-    values=st.lists(st.floats(-10, 10), min_size=5, max_size=10),
+    center=st.booleans(), values=st.lists(st.floats(-10, 10), min_size=5, max_size=10)
 )
 @pytest.mark.skipif(PANDAS_VERSION < (1,), reason="too old for pyarrow")
 @pytest.mark.skipif(POLARS_VERSION < (1,), reason="different null behavior")

--- a/tests/expr_and_series/shift_test.py
+++ b/tests/expr_and_series/shift_test.py
@@ -21,28 +21,16 @@ def test_shift(constructor: Constructor, request: pytest.FixtureRequest) -> None
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     result = df.with_columns(nw.col("a", "b", "c").shift(2)).filter(nw.col("i") > 1)
-    expected = {
-        "i": [2, 3, 4],
-        "a": [0, 1, 2],
-        "b": [1, 2, 3],
-        "c": [5, 4, 3],
-    }
+    expected = {"i": [2, 3, 4], "a": [0, 1, 2], "b": [1, 2, 3], "c": [5, 4, 3]}
     assert_equal_data(result, expected)
 
 
 def test_shift_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
-    result = df.with_columns(
-        df["a"].shift(2),
-        df["b"].shift(2),
-        df["c"].shift(2),
-    ).filter(nw.col("i") > 1)
-    expected = {
-        "i": [2, 3, 4],
-        "a": [0, 1, 2],
-        "b": [1, 2, 3],
-        "c": [5, 4, 3],
-    }
+    result = df.with_columns(df["a"].shift(2), df["b"].shift(2), df["c"].shift(2)).filter(
+        nw.col("i") > 1
+    )
+    expected = {"i": [2, 3, 4], "a": [0, 1, 2], "b": [1, 2, 3], "c": [5, 4, 3]}
     assert_equal_data(result, expected)
 
 

--- a/tests/expr_and_series/sort_test.py
+++ b/tests/expr_and_series/sort_test.py
@@ -25,8 +25,7 @@ def test_sort_expr(
 ) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(
-        "a",
-        nw.col("b").sort(descending=descending, nulls_last=nulls_last),
+        "a", nw.col("b").sort(descending=descending, nulls_last=nulls_last)
     )
     assert_equal_data(result, expected)
 

--- a/tests/expr_and_series/std_test.py
+++ b/tests/expr_and_series/std_test.py
@@ -28,11 +28,7 @@ def test_std(constructor: Constructor, input_data: dict[str, list[float | None]]
         nw.col("a").std(ddof=0).alias("a_ddof_0"),
         nw.col("z").std(ddof=0).alias("z_ddof_0"),
     )
-    expected_results = {
-        "a_ddof_1": [1.0],
-        "a_ddof_0": [0.816497],
-        "z_ddof_0": [0.816497],
-    }
+    expected_results = {"a_ddof_1": [1.0], "a_ddof_0": [0.816497], "z_ddof_0": [0.816497]}
     assert_equal_data(result, expected_results)
     context = (
         pytest.raises(NotImplementedError)
@@ -40,12 +36,8 @@ def test_std(constructor: Constructor, input_data: dict[str, list[float | None]]
         else does_not_raise()
     )
     with context:
-        result = df.select(
-            nw.col("b").std(ddof=2).alias("b_ddof_2"),
-        )
-        expected_results = {
-            "b_ddof_2": [1.632993],
-        }
+        result = df.select(nw.col("b").std(ddof=2).alias("b_ddof_2"))
+        expected_results = {"b_ddof_2": [1.632993]}
         assert_equal_data(result, expected_results)
 
 

--- a/tests/expr_and_series/str/contains_test.py
+++ b/tests/expr_and_series/str/contains_test.py
@@ -20,9 +20,7 @@ def test_contains_case_insensitive(
     result = df.select(
         nw.col("pets").str.contains("(?i)parrot|Dove").alias("case_insensitive_match")
     )
-    expected = {
-        "case_insensitive_match": [False, False, True, True, True, None],
-    }
+    expected = {"case_insensitive_match": [False, False, True, True, True, None]}
     assert_equal_data(result, expected)
 
 
@@ -34,27 +32,21 @@ def test_contains_series_case_insensitive(
 
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(case_insensitive_match=df["pets"].str.contains("(?i)parrot|Dove"))
-    expected = {
-        "case_insensitive_match": [False, False, True, True, True, None],
-    }
+    expected = {"case_insensitive_match": [False, False, True, True, True, None]}
     assert_equal_data(result, expected)
 
 
 def test_contains_case_sensitive(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("pets").str.contains("parrot|Dove").alias("default_match"))
-    expected = {
-        "default_match": [False, False, True, False, False, None],
-    }
+    expected = {"default_match": [False, False, True, False, False, None]}
     assert_equal_data(result, expected)
 
 
 def test_contains_series_case_sensitive(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(default_match=df["pets"].str.contains("parrot|Dove"))
-    expected = {
-        "default_match": [False, False, True, False, False, None],
-    }
+    expected = {"default_match": [False, False, True, False, False, None]}
     assert_equal_data(result, expected)
 
 

--- a/tests/expr_and_series/str/head_test.py
+++ b/tests/expr_and_series/str/head_test.py
@@ -11,16 +11,12 @@ data = {"a": ["foo", "bars"]}
 def test_str_head(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a").str.head(3))
-    expected = {
-        "a": ["foo", "bar"],
-    }
+    expected = {"a": ["foo", "bar"]}
     assert_equal_data(result, expected)
 
 
 def test_str_head_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
-    expected = {
-        "a": ["foo", "bar"],
-    }
+    expected = {"a": ["foo", "bar"]}
     result = df.select(df["a"].str.head(3))
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/str/len_chars_test.py
+++ b/tests/expr_and_series/str/len_chars_test.py
@@ -15,16 +15,12 @@ def test_str_len_chars(constructor: Constructor, request: pytest.FixtureRequest)
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a").str.len_chars())
-    expected = {
-        "a": [3, 6, 4, 3, 2],
-    }
+    expected = {"a": [3, 6, 4, 3, 2]}
     assert_equal_data(result, expected)
 
 
 def test_str_len_chars_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
-    expected = {
-        "a": [3, 6, 4, 3, 2],
-    }
+    expected = {"a": [3, 6, 4, 3, 2]}
     result = df.select(df["a"].str.len_chars())
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/str/replace_test.py
+++ b/tests/expr_and_series/str/replace_test.py
@@ -8,14 +8,7 @@ from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
 replace_data = [
-    (
-        {"a": ["123abc", "abc456"]},
-        r"abc\b",
-        "ABC",
-        1,
-        False,
-        {"a": ["123ABC", "abc456"]},
-    ),
+    ({"a": ["123abc", "abc456"]}, r"abc\b", "ABC", 1, False, {"a": ["123ABC", "abc456"]}),
     ({"a": ["abc abc", "abc456"]}, r"abc", "", 1, False, {"a": [" abc", "456"]}),
     ({"a": ["abc abc abc", "456abc"]}, r"abc", "", -1, False, {"a": ["  ", "456"]}),
     (
@@ -29,13 +22,7 @@ replace_data = [
 ]
 
 replace_all_data = [
-    (
-        {"a": ["123abc", "abc456"]},
-        r"abc\b",
-        "ABC",
-        False,
-        {"a": ["123ABC", "abc456"]},
-    ),
+    ({"a": ["123abc", "abc456"]}, r"abc\b", "ABC", False, {"a": ["123ABC", "abc456"]}),
     ({"a": ["abc abc", "abc456"]}, r"abc", "", False, {"a": [" ", "456"]}),
     ({"a": ["abc abc abc", "456abc"]}, r"abc", "", False, {"a": ["  ", "456"]}),
     (
@@ -49,8 +36,7 @@ replace_all_data = [
 
 
 @pytest.mark.parametrize(
-    ("data", "pattern", "value", "n", "literal", "expected"),
-    replace_data,
+    ("data", "pattern", "value", "n", "literal", "expected"), replace_data
 )
 def test_str_replace_series(
     constructor_eager: ConstructorEager,
@@ -70,8 +56,7 @@ def test_str_replace_series(
 
 
 @pytest.mark.parametrize(
-    ("data", "pattern", "value", "literal", "expected"),
-    replace_all_data,
+    ("data", "pattern", "value", "literal", "expected"), replace_all_data
 )
 def test_str_replace_all_series(
     constructor_eager: ConstructorEager,
@@ -88,8 +73,7 @@ def test_str_replace_all_series(
 
 
 @pytest.mark.parametrize(
-    ("data", "pattern", "value", "n", "literal", "expected"),
-    replace_data,
+    ("data", "pattern", "value", "n", "literal", "expected"), replace_data
 )
 def test_str_replace_expr(
     constructor: Constructor,
@@ -111,8 +95,7 @@ def test_str_replace_expr(
 
 
 @pytest.mark.parametrize(
-    ("data", "pattern", "value", "literal", "expected"),
-    replace_all_data,
+    ("data", "pattern", "value", "literal", "expected"), replace_all_data
 )
 def test_str_replace_all_expr(
     constructor: Constructor,

--- a/tests/expr_and_series/str/starts_with_ends_with_test.py
+++ b/tests/expr_and_series/str/starts_with_ends_with_test.py
@@ -14,34 +14,26 @@ data = {"a": ["fdas", "edfas"]}
 def test_ends_with(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a").str.ends_with("das"))
-    expected = {
-        "a": [True, False],
-    }
+    expected = {"a": [True, False]}
     assert_equal_data(result, expected)
 
 
 def test_ends_with_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(df["a"].str.ends_with("das"))
-    expected = {
-        "a": [True, False],
-    }
+    expected = {"a": [True, False]}
     assert_equal_data(result, expected)
 
 
 def test_starts_with(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data)).lazy()
     result = df.select(nw.col("a").str.starts_with("fda"))
-    expected = {
-        "a": [True, False],
-    }
+    expected = {"a": [True, False]}
     assert_equal_data(result, expected)
 
 
 def test_starts_with_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(df["a"].str.starts_with("fda"))
-    expected = {
-        "a": [True, False],
-    }
+    expected = {"a": [True, False]}
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/str/strip_chars_test.py
+++ b/tests/expr_and_series/str/strip_chars_test.py
@@ -14,10 +14,7 @@ data = {"a": ["foobar", "bar\n", " baz"]}
 
 @pytest.mark.parametrize(
     ("characters", "expected"),
-    [
-        (None, {"a": ["foobar", "bar", "baz"]}),
-        ("foo", {"a": ["bar", "bar\n", " baz"]}),
-    ],
+    [(None, {"a": ["foobar", "bar", "baz"]}), ("foo", {"a": ["bar", "bar\n", " baz"]})],
 )
 def test_str_strip_chars(
     constructor: Constructor, characters: str | None, expected: Any
@@ -29,10 +26,7 @@ def test_str_strip_chars(
 
 @pytest.mark.parametrize(
     ("characters", "expected"),
-    [
-        (None, {"a": ["foobar", "bar", "baz"]}),
-        ("foo", {"a": ["bar", "bar\n", " baz"]}),
-    ],
+    [(None, {"a": ["foobar", "bar", "baz"]}), ("foo", {"a": ["bar", "bar\n", " baz"]})],
 )
 def test_str_strip_chars_series(
     constructor_eager: ConstructorEager, characters: str | None, expected: Any

--- a/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
+++ b/tests/expr_and_series/str/to_uppercase_to_lowercase_test.py
@@ -110,9 +110,7 @@ def test_str_to_uppercase_series(
     ],
 )
 def test_str_to_lowercase(
-    constructor: Constructor,
-    data: dict[str, list[str]],
-    expected: dict[str, list[str]],
+    constructor: Constructor, data: dict[str, list[str]], expected: dict[str, list[str]]
 ) -> None:
     df = nw.from_native(constructor(data))
     result_frame = df.select(nw.col("a").str.to_lowercase())

--- a/tests/expr_and_series/sum_horizontal_test.py
+++ b/tests/expr_and_series/sum_horizontal_test.py
@@ -44,12 +44,8 @@ def test_sumh_all(constructor: Constructor, request: pytest.FixtureRequest) -> N
     data = {"a": [1, 2, 3], "b": [10, 20, 30]}
     df = nw.from_native(constructor(data))
     result = df.select(nw.sum_horizontal(nw.all()))
-    expected = {
-        "a": [11, 22, 33],
-    }
+    expected = {"a": [11, 22, 33]}
     assert_equal_data(result, expected)
     result = df.select(c=nw.sum_horizontal(nw.all()))
-    expected = {
-        "c": [11, 22, 33],
-    }
+    expected = {"c": [11, 22, 33]}
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/unary_test.py
+++ b/tests/expr_and_series/unary_test.py
@@ -13,12 +13,7 @@ from tests.utils import assert_equal_data
 def test_unary(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    data = {
-        "a": [1, 3, 2],
-        "b": [4, 4, 6],
-        "c": [7.0, 8.0, None],
-        "z": [7.0, 8, 9],
-    }
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "c": [7.0, 8.0, None], "z": [7.0, 8, 9]}
     result = nw.from_native(constructor(data)).select(
         a_mean=nw.col("a").mean(),
         a_median=nw.col("a").median(),
@@ -45,12 +40,7 @@ def test_unary(constructor: Constructor, request: pytest.FixtureRequest) -> None
 
 
 def test_unary_series(constructor_eager: ConstructorEager) -> None:
-    data = {
-        "a": [1, 3, 2],
-        "b": [4, 4, 6],
-        "c": [7.0, 8.0, None],
-        "z": [7.0, 8, 9],
-    }
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "c": [7.0, 8.0, None], "z": [7.0, 8, 9]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = {
         "a_mean": [df["a"].mean()],

--- a/tests/expr_and_series/var_test.py
+++ b/tests/expr_and_series/var_test.py
@@ -40,12 +40,8 @@ def test_var(constructor: Constructor, input_data: dict[str, list[float | None]]
         else does_not_raise()
     )
     with context:
-        result = df.select(
-            nw.col("b").var(ddof=2).alias("b_ddof_2"),
-        )
-        expected_results = {
-            "b_ddof_2": [2.666666666666667],
-        }
+        result = df.select(nw.col("b").var(ddof=2).alias("b_ddof_2"))
+        expected_results = {"b_ddof_2": [2.666666666666667]}
         assert_equal_data(result, expected_results)
 
 

--- a/tests/expr_and_series/when_test.py
+++ b/tests/expr_and_series/when_test.py
@@ -22,9 +22,7 @@ def test_when(constructor: Constructor, request: pytest.FixtureRequest) -> None:
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     result = df.select(nw.when(nw.col("a") == 1).then(value=3).alias("a_when"))
-    expected = {
-        "a_when": [3, None, None],
-    }
+    expected = {"a_when": [3, None, None]}
     assert_equal_data(result, expected)
 
 
@@ -33,9 +31,7 @@ def test_when_otherwise(constructor: Constructor, request: pytest.FixtureRequest
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     result = df.select(nw.when(nw.col("a") == 1).then(3).otherwise(6).alias("a_when"))
-    expected = {
-        "a_when": [3, 6, 6],
-    }
+    expected = {"a_when": [3, 6, 6]}
     assert_equal_data(result, expected)
 
 
@@ -48,9 +44,7 @@ def test_multiple_conditions(
     result = df.select(
         nw.when(nw.col("a") < 3, nw.col("c") < 5.0).then(3).alias("a_when")
     )
-    expected = {
-        "a_when": [3, None, None],
-    }
+    expected = {"a_when": [3, None, None]}
     assert_equal_data(result, expected)
 
 
@@ -67,9 +61,7 @@ def test_value_numpy_array(constructor_eager: ConstructorEager) -> None:
     result = df.select(
         nw.when(nw.col("a") == 1).then(np.asanyarray([3, 4, 5])).alias("a_when")
     )
-    expected = {
-        "a_when": [3, None, None],
-    }
+    expected = {"a_when": [3, None, None]}
     assert_equal_data(result, expected)
 
 
@@ -79,9 +71,7 @@ def test_value_series(constructor_eager: ConstructorEager) -> None:
     s = nw.from_native(constructor_eager(s_data))["s"]
     assert isinstance(s, nw.Series)
     result = df.select(nw.when(nw.col("a") == 1).then(s).alias("a_when"))
-    expected = {
-        "a_when": [3, None, None],
-    }
+    expected = {"a_when": [3, None, None]}
     assert_equal_data(result, expected)
 
 
@@ -92,9 +82,7 @@ def test_value_expression(
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     result = df.select(nw.when(nw.col("a") == 1).then(nw.col("a") + 9).alias("a_when"))
-    expected = {
-        "a_when": [10, None, None],
-    }
+    expected = {"a_when": [10, None, None]}
     assert_equal_data(result, expected)
 
 
@@ -104,9 +92,7 @@ def test_otherwise_numpy_array(constructor_eager: ConstructorEager) -> None:
     result = df.select(
         nw.when(nw.col("a") == 1).then(-1).otherwise(np.array([0, 9, 10])).alias("a_when")
     )
-    expected = {
-        "a_when": [-1, 9, 10],
-    }
+    expected = {"a_when": [-1, 9, 10]}
     assert_equal_data(result, expected)
 
 
@@ -116,9 +102,7 @@ def test_otherwise_series(constructor_eager: ConstructorEager) -> None:
     s = nw.from_native(constructor_eager(s_data))["s"]
     assert isinstance(s, nw.Series)
     result = df.select(nw.when(nw.col("a") == 1).then(-1).otherwise(s).alias("a_when"))
-    expected = {
-        "a_when": [-1, 9, 10],
-    }
+    expected = {"a_when": [-1, 9, 10]}
     assert_equal_data(result, expected)
 
 
@@ -131,9 +115,7 @@ def test_otherwise_expression(
     result = df.select(
         nw.when(nw.col("a") == 1).then(-1).otherwise(nw.col("a") + 7).alias("a_when")
     )
-    expected = {
-        "a_when": [-1, 9, 10],
-    }
+    expected = {"a_when": [-1, 9, 10]}
     assert_equal_data(result, expected)
 
 

--- a/tests/frame/array_dunder_test.py
+++ b/tests/frame/array_dunder_test.py
@@ -12,8 +12,7 @@ from tests.utils import assert_equal_data
 
 
 def test_array_dunder(
-    request: pytest.FixtureRequest,
-    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
     if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (
         16,
@@ -28,8 +27,7 @@ def test_array_dunder(
 
 
 def test_array_dunder_with_dtype(
-    request: pytest.FixtureRequest,
-    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
     if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (
         16,
@@ -44,8 +42,7 @@ def test_array_dunder_with_dtype(
 
 
 def test_array_dunder_with_copy(
-    request: pytest.FixtureRequest,
-    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
     if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (
         16,

--- a/tests/frame/double_test.py
+++ b/tests/frame/double_test.py
@@ -14,10 +14,5 @@ def test_double(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
     result = df.with_columns(nw.col("a").alias("o"), nw.all() * 2)
-    expected = {
-        "a": [2, 6, 4],
-        "b": [8, 8, 12],
-        "z": [14.0, 16.0, 18.0],
-        "o": [1, 3, 2],
-    }
+    expected = {"a": [2, 6, 4], "b": [8, 8, 12], "z": [14.0, 16.0, 18.0], "o": [1, 3, 2]}
     assert_equal_data(result, expected)

--- a/tests/frame/drop_nulls_test.py
+++ b/tests/frame/drop_nulls_test.py
@@ -6,20 +6,14 @@ import narwhals.stable.v1 as nw
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
-data = {
-    "a": [1.0, 2.0, None, 4.0],
-    "b": [None, 3.0, None, 5.0],
-}
+data = {"a": [1.0, 2.0, None, 4.0], "b": [None, 3.0, None, 5.0]}
 
 
 def test_drop_nulls(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     result = nw.from_native(constructor(data)).drop_nulls()
-    expected = {
-        "a": [2.0, 4.0],
-        "b": [3.0, 5.0],
-    }
+    expected = {"a": [2.0, 4.0], "b": [3.0, 5.0]}
     assert_equal_data(result, expected)
 
 

--- a/tests/frame/drop_test.py
+++ b/tests/frame/drop_test.py
@@ -17,11 +17,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.parametrize(
     ("to_drop", "expected"),
-    [
-        ("abc", ["b", "z"]),
-        (["abc"], ["b", "z"]),
-        (["abc", "b"], ["z"]),
-    ],
+    [("abc", ["b", "z"]), (["abc"], ["b", "z"]), (["abc", "b"], ["z"])],
 )
 def test_drop(constructor: Constructor, to_drop: list[str], expected: list[str]) -> None:
     data = {"abc": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
@@ -34,10 +30,7 @@ def test_drop(constructor: Constructor, to_drop: list[str], expected: list[str])
 @pytest.mark.parametrize(
     ("strict", "context"),
     [
-        (
-            True,
-            pytest.raises((ColumnNotFoundError, PlColumnNotFoundError), match="z"),
-        ),
+        (True, pytest.raises((ColumnNotFoundError, PlColumnNotFoundError), match="z")),
         (False, does_not_raise()),
     ],
 )

--- a/tests/frame/getitem_test.py
+++ b/tests/frame/getitem_test.py
@@ -10,10 +10,7 @@ import narwhals.stable.v1 as nw
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {
-    "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-    "b": [11, 12, 13, 14, 15, 16],
-}
+data = {"a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], "b": [11, 12, 13, 14, 15, 16]}
 
 
 def test_slice_column(constructor_eager: ConstructorEager) -> None:
@@ -41,8 +38,7 @@ def test_slice_rows_with_step(
 
 def test_slice_rows_with_step_pyarrow() -> None:
     with pytest.raises(
-        NotImplementedError,
-        match="Slicing with step is not supported on PyArrow tables",
+        NotImplementedError, match="Slicing with step is not supported on PyArrow tables"
     ):
         nw.from_native(pa.table(data))[1::2]
 
@@ -67,10 +63,7 @@ def test_slice_fails(constructor_eager: ConstructorEager) -> None:
 def test_gather(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df[[0, 3, 1]]
-    expected = {
-        "a": [1.0, 4.0, 2.0],
-        "b": [11, 14, 12],
-    }
+    expected = {"a": [1.0, 4.0, 2.0], "b": [11, 14, 12]}
     assert_equal_data(result, expected)
     result = df[np.array([0, 3, 1])]
     assert_equal_data(result, expected)
@@ -227,12 +220,7 @@ def test_get_item_works_with_tuple_and_list_and_range_row_and_col_indexing(
 
 
 @pytest.mark.parametrize(
-    ("row_idx", "col"),
-    [
-        ([0, 2], slice(1)),
-        ((0, 2), slice(1)),
-        (range(2), slice(1)),
-    ],
+    ("row_idx", "col"), [([0, 2], slice(1)), ((0, 2), slice(1)), (range(2), slice(1))]
 )
 def test_get_item_works_with_tuple_and_list_and_range_row_indexing_and_slice_col_indexing(
     constructor_eager: ConstructorEager,
@@ -244,17 +232,10 @@ def test_get_item_works_with_tuple_and_list_and_range_row_indexing_and_slice_col
 
 
 @pytest.mark.parametrize(
-    ("row_idx", "col"),
-    [
-        ([0, 2], "a"),
-        ((0, 2), "a"),
-        (range(2), "a"),
-    ],
+    ("row_idx", "col"), [([0, 2], "a"), ((0, 2), "a"), (range(2), "a")]
 )
 def test_get_item_works_with_tuple_and_list_indexing_and_str(
-    constructor_eager: ConstructorEager,
-    row_idx: list[int] | tuple[int] | range,
-    col: str,
+    constructor_eager: ConstructorEager, row_idx: list[int] | tuple[int] | range, col: str
 ) -> None:
     nw_df = nw.from_native(constructor_eager(data), eager_only=True)
     nw_df[row_idx, col]

--- a/tests/frame/interchange_native_namespace_test.py
+++ b/tests/frame/interchange_native_namespace_test.py
@@ -27,9 +27,7 @@ def test_interchange() -> None:
 
 
 @pytest.mark.filterwarnings("ignore:.*The `ArrowDtype` class is not available in pandas")
-def test_ibis(
-    tmpdir: pytest.TempdirFactory,
-) -> None:  # pragma: no cover
+def test_ibis(tmpdir: pytest.TempdirFactory) -> None:  # pragma: no cover
     ibis = pytest.importorskip("ibis")
     df_pl = pl.DataFrame(data)
 

--- a/tests/frame/interchange_select_test.py
+++ b/tests/frame/interchange_select_test.py
@@ -42,9 +42,7 @@ def test_interchange() -> None:
     assert result.columns == ["a", "z"]
 
 
-def test_interchange_ibis(
-    tmpdir: pytest.TempdirFactory,
-) -> None:  # pragma: no cover
+def test_interchange_ibis(tmpdir: pytest.TempdirFactory) -> None:  # pragma: no cover
     ibis = pytest.importorskip("ibis")
     df_pl = pl.DataFrame(data)
 

--- a/tests/frame/interchange_to_pandas_test.py
+++ b/tests/frame/interchange_to_pandas_test.py
@@ -19,8 +19,7 @@ def test_interchange_to_pandas(request: pytest.FixtureRequest) -> None:
 
 
 def test_interchange_ibis_to_pandas(
-    tmpdir: pytest.TempdirFactory,
-    request: pytest.FixtureRequest,
+    tmpdir: pytest.TempdirFactory, request: pytest.FixtureRequest
 ) -> None:  # pragma: no cover
     if PANDAS_VERSION < (1, 5, 0):
         request.applymarker(pytest.mark.xfail)

--- a/tests/frame/item_test.py
+++ b/tests/frame/item_test.py
@@ -10,10 +10,7 @@ from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
 
-@pytest.mark.parametrize(
-    ("row", "column", "expected"),
-    [(0, 2, 7), (1, "z", 8)],
-)
+@pytest.mark.parametrize(("row", "column", "expected"), [(0, 2, 7), (1, "z", 8)])
 def test_item(
     constructor_eager: ConstructorEager,
     row: int | None,
@@ -29,16 +26,8 @@ def test_item(
 @pytest.mark.parametrize(
     ("row", "column", "err_msg"),
     [
-        (
-            0,
-            None,
-            re.escape("cannot call `.item()` with only one of `row` or `column`"),
-        ),
-        (
-            None,
-            0,
-            re.escape("cannot call `.item()` with only one of `row` or `column`"),
-        ),
+        (0, None, re.escape("cannot call `.item()` with only one of `row` or `column`")),
+        (None, 0, re.escape("cannot call `.item()` with only one of `row` or `column`")),
         (
             None,
             None,

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -95,11 +95,7 @@ def test_cross_join(constructor: Constructor, request: pytest.FixtureRequest) ->
 @pytest.mark.parametrize("how", ["inner", "left"])
 @pytest.mark.parametrize("suffix", ["_right", "_custom_suffix"])
 def test_suffix(constructor: Constructor, how: str, suffix: str) -> None:
-    data = {
-        "antananarivo": [1, 3, 2],
-        "bob": [4, 4, 6],
-        "zorro": [7.0, 8, 9],
-    }
+    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zorro": [7.0, 8, 9]}
     df = nw.from_native(constructor(data))
     df_right = df
     result = df.join(
@@ -361,8 +357,7 @@ def test_join_keys_exceptions(constructor: Constructor, how: str) -> None:
 
 
 def test_joinasof_numeric(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
+    constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if any(x in str(constructor) for x in ("pyarrow_table", "cudf", "duckdb")):
         request.applymarker(pytest.mark.xfail)
@@ -419,10 +414,7 @@ def test_joinasof_numeric(
     assert_equal_data(result_nearest_on, expected_nearest)
 
 
-def test_joinasof_time(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
-) -> None:
+def test_joinasof_time(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if any(x in str(constructor) for x in ("pyarrow_table", "cudf", "duckdb")):
         request.applymarker(pytest.mark.xfail)
     if PANDAS_VERSION < (2, 1) and ("pandas_pyarrow" in str(constructor)):
@@ -500,10 +492,7 @@ def test_joinasof_time(
     assert_equal_data(result_nearest_on, expected_nearest)
 
 
-def test_joinasof_by(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
-) -> None:
+def test_joinasof_by(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if any(x in str(constructor) for x in ("pyarrow_table", "cudf", "duckdb")):
         request.applymarker(pytest.mark.xfail)
     if PANDAS_VERSION < (2, 1) and (
@@ -575,8 +564,7 @@ def test_joinasof_keys_exceptions(constructor: Constructor) -> None:
     ):
         df.join_asof(df)  # type: ignore[arg-type]
     with pytest.raises(
-        ValueError,
-        match="If `on` is specified, `left_on` and `right_on` should be None.",
+        ValueError, match="If `on` is specified, `left_on` and `right_on` should be None."
     ):
         df.join_asof(
             df,  # type: ignore[arg-type]
@@ -585,13 +573,11 @@ def test_joinasof_keys_exceptions(constructor: Constructor) -> None:
             on="antananarivo",
         )
     with pytest.raises(
-        ValueError,
-        match="If `on` is specified, `left_on` and `right_on` should be None.",
+        ValueError, match="If `on` is specified, `left_on` and `right_on` should be None."
     ):
         df.join_asof(df, left_on="antananarivo", on="antananarivo")  # type: ignore[arg-type]
     with pytest.raises(
-        ValueError,
-        match="If `on` is specified, `left_on` and `right_on` should be None.",
+        ValueError, match="If `on` is specified, `left_on` and `right_on` should be None."
     ):
         df.join_asof(df, right_on="antananarivo", on="antananarivo")  # type: ignore[arg-type]
 
@@ -600,8 +586,7 @@ def test_joinasof_by_exceptions(constructor: Constructor) -> None:
     data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zorro": [7.0, 8, 9]}
     df = nw.from_native(constructor(data))
     with pytest.raises(
-        ValueError,
-        match="If `by` is specified, `by_left` and `by_right` should be None.",
+        ValueError, match="If `by` is specified, `by_left` and `by_right` should be None."
     ):
         df.join_asof(df, on="antananarivo", by_left="bob", by_right="bob", by="bob")  # type: ignore[arg-type]
 
@@ -618,13 +603,11 @@ def test_joinasof_by_exceptions(constructor: Constructor) -> None:
         df.join_asof(df, on="antananarivo", by_right="bob")  # type: ignore[arg-type]
 
     with pytest.raises(
-        ValueError,
-        match="If `by` is specified, `by_left` and `by_right` should be None.",
+        ValueError, match="If `by` is specified, `by_left` and `by_right` should be None."
     ):
         df.join_asof(df, on="antananarivo", by_left="bob", by="bob")  # type: ignore[arg-type]
 
     with pytest.raises(
-        ValueError,
-        match="If `by` is specified, `by_left` and `by_right` should be None.",
+        ValueError, match="If `by` is specified, `by_left` and `by_right` should be None."
     ):
         df.join_asof(df, on="antananarivo", by_right="bob", by="bob")  # type: ignore[arg-type]

--- a/tests/frame/len_test.py
+++ b/tests/frame/len_test.py
@@ -6,10 +6,7 @@ import narwhals.stable.v1 as nw
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
-data = {
-    "a": [1.0, 2.0, None, 4.0],
-    "b": [None, 3.0, None, 5.0],
-}
+data = {"a": [1.0, 2.0, None, 4.0], "b": [None, 3.0, None, 5.0]}
 
 
 def test_len(constructor_eager: ConstructorEager) -> None:

--- a/tests/frame/pipe_test.py
+++ b/tests/frame/pipe_test.py
@@ -4,10 +4,7 @@ import narwhals.stable.v1 as nw
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
-data = {
-    "a": ["foo", "bars"],
-    "ab": ["foo", "bars"],
-}
+data = {"a": ["foo", "bars"], "ab": ["foo", "bars"]}
 
 
 def test_pipe(constructor: Constructor) -> None:

--- a/tests/frame/row_test.py
+++ b/tests/frame/row_test.py
@@ -15,10 +15,7 @@ def test_row_column(request: Any, constructor_eager: ConstructorEager) -> None:
     if "cudf" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
 
-    data = {
-        "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-        "b": [11, 12, 13, 14, 15, 16],
-    }
+    data = {"a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], "b": [11, 12, 13, 14, 15, 16]}
     result = nw.from_native(constructor_eager(data), eager_only=True).row(2)
     if "pyarrow_table" in str(constructor_eager):
         result = tuple(x.as_py() for x in result)

--- a/tests/frame/schema_test.py
+++ b/tests/frame/schema_test.py
@@ -19,10 +19,7 @@ if TYPE_CHECKING:
     from tests.utils import ConstructorEager
 
 
-data = {
-    "a": [datetime(2020, 1, 1)],
-    "b": [datetime(2020, 1, 1, tzinfo=timezone.utc)],
-}
+data = {"a": [datetime(2020, 1, 1)], "b": [datetime(2020, 1, 1, tzinfo=timezone.utc)]}
 
 
 @pytest.mark.filterwarnings("ignore:Determining|Resolving.*")
@@ -196,8 +193,7 @@ def test_schema_object(method: str, expected: Any) -> None:
 
 
 @pytest.mark.skipif(
-    PANDAS_VERSION < (2,),
-    reason="Before 2.0, pandas would raise on `drop_duplicates`",
+    PANDAS_VERSION < (2,), reason="Before 2.0, pandas would raise on `drop_duplicates`"
 )
 def test_from_non_hashable_column_name() -> None:
     # This is technically super-illegal
@@ -209,10 +205,7 @@ def test_from_non_hashable_column_name() -> None:
     assert df["pizza"].dtype == nw.Int64
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < (2, 2, 0),
-    reason="too old for pyarrow types",
-)
+@pytest.mark.skipif(PANDAS_VERSION < (2, 2, 0), reason="too old for pyarrow types")
 def test_nested_dtypes() -> None:
     duckdb = pytest.importorskip("duckdb")
     df = pl.DataFrame(
@@ -268,10 +261,7 @@ def test_nested_dtypes_ibis(request: pytest.FixtureRequest) -> None:  # pragma: 
     assert nwdf.schema == {"a": nw.List(nw.Int64), "c": nw.Struct({"a": nw.Int64})}
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < (2, 2, 0),
-    reason="too old for pyarrow types",
-)
+@pytest.mark.skipif(PANDAS_VERSION < (2, 2, 0), reason="too old for pyarrow types")
 def test_nested_dtypes_dask() -> None:
     pytest.importorskip("dask")
     pytest.importorskip("dask_expr", exc_type=ImportError)

--- a/tests/frame/sort_test.py
+++ b/tests/frame/sort_test.py
@@ -11,18 +11,10 @@ def test_sort(constructor: Constructor) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df = nw.from_native(constructor(data))
     result = df.sort("a", "b")
-    expected = {
-        "a": [1, 2, 3],
-        "b": [4, 6, 4],
-        "z": [7.0, 9.0, 8.0],
-    }
+    expected = {"a": [1, 2, 3], "b": [4, 6, 4], "z": [7.0, 9.0, 8.0]}
     assert_equal_data(result, expected)
     result = df.sort("a", "b", descending=[True, False])
-    expected = {
-        "a": [3, 2, 1],
-        "b": [4, 6, 4],
-        "z": [8.0, 9.0, 7.0],
-    }
+    expected = {"a": [3, 2, 1], "b": [4, 6, 4], "z": [8.0, 9.0, 7.0]}
     assert_equal_data(result, expected)
 
 

--- a/tests/frame/to_arrow_test.py
+++ b/tests/frame/to_arrow_test.py
@@ -14,8 +14,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.filterwarnings("ignore:.*is_sparse is deprecated:DeprecationWarning")
 def test_to_arrow(
-    request: pytest.FixtureRequest,
-    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
     if "pandas" in str(constructor_eager) and PANDAS_VERSION < (1, 0, 0):
         # pyarrow requires pandas>=1.0.0

--- a/tests/frame/to_pandas_test.py
+++ b/tests/frame/to_pandas_test.py
@@ -13,13 +13,8 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.filterwarnings("ignore:.*Passing a BlockManager.*:DeprecationWarning")
-@pytest.mark.skipif(
-    PANDAS_VERSION < (2, 0, 0),
-    reason="too old for pandas-pyarrow",
-)
-def test_convert_pandas(
-    constructor_eager: ConstructorEager,
-) -> None:
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="too old for pandas-pyarrow")
+def test_convert_pandas(constructor_eager: ConstructorEager) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df_raw = constructor_eager(data)
     result = nw.from_native(df_raw).to_pandas()  # type: ignore[union-attr]

--- a/tests/frame/unique_test.py
+++ b/tests/frame/unique_test.py
@@ -34,10 +34,7 @@ def test_unique(
 ) -> None:
     df_raw = constructor(data)
     df = nw.from_native(df_raw)
-    if isinstance(df, nw.LazyFrame) and keep in {
-        "first",
-        "last",
-    }:
+    if isinstance(df, nw.LazyFrame) and keep in {"first", "last"}:
         context: Any = pytest.raises(ValueError, match="row order")
     elif keep == "foo":
         context = pytest.raises(ValueError, match=": foo")

--- a/tests/frame/unpivot_test.py
+++ b/tests/frame/unpivot_test.py
@@ -13,17 +13,9 @@ from tests.utils import assert_equal_data
 if TYPE_CHECKING:
     from narwhals.stable.v1.dtypes import DType
 
-data = {
-    "a": ["x", "y", "z"],
-    "b": [1, 3, 5],
-    "c": [2, 4, 6],
-}
+data = {"a": ["x", "y", "z"], "b": [1, 3, 5], "c": [2, 4, 6]}
 
-expected_b_only = {
-    "a": ["x", "y", "z"],
-    "variable": ["b", "b", "b"],
-    "value": [1, 3, 5],
-}
+expected_b_only = {"a": ["x", "y", "z"], "variable": ["b", "b", "b"], "value": [1, 3, 5]}
 
 expected_b_c = {
     "a": ["x", "y", "z", "x", "y", "z"],
@@ -53,9 +45,7 @@ def test_unpivot_on(
     ],
 )
 def test_unpivot_var_value_names(
-    constructor: Constructor,
-    variable_name: str | None,
-    value_name: str | None,
+    constructor: Constructor, variable_name: str | None, value_name: str | None
 ) -> None:
     df = nw.from_native(constructor(data))
     result = df.unpivot(
@@ -78,7 +68,7 @@ def test_unpivot_default_var_value_names(constructor: Constructor) -> None:
         (
             {"idx": [0, 1], "a": [1, 2], "b": [1.5, 2.5]},
             [nw.Int64(), nw.String(), nw.Float64()],
-        ),
+        )
     ],
 )
 def test_unpivot_mixed_types(

--- a/tests/frame/with_columns_sequence_test.py
+++ b/tests/frame/with_columns_sequence_test.py
@@ -6,10 +6,7 @@ import narwhals.stable.v1 as nw
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {
-    "a": ["foo", "bars"],
-    "ab": ["foo", "bars"],
-}
+data = {"a": ["foo", "bars"], "ab": ["foo", "bars"]}
 
 
 def test_with_columns(constructor_eager: ConstructorEager) -> None:

--- a/tests/frame/with_columns_test.py
+++ b/tests/frame/with_columns_test.py
@@ -47,8 +47,7 @@ def test_with_columns_order_single_row(constructor: Constructor) -> None:
 
 
 def test_with_columns_dtypes_single_row(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
+    constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if "pyarrow_table" in str(constructor) and PYARROW_VERSION < (15,):
         request.applymarker(pytest.mark.xfail)

--- a/tests/frame/with_row_index_test.py
+++ b/tests/frame/with_row_index_test.py
@@ -6,10 +6,7 @@ import narwhals.stable.v1 as nw
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
-data = {
-    "a": ["foo", "bars"],
-    "ab": ["foo", "bars"],
-}
+data = {"a": ["foo", "bars"], "ab": ["foo", "bars"]}
 
 
 def test_with_row_index(constructor: Constructor, request: pytest.FixtureRequest) -> None:

--- a/tests/frame/write_parquet_test.py
+++ b/tests/frame/write_parquet_test.py
@@ -16,8 +16,7 @@ data = {"a": [1, 2, 3]}
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="too old for pyarrow")
 @pytest.mark.filterwarnings("ignore:.*is_sparse is deprecated:DeprecationWarning")
 def test_write_parquet(
-    constructor_eager: ConstructorEager,
-    tmpdir: pytest.TempdirFactory,
+    constructor_eager: ConstructorEager, tmpdir: pytest.TempdirFactory
 ) -> None:
     path = tmpdir / "foo.parquet"  # type: ignore[operator]
     nw.from_native(constructor_eager(data), eager_only=True).write_parquet(str(path))

--- a/tests/from_dict_test.py
+++ b/tests/from_dict_test.py
@@ -44,17 +44,13 @@ def test_from_dict_without_namespace(constructor: Constructor) -> None:
     assert_equal_data(result, {"c": [1, 2, 3], "d": [4, 5, 6]})
 
 
-def test_from_dict_without_namespace_invalid(
-    constructor: Constructor,
-) -> None:
+def test_from_dict_without_namespace_invalid(constructor: Constructor) -> None:
     df = nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]})).lazy().collect()
     with pytest.raises(TypeError, match="namespace"):
         nw.from_dict({"c": nw.to_native(df["a"]), "d": nw.to_native(df["b"])})
 
 
-def test_from_dict_one_native_one_narwhals(
-    constructor: Constructor,
-) -> None:
+def test_from_dict_one_native_one_narwhals(constructor: Constructor) -> None:
     df = nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]})).lazy().collect()
     result = nw.from_dict({"c": nw.to_native(df["a"]), "d": df["b"]})
     expected = {"c": [1, 2, 3], "d": [4, 5, 6]}

--- a/tests/from_numpy_test.py
+++ b/tests/from_numpy_test.py
@@ -57,11 +57,7 @@ def test_from_numpy_schema_list(
     schema = ["c", "d", "e", "f"]
     df = nw_v1.from_native(constructor(data))
     native_namespace = nw_v1.get_native_namespace(df)
-    result = nw_v1.from_numpy(
-        arr,
-        native_namespace=native_namespace,
-        schema=schema,
-    )
+    result = nw_v1.from_numpy(arr, native_namespace=native_namespace, schema=schema)
     assert result.columns == schema
 
 

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -127,13 +127,7 @@ def test_group_by_depth_1_agg(
 
 
 @pytest.mark.parametrize(
-    ("attr", "ddof"),
-    [
-        ("std", 0),
-        ("var", 0),
-        ("std", 2),
-        ("var", 2),
-    ],
+    ("attr", "ddof"), [("std", 0), ("var", 0), ("std", 2), ("var", 2)]
 )
 def test_group_by_depth_1_std_var(
     constructor: Constructor, attr: str, ddof: int, request: pytest.FixtureRequest
@@ -214,37 +208,17 @@ def test_group_by_simple_named(constructor: Constructor) -> None:
     data = {"a": [1, 1, 2], "b": [4, 5, 6], "c": [7, 2, 1]}
     df = nw.from_native(constructor(data)).lazy()
     result = (
-        df.group_by("a")
-        .agg(
-            b_min=nw.col("b").min(),
-            b_max=nw.col("b").max(),
-        )
-        .sort("a")
+        df.group_by("a").agg(b_min=nw.col("b").min(), b_max=nw.col("b").max()).sort("a")
     )
-    expected = {
-        "a": [1, 2],
-        "b_min": [4, 6],
-        "b_max": [5, 6],
-    }
+    expected = {"a": [1, 2], "b_min": [4, 6], "b_max": [5, 6]}
     assert_equal_data(result, expected)
 
 
 def test_group_by_simple_unnamed(constructor: Constructor) -> None:
     data = {"a": [1, 1, 2], "b": [4, 5, 6], "c": [7, 2, 1]}
     df = nw.from_native(constructor(data)).lazy()
-    result = (
-        df.group_by("a")
-        .agg(
-            nw.col("b").min(),
-            nw.col("c").max(),
-        )
-        .sort("a")
-    )
-    expected = {
-        "a": [1, 2],
-        "b": [4, 6],
-        "c": [7, 1],
-    }
+    result = df.group_by("a").agg(nw.col("b").min(), nw.col("c").max()).sort("a")
+    expected = {"a": [1, 2], "b": [4, 6], "c": [7, 1]}
     assert_equal_data(result, expected)
 
 
@@ -253,25 +227,14 @@ def test_group_by_multiple_keys(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data)).lazy()
     result = (
         df.group_by("a", "b")
-        .agg(
-            c_min=nw.col("c").min(),
-            c_max=nw.col("c").max(),
-        )
+        .agg(c_min=nw.col("c").min(), c_max=nw.col("c").max())
         .sort("a")
     )
-    expected = {
-        "a": [1, 2],
-        "b": [4, 6],
-        "c_min": [2, 1],
-        "c_max": [7, 1],
-    }
+    expected = {"a": [1, 2], "b": [4, 6], "c_min": [2, 1], "c_max": [7, 1]}
     assert_equal_data(result, expected)
 
 
-def test_key_with_nulls(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
-) -> None:
+def test_key_with_nulls(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if "modin" in str(constructor):
         # TODO(unassigned): Modin flaky here?
         request.applymarker(pytest.mark.skip)
@@ -311,8 +274,7 @@ def test_key_with_nulls_ignored(
 
 
 def test_key_with_nulls_iter(
-    constructor_eager: ConstructorEager,
-    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
 ) -> None:
     if PANDAS_VERSION < (1, 0) and "pandas_constructor" in str(constructor_eager):
         # Grouping by null values is not supported in pandas < 1.0.0
@@ -346,8 +308,7 @@ def test_no_agg(constructor: Constructor) -> None:
 
 
 def test_group_by_categorical(
-    constructor: Constructor,
-    request: pytest.FixtureRequest,
+    constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
@@ -362,8 +323,7 @@ def test_group_by_categorical(
     df = nw.from_native(constructor(data))
     result = (
         df.with_columns(
-            g1=nw.col("g1").cast(nw.Categorical()),
-            g2=nw.col("g2").cast(nw.Categorical()),
+            g1=nw.col("g1").cast(nw.Categorical()), g2=nw.col("g2").cast(nw.Categorical())
         )
         .group_by(["g1", "g2"])
         .agg(nw.col("x").sum())

--- a/tests/hypothesis/basic_arithmetic_test.py
+++ b/tests/hypothesis/basic_arithmetic_test.py
@@ -24,21 +24,10 @@ import narwhals.stable.v1 as nw
 )  # type: ignore[misc]
 @pytest.mark.slow
 def test_mean(
-    integer: st.SearchStrategy[list[int]],
-    floats: st.SearchStrategy[float],
+    integer: st.SearchStrategy[list[int]], floats: st.SearchStrategy[float]
 ) -> None:
-    df_pandas = pd.DataFrame(
-        {
-            "integer": integer,
-            "floats": floats,
-        }
-    )
-    df_polars = pl.DataFrame(
-        {
-            "integer": integer,
-            "floats": floats,
-        },
-    )
+    df_pandas = pd.DataFrame({"integer": integer, "floats": floats})
+    df_polars = pl.DataFrame({"integer": integer, "floats": floats})
     df_nw1 = nw.from_native(df_pandas, eager_only=True)
     df_nw2 = nw.from_native(df_polars, eager_only=True)
 

--- a/tests/hypothesis/join_test.py
+++ b/tests/hypothesis/join_test.py
@@ -26,17 +26,8 @@ from tests.utils import assert_equal_data
         min_size=3,
         max_size=3,
     ),
-    st.lists(
-        st.floats(),
-        min_size=3,
-        max_size=3,
-    ),
-    st.lists(
-        st.sampled_from(["a", "b", "c"]),
-        min_size=1,
-        max_size=3,
-        unique=True,
-    ),
+    st.lists(st.floats(), min_size=3, max_size=3),
+    st.lists(st.sampled_from(["a", "b", "c"]), min_size=1, max_size=3, unique=True),
 )  # type: ignore[misc]
 @pytest.mark.skipif(POLARS_VERSION < (0, 20, 13), reason="0.0 == -0.0")
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="requires pyarrow")
@@ -89,8 +80,7 @@ def test_join(  # pragma: no cover
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="requires pyarrow")
 @pytest.mark.slow
 def test_cross_join(  # pragma: no cover
-    integers: st.SearchStrategy[list[int]],
-    other_integers: st.SearchStrategy[list[int]],
+    integers: st.SearchStrategy[list[int]], other_integers: st.SearchStrategy[list[int]]
 ) -> None:
     data = {"a": integers, "b": other_integers}
 
@@ -177,6 +167,5 @@ def test_left_join(  # pragma: no cover
         .pipe(lambda df: df.sort(df.columns))
     )
     assert_equal_data(
-        result_pa,
-        result_pd.pipe(lambda df: df.sort(df.columns)).to_dict(as_series=False),
+        result_pa, result_pd.pipe(lambda df: df.sort(df.columns)).to_dict(as_series=False)
     )

--- a/tests/read_scan_test.py
+++ b/tests/read_scan_test.py
@@ -15,8 +15,7 @@ data = {"a": [1, 2, 3], "b": [4.5, 6.7, 8.9], "z": ["x", "y", "w"]}
 
 
 def test_read_csv(
-    tmpdir: pytest.TempdirFactory,
-    constructor_eager: ConstructorEager,
+    tmpdir: pytest.TempdirFactory, constructor_eager: ConstructorEager
 ) -> None:
     df_pl = pl.DataFrame(data)
     filepath = str(tmpdir / "file.csv")  # type: ignore[operator]
@@ -50,10 +49,7 @@ def test_read_csv_kwargs(tmpdir: pytest.TempdirFactory) -> None:
     assert_equal_data(result, data)
 
 
-def test_scan_csv(
-    tmpdir: pytest.TempdirFactory,
-    constructor: Constructor,
-) -> None:
+def test_scan_csv(tmpdir: pytest.TempdirFactory, constructor: Constructor) -> None:
     df_pl = pl.DataFrame(data)
     filepath = str(tmpdir / "file.csv")  # type: ignore[operator]
     df_pl.write_csv(filepath)
@@ -64,10 +60,7 @@ def test_scan_csv(
     assert isinstance(result, nw.LazyFrame)
 
 
-def test_scan_csv_v1(
-    tmpdir: pytest.TempdirFactory,
-    constructor: Constructor,
-) -> None:
+def test_scan_csv_v1(tmpdir: pytest.TempdirFactory, constructor: Constructor) -> None:
     df_pl = pl.DataFrame(data)
     filepath = str(tmpdir / "file.csv")  # type: ignore[operator]
     df_pl.write_csv(filepath)
@@ -89,8 +82,7 @@ def test_scan_csv_kwargs(tmpdir: pytest.TempdirFactory) -> None:
 
 @pytest.mark.skipif(PANDAS_VERSION < (1, 5), reason="too old for pyarrow")
 def test_read_parquet(
-    tmpdir: pytest.TempdirFactory,
-    constructor_eager: ConstructorEager,
+    tmpdir: pytest.TempdirFactory, constructor_eager: ConstructorEager
 ) -> None:
     df_pl = pl.DataFrame(data)
     filepath = str(tmpdir / "file.parquet")  # type: ignore[operator]
@@ -126,10 +118,7 @@ def test_read_parquet_kwargs(tmpdir: pytest.TempdirFactory) -> None:
 
 
 @pytest.mark.skipif(PANDAS_VERSION < (1, 5), reason="too old for pyarrow")
-def test_scan_parquet(
-    tmpdir: pytest.TempdirFactory,
-    constructor: Constructor,
-) -> None:
+def test_scan_parquet(tmpdir: pytest.TempdirFactory, constructor: Constructor) -> None:
     df_pl = pl.DataFrame(data)
     filepath = str(tmpdir / "file.parquet")  # type: ignore[operator]
     df_pl.write_parquet(filepath)
@@ -141,10 +130,7 @@ def test_scan_parquet(
 
 
 @pytest.mark.skipif(PANDAS_VERSION < (1, 5), reason="too old for pyarrow")
-def test_scan_parquet_v1(
-    tmpdir: pytest.TempdirFactory,
-    constructor: Constructor,
-) -> None:
+def test_scan_parquet_v1(tmpdir: pytest.TempdirFactory, constructor: Constructor) -> None:
     df_pl = pl.DataFrame(data)
     filepath = str(tmpdir / "file.parquet")  # type: ignore[operator]
     df_pl.write_parquet(filepath)

--- a/tests/selectors_test.py
+++ b/tests/selectors_test.py
@@ -59,10 +59,7 @@ def test_string(constructor: Constructor, request: pytest.FixtureRequest) -> Non
     assert_equal_data(result, expected)
 
 
-def test_categorical(
-    request: pytest.FixtureRequest,
-    constructor: Constructor,
-) -> None:
+def test_categorical(request: pytest.FixtureRequest, constructor: Constructor) -> None:
     if "pyarrow_table_constructor" in str(constructor) and PYARROW_VERSION <= (
         15,
     ):  # pragma: no cover

--- a/tests/series_only/__contains___test.py
+++ b/tests/series_only/__contains___test.py
@@ -29,9 +29,7 @@ def test_contains(
 
 @pytest.mark.parametrize("other", ["foo", [1, 2, 3]])
 def test_contains_invalid_type(
-    request: pytest.FixtureRequest,
-    constructor_eager: ConstructorEager,
-    other: Any,
+    request: pytest.FixtureRequest, constructor_eager: ConstructorEager, other: Any
 ) -> None:
     if "polars" not in str(constructor_eager) and "pyarrow_table" not in str(
         constructor_eager

--- a/tests/series_only/array_dunder_test.py
+++ b/tests/series_only/array_dunder_test.py
@@ -11,8 +11,7 @@ from tests.utils import assert_equal_data
 
 
 def test_array_dunder(
-    request: pytest.FixtureRequest,
-    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
     if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (
         16,
@@ -27,8 +26,7 @@ def test_array_dunder(
 
 
 def test_array_dunder_with_dtype(
-    request: pytest.FixtureRequest,
-    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
     if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (
         16,
@@ -43,8 +41,7 @@ def test_array_dunder_with_dtype(
 
 
 def test_array_dunder_with_copy(
-    request: pytest.FixtureRequest,
-    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
     if "pyarrow_table" in str(constructor_eager) and PYARROW_VERSION < (
         16,

--- a/tests/series_only/cast_test.py
+++ b/tests/series_only/cast_test.py
@@ -67,10 +67,7 @@ def test_cast_date_datetime_pyarrow() -> None:
     assert result == expected
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < (2, 0, 0),
-    reason="pyarrow dtype not available",
-)
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="pyarrow dtype not available")
 def test_cast_date_datetime_pandas() -> None:
     # pandas: pyarrow date to datetime
     dfpd = pd.DataFrame({"a": [date(2020, 1, 1), date(2020, 1, 2)]}).astype(

--- a/tests/series_only/scatter_test.py
+++ b/tests/series_only/scatter_test.py
@@ -17,13 +17,9 @@ def test_scatter(
         constructor_eager({"a": [1, 2, 3], "b": [142, 124, 132]}), eager_only=True
     )
     result = df.with_columns(
-        df["a"].scatter([0, 1], [999, 888]),
-        df["b"].scatter([0, 2, 1], df["b"]),
+        df["a"].scatter([0, 1], [999, 888]), df["b"].scatter([0, 2, 1], df["b"])
     )
-    expected = {
-        "a": [999, 888, 3],
-        "b": [142, 132, 124],
-    }
+    expected = {"a": [999, 888, 3], "b": [142, 132, 124]}
     assert_equal_data(result, expected)
 
 
@@ -34,10 +30,7 @@ def test_scatter_unchanged(constructor_eager: ConstructorEager) -> None:
     df.with_columns(
         df["a"].scatter([0, 1], [999, 888]), df["b"].scatter([0, 2, 1], [142, 124, 132])
     )
-    expected = {
-        "a": [1, 2, 3],
-        "b": [142, 124, 132],
-    }
+    expected = {"a": [1, 2, 3], "b": [142, 124, 132]}
     assert_equal_data(df, expected)
 
 

--- a/tests/series_only/to_pandas_test.py
+++ b/tests/series_only/to_pandas_test.py
@@ -17,8 +17,7 @@ data = [1, 3, 2]
 
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="too old for pyarrow")
 def test_convert(
-    request: pytest.FixtureRequest,
-    constructor_eager: ConstructorEager,
+    request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
     if any(
         cname in str(constructor_eager)

--- a/tests/spark_like_test.py
+++ b/tests/spark_like_test.py
@@ -160,11 +160,7 @@ def test_collect_schema(pyspark_constructor: Constructor) -> None:
 # copied from tests/frame/drop_test.py
 @pytest.mark.parametrize(
     ("to_drop", "expected"),
-    [
-        ("abc", ["b", "z"]),
-        (["abc"], ["b", "z"]),
-        (["abc", "b"], ["z"]),
-    ],
+    [("abc", ["b", "z"]), (["abc"], ["b", "z"]), (["abc", "b"], ["z"])],
 )
 def test_drop(
     pyspark_constructor: Constructor, to_drop: list[str], expected: list[str]
@@ -178,10 +174,7 @@ def test_drop(
 
 @pytest.mark.parametrize(
     ("strict", "context"),
-    [
-        (True, pytest.raises(ColumnNotFoundError, match="z")),
-        (False, does_not_raise()),
-    ],
+    [(True, pytest.raises(ColumnNotFoundError, match="z")), (False, does_not_raise())],
 )
 def test_drop_strict(
     pyspark_constructor: Constructor, context: Any, *, strict: bool
@@ -220,18 +213,10 @@ def test_sort(pyspark_constructor: Constructor) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df = nw.from_native(pyspark_constructor(data))
     result = df.sort("a", "b")
-    expected = {
-        "a": [1, 2, 3],
-        "b": [4, 6, 4],
-        "z": [7.0, 9.0, 8.0],
-    }
+    expected = {"a": [1, 2, 3], "b": [4, 6, 4], "z": [7.0, 9.0, 8.0]}
     assert_equal_data(result, expected)
     result = df.sort("a", "b", descending=[True, False]).lazy().collect()
-    expected = {
-        "a": [3, 2, 1],
-        "b": [4, 6, 4],
-        "z": [8.0, 9.0, 7.0],
-    }
+    expected = {"a": [3, 2, 1], "b": [4, 6, 4], "z": [8.0, 9.0, 7.0]}
     assert_equal_data(result, expected)
 
 
@@ -283,10 +268,7 @@ def test_abs(pyspark_constructor: Constructor) -> None:
 @pytest.mark.parametrize("expr1", ["a", nw.col("a")])
 @pytest.mark.parametrize("expr2", ["b", nw.col("b")])
 def test_allh(pyspark_constructor: Constructor, expr1: Any, expr2: Any) -> None:
-    data = {
-        "a": [False, False, True],
-        "b": [False, True, True],
-    }
+    data = {"a": [False, False, True], "b": [False, True, True]}
     df = nw.from_native(pyspark_constructor(data))
     result = df.select(all=nw.all_horizontal(expr1, expr2))
 
@@ -295,10 +277,7 @@ def test_allh(pyspark_constructor: Constructor, expr1: Any, expr2: Any) -> None:
 
 
 def test_allh_all(pyspark_constructor: Constructor) -> None:
-    data = {
-        "a": [False, False, True],
-        "b": [False, True, True],
-    }
+    data = {"a": [False, False, True], "b": [False, True, True]}
     df = nw.from_native(pyspark_constructor(data))
     result = df.select(all=nw.all_horizontal(nw.all()))
     expected = {"all": [False, False, True]}
@@ -336,14 +315,10 @@ def test_sumh_all(pyspark_constructor: Constructor) -> None:
     data = {"a": [1, 2, 3], "b": [10, 20, 30]}
     df = nw.from_native(pyspark_constructor(data))
     result = df.select(nw.sum_horizontal(nw.all()))
-    expected = {
-        "a": [11, 22, 33],
-    }
+    expected = {"a": [11, 22, 33]}
     assert_equal_data(result, expected)
     result = df.select(c=nw.sum_horizontal(nw.all()))
-    expected = {
-        "c": [11, 22, 33],
-    }
+    expected = {"c": [11, 22, 33]}
     assert_equal_data(result, expected)
 
 
@@ -369,12 +344,7 @@ def test_double_alias(pyspark_constructor: Constructor) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
     df = nw.from_native(pyspark_constructor(data))
     result = df.with_columns(nw.col("a").alias("o"), nw.all() * 2)
-    expected = {
-        "a": [2, 6, 4],
-        "b": [8, 8, 12],
-        "z": [14.0, 16.0, 18.0],
-        "o": [1, 3, 2],
-    }
+    expected = {"a": [2, 6, 4], "b": [8, 8, 12], "z": [14.0, 16.0, 18.0], "o": [1, 3, 2]}
     assert_equal_data(result, expected)
 
 
@@ -468,18 +438,11 @@ def test_group_by_simple_named(pyspark_constructor: Constructor) -> None:
     df = nw.from_native(pyspark_constructor(data)).lazy()
     result = (
         df.group_by("a")
-        .agg(
-            b_min=nw.col("b").min(),
-            b_max=nw.col("b").max(),
-        )
+        .agg(b_min=nw.col("b").min(), b_max=nw.col("b").max())
         .collect()
         .sort("a")
     )
-    expected = {
-        "a": [1, 2],
-        "b_min": [4, 6],
-        "b_max": [5, 6],
-    }
+    expected = {"a": [1, 2], "b_min": [4, 6], "b_max": [5, 6]}
     assert_equal_data(result, expected)
 
 
@@ -487,19 +450,9 @@ def test_group_by_simple_unnamed(pyspark_constructor: Constructor) -> None:
     data = {"a": [1, 1, 2], "b": [4, 5, 6], "c": [7, 2, 1]}
     df = nw.from_native(pyspark_constructor(data)).lazy()
     result = (
-        df.group_by("a")
-        .agg(
-            nw.col("b").min(),
-            nw.col("c").max(),
-        )
-        .collect()
-        .sort("a")
+        df.group_by("a").agg(nw.col("b").min(), nw.col("c").max()).collect().sort("a")
     )
-    expected = {
-        "a": [1, 2],
-        "b": [4, 6],
-        "c": [7, 1],
-    }
+    expected = {"a": [1, 2], "b": [4, 6], "c": [7, 1]}
     assert_equal_data(result, expected)
 
 
@@ -508,36 +461,20 @@ def test_group_by_multiple_keys(pyspark_constructor: Constructor) -> None:
     df = nw.from_native(pyspark_constructor(data)).lazy()
     result = (
         df.group_by("a", "b")
-        .agg(
-            c_min=nw.col("c").min(),
-            c_max=nw.col("c").max(),
-        )
+        .agg(c_min=nw.col("c").min(), c_max=nw.col("c").max())
         .collect()
         .sort("a")
     )
-    expected = {
-        "a": [1, 2],
-        "b": [4, 6],
-        "c_min": [2, 1],
-        "c_max": [7, 1],
-    }
+    expected = {"a": [1, 2], "b": [4, 6], "c_min": [2, 1], "c_max": [7, 1]}
     assert_equal_data(result, expected)
 
 
 # copied from tests/group_by_test.py
 @pytest.mark.parametrize(
-    ("attr", "ddof"),
-    [
-        ("std", 0),
-        ("var", 0),
-        ("std", 2),
-        ("var", 2),
-    ],
+    ("attr", "ddof"), [("std", 0), ("var", 0), ("std", 2), ("var", 2)]
 )
 def test_group_by_depth_1_std_var(
-    pyspark_constructor: Constructor,
-    attr: str,
-    ddof: int,
+    pyspark_constructor: Constructor, attr: str, ddof: int
 ) -> None:
     data = {"a": [1, 1, 1, 2, 2, 2], "b": [4, 5, 6, 0, 5, 5]}
     _pow = 0.5 if attr == "std" else 1
@@ -555,16 +492,10 @@ def test_group_by_depth_1_std_var(
 
 # copied from tests/frame/drop_nulls_test.py
 def test_drop_nulls(pyspark_constructor: Constructor) -> None:
-    data = {
-        "a": [1.0, 2.0, None, 4.0],
-        "b": [None, 3.0, None, 5.0],
-    }
+    data = {"a": [1.0, 2.0, None, 4.0], "b": [None, 3.0, None, 5.0]}
 
     result = nw.from_native(pyspark_constructor(data)).drop_nulls()
-    expected = {
-        "a": [2.0, 4.0],
-        "b": [3.0, 5.0],
-    }
+    expected = {"a": [2.0, 4.0], "b": [3.0, 5.0]}
     assert_equal_data(result, expected)
 
 
@@ -577,14 +508,9 @@ def test_drop_nulls(pyspark_constructor: Constructor) -> None:
     ],
 )
 def test_drop_nulls_subset(
-    pyspark_constructor: Constructor,
-    subset: str | list[str],
-    expected: dict[str, float],
+    pyspark_constructor: Constructor, subset: str | list[str], expected: dict[str, float]
 ) -> None:
-    data = {
-        "a": [1.0, 2.0, None, 4.0],
-        "b": [None, 3.0, None, 5.0],
-    }
+    data = {"a": [1.0, 2.0, None, 4.0], "b": [None, 3.0, None, 5.0]}
 
     result = nw.from_native(pyspark_constructor(data)).drop_nulls(subset=subset)
     assert_equal_data(result, expected)
@@ -730,8 +656,7 @@ def test_cross_join(pyspark_constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
     with pytest.raises(
-        ValueError,
-        match="Can not pass `left_on`, `right_on` or `on` keys for cross join",
+        ValueError, match="Can not pass `left_on`, `right_on` or `on` keys for cross join"
     ):
         df.join(other, how="cross", left_on="antananarivo")  # type: ignore[arg-type]
 
@@ -739,11 +664,7 @@ def test_cross_join(pyspark_constructor: Constructor) -> None:
 @pytest.mark.parametrize("how", ["inner", "left"])
 @pytest.mark.parametrize("suffix", ["_right", "_custom_suffix"])
 def test_suffix(pyspark_constructor: Constructor, how: str, suffix: str) -> None:
-    data = {
-        "antananarivo": [1, 3, 2],
-        "bob": [4, 4, 6],
-        "zorro": [7.0, 8, 9],
-    }
+    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zorro": [7.0, 8, 9]}
     df = nw.from_native(pyspark_constructor(data))
     df_right = nw.from_native(pyspark_constructor(data))
     result = df.join(
@@ -842,16 +763,8 @@ def test_semi_join(
 
 
 def test_left_join(pyspark_constructor: Constructor) -> None:
-    data_left = {
-        "antananarivo": [1.0, 2, 3],
-        "bob": [4.0, 5, 6],
-        "idx": [0.0, 1.0, 2.0],
-    }
-    data_right = {
-        "antananarivo": [1.0, 2, 3],
-        "co": [4.0, 5, 7],
-        "idx": [0.0, 1.0, 2.0],
-    }
+    data_left = {"antananarivo": [1.0, 2, 3], "bob": [4.0, 5, 6], "idx": [0.0, 1.0, 2.0]}
+    data_right = {"antananarivo": [1.0, 2, 3], "co": [4.0, 5, 7], "idx": [0.0, 1.0, 2.0]}
     df_left = nw.from_native(pyspark_constructor(data_left))
     df_right = nw.from_native(pyspark_constructor(data_right))
     result = (
@@ -1039,9 +952,7 @@ def test_is_unique(pyspark_constructor: Constructor) -> None:
     data = {"a": [1, 1, 2, None], "b": [1, 2, None, None], "level_0": [0, 1, 2, 3]}
     df = nw.from_native(pyspark_constructor(data))
     result = df.select(
-        a=nw.col("a").is_unique(),
-        b=nw.col("b").is_unique(),
-        level_0=nw.col("level_0"),
+        a=nw.col("a").is_unique(), b=nw.col("b").is_unique(), level_0=nw.col("level_0")
     ).sort("level_0")
     expected = {
         "a": [False, False, True, True],
@@ -1054,10 +965,7 @@ def test_is_unique(pyspark_constructor: Constructor) -> None:
 def test_len(pyspark_constructor: Constructor) -> None:
     data = {"a": [1, 2, float("nan"), 4, None], "b": [None, 3, None, 5, None]}
     df = nw.from_native(pyspark_constructor(data))
-    result = df.select(
-        a=nw.col("a").len(),
-        b=nw.col("b").len(),
-    )
+    result = df.select(a=nw.col("a").len(), b=nw.col("b").len())
     expected = {"a": [5], "b": [5]}
     assert_equal_data(result, expected)
 

--- a/tests/tpch_q1_test.py
+++ b/tests/tpch_q1_test.py
@@ -15,10 +15,7 @@ from tests.utils import PANDAS_VERSION
 from tests.utils import assert_equal_data
 
 
-@pytest.mark.parametrize(
-    "library",
-    ["pandas", "polars", "pyarrow", "dask"],
-)
+@pytest.mark.parametrize("library", ["pandas", "polars", "pyarrow", "dask"])
 @pytest.mark.filterwarnings("ignore:.*Passing a BlockManager.*:DeprecationWarning")
 def test_q1(library: str, request: pytest.FixtureRequest) -> None:
     if library == "dask" and DASK_VERSION < (2024, 10):
@@ -65,7 +62,7 @@ def test_q1(library: str, request: pytest.FixtureRequest) -> None:
                 nw.col("l_extendedprice").mean().alias("avg_price"),
                 nw.col("l_discount").mean().alias("avg_disc"),
                 nw.len().alias("count_order"),
-            ],
+            ]
         )
         .sort(["l_returnflag", "l_linestatus"])
     )
@@ -94,10 +91,7 @@ def test_q1(library: str, request: pytest.FixtureRequest) -> None:
     assert_equal_data(query_result, expected)
 
 
-@pytest.mark.parametrize(
-    "library",
-    ["pandas", "polars"],
-)
+@pytest.mark.parametrize("library", ["pandas", "polars"])
 @pytest.mark.filterwarnings(
     "ignore:.*Passing a BlockManager.*:DeprecationWarning",
     "ignore:.*Complex.*:UserWarning",
@@ -119,7 +113,7 @@ def test_q1_w_generic_funcs(library: str, request: pytest.FixtureRequest) -> Non
                 nw.col("l_extendedprice")
                 * (1.0 - nw.col("l_discount"))
                 * (1.0 + nw.col("l_tax"))
-            ),
+            )
         )
         .group_by(["l_returnflag", "l_linestatus"])
         .agg(
@@ -191,7 +185,7 @@ def test_q1_w_pandas_agg_generic_path() -> None:
                 nw.mean("l_extendedprice").alias("avg_price"),
                 nw.mean("l_discount").alias("avg_disc"),
                 nw.len().alias("count_order"),
-            ],
+            ]
         )
         .sort(["l_returnflag", "l_linestatus"])
     )

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -55,28 +55,13 @@ class MockSeries:
         return self
 
 
-eager_frames = [
-    df_pd,
-    df_pl,
-    df_mpd,
-    df_pa,
-    MockDataFrame(),
-]
+eager_frames = [df_pd, df_pl, df_mpd, df_pa, MockDataFrame()]
 
-lazy_frames = [
-    lf_pl,
-    MockLazyFrame(),
-]
+lazy_frames = [lf_pl, MockLazyFrame()]
 
 all_frames = [*eager_frames, *lazy_frames]
 
-all_series = [
-    series_pd,
-    series_pl,
-    series_mpd,
-    series_pa,
-    MockSeries(),
-]
+all_series = [series_pd, series_pl, series_mpd, series_pa, MockSeries()]
 
 
 @pytest.mark.parametrize(

--- a/tests/translate/to_py_scalar_test.py
+++ b/tests/translate/to_py_scalar_test.py
@@ -35,10 +35,7 @@ from tests.utils import PANDAS_VERSION
         (np.datetime64("2020-01-01", "ns"), datetime(2020, 1, 1)),
     ],
 )
-def test_to_py_scalar(
-    input_value: Any,
-    expected: Any,
-) -> None:
+def test_to_py_scalar(input_value: Any, expected: Any) -> None:
     output = nw.to_py_scalar(input_value)
     if expected == 1:
         assert not isinstance(output, np.int64)
@@ -52,10 +49,7 @@ def test_na_to_py_scalar() -> None:
     assert nw.to_py_scalar(pd.NA) is None
 
 
-@pytest.mark.parametrize(
-    "input_value",
-    [np.array([1, 2]), [1, 2, 3], {"a": [1, 2, 3]}],
-)
+@pytest.mark.parametrize("input_value", [np.array([1, 2]), [1, 2, 3], {"a": [1, 2, 3]}])
 def test_to_py_scalar_value_error(input_value: Any) -> None:
     with pytest.raises(ValueError, match="Expected object convertible to a scalar"):
         nw.to_py_scalar(input_value)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -63,10 +63,7 @@ def test_maybe_align_index_polars() -> None:
         nw.maybe_align_index(df, s[1:])
 
 
-@pytest.mark.parametrize(
-    "column_names",
-    ["b", ["a", "b"]],
-)
+@pytest.mark.parametrize("column_names", ["b", ["a", "b"]])
 def test_maybe_set_index_pandas_column_names(
     column_names: str | list[str] | None,
 ) -> None:
@@ -76,13 +73,7 @@ def test_maybe_set_index_pandas_column_names(
     assert_frame_equal(nw.to_native(result), expected)
 
 
-@pytest.mark.parametrize(
-    "column_names",
-    [
-        "b",
-        ["a", "b"],
-    ],
-)
+@pytest.mark.parametrize("column_names", ["b", ["a", "b"]])
 def test_maybe_set_index_polars_column_names(
     column_names: str | list[str] | None,
 ) -> None:
@@ -104,10 +95,7 @@ def test_maybe_set_index_polars_column_names(
                 nw.from_native(pd.Series([0, 1, 2]), series_only=True),
                 nw.from_native(pd.Series([1, 2, 0]), series_only=True),
             ],
-            [
-                pd.Series([0, 1, 2]),
-                pd.Series([1, 2, 0]),
-            ],
+            [pd.Series([0, 1, 2]), pd.Series([1, 2, 0])],
         ),
     ],
 )
@@ -261,8 +249,7 @@ def test_generate_temporary_column_name_raise() -> None:
     columns = [
         "".join(t)
         for t in product(
-            string.ascii_lowercase + string.digits,
-            string.ascii_lowercase + string.digits,
+            string.ascii_lowercase + string.digits, string.ascii_lowercase + string.digits
         )
     ]
 

--- a/tpch/queries/q10.py
+++ b/tpch/queries/q10.py
@@ -11,10 +11,7 @@ if TYPE_CHECKING:
 
 @nw.narwhalify
 def query(
-    customer_ds: FrameT,
-    nation_ds: FrameT,
-    lineitem_ds: FrameT,
-    orders_ds: FrameT,
+    customer_ds: FrameT, nation_ds: FrameT, lineitem_ds: FrameT, orders_ds: FrameT
 ) -> FrameT:
     var1 = datetime(1993, 10, 1)
     var2 = datetime(1994, 1, 1)

--- a/tpch/queries/q11.py
+++ b/tpch/queries/q11.py
@@ -9,11 +9,7 @@ if TYPE_CHECKING:
 
 
 @nw.narwhalify
-def query(
-    nation_ds: FrameT,
-    partsupp_ds: FrameT,
-    supplier_ds: FrameT,
-) -> FrameT:
+def query(nation_ds: FrameT, partsupp_ds: FrameT, supplier_ds: FrameT) -> FrameT:
     var1 = "GERMANY"
     var2 = 0.0001
 

--- a/tpch/queries/q15.py
+++ b/tpch/queries/q15.py
@@ -10,10 +10,7 @@ if TYPE_CHECKING:
 
 
 @nw.narwhalify
-def query(
-    lineitem_ds: FrameT,
-    supplier_ds: FrameT,
-) -> FrameT:
+def query(lineitem_ds: FrameT, supplier_ds: FrameT) -> FrameT:
     var1 = datetime(1996, 1, 1)
     var2 = datetime(1996, 4, 1)
 

--- a/tpch/queries/q21.py
+++ b/tpch/queries/q21.py
@@ -9,12 +9,7 @@ if TYPE_CHECKING:
 
 
 @nw.narwhalify
-def query(
-    lineitem: FrameT,
-    nation: FrameT,
-    orders: FrameT,
-    supplier: FrameT,
-) -> FrameT:
+def query(lineitem: FrameT, nation: FrameT, orders: FrameT, supplier: FrameT) -> FrameT:
     var1 = "SAUDI ARABIA"
 
     q1 = (
@@ -31,11 +26,7 @@ def query(
     return (
         q1.group_by("l_orderkey")
         .agg(nw.len().alias("n_supp_by_order"))
-        .join(
-            q1,
-            left_on="l_orderkey",
-            right_on="l_orderkey",
-        )
+        .join(q1, left_on="l_orderkey", right_on="l_orderkey")
         .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
         .join(nation, left_on="s_nationkey", right_on="n_nationkey")
         .join(orders, left_on="l_orderkey", right_on="o_orderkey")

--- a/tpch/queries/q3.py
+++ b/tpch/queries/q3.py
@@ -10,11 +10,7 @@ if TYPE_CHECKING:
 
 
 @nw.narwhalify
-def query(
-    customer_ds: FrameT,
-    line_item_ds: FrameT,
-    orders_ds: FrameT,
-) -> FrameT:
+def query(customer_ds: FrameT, line_item_ds: FrameT, orders_ds: FrameT) -> FrameT:
     var_1 = var_2 = datetime(1995, 3, 15)
     var_3 = "BUILDING"
 
@@ -22,10 +18,7 @@ def query(
         customer_ds.filter(nw.col("c_mktsegment") == var_3)
         .join(orders_ds, left_on="c_custkey", right_on="o_custkey")
         .join(line_item_ds, left_on="o_orderkey", right_on="l_orderkey")
-        .filter(
-            nw.col("o_orderdate") < var_2,
-            nw.col("l_shipdate") > var_1,
-        )
+        .filter(nw.col("o_orderdate") < var_2, nw.col("l_shipdate") > var_1)
         .with_columns(
             (nw.col("l_extendedprice") * (1 - nw.col("l_discount"))).alias("revenue")
         )

--- a/tpch/queries/q4.py
+++ b/tpch/queries/q4.py
@@ -10,10 +10,7 @@ if TYPE_CHECKING:
 
 
 @nw.narwhalify
-def query(
-    line_item_ds: FrameT,
-    orders_ds: FrameT,
-) -> FrameT:
+def query(line_item_ds: FrameT, orders_ds: FrameT) -> FrameT:
     var_1 = datetime(1993, 7, 1)
     var_2 = datetime(1993, 10, 1)
 

--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -58,19 +58,13 @@ with open("pyproject.toml", "w", encoding="utf-8") as f:
 
 with open("narwhals/__init__.py", encoding="utf-8") as f:
     content = f.read()
-content = content.replace(
-    f'__version__ = "{old_version}"',
-    f'__version__ = "{version}"',
-)
+content = content.replace(f'__version__ = "{old_version}"', f'__version__ = "{version}"')
 with open("narwhals/__init__.py", "w", encoding="utf-8") as f:
     f.write(content)
 
 with open("docs/installation.md", encoding="utf-8") as f:
     content = f.read()
-content = content.replace(
-    f"'{old_version}'",
-    f"'{version}'",
-)
+content = content.replace(f"'{old_version}'", f"'{version}'")
 with open("docs/installation.md", "w", encoding="utf-8") as f:
     f.write(content)
 


### PR DESCRIPTION
yeah i wrote a script to do this:
```python
import sys
import subprocess
import tokenize_rt

ret = 0
for file in sys.argv[1:]:
    with open(file) as fd:
        src = fd.read()
    tokens = tokenize_rt.src_to_tokens(src)
    n = len(tokens)
    if n < 2:
        continue
    tokens_to_remove: list[int] = []
    parens = 0
    n_commas = 0
    for i in range(len(tokens)):
        token = tokens[i]
        if token.name == 'OP' and token.src == '(':
            parens += 1
        elif token.name == 'OP' and token.src == ')':
            parens -= 1
        elif parens > 0 and token.name == 'OP' and token.src == ',':
            n_commas += 1

        if token.name == 'OP' and token.src == ')' and parens == 0:
            if n_commas > 1:
                j = i-1
                while j >0 and not tokens[j].src.strip():
                    j -= 1
                if tokens[j].name == 'OP' and tokens[j].src == ',':
                    tokens_to_remove.append(j)
            n_commas = 0
    if tokens_to_remove:
        for i in tokens_to_remove[::-1]:
            del tokens[i]
        with open(file, 'w') as fd:
            fd.write(tokenize_rt.tokens_to_src(tokens))
        subprocess.run(['ruff', 'format', file], capture_output=True)
        with open(file) as fd:
            new_src = fd.read()
        if new_src != src:
            ret = 1

sys.exit(ret)
```
😳 