### PR TITLE
feat: add `drop_nulls`, `fill_null`, and `filter` Spark Expressions

### DIFF
--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -316,19 +316,21 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
             # TODO(unauthored): can only specify `limit` when strategy is set to 'backward' or 'forward'
 
+            fill_value: Column | Any
+
             if strategy is not None:
                 match strategy:
                     case "zero":
-                        fill_value = F.lit(0)
+                        fill_value = 0
                     case "one":
-                        fill_value = F.lit(1)
+                        fill_value = 1
                     case _:
                         msg = f"strategy not supported: {strategy}"
                         raise ValueError(msg)
             else:
                 fill_value = value
 
-            return F.ifnull(_input, fill_value)
+            return F.ifnull(_input, F.lit(fill_value))
 
         return self._from_call(_fill_null, "fill_null", returns_scalar=True)
 

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -370,8 +370,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         return self._from_call(
             _filter,
             "filter",
-            predicates=predicates,
-            constraints=constraints,
             returns_scalar=self._returns_scalar,
         )
 

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -352,7 +352,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         self, *predicates: IntoExpr | Iterable[IntoExpr], **constraints: Any
     ) -> Self:
         def _filter(
-            _input: Column, *predicates: IntoExpr | Iterable[IntoExpr], **constraints: Any
+            _input: Column, predicates: Iterable[IntoExpr], constraints: Any
         ) -> Column:
             from pyspark.sql import functions as F  # noqa: N812
 
@@ -370,7 +370,9 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         return self._from_call(
             _filter,
             "filter",
-            returns_scalar=True,
+            predicates=predicates,
+            constraints=constraints,
+            returns_scalar=self._returns_scalar,
         )
 
     def max(self) -> Self:

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -370,8 +370,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         return self._from_call(
             _filter,
             "filter",
-            predicates=predicates,
-            constraints=constraints,
             returns_scalar=True,
         )
 
@@ -528,11 +526,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             values=values,
             returns_scalar=self._returns_scalar,
         )
-
-    def is_nan(self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
-
-        return self._from_call(F.isnan, "is_nan", returns_scalar=True)
 
     def is_unique(self) -> Self:
         def _is_unique(_input: Column) -> Column:

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -295,7 +295,9 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
     def drop_nulls(self) -> Self:
         def _drop_nulls(_input: Column) -> Column:
-            return _input.isNotNull()
+            from pyspark.sql import functions as F  # noqa: N812
+
+            return F.explode(F.filter(F.array(_input), F.isnotnull))
 
         return self._from_call(_drop_nulls, "drop_nulls", returns_scalar=True)
 

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -365,7 +365,9 @@ class SparkLikeExpr(CompliantExpr["Column"]):
                     ],
                 )
             query = reduce(operator.and_, predicates)
-            return F.explode(F.filter(F.array(_input), lambda _: query))
+            return F.explode(
+                F.filter(F.array(_input), lambda _: query)
+            )  # TODO (unauthored): resolve PySparkValueError: [HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN] Function `<lambda>` should return Column, got SparkLikeExpr.
 
         return self._from_call(
             _filter,

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -314,15 +314,19 @@ class SparkLikeExpr(CompliantExpr["Column"]):
                 msg = "must specify either a fill `value` or `strategy`"
                 raise ValueError(msg)
 
-            fill_value = value
-            match strategy:
-                case "zero":
-                    fill_value = F.lit(0)
-                case "one":
-                    fill_value = F.lit(1)
-                case _:
-                    msg = f"strategy not supported: {strategy}"
-                    raise ValueError(msg)
+            # TODO(unauthored): can only specify `limit` when strategy is set to 'backward' or 'forward'
+
+            if strategy is not None:
+                match strategy:
+                    case "zero":
+                        fill_value = F.lit(0)
+                    case "one":
+                        fill_value = F.lit(1)
+                    case _:
+                        msg = f"strategy not supported: {strategy}"
+                        raise ValueError(msg)
+            else:
+                fill_value = value
 
             return F.ifnull(_input, fill_value)
 

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -488,6 +488,11 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             returns_scalar=self._returns_scalar,
         )
 
+    def is_nan(self) -> Self:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        return self._from_call(F.isnan, "is_nan", returns_scalar=True)
+
     def is_unique(self) -> Self:
         def _is_unique(_input: Column) -> Column:
             from pyspark.sql import Window

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -370,6 +370,8 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         return self._from_call(
             _filter,
             "filter",
+            predicates=predicates,
+            constraints=constraints,
             returns_scalar=self._returns_scalar,
         )
 

--- a/tests/expr_and_series/fill_null_test.py
+++ b/tests/expr_and_series/fill_null_test.py
@@ -12,9 +12,7 @@ from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
 
-def test_fill_null(request: pytest.FixtureRequest, constructor: Constructor) -> None:
-    if "pyspark" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
+def test_fill_null(constructor: Constructor) -> None:
     data = {
         "a": [0.0, None, 2, 3, 4],
         "b": [1.0, None, None, 5, 3],

--- a/tests/expr_and_series/fill_null_test.py
+++ b/tests/expr_and_series/fill_null_test.py
@@ -50,7 +50,7 @@ def test_fill_null_exceptions(constructor: Constructor) -> None:
 def test_fill_null_strategies_with_limit_as_none(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
-    if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
+    if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     data_limits = {
         "a": [1, None, None, None, 5, 6, None, None, None, 10],
@@ -120,7 +120,7 @@ def test_fill_null_strategies_with_limit_as_none(
 def test_fill_null_limits(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
-    if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
+    if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     context: Any = (
         pytest.raises(NotImplementedError, match="The limit keyword is not supported")

--- a/tests/expr_and_series/is_nan_test.py
+++ b/tests/expr_and_series/is_nan_test.py
@@ -25,7 +25,7 @@ NON_NULLABLE_CONSTRUCTORS = [
 
 
 def test_nan(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if "duckdb" in str(constructor):
+    if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     data_na = {"int": [0, 1, None]}
     df = nw.from_native(constructor(data_na)).with_columns(
@@ -96,7 +96,7 @@ def test_nan_series(constructor_eager: ConstructorEager) -> None:
 
 
 def test_nan_non_float(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if "duckdb" in str(constructor):
+    if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     from polars.exceptions import InvalidOperationError as PlInvalidOperationError
     from pyarrow.lib import ArrowNotImplementedError

--- a/tests/expr_and_series/is_nan_test.py
+++ b/tests/expr_and_series/is_nan_test.py
@@ -25,7 +25,7 @@ NON_NULLABLE_CONSTRUCTORS = [
 
 
 def test_nan(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
+    if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     data_na = {"int": [0, 1, None]}
     df = nw.from_native(constructor(data_na)).with_columns(
@@ -96,7 +96,7 @@ def test_nan_series(constructor_eager: ConstructorEager) -> None:
 
 
 def test_nan_non_float(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
+    if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     from polars.exceptions import InvalidOperationError as PlInvalidOperationError
     from pyarrow.lib import ArrowNotImplementedError


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Builds on #1714 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Added support for the following methods - made sure to remove all pyspark constructor checks in the main test suite:
- `drop_nulls`
- `fill_null`
  - noticed the only strategies currently supported in `nw.Expr.fill_null` are "forward" and "backward" - are there plans to add more strategies (possibly in v2)?
- `filter` (_work in progress_)
  - solution works fine in PySpark but doesn't carry over to narwhals (`pyspark.sql.function.filter` expects the predicate to return a `Column`; however, it raises an error since `_from_call` returns `SparkLikeExpr`).
  - lmk if I'm missing something basic