### PR TITLE
chore: refactor `isinstance_or_issubclass` to allow tuples

### DIFF
--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -86,7 +86,7 @@ def narwhals_to_native_dtype(
         return pyspark_types.StringType()
     if isinstance_or_issubclass(dtype, dtypes.Boolean):
         return pyspark_types.BooleanType()
-    if any(isinstance_or_issubclass(dtype, t) for t in [dtypes.Date, dtypes.Datetime]):
+    if isinstance_or_issubclass(dtype, (dtypes.Date, dtypes.Datetime)):
         msg = "Converting to Date or Datetime dtype is not supported yet"
         raise NotImplementedError(msg)
     if isinstance_or_issubclass(dtype, dtypes.List):  # pragma: no cover
@@ -98,9 +98,8 @@ def narwhals_to_native_dtype(
     if isinstance_or_issubclass(dtype, dtypes.Array):  # pragma: no cover
         msg = "Converting to Array dtype is not supported yet"
         raise NotImplementedError(msg)
-    if any(
-        isinstance_or_issubclass(dtype, t)
-        for t in [dtypes.UInt64, dtypes.UInt32, dtypes.UInt16, dtypes.UInt8]
+    if isinstance_or_issubclass(
+        dtype, (dtypes.UInt64, dtypes.UInt32, dtypes.UInt16, dtypes.UInt8)
     ):  # pragma: no cover
         msg = "Unsigned integer types are not supported by PySpark"
         raise UnsupportedDTypeError(msg)

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -388,12 +388,14 @@ def parse_version(version: str) -> tuple[int, ...]:
     return tuple(int(re.sub(r"\D", "", str(v))) for v in version.split("."))
 
 
-def isinstance_or_issubclass(obj: Any, cls: Any) -> bool:
+def isinstance_or_issubclass(obj_or_cls: object | type, cls_or_tuple: Any) -> bool:
     from narwhals.dtypes import DType
 
-    if isinstance(obj, DType):
-        return isinstance(obj, cls)
-    return isinstance(obj, cls) or (isinstance(obj, type) and issubclass(obj, cls))
+    if isinstance(obj_or_cls, DType):
+        return isinstance(obj_or_cls, cls_or_tuple)
+    return isinstance(obj_or_cls, cls_or_tuple) or (
+        isinstance(obj_or_cls, type) and issubclass(obj_or_cls, cls_or_tuple)
+    )
 
 
 def validate_laziness(items: Iterable[Any]) -> None:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
