### PR TITLE
feat: duckdb replace_all with regex

### DIFF
--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -662,8 +662,17 @@ class DuckDBExprStringNamespace:
         from duckdb import FunctionExpression
 
         if literal is False:
-            msg = "`replace_all` for DuckDB currently only supports `literal=True`."
-            raise NotImplementedError(msg)
+            return self._compliant_expr._from_call(
+                lambda _input: FunctionExpression(
+                    "regexp_replace",
+                    _input,
+                    ConstantExpression(pattern),
+                    ConstantExpression(value),
+                    ConstantExpression("g"),
+                ),
+                "replace_all",
+                returns_scalar=self._compliant_expr._returns_scalar,
+            )
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression(
                 "replace", _input, ConstantExpression(pattern), ConstantExpression(value)

--- a/tests/expr_and_series/str/replace_test.py
+++ b/tests/expr_and_series/str/replace_test.py
@@ -116,15 +116,12 @@ def test_str_replace_expr(
 )
 def test_str_replace_all_expr(
     constructor: Constructor,
-    request: pytest.FixtureRequest,
     data: dict[str, list[str]],
     pattern: str,
     value: str,
     literal: bool,  # noqa: FBT001
     expected: dict[str, list[str]],
 ) -> None:
-    if "duckdb" in str(constructor) and literal is False:
-        request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     result = df.select(
         nw.col("a").str.replace_all(pattern=pattern, value=value, literal=literal)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #1728 

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Turns out all duckdb regex functions support a limited set of regex options that are documented here:
https://duckdb.org/docs/sql/functions/regular_expressions.html but not on their text functions page here https://duckdb.org/docs/sql/functions/char.html#regexp_replacestring-pattern-replacement.

Adding the global `'g'` option prevents the regexp from returning after the first match :)