### PR TITLE
feat: add `Expr.dt` methods to `PySpark`

### DIFF
--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -7,6 +7,7 @@ from typing import Literal
 from typing import Sequence
 
 from narwhals._expression_parsing import infer_new_root_output_names
+from narwhals._spark_like.expr_dt import SparkLikeExprDateTimeNamespace
 from narwhals._spark_like.expr_name import SparkLikeExprNameNamespace
 from narwhals._spark_like.expr_str import SparkLikeExprStringNamespace
 from narwhals._spark_like.utils import get_column_name
@@ -542,3 +543,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
     @property
     def name(self: Self) -> SparkLikeExprNameNamespace:
         return SparkLikeExprNameNamespace(self)
+
+    @property
+    def dt(self: Self) -> SparkLikeExprDateTimeNamespace:
+        return SparkLikeExprDateTimeNamespace(self)

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -495,33 +495,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
         return self._from_call(F.skewness, "skew", returns_scalar=True)
 
-    def sort(self, *, descending: bool = False, nulls_last: bool = True) -> Self:
-        def _sort(_input: Column, *, descending: bool, nulls_last: bool) -> Column:
-            from pyspark.sql import Window
-            from pyspark.sql import functions as F  # noqa: N812
-
-            window = Window.orderBy(
-                _input.desc() if descending else _input.asc(),
-                (
-                    F.col("*").asc_nulls_last()
-                    if nulls_last
-                    else F.col("*").asc_nulls_first()
-                ),
-            ).rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
-
-            row_num = F.row_number().over(window)
-            collect_window = Window.orderBy(row_num)
-
-            return F.first(_input).over(collect_window)
-
-        return self._from_call(
-            _sort,
-            "sort",
-            descending=descending,
-            nulls_last=nulls_last,
-            returns_scalar=self._returns_scalar,
-        )
-
     def n_unique(self: Self) -> Self:
         from pyspark.sql import functions as F  # noqa: N812
         from pyspark.sql.types import IntegerType

--- a/narwhals/_spark_like/expr_dt.py
+++ b/narwhals/_spark_like/expr_dt.py
@@ -80,7 +80,7 @@ class SparkLikeExprDateTimeNamespace:
         from pyspark.sql import functions as F  # noqa: N812
 
         def _millisecond(_input: Column) -> Column:
-            return F.date_format(_input, "SSS").cast("int")
+            return F.floor((F.unix_micros(_input) % 1_000_000) / 1000)
 
         return self._compliant_expr._from_call(
             _millisecond,
@@ -92,7 +92,7 @@ class SparkLikeExprDateTimeNamespace:
         from pyspark.sql import functions as F  # noqa: N812
 
         def _microsecond(_input: Column) -> Column:
-            return F.date_format(_input, "SSSSSS").cast("int")
+            return F.unix_micros(_input) % 1_000_000
 
         return self._compliant_expr._from_call(
             _microsecond,
@@ -104,7 +104,7 @@ class SparkLikeExprDateTimeNamespace:
         from pyspark.sql import functions as F  # noqa: N812
 
         def _nanosecond(_input: Column) -> Column:
-            return F.date_format(_input, "SSSSSS").cast("int") * 1000
+            return (F.unix_micros(_input) % 1_000_000) * 1000
 
         return self._compliant_expr._from_call(
             _nanosecond,

--- a/narwhals/_spark_like/expr_dt.py
+++ b/narwhals/_spark_like/expr_dt.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyspark.sql import Column
+    from typing_extensions import Self
+
+    from narwhals._spark_like.expr import SparkLikeExpr
+
+
+class SparkLikeExprDateTimeNamespace:
+    def __init__(self: Self, expr: SparkLikeExpr) -> None:
+        self._compliant_expr = expr
+
+    def date(self: Self) -> SparkLikeExpr:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        return self._compliant_expr._from_call(
+            F.to_date,
+            "date",
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )
+
+    def year(self: Self) -> SparkLikeExpr:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        return self._compliant_expr._from_call(
+            F.year,
+            "year",
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )
+
+    def month(self: Self) -> SparkLikeExpr:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        return self._compliant_expr._from_call(
+            F.month,
+            "month",
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )
+
+    def day(self: Self) -> SparkLikeExpr:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        return self._compliant_expr._from_call(
+            F.dayofmonth,
+            "day",
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )
+
+    def hour(self: Self) -> SparkLikeExpr:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        return self._compliant_expr._from_call(
+            F.hour,
+            "hour",
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )
+
+    def minute(self: Self) -> SparkLikeExpr:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        return self._compliant_expr._from_call(
+            F.minute,
+            "minute",
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )
+
+    def second(self: Self) -> SparkLikeExpr:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        return self._compliant_expr._from_call(
+            F.second,
+            "second",
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )
+
+    def millisecond(self: Self) -> SparkLikeExpr:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        def _millisecond(_input: Column) -> Column:
+            return F.date_format(_input, "SSS").cast("int")
+
+        return self._compliant_expr._from_call(
+            _millisecond,
+            "millisecond",
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )
+
+    def microsecond(self: Self) -> SparkLikeExpr:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        def _microsecond(_input: Column) -> Column:
+            return F.date_format(_input, "SSSSSS").cast("int")
+
+        return self._compliant_expr._from_call(
+            _microsecond,
+            "microsecond",
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )
+
+    def nanosecond(self: Self) -> SparkLikeExpr:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        def _nanosecond(_input: Column) -> Column:
+            return F.date_format(_input, "SSSSSS").cast("int") * 1000
+
+        return self._compliant_expr._from_call(
+            _nanosecond,
+            "nanosecond",
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )
+
+    def ordinal_day(self: Self) -> SparkLikeExpr:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        return self._compliant_expr._from_call(
+            F.dayofyear,
+            "ordinal_day",
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )
+
+    def weekday(self: Self) -> SparkLikeExpr:
+        from pyspark.sql import functions as F  # noqa: N812
+
+        def _weekday(_input: Column) -> Column:
+            # PySpark's dayofweek returns 1-7 for Sunday-Saturday
+            return (F.dayofweek(_input) + 6) % 7
+
+        return self._compliant_expr._from_call(
+            _weekday,
+            "weekday",
+            returns_scalar=self._compliant_expr._returns_scalar,
+        )

--- a/tests/expr_and_series/dt/datetime_attributes_test.py
+++ b/tests/expr_and_series/dt/datetime_attributes_test.py
@@ -49,8 +49,6 @@ def test_datetime_attributes(
         request.applymarker(pytest.mark.xfail)
     if attribute == "date" and "cudf" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    if "pyspark" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor(data))
     result = df.select(getattr(nw.col("a").dt, attribute)())


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #1714 
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Added the following functions:
- `date`
- `year`
- `month`
- `day`
- `hour`
- `minute`
- `second`
- `millisecond`
- `microsecond`
- `nanosecond`
- `ordinal_day`
- `weekday`
