### PR TITLE
test: decouple pyspark constructor from pandas

### DIFF
--- a/tests/expr_and_series/arg_max_test.py
+++ b/tests/expr_and_series/arg_max_test.py
@@ -6,7 +6,7 @@ import narwhals.stable.v1 as nw
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9], "i": [3, 1, 5]}
+data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0], "i": [3, 1, 5]}
 
 
 def test_expr_arg_max_expr(

--- a/tests/expr_and_series/arg_min_test.py
+++ b/tests/expr_and_series/arg_min_test.py
@@ -6,7 +6,7 @@ import narwhals.stable.v1 as nw
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
 
 
 def test_expr_arg_min_expr(

--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -45,7 +45,7 @@ def test_arithmetic_expr(
     ):
         request.applymarker(pytest.mark.xfail)
 
-    data = {"a": [1.0, 2, 3]}
+    data = {"a": [1.0, 2.0, 3.0]}
     df = nw.from_native(constructor(data))
     result = df.select(getattr(nw.col("a"), attr)(rhs))
     assert_equal_data(result, {"a": expected})
@@ -57,7 +57,7 @@ def test_arithmetic_expr(
         ("__radd__", 1, [2, 3, 4]),
         ("__rsub__", 1, [0, -1, -2]),
         ("__rmul__", 2, [2, 4, 6]),
-        ("__rtruediv__", 2.0, [2, 1, 2 / 3]),
+        ("__rtruediv__", 2.0, [2.0, 1.0, 2 / 3]),
         ("__rfloordiv__", 2, [2, 1, 0]),
         ("__rmod__", 2, [0, 0, 2]),
         ("__rpow__", 2, [2, 4, 8]),
@@ -119,7 +119,7 @@ def test_arithmetic_series(
         ("__radd__", 1, [2, 3, 4]),
         ("__rsub__", 1, [0, -1, -2]),
         ("__rmul__", 2, [2, 4, 6]),
-        ("__rtruediv__", 2.0, [2, 1, 2 / 3]),
+        ("__rtruediv__", 2.0, [2.0, 1.0, 2 / 3]),
         ("__rfloordiv__", 2, [2, 1, 0]),
         ("__rmod__", 2, [0, 0, 2]),
         ("__rpow__", 2, [2, 4, 8]),
@@ -231,7 +231,7 @@ def test_mod(left: int, right: int) -> None:
         ("__add__", nw.lit(1), [2, 3, 5]),
         ("__sub__", nw.lit(1), [0, -1, -3]),
         ("__mul__", nw.lit(2), [2, 4, 8]),
-        ("__truediv__", nw.lit(2.0), [2, 1, 0.5]),
+        ("__truediv__", nw.lit(2.0), [2.0, 1.0, 0.5]),
         ("__truediv__", nw.lit(1), [1, 0.5, 0.25]),
         ("__floordiv__", nw.lit(2), [2, 1, 0]),
         ("__mod__", nw.lit(3), [0, 1, 3]),
@@ -254,7 +254,7 @@ def test_arithmetic_expr_left_literal(
     ):
         request.applymarker(pytest.mark.xfail)
 
-    data = {"a": [1.0, 2, 4]}
+    data = {"a": [1.0, 2.0, 4.0]}
     df = nw.from_native(constructor(data))
     result = df.select(getattr(lhs, attr)(nw.col("a")))
     assert_equal_data(result, {"literal": expected})
@@ -266,8 +266,8 @@ def test_arithmetic_expr_left_literal(
         ("__add__", nw.lit(1), [2, 3, 5]),
         ("__sub__", nw.lit(1), [0, -1, -3]),
         ("__mul__", nw.lit(2), [2, 4, 8]),
-        ("__truediv__", nw.lit(2.0), [2, 1, 0.5]),
-        ("__truediv__", nw.lit(1), [1, 0.5, 0.25]),
+        ("__truediv__", nw.lit(2.0), [2.0, 1.0, 0.5]),
+        ("__truediv__", nw.lit(1), [1.0, 0.5, 0.25]),
         ("__floordiv__", nw.lit(2), [2, 1, 0]),
         ("__mod__", nw.lit(3), [0, 1, 3]),
         ("__pow__", nw.lit(2), [2, 4, 16]),
@@ -285,7 +285,7 @@ def test_arithmetic_series_left_literal(
     ):
         request.applymarker(pytest.mark.xfail)
 
-    data = {"a": [1.0, 2, 4]}
+    data = {"a": [1.0, 2.0, 4.0]}
     df = nw.from_native(constructor_eager(data))
     result = df.select(getattr(lhs, attr)(nw.col("a")))
     assert_equal_data(result, {"literal": expected})

--- a/tests/expr_and_series/binary_test.py
+++ b/tests/expr_and_series/binary_test.py
@@ -13,7 +13,7 @@ def test_expr_binary(constructor: Constructor, request: pytest.FixtureRequest) -
         constructor
     ):
         request.applymarker(pytest.mark.xfail)
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df_raw = constructor(data)
     result = nw.from_native(df_raw).with_columns(
         a=(1 + 3 * nw.col("a")) * (1 / nw.col("a")),

--- a/tests/expr_and_series/double_selected_test.py
+++ b/tests/expr_and_series/double_selected_test.py
@@ -6,7 +6,7 @@ from tests.utils import assert_equal_data
 
 
 def test_double_selected(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7, 8, 9]}
     df = nw.from_native(constructor(data))
 
     result = df.select(nw.col("a", "b") * 2)

--- a/tests/expr_and_series/double_test.py
+++ b/tests/expr_and_series/double_test.py
@@ -6,7 +6,7 @@ from tests.utils import assert_equal_data
 
 
 def test_double(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     result = df.with_columns(nw.all() * 2)
     expected = {"a": [2, 6, 4], "b": [8, 8, 12], "z": [14.0, 16.0, 18.0]}
@@ -14,7 +14,7 @@ def test_double(constructor: Constructor) -> None:
 
 
 def test_double_alias(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     result = df.with_columns(nw.col("a").alias("o"), nw.all() * 2)
     expected = {

--- a/tests/expr_and_series/fill_null_test.py
+++ b/tests/expr_and_series/fill_null_test.py
@@ -16,9 +16,9 @@ def test_fill_null(request: pytest.FixtureRequest, constructor: Constructor) -> 
     if "pyspark" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     data = {
-        "a": [0.0, None, 2, 3, 4],
-        "b": [1.0, None, None, 5, 3],
-        "c": [5.0, None, 3, 2, 1],
+        "a": [0.0, None, 2.0, 3.0, 4.0],
+        "b": [1.0, None, None, 5.0, 3.0],
+        "c": [5.0, None, 3.0, 2.0, 1.0],
     }
     df = nw.from_native(constructor(data))
 
@@ -33,7 +33,7 @@ def test_fill_null(request: pytest.FixtureRequest, constructor: Constructor) -> 
 
 def test_fill_null_exceptions(constructor: Constructor) -> None:
     data = {
-        "a": [0.0, None, 2, 3, 4],
+        "a": [0.0, None, 2.0, 3.0, 4.0],
     }
     df = nw.from_native(constructor(data))
 

--- a/tests/expr_and_series/is_duplicated_test.py
+++ b/tests/expr_and_series/is_duplicated_test.py
@@ -11,7 +11,7 @@ from tests.utils import assert_equal_data
 def test_is_duplicated_expr(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
-    if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
+    if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     data = {"a": [1, 1, 2], "b": [1, 2, 3], "index": [0, 1, 2]}
     df = nw.from_native(constructor(data))
@@ -23,7 +23,7 @@ def test_is_duplicated_expr(
 def test_is_duplicated_w_nulls_expr(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
-    if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
+    if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     data = {"a": [1, 1, None], "b": [1, None, None], "index": [0, 1, 2]}
     df = nw.from_native(constructor(data))

--- a/tests/expr_and_series/is_unique_test.py
+++ b/tests/expr_and_series/is_unique_test.py
@@ -9,7 +9,7 @@ from tests.utils import assert_equal_data
 
 
 def test_is_unique_expr(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
+    if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     data = {
         "a": [1, 1, 2],
@@ -29,7 +29,7 @@ def test_is_unique_expr(constructor: Constructor, request: pytest.FixtureRequest
 def test_is_unique_w_nulls_expr(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
-    if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
+    if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     data = {
         "a": [None, 1, 2],

--- a/tests/expr_and_series/lit_test.py
+++ b/tests/expr_and_series/lit_test.py
@@ -29,7 +29,7 @@ def test_lit(
 ) -> None:
     if "pyspark" in str(constructor) and dtype is not None:
         request.applymarker(pytest.mark.xfail)
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df_raw = constructor(data)
     df = nw.from_native(df_raw).lazy()
     result = df.with_columns(nw.lit(2, dtype).alias("lit"))
@@ -43,7 +43,7 @@ def test_lit(
 
 
 def test_lit_error(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df_raw = constructor(data)
     df = nw.from_native(df_raw).lazy()
     with pytest.raises(

--- a/tests/expr_and_series/max_test.py
+++ b/tests/expr_and_series/max_test.py
@@ -7,7 +7,7 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
 
 
 @pytest.mark.parametrize("expr", [nw.col("a", "b", "z").max(), nw.max("a", "b", "z")])

--- a/tests/expr_and_series/mean_test.py
+++ b/tests/expr_and_series/mean_test.py
@@ -7,7 +7,7 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {"a": [1, 3, 2], "b": [4, 4, 7], "z": [7.0, 8, 9]}
+data = {"a": [1, 3, 2], "b": [4, 4, 7], "z": [7.0, 8.0, 9.0]}
 
 
 @pytest.mark.parametrize("expr", [nw.col("a", "b", "z").mean(), nw.mean("a", "b", "z")])

--- a/tests/expr_and_series/median_test.py
+++ b/tests/expr_and_series/median_test.py
@@ -11,7 +11,7 @@ from tests.utils import assert_equal_data
 data = {
     "a": [3, 8, 2, None],
     "b": [5, 5, None, 7],
-    "z": [7.0, 8, 9, None],
+    "z": [7.0, 8.0, 9.0, None],
     "s": ["f", "a", "x", "x"],
 }
 

--- a/tests/expr_and_series/min_test.py
+++ b/tests/expr_and_series/min_test.py
@@ -7,7 +7,7 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
 
 
 @pytest.mark.parametrize("expr", [nw.col("a", "b", "z").min(), nw.min("a", "b", "z")])

--- a/tests/expr_and_series/n_unique_test.py
+++ b/tests/expr_and_series/n_unique_test.py
@@ -7,7 +7,7 @@ from tests.utils import assert_equal_data
 
 data = {
     "a": [1.0, None, None, 3.0],
-    "b": [1.0, None, 4, 5.0],
+    "b": [1.0, None, 4.0, 5.0],
 }
 
 

--- a/tests/expr_and_series/nth_test.py
+++ b/tests/expr_and_series/nth_test.py
@@ -8,7 +8,7 @@ from tests.utils import POLARS_VERSION
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
-data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8, 9]}
+data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8.0, 9.0]}
 
 
 @pytest.mark.parametrize(
@@ -16,7 +16,7 @@ data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8, 9]}
     [
         (0, {"a": [1, 3, 2]}),
         ([0, 1], {"a": [1, 3, 2], "b": [4, 4, 6]}),
-        ([0, 2], {"a": [1, 3, 2], "z": [7.1, 8, 9]}),
+        ([0, 2], {"a": [1, 3, 2], "z": [7.1, 8.0, 9.0]}),
     ],
 )
 def test_nth(

--- a/tests/expr_and_series/null_count_test.py
+++ b/tests/expr_and_series/null_count_test.py
@@ -7,7 +7,7 @@ from tests.utils import assert_equal_data
 
 data = {
     "a": [1.0, None, None, 3.0],
-    "b": [1.0, None, 4, 5.0],
+    "b": [1.0, None, 4.0, 5.0],
 }
 
 

--- a/tests/expr_and_series/quantile_test.py
+++ b/tests/expr_and_series/quantile_test.py
@@ -35,7 +35,7 @@ def test_quantile_expr(
         request.applymarker(pytest.mark.xfail)
 
     q = 0.3
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df_raw = constructor(data)
     df = nw.from_native(df_raw)
 
@@ -71,7 +71,7 @@ def test_quantile_series(
 ) -> None:
     q = 0.3
 
-    series = nw.from_native(constructor_eager({"a": [7.0, 8, 9]}), eager_only=True)[
+    series = nw.from_native(constructor_eager({"a": [7.0, 8.0, 9.0]}), eager_only=True)[
         "a"
     ].alias("a")
     result = series.quantile(quantile=q, interpolation=interpolation)

--- a/tests/expr_and_series/std_test.py
+++ b/tests/expr_and_series/std_test.py
@@ -9,8 +9,8 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
-data_with_nulls = {"a": [1, 3, 2, None], "b": [4, 4, 6, None], "z": [7.0, 8, 9, None]}
+data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
+data_with_nulls = {"a": [1, 3, 2, None], "b": [4, 4, 6, None], "z": [7.0, 8.0, 9.0, None]}
 
 expected_results = {
     "a_ddof_1": [1.0],

--- a/tests/expr_and_series/sum_horizontal_test.py
+++ b/tests/expr_and_series/sum_horizontal_test.py
@@ -15,7 +15,7 @@ def test_sumh(
 ) -> None:
     if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     result = df.with_columns(horizontal_sum=nw.sum_horizontal(col_expr, nw.col("b")))
     expected = {

--- a/tests/expr_and_series/sum_test.py
+++ b/tests/expr_and_series/sum_test.py
@@ -7,7 +7,7 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
 
 
 @pytest.mark.parametrize("expr", [nw.col("a", "b", "z").sum(), nw.sum("a", "b", "z")])

--- a/tests/expr_and_series/unary_test.py
+++ b/tests/expr_and_series/unary_test.py
@@ -17,7 +17,7 @@ def test_unary(constructor: Constructor, request: pytest.FixtureRequest) -> None
         "a": [1, 3, 2],
         "b": [4, 4, 6],
         "c": [7.0, 8.0, None],
-        "z": [7.0, 8, 9],
+        "z": [7.0, 8.0, 9.0],
     }
     result = nw.from_native(constructor(data)).select(
         a_mean=nw.col("a").mean(),
@@ -49,7 +49,7 @@ def test_unary_series(constructor_eager: ConstructorEager) -> None:
         "a": [1, 3, 2],
         "b": [4, 4, 6],
         "c": [7.0, 8.0, None],
-        "z": [7.0, 8, 9],
+        "z": [7.0, 8.0, 9.0],
     }
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = {

--- a/tests/expr_and_series/var_test.py
+++ b/tests/expr_and_series/var_test.py
@@ -9,8 +9,8 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
-data_with_nulls = {"a": [1, 3, 2, None], "b": [4, 4, 6, None], "z": [7.0, 8, 9, None]}
+data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
+data_with_nulls = {"a": [1, 3, 2, None], "b": [4, 4, 6, None], "z": [7.0, 8.0, 9.0, None]}
 
 expected_results = {
     "a_ddof_1": [1.0],

--- a/tests/frame/add_test.py
+++ b/tests/frame/add_test.py
@@ -10,7 +10,7 @@ from tests.utils import assert_equal_data
 def test_add(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     result = df.with_columns(
         c=nw.col("a") + nw.col("b"),

--- a/tests/frame/columns_test.py
+++ b/tests/frame/columns_test.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.filterwarnings("ignore:Determining|Resolving.*")
 def test_columns(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     result = df.columns
     expected = ["a", "b", "z"]

--- a/tests/frame/concat_test.py
+++ b/tests/frame/concat_test.py
@@ -12,7 +12,7 @@ def test_concat_horizontal(
 ) -> None:
     if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df_left = nw.from_native(constructor(data)).lazy()
 
     data_right = {"c": [6, 12, -1], "d": [0, -4, 2]}
@@ -22,7 +22,7 @@ def test_concat_horizontal(
     expected = {
         "a": [1, 3, 2],
         "b": [4, 4, 6],
-        "z": [7.0, 8, 9],
+        "z": [7.0, 8.0, 9.0],
         "c": [6, 12, -1],
         "d": [0, -4, 2],
     }
@@ -33,7 +33,7 @@ def test_concat_horizontal(
 
 
 def test_concat_vertical(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df_left = (
         nw.from_native(constructor(data)).lazy().rename({"a": "c", "b": "d"}).drop("z")
     )

--- a/tests/frame/double_test.py
+++ b/tests/frame/double_test.py
@@ -6,7 +6,7 @@ from tests.utils import assert_equal_data
 
 
 def test_double(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
 
     result = df.with_columns(nw.all() * 2)

--- a/tests/frame/drop_test.py
+++ b/tests/frame/drop_test.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     ],
 )
 def test_drop(constructor: Constructor, to_drop: list[str], expected: list[str]) -> None:
-    data = {"abc": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"abc": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     assert df.drop(to_drop).collect_schema().names() == expected
     if not isinstance(to_drop, str):

--- a/tests/frame/filter_test.py
+++ b/tests/frame/filter_test.py
@@ -12,7 +12,7 @@ from tests.utils import assert_equal_data
 
 
 def test_filter(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     result = df.filter(nw.col("a") > 1)
     expected = {"a": [3, 2], "b": [4, 6], "z": [8.0, 9.0]}
@@ -24,7 +24,7 @@ def test_filter_with_boolean_list(
 ) -> None:
     if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     context = (
         pytest.raises(TypeError, match="not supported")
@@ -38,7 +38,7 @@ def test_filter_with_boolean_list(
 
 
 def test_filter_raise_on_agg_predicate(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
 
     context = (
@@ -56,7 +56,7 @@ def test_filter_raise_on_agg_predicate(constructor: Constructor) -> None:
 
 
 def test_filter_raise_on_shape_mismatch(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
 
     context = (

--- a/tests/frame/head_test.py
+++ b/tests/frame/head_test.py
@@ -6,7 +6,7 @@ from tests.utils import assert_equal_data
 
 
 def test_head(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     expected = {"a": [1, 3], "b": [4, 4], "z": [7.0, 8.0]}
 
     df_raw = constructor(data)

--- a/tests/frame/invalid_test.py
+++ b/tests/frame/invalid_test.py
@@ -10,7 +10,7 @@ from tests.utils import NUMPY_VERSION
 
 
 def test_invalid() -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(pa.table({"a": [1, 2], "b": [3, 4]}))
     with pytest.raises(ValueError, match="Multi-output"):
         df.select(nw.all() + nw.all())

--- a/tests/frame/is_duplicated_test.py
+++ b/tests/frame/is_duplicated_test.py
@@ -6,7 +6,7 @@ from tests.utils import assert_equal_data
 
 
 def test_is_duplicated(constructor_eager: ConstructorEager) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df_raw = constructor_eager(data)
     df = nw.from_native(df_raw, eager_only=True)
     result = nw.concat([df, df.head(1)]).is_duplicated()

--- a/tests/frame/is_empty_test.py
+++ b/tests/frame/is_empty_test.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 def test_is_empty(
     constructor_eager: ConstructorEager, threshold: Any, expected: Any
 ) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df_raw = constructor_eager(data)
     df = nw.from_native(df_raw, eager_only=True)
     result = df.filter(nw.col("a") > threshold).is_empty()

--- a/tests/frame/is_unique_test.py
+++ b/tests/frame/is_unique_test.py
@@ -6,7 +6,7 @@ from tests.utils import assert_equal_data
 
 
 def test_is_unique(constructor_eager: ConstructorEager) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df_raw = constructor_eager(data)
     df = nw.from_native(df_raw, eager_only=True)
     result = nw.concat([df, df.head(1)]).is_unique()

--- a/tests/frame/item_test.py
+++ b/tests/frame/item_test.py
@@ -20,7 +20,7 @@ def test_item(
     column: int | str | None,
     expected: Any,
 ) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
     assert_equal_data({"a": [df.item(row, column)]}, {"a": [expected]})
     assert_equal_data({"a": [df.select("a").head(1).item()]}, {"a": [1]})
@@ -52,6 +52,6 @@ def test_item_value_error(
     column: int | str | None,
     err_msg: str,
 ) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     with pytest.raises(ValueError, match=err_msg):
         nw.from_native(constructor_eager(data), eager_only=True).item(row, column)

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -21,7 +21,7 @@ def test_inner_join_two_keys(constructor: Constructor) -> None:
     data = {
         "antananarivo": [1, 3, 2],
         "bob": [4, 4, 6],
-        "zor ro": [7.0, 8, 9],
+        "zor ro": [7.0, 8.0, 9.0],
         "idx": [0, 1, 2],
     }
     df = nw_main.from_native(constructor(data))
@@ -38,9 +38,9 @@ def test_inner_join_two_keys(constructor: Constructor) -> None:
     expected = {
         "antananarivo": [1, 3, 2],
         "bob": [4, 4, 6],
-        "zor ro": [7.0, 8, 9],
+        "zor ro": [7.0, 8.0, 9.0],
         "idx": [0, 1, 2],
-        "zor ro_right": [7.0, 8, 9],
+        "zor ro_right": [7.0, 8.0, 9.0],
     }
     assert_equal_data(result, expected)
     assert_equal_data(result_on, expected)
@@ -50,7 +50,7 @@ def test_inner_join_single_key(constructor: Constructor) -> None:
     data = {
         "antananarivo": [1, 3, 2],
         "bob": [4, 4, 6],
-        "zor ro": [7.0, 8, 9],
+        "zor ro": [7.0, 8.0, 9.0],
         "idx": [0, 1, 2],
     }
     df = nw.from_native(constructor(data))
@@ -67,10 +67,10 @@ def test_inner_join_single_key(constructor: Constructor) -> None:
     expected = {
         "antananarivo": [1, 3, 2],
         "bob": [4, 4, 6],
-        "zor ro": [7.0, 8, 9],
+        "zor ro": [7.0, 8.0, 9.0],
         "idx": [0, 1, 2],
         "bob_right": [4, 4, 6],
-        "zor ro_right": [7.0, 8, 9],
+        "zor ro_right": [7.0, 8.0, 9.0],
     }
     assert_equal_data(result, expected)
     assert_equal_data(result_on, expected)
@@ -100,7 +100,7 @@ def test_suffix(constructor: Constructor, how: str, suffix: str) -> None:
     data = {
         "antananarivo": [1, 3, 2],
         "bob": [4, 4, 6],
-        "zor ro": [7.0, 8, 9],
+        "zor ro": [7.0, 8.0, 9.0],
     }
     df = nw.from_native(constructor(data))
     df_right = df
@@ -168,7 +168,7 @@ def test_anti_join(
     filter_expr: nw.Expr,
     expected: dict[str, list[Any]],
 ) -> None:
-    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8, 9]}
+    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     other = df.filter(filter_expr)
     result = df.join(other, how="anti", left_on=join_key, right_on=join_key)  # type: ignore[arg-type]
@@ -206,7 +206,7 @@ def test_semi_join(
     filter_expr: nw.Expr,
     expected: dict[str, list[Any]],
 ) -> None:
-    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8, 9]}
+    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     other = df.filter(filter_expr)
     result = df.join(other, how="semi", left_on=join_key, right_on=join_key).sort(  # type: ignore[arg-type]
@@ -217,7 +217,7 @@ def test_semi_join(
 
 @pytest.mark.parametrize("how", ["right", "full"])
 def test_join_not_implemented(constructor: Constructor, how: str) -> None:
-    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8, 9]}
+    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
 
     with pytest.raises(
@@ -231,13 +231,13 @@ def test_join_not_implemented(constructor: Constructor, how: str) -> None:
 
 def test_left_join(constructor: Constructor) -> None:
     data_left = {
-        "antananarivo": [1.0, 2, 3],
-        "bob": [4.0, 5, 6],
+        "antananarivo": [1.0, 2.0, 3.0],
+        "bob": [4.0, 5.0, 6.0],
         "idx": [0.0, 1.0, 2.0],
     }
     data_right = {
-        "antananarivo": [1.0, 2, 3],
-        "co": [4.0, 5, 7],
+        "antananarivo": [1.0, 2.0, 3.0],
+        "co": [4.0, 5.0, 7.0],
         "idx": [0.0, 1.0, 2.0],
     }
     df_left = nw.from_native(constructor(data_left))
@@ -286,15 +286,15 @@ def test_left_join_multiple_column(constructor: Constructor) -> None:
 
 def test_left_join_overlapping_column(constructor: Constructor) -> None:
     data_left = {
-        "antananarivo": [1.0, 2, 3],
-        "bob": [4.0, 5, 6],
-        "d": [1.0, 4, 2],
+        "antananarivo": [1.0, 2.0, 3.0],
+        "bob": [4.0, 5.0, 6.0],
+        "d": [1.0, 4.0, 2.0],
         "idx": [0.0, 1.0, 2.0],
     }
     data_right = {
-        "antananarivo": [1.0, 2, 3],
-        "c": [4.0, 5, 6],
-        "d": [1.0, 4, 2],
+        "antananarivo": [1.0, 2.0, 3.0],
+        "c": [4.0, 5.0, 6.0],
+        "d": [1.0, 4.0, 2.0],
         "idx": [0.0, 1.0, 2.0],
     }
     df_left = nw.from_native(constructor(data_left))
@@ -331,7 +331,7 @@ def test_left_join_overlapping_column(constructor: Constructor) -> None:
 
 @pytest.mark.parametrize("how", ["inner", "left", "semi", "anti"])
 def test_join_keys_exceptions(constructor: Constructor, how: str) -> None:
-    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8, 9]}
+    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
 
     with pytest.raises(
@@ -536,7 +536,7 @@ def test_joinasof_by(
 def test_joinasof_not_implemented(
     constructor: Constructor, strategy: Literal["backward", "forward"]
 ) -> None:
-    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8, 9]}
+    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
 
     with pytest.raises(
@@ -552,7 +552,7 @@ def test_joinasof_not_implemented(
 
 
 def test_joinasof_keys_exceptions(constructor: Constructor) -> None:
-    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8, 9]}
+    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
 
     with pytest.raises(
@@ -593,7 +593,7 @@ def test_joinasof_keys_exceptions(constructor: Constructor) -> None:
 
 
 def test_joinasof_by_exceptions(constructor: Constructor) -> None:
-    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8, 9]}
+    data = {"antananarivo": [1, 3, 2], "bob": [4, 4, 6], "zor ro": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     with pytest.raises(
         ValueError,

--- a/tests/frame/reindex_test.py
+++ b/tests/frame/reindex_test.py
@@ -8,7 +8,7 @@ import pytest
 import narwhals.stable.v1 as nw
 from tests.utils import assert_equal_data
 
-data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
 
 
 @pytest.mark.parametrize("df_raw", [pd.DataFrame(data)])

--- a/tests/frame/rename_test.py
+++ b/tests/frame/rename_test.py
@@ -6,8 +6,8 @@ from tests.utils import assert_equal_data
 
 
 def test_rename(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     result = df.rename({"a": "x", "b": "y"})
-    expected = {"x": [1, 3, 2], "y": [4, 4, 6], "z": [7.0, 8, 9]}
+    expected = {"x": [1, 3, 2], "y": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     assert_equal_data(result, expected)

--- a/tests/frame/rows_test.py
+++ b/tests/frame/rows_test.py
@@ -11,7 +11,7 @@ import narwhals.stable.v1 as nw
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
 
-data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
 data_na = {"a": [None, 3, 2], "b": [4, 4, 6], "z": [7.0, None, 9]}
 
 
@@ -38,7 +38,7 @@ def test_iter_rows(
     if "cudf" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
 
-    data = {"a": [1, 3, 2], "_b": [4, 4, 6], "z": [7.0, 8, 9], "1": [5, 6, 7]}
+    data = {"a": [1, 3, 2], "_b": [4, 4, 6], "z": [7.0, 8.0, 9.0], "1": [5, 6, 7]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = list(df.iter_rows(named=named))
     assert result == expected
@@ -94,7 +94,7 @@ def test_rows_eager(
     expected: list[tuple[Any, ...]] | list[dict[str, Any]],
 ) -> None:
     # posit-dev/py-shiny relies on `.rows(named=False)` to return unnamed rows
-    data = {"a": [1, 3, 2], "_b": [4, 4, 6], "z": [7.0, 8, 9], "1": [5, 6, 7]}
+    data = {"a": [1, 3, 2], "_b": [4, 4, 6], "z": [7.0, 8.0, 9.0], "1": [5, 6, 7]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.rows(named=named)
     assert result == expected

--- a/tests/frame/schema_test.py
+++ b/tests/frame/schema_test.py
@@ -27,7 +27,9 @@ data = {
 
 @pytest.mark.filterwarnings("ignore:Determining|Resolving.*")
 def test_schema(constructor: Constructor) -> None:
-    df = nw.from_native(constructor({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8, 9]}))
+    df = nw.from_native(
+        constructor({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8.0, 9.0]})
+    )
     result = df.schema
     expected = {"a": nw.Int64, "b": nw.Int64, "z": nw.Float64}
 
@@ -38,7 +40,9 @@ def test_schema(constructor: Constructor) -> None:
 
 
 def test_collect_schema(constructor: Constructor) -> None:
-    df = nw.from_native(constructor({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8, 9]}))
+    df = nw.from_native(
+        constructor({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8.0, 9.0]})
+    )
     expected = {"a": nw.Int64, "b": nw.Int64, "z": nw.Float64}
 
     result = df.collect_schema()

--- a/tests/frame/select_test.py
+++ b/tests/frame/select_test.py
@@ -20,7 +20,7 @@ class Foo: ...
 
 
 def test_select(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     result = df.select("a")
     expected = {"a": [1, 3, 2]}
@@ -82,7 +82,7 @@ def test_missing_columns(
 ) -> None:
     if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     selected_columns = ["a", "e", "f"]
     msg = (

--- a/tests/frame/sort_test.py
+++ b/tests/frame/sort_test.py
@@ -8,7 +8,7 @@ from tests.utils import assert_equal_data
 
 
 def test_sort(constructor: Constructor) -> None:
-    data = {"an tan": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"an tan": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     result = df.sort("an tan", "b")
     expected = {

--- a/tests/frame/tail_test.py
+++ b/tests/frame/tail_test.py
@@ -13,7 +13,7 @@ def test_tail(request: pytest.FixtureRequest, constructor: Constructor) -> None:
     if "pyspark" in str(constructor):
         request.applymarker(pytest.mark.xfail)
 
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     expected = {"a": [3, 2], "b": [4, 6], "z": [8.0, 9]}
 
     df_raw = constructor(data)

--- a/tests/frame/to_arrow_test.py
+++ b/tests/frame/to_arrow_test.py
@@ -21,7 +21,7 @@ def test_to_arrow(
         # pyarrow requires pandas>=1.0.0
         request.applymarker(pytest.mark.xfail)
 
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8.0, 9.0]}
     df_raw = constructor_eager(data)
     result = nw.from_native(df_raw, eager_only=True).to_arrow()
 

--- a/tests/frame/to_dict_test.py
+++ b/tests/frame/to_dict_test.py
@@ -11,14 +11,14 @@ from tests.utils import assert_equal_data
     "ignore:.*all arguments of to_dict except for the argument:FutureWarning"
 )
 def test_to_dict(constructor_eager: ConstructorEager) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "c": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "c": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.to_dict(as_series=False)
     assert result == data
 
 
 def test_to_dict_as_series(constructor_eager: ConstructorEager) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "c": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "c": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.to_dict(as_series=True)
     assert isinstance(result["a"], nw.Series)

--- a/tests/frame/to_native_test.py
+++ b/tests/frame/to_native_test.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 
 def test_to_native(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8.0, 9.0]}
     df_raw = constructor(data)
     df = nw.from_native(df_raw)
 

--- a/tests/frame/to_numpy_test.py
+++ b/tests/frame/to_numpy_test.py
@@ -16,11 +16,11 @@ if TYPE_CHECKING:
 
 
 def test_to_numpy(constructor_eager: ConstructorEager) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8.0, 9.0]}
     df_raw = constructor_eager(data)
     result = nw.from_native(df_raw, eager_only=True).to_numpy()
 
-    expected = np.array([[1, 3, 2], [4, 4, 6], [7.1, 8, 9]]).T
+    expected = np.array([[1, 3, 2], [4, 4, 6], [7.1, 8.0, 9.0]]).T
     np.testing.assert_array_equal(result, expected)
     assert result.dtype == "float64"
 

--- a/tests/frame/to_pandas_test.py
+++ b/tests/frame/to_pandas_test.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 def test_convert_pandas(
     constructor_eager: ConstructorEager,
 ) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df_raw = constructor_eager(data)
     result = nw.from_native(df_raw).to_pandas()  # type: ignore[union-attr]
 

--- a/tests/frame/to_polars_test.py
+++ b/tests/frame/to_polars_test.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.filterwarnings("ignore:.*Passing a BlockManager.*:DeprecationWarning")
 def test_convert_polars(constructor_eager: ConstructorEager) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.1, 8.0, 9.0]}
     df_raw = constructor_eager(data)
     result = nw.from_native(df_raw).to_polars()  # type: ignore[union-attr]
 

--- a/tests/frame/unique_test.py
+++ b/tests/frame/unique_test.py
@@ -12,7 +12,7 @@ from narwhals.exceptions import ColumnNotFoundError
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
-data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
 
 
 @pytest.mark.parametrize("subset", ["b", ["b"]])

--- a/tests/frame/with_columns_test.py
+++ b/tests/frame/with_columns_test.py
@@ -22,23 +22,23 @@ def test_with_columns_int_col_name_pandas() -> None:
 
 
 def test_with_columns_order(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     result = df.with_columns(nw.col("a") + 1, d=nw.col("a") - 1)
     assert result.collect_schema().names() == ["a", "b", "z", "d"]
-    expected = {"a": [2, 4, 3], "b": [4, 4, 6], "z": [7.0, 8, 9], "d": [0, 2, 1]}
+    expected = {"a": [2, 4, 3], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0], "d": [0, 2, 1]}
     assert_equal_data(result, expected)
 
 
 def test_with_columns_empty(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
     result = df.select().with_columns()
     assert_equal_data(result, {})
 
 
 def test_with_columns_order_single_row(constructor: Constructor) -> None:
-    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8, 9], "i": [0, 1, 2]}
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0], "i": [0, 1, 2]}
     df = nw.from_native(constructor(data)).filter(nw.col("i") < 1).drop("i")
     result = df.with_columns(nw.col("a") + 1, d=nw.col("a") - 1)
     assert result.collect_schema().names() == ["a", "b", "z", "d"]

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -15,7 +15,7 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-data = {"a": [1, 1, 3], "b": [4, 4, 6], "c": [7.0, 8, 9]}
+data = {"a": [1, 1, 3], "b": [4, 4, 6], "c": [7.0, 8.0, 9.0]}
 
 df_pandas = pd.DataFrame(data)
 df_lazy = pl.LazyFrame(data)

--- a/tests/series_only/is_sorted_test.py
+++ b/tests/series_only/is_sorted_test.py
@@ -8,7 +8,7 @@ from tests.utils import assert_equal_data
 
 data = [1, 3, 2]
 data_dups = [4, 4, 6]
-data_sorted = [7.0, 8, 9]
+data_sorted = [7.0, 8.0, 9.0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related to [comment](https://github.com/narwhals-dev/narwhals/pull/1825#discussion_r1921597932) and [other comment](https://github.com/narwhals-dev/narwhals/pull/1830#discussion_r1921599042)

## Checklist

- [x] Code follows style guide (ruff)
- [x] These are the tests!
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

The main issue was having lists of mixed type for pyspark (e.g. int and float together) without being able to specify the schema