### PR TITLE
chore: simplify imports

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -95,4 +95,4 @@ jobs:
       - name: Run doctests
         # reprs differ between versions, so we only run doctests on the latest Python
         if: matrix.python-version == '3.13'
-        run: pytest narwhals --doctest-modules
+        run: pytest narwhals/*.py --doctest-modules

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -10,6 +10,7 @@ from typing import Sequence
 from typing import overload
 
 import pyarrow as pa
+import pyarrow.compute as pc
 
 from narwhals._arrow.utils import broadcast_series
 from narwhals._arrow.utils import convert_str_slice_to_int_slice
@@ -588,8 +589,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         return pa_csv.write_csv(pa_table, file)
 
     def is_duplicated(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         from narwhals._arrow.series import ArrowSeries
 
         columns = self.columns
@@ -624,8 +623,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         return res.fill_null(res.null_count() > 1, strategy=None, limit=None)
 
     def is_unique(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         from narwhals._arrow.series import ArrowSeries
 
         is_duplicated = self.is_duplicated()._native_series
@@ -647,7 +644,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         # The param `maintain_order` is only here for compatibility with the Polars API
         # and has no effect on the output.
         import numpy as np  # ignore-banned-import
-        import pyarrow.compute as pc
 
         df = self._native_frame
         check_column_exists(self.columns, subset)
@@ -685,7 +681,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         seed: int | None,
     ) -> Self:
         import numpy as np  # ignore-banned-import
-        import pyarrow.compute as pc
 
         frame = self._native_frame
         num_rows = len(self)

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -9,6 +9,8 @@ from typing import Literal
 from typing import Sequence
 from typing import overload
 
+import pyarrow as pa
+
 from narwhals._arrow.utils import broadcast_series
 from narwhals._arrow.utils import convert_str_slice_to_int_slice
 from narwhals._arrow.utils import native_to_narwhals_dtype
@@ -31,7 +33,6 @@ if TYPE_CHECKING:
     import numpy as np
     import pandas as pd
     import polars as pl
-    import pyarrow as pa
     from typing_extensions import Self
 
     from narwhals._arrow.group_by import ArrowGroupBy
@@ -289,8 +290,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         return self._native_frame.schema.names  # type: ignore[no-any-return]
 
     def select(self: Self, *exprs: IntoArrowExpr, **named_exprs: IntoArrowExpr) -> Self:
-        import pyarrow as pa
-
         new_series = evaluate_into_exprs(self, *exprs, **named_exprs)
         if not new_series:
             # return empty dataframe, like Polars does
@@ -469,8 +468,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
             return {name: col.to_pylist() for name, col in names_and_values}
 
     def with_row_index(self: Self, name: str) -> Self:
-        import pyarrow as pa
-
         df = self._native_frame
         cols = self.columns
 
@@ -506,8 +503,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         return self._from_native_frame(self._native_frame.filter(mask_native))
 
     def null_count(self: Self) -> Self:
-        import pyarrow as pa
-
         df = self._native_frame
         names_and_values = zip(df.column_names, df.columns)
 
@@ -583,7 +578,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         pp.write_table(self._native_frame, file)
 
     def write_csv(self: Self, file: Any) -> Any:
-        import pyarrow as pa
         import pyarrow.csv as pa_csv
 
         pa_table = self._native_frame
@@ -594,7 +588,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         return pa_csv.write_csv(pa_table, file)
 
     def is_duplicated(self: Self) -> ArrowSeries:
-        import pyarrow as pa
         import pyarrow.compute as pc
 
         from narwhals._arrow.series import ArrowSeries
@@ -654,7 +647,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         # The param `maintain_order` is only here for compatibility with the Polars API
         # and has no effect on the output.
         import numpy as np  # ignore-banned-import
-        import pyarrow as pa
         import pyarrow.compute as pc
 
         df = self._native_frame
@@ -713,8 +705,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         variable_name: str | None,
         value_name: str | None,
     ) -> Self:
-        import pyarrow as pa
-
         native_frame = self._native_frame
         variable_name = variable_name if variable_name is not None else "variable"
         value_name = value_name if value_name is not None else "value"

--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -7,6 +7,8 @@ from typing import Callable
 from typing import Iterator
 from typing import Sequence
 
+import pyarrow as pa
+
 from narwhals._expression_parsing import is_simple_aggregation
 from narwhals._expression_parsing import parse_into_exprs
 from narwhals.exceptions import AnonymousExprError
@@ -14,7 +16,6 @@ from narwhals.utils import generate_temporary_column_name
 from narwhals.utils import remove_prefix
 
 if TYPE_CHECKING:
-    import pyarrow as pa
     import pyarrow.compute as pc
     from typing_extensions import Self
 
@@ -41,8 +42,6 @@ class ArrowGroupBy:
     def __init__(
         self: Self, df: ArrowDataFrame, keys: list[str], *, drop_null_keys: bool
     ) -> None:
-        import pyarrow as pa
-
         if drop_null_keys:
             self._df = df.drop_nulls(keys)
         else:
@@ -74,7 +73,6 @@ class ArrowGroupBy:
         )
 
     def __iter__(self: Self) -> Iterator[tuple[Any, ArrowDataFrame]]:
-        import pyarrow as pa
         import pyarrow.compute as pc
 
         col_token = generate_temporary_column_name(n_bytes=8, columns=self._df.columns)

--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -8,6 +8,7 @@ from typing import Iterator
 from typing import Sequence
 
 import pyarrow as pa
+import pyarrow.compute as pc
 
 from narwhals._expression_parsing import is_simple_aggregation
 from narwhals._expression_parsing import parse_into_exprs
@@ -16,7 +17,6 @@ from narwhals.utils import generate_temporary_column_name
 from narwhals.utils import remove_prefix
 
 if TYPE_CHECKING:
-    import pyarrow.compute as pc
     from typing_extensions import Self
 
     from narwhals._arrow.dataframe import ArrowDataFrame
@@ -73,8 +73,6 @@ class ArrowGroupBy:
         )
 
     def __iter__(self: Self) -> Iterator[tuple[Any, ArrowDataFrame]]:
-        import pyarrow.compute as pc
-
         col_token = generate_temporary_column_name(n_bytes=8, columns=self._df.columns)
         null_token = "__null_token_value__"  # noqa: S105
 
@@ -112,8 +110,6 @@ def agg_arrow(
     from_dataframe: Callable[[Any], ArrowDataFrame],
     backend_version: tuple[int, ...],
 ) -> ArrowDataFrame:
-    import pyarrow.compute as pc
-
     all_simple_aggs = True
     for expr in exprs:
         if not (

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -7,6 +7,8 @@ from typing import Iterable
 from typing import Literal
 from typing import Sequence
 
+import pyarrow as pa
+
 from narwhals._arrow.dataframe import ArrowDataFrame
 from narwhals._arrow.expr import ArrowExpr
 from narwhals._arrow.selectors import ArrowSelectorNamespace
@@ -85,8 +87,6 @@ class ArrowNamespace(CompliantNamespace[ArrowSeries]):
         )
 
     def _create_compliant_series(self: Self, value: Any) -> ArrowSeries:
-        import pyarrow as pa
-
         from narwhals._arrow.series import ArrowSeries
 
         return ArrowSeries(
@@ -428,7 +428,6 @@ class ArrowWhen:
         self._version = version
 
     def __call__(self: Self, df: ArrowDataFrame) -> Sequence[ArrowSeries]:
-        import pyarrow as pa
         import pyarrow.compute as pc
 
         from narwhals._expression_parsing import parse_into_expr

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -8,6 +8,7 @@ from typing import Literal
 from typing import Sequence
 
 import pyarrow as pa
+import pyarrow.compute as pc
 
 from narwhals._arrow.dataframe import ArrowDataFrame
 from narwhals._arrow.expr import ArrowExpr
@@ -266,8 +267,6 @@ class ArrowNamespace(CompliantNamespace[ArrowSeries]):
         )
 
     def min_horizontal(self: Self, *exprs: IntoArrowExpr) -> ArrowExpr:
-        import pyarrow.compute as pc
-
         parsed_exprs = parse_into_exprs(*exprs, namespace=self)
 
         def func(df: ArrowDataFrame) -> list[ArrowSeries]:
@@ -295,8 +294,6 @@ class ArrowNamespace(CompliantNamespace[ArrowSeries]):
         )
 
     def max_horizontal(self: Self, *exprs: IntoArrowExpr) -> ArrowExpr:
-        import pyarrow.compute as pc
-
         parsed_exprs = parse_into_exprs(*exprs, namespace=self)
 
         def func(df: ArrowDataFrame) -> list[ArrowSeries]:
@@ -369,8 +366,6 @@ class ArrowNamespace(CompliantNamespace[ArrowSeries]):
         separator: str,
         ignore_nulls: bool,
     ) -> ArrowExpr:
-        import pyarrow.compute as pc
-
         parsed_exprs = [
             *parse_into_exprs(*exprs, namespace=self),
             *parse_into_exprs(*more_exprs, namespace=self),
@@ -428,8 +423,6 @@ class ArrowWhen:
         self._version = version
 
     def __call__(self: Self, df: ArrowDataFrame) -> Sequence[ArrowSeries]:
-        import pyarrow.compute as pc
-
         from narwhals._expression_parsing import parse_into_expr
 
         plx = df.__narwhals_namespace__()

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -108,68 +108,46 @@ class ArrowSeries(CompliantSeries):
         return len(self._native_series)
 
     def __eq__(self: Self, other: object) -> Self:  # type: ignore[override]
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.equal(ser, other))
 
     def __ne__(self: Self, other: object) -> Self:  # type: ignore[override]
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.not_equal(ser, other))
 
     def __ge__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.greater_equal(ser, other))
 
     def __gt__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.greater(ser, other))
 
     def __le__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.less_equal(ser, other))
 
     def __lt__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.less(ser, other))
 
     def __and__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.and_kleene(ser, other))
 
     def __rand__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.and_kleene(other, ser))
 
     def __or__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.or_kleene(ser, other))
 
     def __ror__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.or_kleene(other, ser))
 
     def __add__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.add(ser, other))
 
@@ -177,8 +155,6 @@ class ArrowSeries(CompliantSeries):
         return self + other  # type: ignore[no-any-return]
 
     def __sub__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.subtract(ser, other))
 
@@ -186,8 +162,6 @@ class ArrowSeries(CompliantSeries):
         return (self - other) * (-1)  # type: ignore[no-any-return]
 
     def __mul__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.multiply(ser, other))
 
@@ -195,14 +169,10 @@ class ArrowSeries(CompliantSeries):
         return self * other  # type: ignore[no-any-return]
 
     def __pow__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.power(ser, other))
 
     def __rpow__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         return self._from_native_series(pc.power(other, ser))
 
@@ -215,8 +185,6 @@ class ArrowSeries(CompliantSeries):
         return self._from_native_series(floordiv_compat(other, ser))
 
     def __truediv__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         if not isinstance(other, (pa.Array, pa.ChunkedArray)):
             # scalar
@@ -224,8 +192,6 @@ class ArrowSeries(CompliantSeries):
         return self._from_native_series(pc.divide(*cast_for_truediv(ser, other)))
 
     def __rtruediv__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         if not isinstance(other, (pa.Array, pa.ChunkedArray)):
             # scalar
@@ -233,24 +199,18 @@ class ArrowSeries(CompliantSeries):
         return self._from_native_series(pc.divide(*cast_for_truediv(other, ser)))
 
     def __mod__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         floor_div = (self // other)._native_series
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         res = pc.subtract(ser, pc.multiply(floor_div, other))
         return self._from_native_series(res)
 
     def __rmod__(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         floor_div = (other // self)._native_series
         ser, other = broadcast_and_extract_native(self, other, self._backend_version)
         res = pc.subtract(other, pc.multiply(floor_div, ser))
         return self._from_native_series(res)
 
     def __invert__(self: Self) -> Self:
-        import pyarrow.compute as pc
-
         return self._from_native_series(pc.invert(self._native_series))
 
     def len(self: Self, *, _return_py_scalar: bool = True) -> int:
@@ -264,13 +224,9 @@ class ArrowSeries(CompliantSeries):
         return self._from_native_series(ser.filter(other))
 
     def mean(self: Self, *, _return_py_scalar: bool = True) -> int:
-        import pyarrow.compute as pc
-
         return maybe_extract_py_scalar(pc.mean(self._native_series), _return_py_scalar)  # type: ignore[no-any-return]
 
     def median(self: Self, *, _return_py_scalar: bool = True) -> int:
-        import pyarrow.compute as pc
-
         from narwhals.exceptions import InvalidOperationError
 
         if not self.dtype.is_numeric():
@@ -282,37 +238,25 @@ class ArrowSeries(CompliantSeries):
         )
 
     def min(self: Self, *, _return_py_scalar: bool = True) -> int:
-        import pyarrow.compute as pc
-
         return maybe_extract_py_scalar(pc.min(self._native_series), _return_py_scalar)  # type: ignore[no-any-return]
 
     def max(self: Self, *, _return_py_scalar: bool = True) -> int:
-        import pyarrow.compute as pc
-
         return maybe_extract_py_scalar(pc.max(self._native_series), _return_py_scalar)  # type: ignore[no-any-return]
 
     def arg_min(self: Self, *, _return_py_scalar: bool = True) -> int:
-        import pyarrow.compute as pc
-
         index_min = pc.index(self._native_series, pc.min(self._native_series))
         return maybe_extract_py_scalar(index_min, _return_py_scalar)  # type: ignore[no-any-return]
 
     def arg_max(self: Self, *, _return_py_scalar: bool = True) -> int:
-        import pyarrow.compute as pc
-
         index_max = pc.index(self._native_series, pc.max(self._native_series))
         return maybe_extract_py_scalar(index_max, _return_py_scalar)  # type: ignore[no-any-return]
 
     def sum(self: Self, *, _return_py_scalar: bool = True) -> int:
-        import pyarrow.compute as pc
-
         return maybe_extract_py_scalar(  # type: ignore[no-any-return]
             pc.sum(self._native_series, min_count=0), _return_py_scalar
         )
 
     def drop_nulls(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._from_native_series(pc.drop_null(self._native_series))
 
     def shift(self: Self, n: int) -> Self:
@@ -327,22 +271,16 @@ class ArrowSeries(CompliantSeries):
         return self._from_native_series(result)
 
     def std(self: Self, ddof: int, *, _return_py_scalar: bool = True) -> float:
-        import pyarrow.compute as pc
-
         return maybe_extract_py_scalar(  # type: ignore[no-any-return]
             pc.stddev(self._native_series, ddof=ddof), _return_py_scalar
         )
 
     def var(self: Self, ddof: int, *, _return_py_scalar: bool = True) -> float:
-        import pyarrow.compute as pc
-
         return maybe_extract_py_scalar(  # type: ignore[no-any-return]
             pc.variance(self._native_series, ddof=ddof), _return_py_scalar
         )
 
     def skew(self: Self, *, _return_py_scalar: bool = True) -> float | None:
-        import pyarrow.compute as pc
-
         ser = self._native_series
         ser_not_null = pc.drop_null(ser)
         if len(ser_not_null) == 0:
@@ -361,13 +299,9 @@ class ArrowSeries(CompliantSeries):
             )
 
     def count(self: Self, *, _return_py_scalar: bool = True) -> int:
-        import pyarrow.compute as pc
-
         return maybe_extract_py_scalar(pc.count(self._native_series), _return_py_scalar)  # type: ignore[no-any-return]
 
     def n_unique(self: Self, *, _return_py_scalar: bool = True) -> int:
-        import pyarrow.compute as pc
-
         unique_values = pc.unique(self._native_series)
         return maybe_extract_py_scalar(  # type: ignore[no-any-return]
             pc.count(unique_values, mode="all"), _return_py_scalar
@@ -404,7 +338,6 @@ class ArrowSeries(CompliantSeries):
 
     def scatter(self: Self, indices: int | Sequence[int], values: Any) -> Self:
         import numpy as np  # ignore-banned-import
-        import pyarrow.compute as pc
 
         mask = np.zeros(self.len(), dtype=bool)
         mask[indices] = True
@@ -443,13 +376,9 @@ class ArrowSeries(CompliantSeries):
         return native_to_narwhals_dtype(self._native_series.type, self._version)
 
     def abs(self: Self) -> Self:
-        import pyarrow.compute as pc
-
         return self._from_native_series(pc.abs(self._native_series))
 
     def cum_sum(self: Self, *, reverse: bool) -> Self:
-        import pyarrow.compute as pc
-
         native_series = self._native_series
         result = (
             pc.cumulative_sum(native_series, skip_nulls=True)
@@ -459,29 +388,21 @@ class ArrowSeries(CompliantSeries):
         return self._from_native_series(result)
 
     def round(self: Self, decimals: int) -> Self:
-        import pyarrow.compute as pc
-
         return self._from_native_series(
             pc.round(self._native_series, decimals, round_mode="half_towards_infinity")
         )
 
     def diff(self: Self) -> Self:
-        import pyarrow.compute as pc
-
         return self._from_native_series(
             pc.pairwise_diff(self._native_series.combine_chunks())
         )
 
     def any(self: Self, *, _return_py_scalar: bool = True) -> bool:
-        import pyarrow.compute as pc
-
         return maybe_extract_py_scalar(  # type: ignore[no-any-return]
             pc.any(self._native_series, min_count=0), _return_py_scalar
         )
 
     def all(self: Self, *, _return_py_scalar: bool = True) -> bool:
-        import pyarrow.compute as pc
-
         return maybe_extract_py_scalar(  # type: ignore[no-any-return]
             pc.all(self._native_series, min_count=0), _return_py_scalar
         )
@@ -492,8 +413,6 @@ class ArrowSeries(CompliantSeries):
         upper_bound: Any,
         closed: Literal["left", "right", "none", "both"],
     ) -> Self:
-        import pyarrow.compute as pc
-
         ser = self._native_series
         _, lower_bound = broadcast_and_extract_native(
             self, lower_bound, self._backend_version
@@ -529,13 +448,9 @@ class ArrowSeries(CompliantSeries):
         return self._from_native_series(ser.is_null())
 
     def is_nan(self: Self) -> Self:
-        import pyarrow.compute as pc
-
         return self._from_native_series(pc.is_nan(self._native_series))
 
     def cast(self: Self, dtype: DType) -> Self:
-        import pyarrow.compute as pc
-
         ser = self._native_series
         dtype = narwhals_to_native_dtype(dtype, self._version)
         return self._from_native_series(pc.cast(ser, dtype))
@@ -560,8 +475,6 @@ class ArrowSeries(CompliantSeries):
             return self._from_native_series(ser.slice(abs(n)))
 
     def is_in(self: Self, other: Any) -> Self:
-        import pyarrow.compute as pc
-
         value_set = pa.array(other)
         ser = self._native_series
         return self._from_native_series(pc.is_in(ser, value_set=value_set))
@@ -598,8 +511,6 @@ class ArrowSeries(CompliantSeries):
         normalize: bool = False,
     ) -> ArrowDataFrame:
         """Parallel is unused, exists for compatibility."""
-        import pyarrow.compute as pc
-
         from narwhals._arrow.dataframe import ArrowDataFrame
 
         index_name_ = "index" if self._name is None else self._name
@@ -624,8 +535,6 @@ class ArrowSeries(CompliantSeries):
         )
 
     def zip_with(self: Self, mask: Self, other: Self) -> Self:
-        import pyarrow.compute as pc
-
         mask = mask._native_series.combine_chunks()
         return self._from_native_series(
             pc.if_else(
@@ -644,7 +553,6 @@ class ArrowSeries(CompliantSeries):
         seed: int | None,
     ) -> Self:
         import numpy as np  # ignore-banned-import
-        import pyarrow.compute as pc
 
         ser = self._native_series
         num_rows = len(self)
@@ -665,7 +573,6 @@ class ArrowSeries(CompliantSeries):
         limit: int | None,
     ) -> Self:
         import numpy as np  # ignore-banned-import
-        import pyarrow.compute as pc
 
         def fill_aux(
             arr: pa.Array,
@@ -735,7 +642,6 @@ class ArrowSeries(CompliantSeries):
 
     def is_first_distinct(self: Self) -> Self:
         import numpy as np  # ignore-banned-import
-        import pyarrow.compute as pc
 
         row_number = pa.array(np.arange(len(self)))
         col_token = generate_temporary_column_name(n_bytes=8, columns=[self.name])
@@ -751,7 +657,6 @@ class ArrowSeries(CompliantSeries):
 
     def is_last_distinct(self: Self) -> Self:
         import numpy as np  # ignore-banned-import
-        import pyarrow.compute as pc
 
         row_number = pa.array(np.arange(len(self)))
         col_token = generate_temporary_column_name(n_bytes=8, columns=[self.name])
@@ -769,7 +674,6 @@ class ArrowSeries(CompliantSeries):
         if not isinstance(descending, bool):
             msg = f"argument 'descending' should be boolean, found {type(descending)}"
             raise TypeError(msg)
-        import pyarrow.compute as pc
 
         ser = self._native_series
         if descending:
@@ -781,15 +685,12 @@ class ArrowSeries(CompliantSeries):
     def unique(self: Self, *, maintain_order: bool) -> ArrowSeries:
         # The param `maintain_order` is only here for compatibility with the Polars API
         # and has no effect on the output.
-        import pyarrow.compute as pc
 
         return self._from_native_series(pc.unique(self._native_series))
 
     def replace_strict(
         self, old: Sequence[Any], new: Sequence[Any], *, return_dtype: DType | None
     ) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         # https://stackoverflow.com/a/79111029/4451315
         idxs = pc.index_in(self._native_series, pa.array(old))
         result_native = pc.take(pa.array(new), idxs)
@@ -806,8 +707,6 @@ class ArrowSeries(CompliantSeries):
         return result
 
     def sort(self: Self, *, descending: bool, nulls_last: bool) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         series = self._native_series
         order = "descending" if descending else "ascending"
         null_placement = "at_end" if nulls_last else "at_start"
@@ -857,8 +756,6 @@ class ArrowSeries(CompliantSeries):
         *,
         _return_py_scalar: bool = True,
     ) -> Any:
-        import pyarrow.compute as pc
-
         return maybe_extract_py_scalar(
             pc.quantile(self._native_series, q=quantile, interpolation=interpolation)[0],
             _return_py_scalar,
@@ -870,8 +767,6 @@ class ArrowSeries(CompliantSeries):
     def clip(
         self: Self, lower_bound: Self | Any | None, upper_bound: Self | Any | None
     ) -> Self:
-        import pyarrow.compute as pc
-
         arr = self._native_series
         _, lower_bound = broadcast_and_extract_native(
             self, lower_bound, self._backend_version
@@ -895,8 +790,6 @@ class ArrowSeries(CompliantSeries):
         )[self.name]
 
     def is_finite(self: Self) -> Self:
-        import pyarrow.compute as pc
-
         return self._from_native_series(pc.is_finite(self._native_series))
 
     def cum_count(self: Self, *, reverse: bool) -> Self:
@@ -907,8 +800,6 @@ class ArrowSeries(CompliantSeries):
         if self._backend_version < (13, 0, 0):
             msg = "cum_min method is not supported for pyarrow < 13.0.0"
             raise NotImplementedError(msg)
-
-        import pyarrow.compute as pc
 
         native_series = self._native_series
 
@@ -924,8 +815,6 @@ class ArrowSeries(CompliantSeries):
             msg = "cum_max method is not supported for pyarrow < 13.0.0"
             raise NotImplementedError(msg)
 
-        import pyarrow.compute as pc
-
         native_series = self._native_series
 
         result = (
@@ -939,8 +828,6 @@ class ArrowSeries(CompliantSeries):
         if self._backend_version < (13, 0, 0):
             msg = "cum_max method is not supported for pyarrow < 13.0.0"
             raise NotImplementedError(msg)
-
-        import pyarrow.compute as pc
 
         native_series = self._native_series
 
@@ -958,8 +845,6 @@ class ArrowSeries(CompliantSeries):
         min_periods: int | None,
         center: bool,
     ) -> Self:
-        import pyarrow.compute as pc
-
         min_periods = min_periods if min_periods is not None else window_size
         padded_series, offset = pad_series(self, window_size=window_size, center=center)
 
@@ -994,8 +879,6 @@ class ArrowSeries(CompliantSeries):
         min_periods: int | None,
         center: bool,
     ) -> Self:
-        import pyarrow.compute as pc
-
         min_periods = min_periods if min_periods is not None else window_size
         padded_series, offset = pad_series(self, window_size=window_size, center=center)
 
@@ -1034,8 +917,6 @@ class ArrowSeries(CompliantSeries):
         center: bool,
         ddof: int,
     ) -> Self:
-        import pyarrow.compute as pc  # ignore-banned-import
-
         min_periods = min_periods if min_periods is not None else window_size
         padded_series, offset = pad_series(self, window_size=window_size, center=center)
 
@@ -1107,7 +988,6 @@ class ArrowSeries(CompliantSeries):
             raise ValueError(msg)
 
         # ignore-banned-import
-        import pyarrow.compute as pc  # ignore-banned-import
 
         sort_keys = "descending" if descending else "ascending"
         tiebreaker = "first" if method == "ordinal" else method

--- a/narwhals/_arrow/series_cat.py
+++ b/narwhals/_arrow/series_cat.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pyarrow as pa
+
 if TYPE_CHECKING:
     from typing_extensions import Self
 
@@ -13,8 +15,6 @@ class ArrowSeriesCatNamespace:
         self._compliant_series = series
 
     def get_categories(self: Self) -> ArrowSeries:
-        import pyarrow as pa
-
         ca = self._compliant_series._native_series
         out = pa.chunked_array(
             [pa.concat_arrays(x.dictionary for x in ca.chunks).unique()]

--- a/narwhals/_arrow/series_dt.py
+++ b/narwhals/_arrow/series_dt.py
@@ -20,8 +20,6 @@ class ArrowSeriesDateTimeNamespace:
         self._compliant_series = series
 
     def to_string(self: Self, format: str) -> ArrowSeries:  # noqa: A002
-        import pyarrow.compute as pc
-
         # PyArrow differs from other libraries in that %S also prints out
         # the fractional part of the second...:'(
         # https://arrow.apache.org/docs/python/generated/pyarrow.compute.strftime.html
@@ -31,8 +29,6 @@ class ArrowSeriesDateTimeNamespace:
         )
 
     def replace_time_zone(self: Self, time_zone: str | None) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         if time_zone is not None:
             result = pc.assume_timezone(
                 pc.local_timestamp(self._compliant_series._native_series), time_zone
@@ -54,8 +50,6 @@ class ArrowSeriesDateTimeNamespace:
         return self._compliant_series._from_native_series(result)
 
     def timestamp(self: Self, time_unit: Literal["ns", "us", "ms"] = "us") -> ArrowSeries:
-        import pyarrow.compute as pc
-
         s = self._compliant_series._native_series
         dtype = self._compliant_series.dtype
         dtypes = import_dtypes_module(self._compliant_series._version)
@@ -112,65 +106,47 @@ class ArrowSeriesDateTimeNamespace:
         )
 
     def year(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.year(self._compliant_series._native_series)
         )
 
     def month(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.month(self._compliant_series._native_series)
         )
 
     def day(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.day(self._compliant_series._native_series)
         )
 
     def hour(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.hour(self._compliant_series._native_series)
         )
 
     def minute(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.minute(self._compliant_series._native_series)
         )
 
     def second(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.second(self._compliant_series._native_series)
         )
 
     def millisecond(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.millisecond(self._compliant_series._native_series)
         )
 
     def microsecond(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         arr = self._compliant_series._native_series
         result = pc.add(pc.multiply(pc.millisecond(arr), 1000), pc.microsecond(arr))
 
         return self._compliant_series._from_native_series(result)
 
     def nanosecond(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         arr = self._compliant_series._native_series
         result = pc.add(
             pc.multiply(self.microsecond()._native_series, 1000), pc.nanosecond(arr)
@@ -178,15 +154,11 @@ class ArrowSeriesDateTimeNamespace:
         return self._compliant_series._from_native_series(result)
 
     def ordinal_day(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.day_of_year(self._compliant_series._native_series)
         )
 
     def weekday(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.day_of_week(self._compliant_series._native_series, count_from_zero=False)
         )
@@ -208,8 +180,6 @@ class ArrowSeriesDateTimeNamespace:
         )
 
     def total_seconds(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         arr = self._compliant_series._native_series
         unit = arr.type.unit
 
@@ -226,8 +196,6 @@ class ArrowSeriesDateTimeNamespace:
         )
 
     def total_milliseconds(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         arr = self._compliant_series._native_series
         unit = arr.type.unit
 
@@ -250,8 +218,6 @@ class ArrowSeriesDateTimeNamespace:
         )
 
     def total_microseconds(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         arr = self._compliant_series._native_series
         unit = arr.type.unit
 
@@ -273,8 +239,6 @@ class ArrowSeriesDateTimeNamespace:
         )
 
     def total_nanoseconds(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         arr = self._compliant_series._native_series
         unit = arr.type.unit
 

--- a/narwhals/_arrow/series_dt.py
+++ b/narwhals/_arrow/series_dt.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Literal
 
+import pyarrow as pa
+import pyarrow.compute as pc
+
 from narwhals._arrow.utils import floordiv_compat
 from narwhals.utils import import_dtypes_module
 
@@ -39,8 +42,6 @@ class ArrowSeriesDateTimeNamespace:
         return self._compliant_series._from_native_series(result)
 
     def convert_time_zone(self: Self, time_zone: str) -> ArrowSeries:
-        import pyarrow as pa
-
         if self._compliant_series.dtype.time_zone is None:  # type: ignore[attr-defined]
             result = self.replace_time_zone("UTC")._native_series.cast(
                 pa.timestamp(self._compliant_series._native_series.type.unit, time_zone)
@@ -53,7 +54,6 @@ class ArrowSeriesDateTimeNamespace:
         return self._compliant_series._from_native_series(result)
 
     def timestamp(self: Self, time_unit: Literal["ns", "us", "ms"] = "us") -> ArrowSeries:
-        import pyarrow as pa
         import pyarrow.compute as pc
 
         s = self._compliant_series._native_series
@@ -107,8 +107,6 @@ class ArrowSeriesDateTimeNamespace:
         return self._compliant_series._from_native_series(result)
 
     def date(self: Self) -> ArrowSeries:
-        import pyarrow as pa
-
         return self._compliant_series._from_native_series(
             self._compliant_series._native_series.cast(pa.date32())
         )
@@ -194,9 +192,6 @@ class ArrowSeriesDateTimeNamespace:
         )
 
     def total_minutes(self: Self) -> ArrowSeries:
-        import pyarrow as pa
-        import pyarrow.compute as pc
-
         arr = self._compliant_series._native_series
         unit = arr.type.unit
 
@@ -213,7 +208,6 @@ class ArrowSeriesDateTimeNamespace:
         )
 
     def total_seconds(self: Self) -> ArrowSeries:
-        import pyarrow as pa
         import pyarrow.compute as pc
 
         arr = self._compliant_series._native_series
@@ -232,7 +226,6 @@ class ArrowSeriesDateTimeNamespace:
         )
 
     def total_milliseconds(self: Self) -> ArrowSeries:
-        import pyarrow as pa
         import pyarrow.compute as pc
 
         arr = self._compliant_series._native_series
@@ -257,7 +250,6 @@ class ArrowSeriesDateTimeNamespace:
         )
 
     def total_microseconds(self: Self) -> ArrowSeries:
-        import pyarrow as pa
         import pyarrow.compute as pc
 
         arr = self._compliant_series._native_series
@@ -281,7 +273,6 @@ class ArrowSeriesDateTimeNamespace:
         )
 
     def total_nanoseconds(self: Self) -> ArrowSeries:
-        import pyarrow as pa
         import pyarrow.compute as pc
 
         arr = self._compliant_series._native_series

--- a/narwhals/_arrow/series_list.py
+++ b/narwhals/_arrow/series_list.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pyarrow as pa
+import pyarrow.compute as pc
+
 if TYPE_CHECKING:
     from typing_extensions import Self
 
@@ -13,9 +16,6 @@ class ArrowSeriesListNamespace:
         self._arrow_series = series
 
     def len(self: Self) -> ArrowSeries:
-        import pyarrow as pa
-        import pyarrow.compute as pc
-
         return self._arrow_series._from_native_series(
             pc.cast(pc.list_value_length(self._arrow_series._native_series), pa.uint32())
         )

--- a/narwhals/_arrow/series_str.py
+++ b/narwhals/_arrow/series_str.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pyarrow.compute as pc
+
 from narwhals._arrow.utils import parse_datetime_format
 
 if TYPE_CHECKING:
@@ -15,8 +17,6 @@ class ArrowSeriesStringNamespace:
         self._compliant_series = series
 
     def len_chars(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.utf8_length(self._compliant_series._native_series)
         )
@@ -24,8 +24,6 @@ class ArrowSeriesStringNamespace:
     def replace(
         self: Self, pattern: str, value: str, *, literal: bool, n: int
     ) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         method = "replace_substring" if literal else "replace_substring_regex"
         return self._compliant_series._from_native_series(
             getattr(pc, method)(
@@ -42,8 +40,6 @@ class ArrowSeriesStringNamespace:
         return self.replace(pattern, value, literal=literal, n=-1)
 
     def strip_chars(self: Self, characters: str | None) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         whitespace = " \t\n\r\v\f"
         return self._compliant_series._from_native_series(
             pc.utf8_trim(
@@ -53,30 +49,22 @@ class ArrowSeriesStringNamespace:
         )
 
     def starts_with(self: Self, prefix: str) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.equal(self.slice(0, len(prefix))._native_series, prefix)
         )
 
     def ends_with(self: Self, suffix: str) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.equal(self.slice(-len(suffix), None)._native_series, suffix)
         )
 
     def contains(self: Self, pattern: str, *, literal: bool) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         check_func = pc.match_substring if literal else pc.match_substring_regex
         return self._compliant_series._from_native_series(
             check_func(self._compliant_series._native_series, pattern)
         )
 
     def slice(self: Self, offset: int, length: int | None) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         stop = offset + length if length is not None else None
         return self._compliant_series._from_native_series(
             pc.utf8_slice_codeunits(
@@ -85,8 +73,6 @@ class ArrowSeriesStringNamespace:
         )
 
     def to_datetime(self: Self, format: str | None) -> ArrowSeries:  # noqa: A002
-        import pyarrow.compute as pc
-
         if format is None:
             format = parse_datetime_format(self._compliant_series._native_series)
 
@@ -95,15 +81,11 @@ class ArrowSeriesStringNamespace:
         )
 
     def to_uppercase(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.utf8_upper(self._compliant_series._native_series),
         )
 
     def to_lowercase(self: Self) -> ArrowSeries:
-        import pyarrow.compute as pc
-
         return self._compliant_series._from_native_series(
             pc.utf8_lower(self._compliant_series._native_series),
         )

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -448,8 +448,6 @@ TIME_FORMATS = ((HMS_RE, "%H:%M:%S"), (HM_RE, "%H:%M"), (HMS_RE_NO_SEP, "%H%M%S"
 
 def parse_datetime_format(arr: pa.StringArray) -> str:
     """Try to infer datetime format from StringArray."""
-    import pyarrow.compute as pc
-
     matches = pa.concat_arrays(  # converts from ChunkedArray to StructArray
         pc.extract_regex(pc.drop_null(arr).slice(0, 10), pattern=FULL_RE).chunks
     )
@@ -485,8 +483,6 @@ def parse_datetime_format(arr: pa.StringArray) -> str:
 
 
 def _parse_date_format(arr: pa.Array) -> str:
-    import pyarrow.compute as pc
-
     for date_rgx, date_fmt in DATE_FORMATS:
         matches = pc.extract_regex(arr, pattern=date_rgx)
         if date_fmt == "%Y%m%d" and pc.all(matches.is_valid()).as_py():
@@ -507,8 +503,6 @@ def _parse_date_format(arr: pa.Array) -> str:
 
 
 def _parse_time_format(arr: pa.Array) -> str:
-    import pyarrow.compute as pc
-
     for time_rgx, time_fmt in TIME_FORMATS:
         matches = pc.extract_regex(arr, pattern=time_rgx)
         if pc.all(matches.is_valid()).as_py():

--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -8,6 +8,7 @@ from typing import Literal
 from typing import Sequence
 
 import dask.dataframe as dd
+import pandas as pd
 
 from narwhals._dask.utils import add_row_index
 from narwhals._dask.utils import parse_exprs_and_named_exprs
@@ -81,8 +82,6 @@ class DaskLazyFrame(CompliantLazyFrame):
         return self._from_native_frame(df)
 
     def collect(self) -> Any:
-        import pandas as pd
-
         from narwhals._pandas_like.dataframe import PandasLikeDataFrame
 
         result = self._native_frame.compute()
@@ -127,8 +126,6 @@ class DaskLazyFrame(CompliantLazyFrame):
 
         if not new_series:
             # return empty dataframe, like Polars does
-            import pandas as pd
-
             return self._from_native_frame(
                 dd.from_pandas(pd.DataFrame(), npartitions=self._native_frame.npartitions)
             )

--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -7,6 +7,8 @@ from typing import Iterable
 from typing import Literal
 from typing import Sequence
 
+import dask.dataframe as dd
+
 from narwhals._dask.utils import add_row_index
 from narwhals._dask.utils import parse_exprs_and_named_exprs
 from narwhals._pandas_like.utils import native_to_narwhals_dtype
@@ -23,7 +25,6 @@ from narwhals.utils import validate_backend_version
 if TYPE_CHECKING:
     from types import ModuleType
 
-    import dask.dataframe as dd
     from typing_extensions import Self
 
     from narwhals._dask.expr import DaskExpr
@@ -111,8 +112,6 @@ class DaskLazyFrame(CompliantLazyFrame):
         *exprs: IntoDaskExpr,
         **named_exprs: IntoDaskExpr,
     ) -> Self:
-        import dask.dataframe as dd
-
         if exprs and all(isinstance(x, str) for x in exprs) and not named_exprs:
             # This is a simple slice => fastpath!
             return self._from_native_frame(

--- a/narwhals/_dask/expr_str.py
+++ b/narwhals/_dask/expr_str.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import dask.dataframe as dd
+
 if TYPE_CHECKING:
     from typing_extensions import Self
 
@@ -93,8 +95,6 @@ class DaskExprStringNamespace:
         )
 
     def to_datetime(self: Self, format: str | None) -> DaskExpr:  # noqa: A002
-        import dask.dataframe as dd
-
         return self._compliant_expr._from_call(
             lambda _input, format: dd.to_datetime(_input, format=format),
             "to_datetime",

--- a/narwhals/_dask/group_by.py
+++ b/narwhals/_dask/group_by.py
@@ -6,19 +6,20 @@ from typing import Any
 from typing import Callable
 from typing import Sequence
 
+import dask.dataframe as dd
+
+try:
+    import dask.dataframe.dask_expr as dx
+except ModuleNotFoundError:  # pragma: no cover
+    import dask_expr as dx
+
+
 from narwhals._expression_parsing import is_simple_aggregation
 from narwhals._expression_parsing import parse_into_exprs
 from narwhals.exceptions import AnonymousExprError
 from narwhals.utils import remove_prefix
 
 if TYPE_CHECKING:
-    import dask.dataframe as dd
-
-    try:
-        import dask.dataframe.dask_expr as dx
-    except ModuleNotFoundError:
-        import dask_expr as dx
-
     import pandas as pd
 
     from narwhals._dask.dataframe import DaskLazyFrame
@@ -27,8 +28,6 @@ if TYPE_CHECKING:
 
 
 def n_unique() -> dd.Aggregation:
-    import dask.dataframe as dd
-
     def chunk(s: pd.core.groupby.generic.SeriesGroupBy) -> int:
         return s.nunique(dropna=False)  # type: ignore[no-any-return]
 
@@ -49,11 +48,6 @@ def var(
 ]:
     from functools import partial
 
-    try:
-        import dask.dataframe.dask_expr as dx
-    except ModuleNotFoundError:  # pragma: no cover
-        import dask_expr as dx
-
     return partial(dx._groupby.GroupBy.var, ddof=ddof)
 
 
@@ -63,11 +57,6 @@ def std(
     [pd.core.groupby.generic.SeriesGroupBy], pd.core.groupby.generic.SeriesGroupBy
 ]:
     from functools import partial
-
-    try:
-        import dask.dataframe.dask_expr as dx
-    except ModuleNotFoundError:  # pragma: no cover
-        import dask_expr as dx
 
     return partial(dx._groupby.GroupBy.std, ddof=ddof)
 

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -8,6 +8,9 @@ from typing import Literal
 from typing import Sequence
 from typing import cast
 
+import dask.dataframe as dd
+import pandas as pd
+
 from narwhals._dask.dataframe import DaskLazyFrame
 from narwhals._dask.expr import DaskExpr
 from narwhals._dask.selectors import DaskSelectorNamespace
@@ -69,9 +72,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
         )
 
     def lit(self, value: Any, dtype: DType | None) -> DaskExpr:
-        import dask.dataframe as dd
-        import pandas as pd
-
         def func(df: DaskLazyFrame) -> list[dx.Series]:
             return [
                 dd.from_pandas(
@@ -99,7 +99,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
         )
 
     def len(self) -> DaskExpr:
-        import dask.dataframe as dd
         import pandas as pd
 
         def func(df: DaskLazyFrame) -> list[dx.Series]:
@@ -188,8 +187,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
         *,
         how: Literal["horizontal", "vertical", "diagonal"],
     ) -> DaskLazyFrame:
-        import dask.dataframe as dd
-
         if len(list(items)) == 0:
             msg = "No items to concatenate"  # pragma: no cover
             raise AssertionError(msg)
@@ -265,8 +262,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
         )
 
     def min_horizontal(self, *exprs: IntoDaskExpr) -> DaskExpr:
-        import dask.dataframe as dd
-
         parsed_exprs = parse_into_exprs(*exprs, namespace=self)
 
         def func(df: DaskLazyFrame) -> list[dx.Series]:
@@ -287,8 +282,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
         )
 
     def max_horizontal(self, *exprs: IntoDaskExpr) -> DaskExpr:
-        import dask.dataframe as dd
-
         parsed_exprs = parse_into_exprs(*exprs, namespace=self)
 
         def func(df: DaskLazyFrame) -> list[dx.Series]:

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -99,8 +99,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
         )
 
     def len(self) -> DaskExpr:
-        import pandas as pd
-
         def func(df: DaskLazyFrame) -> list[dx.Series]:
             if not df.columns:
                 return [

--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -7,6 +7,8 @@ from typing import Iterable
 from typing import Literal
 from typing import Sequence
 
+from duckdb import ColumnExpression
+
 from narwhals._duckdb.utils import native_to_narwhals_dtype
 from narwhals._duckdb.utils import parse_exprs_and_named_exprs
 from narwhals.dependencies import get_duckdb
@@ -134,8 +136,6 @@ class DuckDBLazyFrame:
         *exprs: Any,
         **named_exprs: Any,
     ) -> Self:
-        from duckdb import ColumnExpression
-
         new_columns_map = parse_exprs_and_named_exprs(self, *exprs, **named_exprs)
         result = []
         for col in self._native_frame.columns:

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -6,6 +6,11 @@ from typing import Callable
 from typing import Literal
 from typing import Sequence
 
+from duckdb import CaseExpression
+from duckdb import ColumnExpression
+from duckdb import ConstantExpression
+from duckdb import FunctionExpression
+
 from narwhals._duckdb.expr_dt import DuckDBExprDateTimeNamespace
 from narwhals._duckdb.expr_name import DuckDBExprNameNamespace
 from narwhals._duckdb.expr_str import DuckDBExprStringNamespace
@@ -76,8 +81,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         version: Version,
     ) -> Self:
         def func(_: DuckDBLazyFrame) -> list[duckdb.Expression]:
-            from duckdb import ColumnExpression
-
             return [ColumnExpression(col_name) for col_name in column_names]
 
         return cls(
@@ -100,8 +103,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         version: Version,
     ) -> Self:
         def func(df: DuckDBLazyFrame) -> list[duckdb.Expression]:
-            from duckdb import ColumnExpression
-
             columns = df.columns
 
             return [ColumnExpression(columns[i]) for i in column_indices]
@@ -310,8 +311,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def abs(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("abs", _input),
             "abs",
@@ -319,8 +318,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def mean(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("mean", _input),
             "mean",
@@ -328,10 +325,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def skew(self) -> Self:
-        from duckdb import CaseExpression
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         def func(_input: duckdb.Expression) -> duckdb.Expression:
             count = FunctionExpression("count", _input)
             return CaseExpression(

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -7,6 +7,7 @@ from typing import Literal
 from typing import Sequence
 
 from duckdb import CaseExpression
+from duckdb import CoalesceOperator
 from duckdb import ColumnExpression
 from duckdb import ConstantExpression
 from duckdb import FunctionExpression
@@ -342,8 +343,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         return self._from_call(func, "skew", returns_scalar=True)
 
     def median(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("median", _input),
             "median",
@@ -351,8 +350,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def all(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("bool_and", _input),
             "all",
@@ -360,8 +357,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def any(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("bool_or", _input),
             "any",
@@ -373,9 +368,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         quantile: float,
         interpolation: Literal["nearest", "higher", "lower", "midpoint", "linear"],
     ) -> Self:
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         def func(_input: duckdb.Expression) -> duckdb.Expression:
             if interpolation == "linear":
                 return FunctionExpression(
@@ -391,8 +383,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def clip(self, lower_bound: Any, upper_bound: Any) -> Self:
-        from duckdb import FunctionExpression
-
         def func(
             _input: duckdb.Expression, lower_bound: Any, upper_bound: Any
         ) -> duckdb.Expression:
@@ -434,17 +424,11 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def sum(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("sum", _input), "sum", returns_scalar=True
         )
 
     def n_unique(self) -> Self:
-        from duckdb import CaseExpression
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         def func(_input: duckdb.Expression) -> duckdb.Expression:
             # https://stackoverflow.com/a/79338887/4451315
             return FunctionExpression(
@@ -463,8 +447,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def count(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("count", _input),
             "count",
@@ -472,15 +454,11 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def len(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("count"), "len", returns_scalar=True
         )
 
     def std(self, ddof: int) -> Self:
-        from duckdb import FunctionExpression
-
         if ddof == 1:
             func = "stddev_samp"
         elif ddof == 0:
@@ -493,8 +471,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def var(self, ddof: int) -> Self:
-        from duckdb import FunctionExpression
-
         if ddof == 1:
             func = "var_samp"
         elif ddof == 0:
@@ -507,22 +483,16 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def max(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("max", _input), "max", returns_scalar=True
         )
 
     def min(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("min", _input), "min", returns_scalar=True
         )
 
     def null_count(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("sum", _input.isnull().cast("int")),
             "null_count",
@@ -535,8 +505,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def is_nan(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("isnan", _input),
             "is_nan",
@@ -544,8 +512,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def is_finite(self) -> Self:
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression("isfinite", _input),
             "is_finite",
@@ -553,8 +519,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def is_in(self, other: Sequence[Any]) -> Self:
-        from duckdb import ConstantExpression
-
         return self._from_call(
             lambda _input: _input.isin(*[ConstantExpression(x) for x in other]),
             "is_in",
@@ -562,9 +526,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def round(self, decimals: int) -> Self:
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         return self._from_call(
             lambda _input: FunctionExpression(
                 "round", _input, ConstantExpression(decimals)
@@ -574,9 +535,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def fill_null(self, value: Any, strategy: Any, limit: int | None) -> Self:
-        from duckdb import CoalesceOperator
-        from duckdb import ConstantExpression
-
         if strategy is not None:
             msg = "todo"
             raise NotImplementedError(msg)

--- a/narwhals/_duckdb/expr_dt.py
+++ b/narwhals/_duckdb/expr_dt.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from duckdb import ConstantExpression
+from duckdb import FunctionExpression
+
 if TYPE_CHECKING:
     from narwhals._duckdb.expr import DuckDBExpr
 
@@ -11,8 +14,6 @@ class DuckDBExprDateTimeNamespace:
         self._compliant_expr = expr
 
     def year(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("year", _input),
             "year",
@@ -20,8 +21,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def month(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("month", _input),
             "month",
@@ -29,8 +28,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def day(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("day", _input),
             "day",
@@ -38,8 +35,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def hour(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("hour", _input),
             "hour",
@@ -47,8 +42,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def minute(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("minute", _input),
             "minute",
@@ -56,8 +49,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def second(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("second", _input),
             "second",
@@ -65,8 +56,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def millisecond(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("millisecond", _input)
             - FunctionExpression("second", _input) * 1_000,
@@ -75,8 +64,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def microsecond(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("microsecond", _input)
             - FunctionExpression("second", _input) * 1_000_000,
@@ -85,8 +72,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def nanosecond(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("nanosecond", _input)
             - FunctionExpression("second", _input) * 1_000_000_000,
@@ -95,9 +80,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def to_string(self, format: str) -> DuckDBExpr:  # noqa: A002
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression(
                 "strftime", _input, ConstantExpression(format)
@@ -107,8 +89,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def weekday(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("isodow", _input),
             "weekday",
@@ -116,8 +96,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def ordinal_day(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("dayofyear", _input),
             "ordinal_day",
@@ -132,9 +110,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def total_minutes(self) -> DuckDBExpr:
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression(
                 "datepart", ConstantExpression("minute"), _input
@@ -144,9 +119,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def total_seconds(self) -> DuckDBExpr:
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: 60
             * FunctionExpression("datepart", ConstantExpression("minute"), _input)
@@ -156,9 +128,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def total_milliseconds(self) -> DuckDBExpr:
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: 60_000
             * FunctionExpression("datepart", ConstantExpression("minute"), _input)
@@ -168,9 +137,6 @@ class DuckDBExprDateTimeNamespace:
         )
 
     def total_microseconds(self) -> DuckDBExpr:
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: 60_000_000
             * FunctionExpression("datepart", ConstantExpression("minute"), _input)

--- a/narwhals/_duckdb/expr_str.py
+++ b/narwhals/_duckdb/expr_str.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import NoReturn
 
+from duckdb import ConstantExpression
+from duckdb import FunctionExpression
+
 if TYPE_CHECKING:
     import duckdb
 
@@ -14,9 +17,6 @@ class DuckDBExprStringNamespace:
         self._compliant_expr = expr
 
     def starts_with(self, prefix: str) -> DuckDBExpr:
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression(
                 "starts_with", _input, ConstantExpression(prefix)
@@ -26,9 +26,6 @@ class DuckDBExprStringNamespace:
         )
 
     def ends_with(self, suffix: str) -> DuckDBExpr:
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression(
                 "ends_with", _input, ConstantExpression(suffix)
@@ -38,9 +35,6 @@ class DuckDBExprStringNamespace:
         )
 
     def contains(self, pattern: str, *, literal: bool) -> DuckDBExpr:
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         def func(_input: duckdb.Expression) -> duckdb.Expression:
             if literal:
                 return FunctionExpression("contains", _input, ConstantExpression(pattern))
@@ -53,9 +47,6 @@ class DuckDBExprStringNamespace:
         )
 
     def slice(self, offset: int, length: int) -> DuckDBExpr:
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         def func(_input: duckdb.Expression) -> duckdb.Expression:
             return FunctionExpression(
                 "array_slice",
@@ -73,8 +64,6 @@ class DuckDBExprStringNamespace:
         )
 
     def len_chars(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("length", _input),
             "len_chars",
@@ -82,8 +71,6 @@ class DuckDBExprStringNamespace:
         )
 
     def to_lowercase(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("lower", _input),
             "to_lowercase",
@@ -91,8 +78,6 @@ class DuckDBExprStringNamespace:
         )
 
     def to_uppercase(self) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression("upper", _input),
             "to_uppercase",
@@ -101,9 +86,6 @@ class DuckDBExprStringNamespace:
 
     def strip_chars(self, characters: str | None) -> DuckDBExpr:
         import string
-
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
 
         return self._compliant_expr._from_call(
             lambda _input: FunctionExpression(
@@ -120,9 +102,6 @@ class DuckDBExprStringNamespace:
     def replace_all(
         self, pattern: str, value: str, *, literal: bool = False
     ) -> DuckDBExpr:
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
-
         if literal is False:
             return self._compliant_expr._from_call(
                 lambda _input: FunctionExpression(

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -10,6 +10,12 @@ from typing import Literal
 from typing import Sequence
 from typing import cast
 
+from duckdb import CaseExpression
+from duckdb import CoalesceOperator
+from duckdb import ColumnExpression
+from duckdb import ConstantExpression
+from duckdb import FunctionExpression
+
 from narwhals._duckdb.expr import DuckDBExpr
 from narwhals._duckdb.utils import narwhals_to_native_dtype
 from narwhals._expression_parsing import combine_root_names
@@ -37,8 +43,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
 
     def all(self) -> DuckDBExpr:
         def _all(df: DuckDBLazyFrame) -> list[duckdb.Expression]:
-            from duckdb import ColumnExpression
-
             return [ColumnExpression(col_name) for col_name in df.columns]
 
         return DuckDBExpr(
@@ -86,9 +90,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
             *parse_into_exprs(*exprs, namespace=self),
             *parse_into_exprs(*more_exprs, namespace=self),
         ]
-        from duckdb import CaseExpression
-        from duckdb import ConstantExpression
-        from duckdb import FunctionExpression
 
         def func(df: DuckDBLazyFrame) -> list[duckdb.Expression]:
             cols = [s for _expr in parsed_exprs for s in _expr(df)]
@@ -193,8 +194,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
         )
 
     def max_horizontal(self, *exprs: IntoDuckDBExpr) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         parsed_exprs = parse_into_exprs(*exprs, namespace=self)
 
         def func(df: DuckDBLazyFrame) -> list[duckdb.Expression]:
@@ -215,8 +214,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
         )
 
     def min_horizontal(self, *exprs: IntoDuckDBExpr) -> DuckDBExpr:
-        from duckdb import FunctionExpression
-
         parsed_exprs = parse_into_exprs(*exprs, namespace=self)
 
         def func(df: DuckDBLazyFrame) -> list[duckdb.Expression]:
@@ -237,9 +234,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
         )
 
     def sum_horizontal(self, *exprs: IntoDuckDBExpr) -> DuckDBExpr:
-        from duckdb import CoalesceOperator
-        from duckdb import ConstantExpression
-
         parsed_exprs = parse_into_exprs(*exprs, namespace=self)
 
         def func(df: DuckDBLazyFrame) -> list[duckdb.Expression]:
@@ -285,8 +279,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
         )
 
     def lit(self, value: Any, dtype: DType | None) -> DuckDBExpr:
-        from duckdb import ConstantExpression
-
         def func(_df: DuckDBLazyFrame) -> list[duckdb.Expression]:
             if dtype is not None:
                 return [
@@ -310,8 +302,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
 
     def len(self) -> DuckDBExpr:
         def func(_df: DuckDBLazyFrame) -> list[duckdb.Expression]:
-            from duckdb import FunctionExpression
-
             return [FunctionExpression("count").alias("len")]
 
         return DuckDBExpr(
@@ -346,9 +336,6 @@ class DuckDBWhen:
         self._version = version
 
     def __call__(self, df: DuckDBLazyFrame) -> Sequence[duckdb.Expression]:
-        from duckdb import CaseExpression
-        from duckdb import ConstantExpression
-
         from narwhals._expression_parsing import parse_into_expr
 
         plx = df.__narwhals_namespace__()

--- a/narwhals/_duckdb/utils.py
+++ b/narwhals/_duckdb/utils.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Sequence
 
+from duckdb import ColumnExpression
+
 from narwhals.dtypes import DType
 from narwhals.exceptions import InvalidIntoExprError
 from narwhals.utils import import_dtypes_module
@@ -79,8 +81,6 @@ def _columns_from_expr(
     df: DuckDBLazyFrame, expr: IntoDuckDBExpr
 ) -> Sequence[duckdb.Expression]:
     if isinstance(expr, str):  # pragma: no cover
-        from duckdb import ColumnExpression
-
         return [ColumnExpression(expr)]
     elif hasattr(expr, "__narwhals_expr__"):
         col_output_list = expr._call(df)

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -701,6 +701,9 @@ def narwhals_to_native_dtype(  # noqa: PLR0915
             except ImportError as exc:  # pragma: no cover
                 msg = f"Unable to convert to {dtype} to to the following exception: {exc.msg}"
                 raise ImportError(msg) from exc
+            from narwhals._arrow.utils import (
+                narwhals_to_native_dtype as arrow_narwhals_to_native_dtype,
+            )
 
             return pd.ArrowDtype(
                 pa.struct(

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -10,12 +10,6 @@ from typing import Literal
 from typing import Sequence
 from typing import TypeVar
 
-from narwhals._arrow.utils import (
-    narwhals_to_native_dtype as arrow_narwhals_to_native_dtype,
-)
-from narwhals._arrow.utils import (
-    native_to_narwhals_dtype as arrow_native_to_narwhals_dtype,
-)
 from narwhals.exceptions import ColumnNotFoundError
 from narwhals.exceptions import ShapeError
 from narwhals.utils import Implementation
@@ -478,6 +472,10 @@ def native_to_narwhals_dtype(
     dtypes = import_dtypes_module(version)
 
     if dtype.startswith(("large_list", "list", "struct", "fixed_size_list")):
+        from narwhals._arrow.utils import (
+            native_to_narwhals_dtype as arrow_native_to_narwhals_dtype,
+        )
+
         native_dtype = native_column.dtype
         if hasattr(native_dtype, "to_arrow"):  # pragma: no cover
             # cudf, cudf.pandas
@@ -669,6 +667,10 @@ def narwhals_to_native_dtype(  # noqa: PLR0915
         msg = "Converting to Enum is not (yet) supported"
         raise NotImplementedError(msg)
     if isinstance_or_issubclass(dtype, dtypes.List):
+        from narwhals._arrow.utils import (
+            narwhals_to_native_dtype as arrow_narwhals_to_native_dtype,
+        )
+
         if implementation is Implementation.PANDAS and backend_version >= (2, 2):
             try:
                 import pandas as pd

--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -6,6 +6,8 @@ from typing import Literal
 from typing import Sequence
 from typing import overload
 
+import polars as pl
+
 from narwhals._polars.namespace import PolarsNamespace
 from narwhals._polars.utils import convert_str_slice_to_int_slice
 from narwhals._polars.utils import extract_args_kwargs
@@ -22,7 +24,6 @@ if TYPE_CHECKING:
     from typing import TypeVar
 
     import numpy as np
-    import polars as pl
     from typing_extensions import Self
 
     from narwhals._polars.group_by import PolarsGroupBy
@@ -88,8 +89,6 @@ class PolarsDataFrame:
     def _from_native_object(
         self: Self, obj: pl.Series | pl.DataFrame | T
     ) -> Self | PolarsSeries | T:
-        import polars as pl
-
         if isinstance(obj, pl.Series):
             from narwhals._polars.series import PolarsSeries
 
@@ -380,8 +379,6 @@ class PolarsLazyFrame:
 
     def __getattr__(self: Self, attr: str) -> Any:
         def func(*args: Any, **kwargs: Any) -> Any:
-            import polars as pl
-
             args, kwargs = extract_args_kwargs(args, kwargs)  # type: ignore[assignment]
             try:
                 return self._from_native_frame(

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -5,13 +5,14 @@ from typing import Any
 from typing import Callable
 from typing import Sequence
 
+import polars as pl
+
 from narwhals._polars.utils import extract_args_kwargs
 from narwhals._polars.utils import extract_native
 from narwhals._polars.utils import narwhals_to_native_dtype
 from narwhals.utils import Implementation
 
 if TYPE_CHECKING:
-    import polars as pl
     from typing_extensions import Self
 
     from narwhals.dtypes import DType
@@ -81,8 +82,6 @@ class PolarsExpr:
 
     def is_nan(self: Self) -> Self:
         if self._backend_version < (1, 18):  # pragma: no cover
-            import polars as pl
-
             return self._from_native_expr(
                 pl.when(self._native_expr.is_not_null()).then(self._native_expr.is_nan())
             )

--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -8,6 +8,8 @@ from typing import Sequence
 from typing import cast
 from typing import overload
 
+import polars as pl
+
 from narwhals._expression_parsing import parse_into_exprs
 from narwhals._polars.utils import extract_args_kwargs
 from narwhals._polars.utils import narwhals_to_native_dtype
@@ -96,8 +98,6 @@ class PolarsNamespace:
         *,
         how: Literal["vertical", "horizontal", "diagonal"],
     ) -> PolarsDataFrame | PolarsLazyFrame:
-        import polars as pl
-
         from narwhals._polars.dataframe import PolarsDataFrame
         from narwhals._polars.dataframe import PolarsLazyFrame
 

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -5,6 +5,8 @@ from typing import Any
 from typing import Sequence
 from typing import overload
 
+import polars as pl
+
 from narwhals._polars.utils import extract_args_kwargs
 from narwhals._polars.utils import extract_native
 from narwhals._polars.utils import narwhals_to_native_dtype
@@ -17,7 +19,6 @@ if TYPE_CHECKING:
     from typing import TypeVar
 
     import numpy as np
-    import polars as pl
     from typing_extensions import Self
 
     from narwhals._polars.dataframe import PolarsDataFrame
@@ -223,8 +224,6 @@ class PolarsSeries:
         return self._from_native_series(self._native_series.__invert__())
 
     def is_nan(self: Self) -> Self:
-        import polars as pl
-
         native = self._native_series
 
         if self._backend_version < (1, 18):  # pragma: no cover

--- a/narwhals/_polars/utils.py
+++ b/narwhals/_polars/utils.py
@@ -7,11 +7,11 @@ from typing import Literal
 from typing import TypeVar
 from typing import overload
 
+import polars as pl
+
 from narwhals.utils import import_dtypes_module
 
 if TYPE_CHECKING:
-    import polars as pl
-
     from narwhals._polars.dataframe import PolarsDataFrame
     from narwhals._polars.dataframe import PolarsLazyFrame
     from narwhals._polars.expr import PolarsExpr
@@ -71,8 +71,6 @@ def native_to_narwhals_dtype(
     version: Version,
     backend_version: tuple[int, ...],
 ) -> DType:
-    import polars as pl
-
     dtypes = import_dtypes_module(version)
     if dtype == pl.Float64:
         return dtypes.Float64()

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -6,6 +6,7 @@ from typing import Callable
 from typing import Literal
 from typing import Sequence
 
+from pyspark.sql import Window
 from pyspark.sql import functions as F  # noqa: N812
 
 from narwhals._expression_parsing import infer_new_root_output_names
@@ -454,8 +455,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
     def is_unique(self) -> Self:
         def _is_unique(_input: Column) -> Column:
-            from pyspark.sql import Window
-
             # Create a window spec that treats each value separately
             return F.count("*").over(Window.partitionBy(_input)) == 1
 

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -6,6 +6,8 @@ from typing import Callable
 from typing import Literal
 from typing import Sequence
 
+from pyspark.sql import functions as F  # noqa: N812
+
 from narwhals._expression_parsing import infer_new_root_output_names
 from narwhals._spark_like.expr_dt import SparkLikeExprDateTimeNamespace
 from narwhals._spark_like.expr_name import SparkLikeExprNameNamespace
@@ -76,8 +78,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         version: Version,
     ) -> Self:
         def func(_: SparkLikeLazyFrame) -> list[Column]:
-            from pyspark.sql import functions as F  # noqa: N812
-
             return [F.col(col_name) for col_name in column_names]
 
         return cls(
@@ -100,8 +100,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         version: Version,
     ) -> Self:
         def func(df: SparkLikeLazyFrame) -> list[Column]:
-            from pyspark.sql import functions as F  # noqa: N812
-
             columns = df.columns
             return [F.col(columns[i]) for i in column_indices]
 
@@ -201,8 +199,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
     def __floordiv__(self, other: SparkLikeExpr) -> Self:
         def _floordiv(_input: Column, other: Column) -> Column:
-            from pyspark.sql import functions as F  # noqa: N812
-
             return F.floor(_input / other)
 
         return self._from_call(
@@ -281,8 +277,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         )
 
     def abs(self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._from_call(F.abs, "abs", returns_scalar=self._returns_scalar)
 
     def alias(self, name: str) -> Self:
@@ -304,13 +298,9 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         )
 
     def all(self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._from_call(F.bool_and, "all", returns_scalar=True)
 
     def any(self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._from_call(F.bool_or, "any", returns_scalar=True)
 
     def cast(self: Self, dtype: DType | type[DType]) -> Self:
@@ -323,24 +313,17 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         )
 
     def count(self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._from_call(F.count, "count", returns_scalar=True)
 
     def max(self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._from_call(F.max, "max", returns_scalar=True)
 
     def mean(self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._from_call(F.mean, "mean", returns_scalar=True)
 
     def median(self) -> Self:
         def _median(_input: Column) -> Column:
             import pyspark  # ignore-banned-import
-            from pyspark.sql import functions as F  # noqa: N812
 
             if parse_version(pyspark.__version__) < (3, 4):
                 # Use percentile_approx with default accuracy parameter (10000)
@@ -351,21 +334,15 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         return self._from_call(_median, "median", returns_scalar=True)
 
     def min(self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._from_call(F.min, "min", returns_scalar=True)
 
     def null_count(self) -> Self:
         def _null_count(_input: Column) -> Column:
-            from pyspark.sql import functions as F  # noqa: N812
-
             return F.count_if(F.isnull(_input))
 
         return self._from_call(_null_count, "null_count", returns_scalar=True)
 
     def sum(self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._from_call(F.sum, "sum", returns_scalar=True)
 
     def std(self: Self, ddof: int) -> Self:
@@ -396,8 +373,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         upper_bound: Any | None = None,
     ) -> Self:
         def _clip(_input: Column, lower_bound: Any, upper_bound: Any) -> Column:
-            from pyspark.sql import functions as F  # noqa: N812
-
             result = _input
             if lower_bound is not None:
                 # Convert lower_bound to a literal Column
@@ -445,7 +420,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
     def is_duplicated(self) -> Self:
         def _is_duplicated(_input: Column) -> Column:
             from pyspark.sql import Window
-            from pyspark.sql import functions as F  # noqa: N812
 
             # Create a window spec that treats each value separately.
             return F.count("*").over(Window.partitionBy(_input)) > 1
@@ -456,8 +430,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
     def is_finite(self) -> Self:
         def _is_finite(_input: Column) -> Column:
-            from pyspark.sql import functions as F  # noqa: N812
-
             # A value is finite if it's not NaN, and not infinite, while NULLs should be
             # preserved
             is_finite_condition = (
@@ -483,7 +455,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
     def is_unique(self) -> Self:
         def _is_unique(_input: Column) -> Column:
             from pyspark.sql import Window
-            from pyspark.sql import functions as F  # noqa: N812
 
             # Create a window spec that treats each value separately
             return F.count("*").over(Window.partitionBy(_input)) == 1
@@ -494,8 +465,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
     def len(self) -> Self:
         def _len(_input: Column) -> Column:
-            from pyspark.sql import functions as F  # noqa: N812
-
             # Use count(*) to count all rows including nulls
             return F.count("*")
 
@@ -503,8 +472,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
     def round(self, decimals: int) -> Self:
         def _round(_input: Column, decimals: int) -> Column:
-            from pyspark.sql import functions as F  # noqa: N812
-
             return F.round(_input, decimals)
 
         return self._from_call(
@@ -515,12 +482,9 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         )
 
     def skew(self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._from_call(F.skewness, "skew", returns_scalar=True)
 
     def n_unique(self: Self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
         from pyspark.sql.types import IntegerType
 
         def _n_unique(_input: Column) -> Column:
@@ -555,13 +519,9 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         )
 
     def is_null(self: Self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._from_call(F.isnull, "is_null", returns_scalar=self._returns_scalar)
 
     def is_nan(self: Self) -> Self:
-        from pyspark.sql import functions as F  # noqa: N812
-
         def _is_nan(_input: Column) -> Column:
             return F.when(F.isnull(_input), None).otherwise(F.isnan(_input))
 

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -420,8 +420,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
     def is_duplicated(self) -> Self:
         def _is_duplicated(_input: Column) -> Column:
-            from pyspark.sql import Window
-
             # Create a window spec that treats each value separately.
             return F.count("*").over(Window.partitionBy(_input)) > 1
 
@@ -501,8 +499,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             raise ValueError(msg)
 
         def func(df: SparkLikeLazyFrame) -> list[Column]:
-            from pyspark.sql import Window
-
             return [expr.over(Window.partitionBy(*keys)) for expr in self._call(df)]
 
         return self.__class__(

--- a/narwhals/_spark_like/expr_dt.py
+++ b/narwhals/_spark_like/expr_dt.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pyspark.sql import functions as F  # noqa: N812
+
 if TYPE_CHECKING:
     from pyspark.sql import Column
     from typing_extensions import Self
@@ -14,8 +16,6 @@ class SparkLikeExprDateTimeNamespace:
         self._compliant_expr = expr
 
     def date(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             F.to_date,
             "date",
@@ -23,8 +23,6 @@ class SparkLikeExprDateTimeNamespace:
         )
 
     def year(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             F.year,
             "year",
@@ -32,8 +30,6 @@ class SparkLikeExprDateTimeNamespace:
         )
 
     def month(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             F.month,
             "month",
@@ -41,8 +37,6 @@ class SparkLikeExprDateTimeNamespace:
         )
 
     def day(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             F.day,
             "day",
@@ -50,8 +44,6 @@ class SparkLikeExprDateTimeNamespace:
         )
 
     def hour(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             F.hour,
             "hour",
@@ -59,8 +51,6 @@ class SparkLikeExprDateTimeNamespace:
         )
 
     def minute(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             F.minute,
             "minute",
@@ -68,8 +58,6 @@ class SparkLikeExprDateTimeNamespace:
         )
 
     def second(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             F.second,
             "second",
@@ -77,8 +65,6 @@ class SparkLikeExprDateTimeNamespace:
         )
 
     def millisecond(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         def _millisecond(_input: Column) -> Column:
             return F.floor((F.unix_micros(_input) % 1_000_000) / 1000)
 
@@ -89,8 +75,6 @@ class SparkLikeExprDateTimeNamespace:
         )
 
     def microsecond(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         def _microsecond(_input: Column) -> Column:
             return F.unix_micros(_input) % 1_000_000
 
@@ -101,8 +85,6 @@ class SparkLikeExprDateTimeNamespace:
         )
 
     def nanosecond(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         def _nanosecond(_input: Column) -> Column:
             return (F.unix_micros(_input) % 1_000_000) * 1000
 
@@ -113,8 +95,6 @@ class SparkLikeExprDateTimeNamespace:
         )
 
     def ordinal_day(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             F.dayofyear,
             "ordinal_day",
@@ -122,8 +102,6 @@ class SparkLikeExprDateTimeNamespace:
         )
 
     def weekday(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         def _weekday(_input: Column) -> Column:
             # PySpark's dayofweek returns 1-7 for Sunday-Saturday
             return (F.dayofweek(_input) + 6) % 7

--- a/narwhals/_spark_like/expr_str.py
+++ b/narwhals/_spark_like/expr_str.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import overload
 
+from pyspark.sql import functions as F  # noqa: N812
+
 if TYPE_CHECKING:
     from pyspark.sql import Column
     from typing_extensions import Self
@@ -15,8 +17,6 @@ class SparkLikeExprStringNamespace:
         self._compliant_expr = expr
 
     def len_chars(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             F.char_length,
             "len",
@@ -26,8 +26,6 @@ class SparkLikeExprStringNamespace:
     def replace_all(
         self: Self, pattern: str, value: str, *, literal: bool = False
     ) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         def func(_input: Column, pattern: str, value: str, *, literal: bool) -> Column:
             replace_all_func = F.replace if literal else F.regexp_replace
             return replace_all_func(_input, F.lit(pattern), F.lit(value))
@@ -44,8 +42,6 @@ class SparkLikeExprStringNamespace:
     def strip_chars(self: Self, characters: str | None) -> SparkLikeExpr:
         import string
 
-        from pyspark.sql import functions as F  # noqa: N812
-
         def func(_input: Column, characters: str | None) -> Column:
             to_remove = characters if characters is not None else string.whitespace
             return F.btrim(_input, F.lit(to_remove))
@@ -58,8 +54,6 @@ class SparkLikeExprStringNamespace:
         )
 
     def starts_with(self: Self, prefix: str) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             lambda _input, prefix: F.startswith(_input, F.lit(prefix)),
             "starts_with",
@@ -68,8 +62,6 @@ class SparkLikeExprStringNamespace:
         )
 
     def ends_with(self: Self, suffix: str) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             lambda _input, suffix: F.endswith(_input, F.lit(suffix)),
             "ends_with",
@@ -78,8 +70,6 @@ class SparkLikeExprStringNamespace:
         )
 
     def contains(self: Self, pattern: str, *, literal: bool) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         def func(_input: Column, pattern: str, *, literal: bool) -> Column:
             contains_func = F.contains if literal else F.regexp
             return contains_func(_input, F.lit(pattern))
@@ -93,8 +83,6 @@ class SparkLikeExprStringNamespace:
         )
 
     def slice(self: Self, offset: int, length: int | None = None) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         # From the docs: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.substring.html
         # The position is not zero based, but 1 based index.
         def func(_input: Column, offset: int, length: int | None) -> Column:
@@ -113,8 +101,6 @@ class SparkLikeExprStringNamespace:
         )
 
     def to_uppercase(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             F.upper,
             "to_uppercase",
@@ -122,8 +108,6 @@ class SparkLikeExprStringNamespace:
         )
 
     def to_lowercase(self: Self) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             F.lower,
             "to_lowercase",
@@ -131,8 +115,6 @@ class SparkLikeExprStringNamespace:
         )
 
     def to_datetime(self: Self, format: str | None) -> SparkLikeExpr:  # noqa: A002
-        from pyspark.sql import functions as F  # noqa: N812
-
         return self._compliant_expr._from_call(
             lambda _input: F.to_timestamp(
                 F.replace(_input, F.lit("T"), F.lit(" ")),

--- a/narwhals/_spark_like/group_by.py
+++ b/narwhals/_spark_like/group_by.py
@@ -7,6 +7,8 @@ from typing import Any
 from typing import Callable
 from typing import Sequence
 
+from pyspark.sql import functions as F  # noqa: N812
+
 from narwhals._expression_parsing import is_simple_aggregation
 from narwhals._expression_parsing import parse_into_exprs
 from narwhals._spark_like.utils import _std
@@ -76,8 +78,6 @@ class SparkLikeLazyGroupBy:
 
 
 def get_spark_function(function_name: str, **kwargs: Any) -> Column:
-    from pyspark.sql import functions as F  # noqa: N812
-
     if function_name in {"std", "var"}:
         import numpy as np  # ignore-banned-import
 

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -7,6 +7,8 @@ from typing import Any
 from typing import Iterable
 from typing import Literal
 
+from pyspark.sql import functions as F  # noqa: N812
+
 from narwhals._expression_parsing import combine_root_names
 from narwhals._expression_parsing import parse_into_expr
 from narwhals._expression_parsing import parse_into_exprs
@@ -166,7 +168,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
         )
 
     def mean_horizontal(self, *exprs: IntoSparkLikeExpr) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
         from pyspark.sql.types import IntegerType
 
         parsed_exprs = parse_into_exprs(*exprs, namespace=self)
@@ -197,8 +198,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
         )
 
     def max_horizontal(self, *exprs: IntoSparkLikeExpr) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         parsed_exprs = parse_into_exprs(*exprs, namespace=self)
 
         def func(df: SparkLikeLazyFrame) -> list[Column]:
@@ -219,8 +218,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
         )
 
     def min_horizontal(self, *exprs: IntoSparkLikeExpr) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
-
         parsed_exprs = parse_into_exprs(*exprs, namespace=self)
 
         def func(df: SparkLikeLazyFrame) -> list[Column]:
@@ -289,7 +286,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
         separator: str,
         ignore_nulls: bool,
     ) -> SparkLikeExpr:
-        from pyspark.sql import functions as F  # noqa: N812
         from pyspark.sql.types import StringType
 
         parsed_exprs = [
@@ -374,8 +370,6 @@ class SparkLikeWhen:
         self._version = version
 
     def __call__(self, df: SparkLikeLazyFrame) -> list[Column]:
-        from pyspark.sql import functions as F  # noqa: N812
-
         plx = df.__narwhals_namespace__()
         condition = parse_into_expr(self._condition, namespace=plx)(df)[0]
 

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -4,6 +4,8 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 from typing import Any
 
+from pyspark.sql import functions as F  # noqa: N812
+
 from narwhals.exceptions import InvalidIntoExprError
 from narwhals.exceptions import UnsupportedDTypeError
 from narwhals.utils import import_dtypes_module
@@ -114,8 +116,6 @@ def get_column_name(df: SparkLikeLazyFrame, column: Column) -> str:
 
 def _columns_from_expr(df: SparkLikeLazyFrame, expr: IntoSparkLikeExpr) -> list[Column]:
     if isinstance(expr, str):  # pragma: no cover
-        from pyspark.sql import functions as F  # noqa: N812
-
         return [F.col(expr)]
     elif hasattr(expr, "__narwhals_expr__"):
         col_output_list = expr._call(df)
@@ -162,7 +162,6 @@ def maybe_evaluate(df: SparkLikeLazyFrame, obj: Any) -> Any:
         column_result = column_results[0]
         if obj._returns_scalar:
             # Return scalar, let PySpark do its broadcasting
-            from pyspark.sql import functions as F  # noqa: N812
             from pyspark.sql.window import Window
 
             return column_result.over(Window.partitionBy(F.lit(1)))
@@ -172,8 +171,6 @@ def maybe_evaluate(df: SparkLikeLazyFrame, obj: Any) -> Any:
 
 def _std(_input: Column | str, ddof: int, np_version: tuple[int, ...]) -> Column:
     if np_version > (2, 0):
-        from pyspark.sql import functions as F  # noqa: N812
-
         if ddof == 1:
             return F.stddev_samp(_input)
 
@@ -181,7 +178,6 @@ def _std(_input: Column | str, ddof: int, np_version: tuple[int, ...]) -> Column
         return F.stddev_samp(_input) * F.sqrt((n_rows - 1) / (n_rows - ddof))
 
     from pyspark.pandas.spark.functions import stddev
-    from pyspark.sql import functions as F  # noqa: N812
 
     input_col = F.col(_input) if isinstance(_input, str) else _input
     return stddev(input_col, ddof=ddof)
@@ -189,8 +185,6 @@ def _std(_input: Column | str, ddof: int, np_version: tuple[int, ...]) -> Column
 
 def _var(_input: Column | str, ddof: int, np_version: tuple[int, ...]) -> Column:
     if np_version > (2, 0):
-        from pyspark.sql import functions as F  # noqa: N812
-
         if ddof == 1:
             return F.var_samp(_input)
 
@@ -198,7 +192,6 @@ def _var(_input: Column | str, ddof: int, np_version: tuple[int, ...]) -> Column
         return F.var_samp(_input) * (n_rows - 1) / (n_rows - ddof)
 
     from pyspark.pandas.spark.functions import var
-    from pyspark.sql import functions as F  # noqa: N812
 
     input_col = F.col(_input) if isinstance(_input, str) else _input
     return var(input_col, ddof=ddof)

--- a/tests/no_imports_test.py
+++ b/tests/no_imports_test.py
@@ -14,6 +14,7 @@ def test_polars(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delitem(sys.modules, "pandas")
     monkeypatch.delitem(sys.modules, "numpy")
     monkeypatch.delitem(sys.modules, "pyarrow")
+    monkeypatch.delitem(sys.modules, "duckdb")
     monkeypatch.delitem(sys.modules, "dask", raising=False)
     monkeypatch.delitem(sys.modules, "ibis", raising=False)
     monkeypatch.delitem(sys.modules, "pyspark", raising=False)
@@ -28,11 +29,13 @@ def test_polars(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "dask" not in sys.modules
     assert "ibis" not in sys.modules
     assert "pyspark" not in sys.modules
+    assert "duckdb" not in sys.modules
 
 
 def test_pandas(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delitem(sys.modules, "polars")
     monkeypatch.delitem(sys.modules, "pyarrow")
+    monkeypatch.delitem(sys.modules, "duckdb")
     monkeypatch.delitem(sys.modules, "dask", raising=False)
     monkeypatch.delitem(sys.modules, "ibis", raising=False)
     monkeypatch.delitem(sys.modules, "pyspark", raising=False)
@@ -47,6 +50,7 @@ def test_pandas(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "dask" not in sys.modules
     assert "ibis" not in sys.modules
     assert "pyspark" not in sys.modules
+    assert "duckdb" not in sys.modules
 
 
 def test_dask(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -55,6 +59,7 @@ def test_dask(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.delitem(sys.modules, "polars")
     monkeypatch.delitem(sys.modules, "pyarrow")
+    monkeypatch.delitem(sys.modules, "duckdb")
     monkeypatch.delitem(sys.modules, "pyspark", raising=False)
     df = dd.from_pandas(pd.DataFrame({"a": [1, 1, 2], "b": [4, 5, 6]}))
     nw.from_native(df).group_by("a").agg(nw.col("b").mean()).filter(nw.col("a") > 1)
@@ -64,11 +69,13 @@ def test_dask(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "pyarrow" not in sys.modules
     assert "dask" in sys.modules
     assert "pyspark" not in sys.modules
+    assert "duckdb" not in sys.modules
 
 
 def test_pyarrow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delitem(sys.modules, "polars")
     monkeypatch.delitem(sys.modules, "pandas")
+    monkeypatch.delitem(sys.modules, "duckdb")
     monkeypatch.delitem(sys.modules, "dask", raising=False)
     monkeypatch.delitem(sys.modules, "ibis", raising=False)
     monkeypatch.delitem(sys.modules, "pyspark", raising=False)
@@ -81,3 +88,4 @@ def test_pyarrow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "dask" not in sys.modules
     assert "ibis" not in sys.modules
     assert "pyspark" not in sys.modules
+    assert "duckdb" not in sys.modules

--- a/tests/no_imports_test.py
+++ b/tests/no_imports_test.py
@@ -14,7 +14,7 @@ def test_polars(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delitem(sys.modules, "pandas")
     monkeypatch.delitem(sys.modules, "numpy")
     monkeypatch.delitem(sys.modules, "pyarrow")
-    monkeypatch.delitem(sys.modules, "duckdb")
+    monkeypatch.delitem(sys.modules, "duckdb", raising=False)
     monkeypatch.delitem(sys.modules, "dask", raising=False)
     monkeypatch.delitem(sys.modules, "ibis", raising=False)
     monkeypatch.delitem(sys.modules, "pyspark", raising=False)
@@ -35,7 +35,7 @@ def test_polars(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_pandas(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delitem(sys.modules, "polars")
     monkeypatch.delitem(sys.modules, "pyarrow")
-    monkeypatch.delitem(sys.modules, "duckdb")
+    monkeypatch.delitem(sys.modules, "duckdb", raising=False)
     monkeypatch.delitem(sys.modules, "dask", raising=False)
     monkeypatch.delitem(sys.modules, "ibis", raising=False)
     monkeypatch.delitem(sys.modules, "pyspark", raising=False)
@@ -59,7 +59,7 @@ def test_dask(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.delitem(sys.modules, "polars")
     monkeypatch.delitem(sys.modules, "pyarrow")
-    monkeypatch.delitem(sys.modules, "duckdb")
+    monkeypatch.delitem(sys.modules, "duckdb", raising=False)
     monkeypatch.delitem(sys.modules, "pyspark", raising=False)
     df = dd.from_pandas(pd.DataFrame({"a": [1, 1, 2], "b": [4, 5, 6]}))
     nw.from_native(df).group_by("a").agg(nw.col("b").mean()).filter(nw.col("a") > 1)
@@ -75,7 +75,7 @@ def test_dask(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_pyarrow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delitem(sys.modules, "polars")
     monkeypatch.delitem(sys.modules, "pandas")
-    monkeypatch.delitem(sys.modules, "duckdb")
+    monkeypatch.delitem(sys.modules, "duckdb", raising=False)
     monkeypatch.delitem(sys.modules, "dask", raising=False)
     monkeypatch.delitem(sys.modules, "ibis", raising=False)
     monkeypatch.delitem(sys.modules, "pyspark", raising=False)


### PR DESCRIPTION
It should be possible to do something similar for pyspark

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
