### PR TITLE
fix root names in pyspark reduction with nw.all()

### DIFF
--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -102,7 +102,9 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             for _input in inputs:
                 input_col_name = get_column_name(df, _input)
                 column_result = call(_input, **_kwargs)
-                if not returns_scalar:
+                if not returns_scalar or (
+                    (self._depth == 0) and (self._function_name == "all")
+                ):
                     column_result = column_result.alias(input_col_name)
                 results.append(column_result)
             return results

--- a/tests/expr_and_series/n_unique_test.py
+++ b/tests/expr_and_series/n_unique_test.py
@@ -13,7 +13,7 @@ data = {
 
 def test_n_unique(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
-    result = df.select(nw.col("a", "b").n_unique())
+    result = df.select(nw.all().n_unique())
     expected = {"a": [3], "b": [4]}
     assert_equal_data(result, expected)
 


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #1780 

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Checking if the parent expression is the root and if that expression is "all" to also alias the result seems to alleviate this problem in this particular test. 

This may need to be revisited when the `.name` namespace is created for pyspark as I am unsure whether or not this approach play nicely with multi columnar renaming functions like `prefix`, `suffix` or `map`.