### PR TITLE
Track is multi output

### DIFF
--- a/narwhals/_arrow/selectors.py
+++ b/narwhals/_arrow/selectors.py
@@ -169,11 +169,3 @@ class ArrowSelector(ArrowExpr):
             )
         else:
             return self._to_expr() & other
-
-    def __invert__(self: Self) -> ArrowSelector:
-        return (
-            ArrowSelectorNamespace(
-                backend_version=self._backend_version, version=self._version
-            ).all()
-            - self
-        )

--- a/narwhals/_dask/selectors.py
+++ b/narwhals/_dask/selectors.py
@@ -177,11 +177,3 @@ class DaskSelector(DaskExpr):
             )
         else:
             return self._to_expr() & other
-
-    def __invert__(self: Self) -> DaskSelector:
-        return (
-            DaskSelectorNamespace(
-                backend_version=self._backend_version, version=self._version
-            ).all()
-            - self
-        )

--- a/narwhals/_pandas_like/selectors.py
+++ b/narwhals/_pandas_like/selectors.py
@@ -178,13 +178,3 @@ class PandasSelector(PandasLikeExpr):
             )
         else:
             return self._to_expr() & other
-
-    def __invert__(self: Self) -> PandasSelector:
-        return (
-            PandasSelectorNamespace(
-                implementation=self._implementation,
-                backend_version=self._backend_version,
-                version=self._version,
-            ).all()
-            - self
-        )

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -3644,7 +3644,7 @@ class LazyFrame(BaseFrame[FrameT]):
             msg = "Binary operations between Series and LazyFrame are not supported."
             raise TypeError(msg)
         if isinstance(arg, Expr):
-            if arg._is_order_dependent:
+            if arg._metadata["is_order_dependent"]:
                 msg = (
                     "Order-dependent expressions are not supported for use in LazyFrame.\n\n"
                     "Hints:\n"
@@ -3655,7 +3655,7 @@ class LazyFrame(BaseFrame[FrameT]):
                     "  they will be supported."
                 )
                 raise OrderDependentExprError(msg)
-            if arg._changes_length:
+            if arg._metadata["changes_length"]:
                 msg = (
                     "Length-changing expressions are not supported for use in LazyFrame, unless\n"
                     "followed by an aggregation.\n\n"

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from narwhals.expr import Expr
 
 from abc import abstractmethod
 from typing import TYPE_CHECKING
@@ -142,7 +143,7 @@ class BaseFrame(Generic[FrameT]):
     ) -> Self:
         flat_predicates = flatten(predicates)
         if any(
-            getattr(x, "_aggregates", False) or getattr(x, "_changes_length", False)
+            isinstance(x, Expr) and (x._metadata['aggregates'] or x._metadata['changes_length'])
             for x in flat_predicates
         ):
             msg = "Expressions which aggregate or change length cannot be passed to `filter`."

--- a/narwhals/exceptions.py
+++ b/narwhals/exceptions.py
@@ -98,6 +98,13 @@ class LengthChangingExprError(ValueError):
         self.message = message
         super().__init__(self.message)
 
+class MultiOutputExprError(ValueError):
+    """Exception raised when trying to combine expressions where one has multiple outputs."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(self.message)
+
 
 class UnsupportedDTypeError(ValueError):
     """Exception raised when trying to convert to a DType which is not supported by the given backend."""

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -46,7 +46,7 @@ class Expr:
             "Narwhals Expr\n"
             f"is_order_dependent: {self._metadata['is_order_dependent']}\n"
             f"changes_length: {self._metadata['changes_length']}\n"
-            f"aggregates: {self._metadata['aggregates']}"
+            f"aggregates: {self._metadata['aggregates']}\n"
             f"is_multi_output: {self._metadata['is_multi_output']}"
         )
 
@@ -520,7 +520,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).any(),
-            ExprMetadata({**self._metadata, 'aggregates': True})
+            ExprMetadata({**self._metadata, 'aggregates': True, 'changes_length': False})
         )
 
     def all(self) -> Self:
@@ -574,7 +574,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).all(),
-            ExprMetadata({**self._metadata, 'aggregates': True})
+            ExprMetadata({**self._metadata, 'aggregates': True, 'changes_length': False})
         )
 
     def ewm_mean(
@@ -731,7 +731,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).mean(),
-            ExprMetadata({**self._metadata, 'aggregates': True})
+            ExprMetadata({**self._metadata, 'aggregates': True, 'changes_length': False})
         )
 
     def median(self) -> Self:
@@ -788,7 +788,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).median(),
-            ExprMetadata({**self._metadata, 'aggregates': True})
+            ExprMetadata({**self._metadata, 'aggregates': True, 'changes_length': False})
         )
 
     def std(self, *, ddof: int = 1) -> Self:
@@ -845,7 +845,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).std(ddof=ddof),
-            ExprMetadata({**self._metadata, 'aggregates': True})
+            ExprMetadata({**self._metadata, 'aggregates': True, 'changes_length': False})
         )
 
     def var(self, *, ddof: int = 1) -> Self:
@@ -903,7 +903,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).var(ddof=ddof),
-            ExprMetadata({**self._metadata, 'aggregates': True})
+            ExprMetadata({**self._metadata, 'aggregates': True, 'changes_length': False})
         )
 
     def map_batches(
@@ -1039,7 +1039,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).skew(),
-            ExprMetadata({**self._metadata, 'aggregates': True})
+            ExprMetadata({**self._metadata, 'aggregates': True, 'changes_length': False})
         )
 
     def sum(self) -> Expr:
@@ -1091,7 +1091,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).sum(),
-            ExprMetadata({**self._metadata, 'aggregates': True})
+            ExprMetadata({**self._metadata, 'aggregates': True, 'changes_length': False})
         )
 
     def min(self) -> Self:
@@ -1145,7 +1145,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).min(),
-            ExprMetadata({**self._metadata, 'aggregates': True})
+            ExprMetadata({**self._metadata, 'aggregates': True, 'changes_length': False})
         )
 
     def max(self) -> Self:
@@ -1199,7 +1199,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).max(),
-            ExprMetadata({**self._metadata, 'aggregates': True})
+            ExprMetadata({**self._metadata, 'aggregates': True, 'changes_length': False})
         )
 
     def arg_min(self) -> Self:

--- a/narwhals/expr_cat.py
+++ b/narwhals/expr_cat.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 from typing import Generic
 from typing import TypeVar
 
+from narwhals._expression_parsing import ExprMetadata
+
 if TYPE_CHECKING:
     from typing_extensions import Self
 
@@ -63,7 +65,5 @@ class ExprCatNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).cat.get_categories(),
-            self._expr._is_order_dependent,
-            changes_length=True,
-            aggregates=self._expr._aggregates,
+            ExprMetadata({**self._expr._metadata, "changes_length": True}),  # type: ignore[typeddict-item]
         )

--- a/narwhals/expr_dt.py
+++ b/narwhals/expr_dt.py
@@ -71,10 +71,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             a: [[2012-01-07,2023-03-10]]
         """
         return self._expr.__class__(
-            lambda plx: self._expr._to_compliant_expr(plx).dt.date(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            lambda plx: self._expr._to_compliant_expr(plx).dt.date(), self._expr._metadata
         )
 
     def year(self: Self) -> ExprT:
@@ -142,10 +139,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             year: [[1978,2024,2065]]
         """
         return self._expr.__class__(
-            lambda plx: self._expr._to_compliant_expr(plx).dt.year(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            lambda plx: self._expr._to_compliant_expr(plx).dt.year(), self._expr._metadata
         )
 
     def month(self: Self) -> ExprT:
@@ -214,9 +208,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.month(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def day(self: Self) -> ExprT:
@@ -284,10 +276,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             day: [[1,13,1]]
         """
         return self._expr.__class__(
-            lambda plx: self._expr._to_compliant_expr(plx).dt.day(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            lambda plx: self._expr._to_compliant_expr(plx).dt.day(), self._expr._metadata
         )
 
     def hour(self: Self) -> ExprT:
@@ -355,10 +344,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             hour: [[1,5,10]]
         """
         return self._expr.__class__(
-            lambda plx: self._expr._to_compliant_expr(plx).dt.hour(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            lambda plx: self._expr._to_compliant_expr(plx).dt.hour(), self._expr._metadata
         )
 
     def minute(self: Self) -> ExprT:
@@ -427,9 +413,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.minute(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def second(self: Self) -> ExprT:
@@ -496,9 +480,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.second(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def millisecond(self: Self) -> ExprT:
@@ -565,9 +547,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.millisecond(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def microsecond(self: Self) -> ExprT:
@@ -634,9 +614,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.microsecond(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def nanosecond(self: Self) -> ExprT:
@@ -703,9 +681,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.nanosecond(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def ordinal_day(self: Self) -> ExprT:
@@ -764,9 +740,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.ordinal_day(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def weekday(self: Self) -> ExprT:
@@ -823,9 +797,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.weekday(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def total_minutes(self: Self) -> ExprT:
@@ -889,9 +861,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.total_minutes(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def total_seconds(self: Self) -> ExprT:
@@ -955,9 +925,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.total_seconds(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def total_milliseconds(self: Self) -> ExprT:
@@ -1026,9 +994,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.total_milliseconds(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def total_microseconds(self: Self) -> ExprT:
@@ -1097,9 +1063,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.total_microseconds(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def total_nanoseconds(self: Self) -> ExprT:
@@ -1155,9 +1119,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.total_nanoseconds(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def to_string(self: Self, format: str) -> ExprT:  # noqa: A002
@@ -1256,9 +1218,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.to_string(format),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def replace_time_zone(self: Self, time_zone: str | None) -> ExprT:
@@ -1325,9 +1285,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).dt.replace_time_zone(
                 time_zone
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def convert_time_zone(self: Self, time_zone: str) -> ExprT:
@@ -1400,9 +1358,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).dt.convert_time_zone(
                 time_zone
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def timestamp(self: Self, time_unit: Literal["ns", "us", "ms"] = "us") -> ExprT:
@@ -1476,7 +1432,5 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             raise ValueError(msg)
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.timestamp(time_unit),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )

--- a/narwhals/expr_list.py
+++ b/narwhals/expr_list.py
@@ -74,7 +74,5 @@ class ExprListNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).list.len(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )

--- a/narwhals/expr_name.py
+++ b/narwhals/expr_name.py
@@ -60,9 +60,7 @@ class ExprNameNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).name.keep(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def map(self: Self, function: Callable[[str], str]) -> ExprT:
@@ -112,9 +110,7 @@ class ExprNameNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).name.map(function),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def prefix(self: Self, prefix: str) -> ExprT:
@@ -163,9 +159,7 @@ class ExprNameNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).name.prefix(prefix),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def suffix(self: Self, suffix: str) -> ExprT:
@@ -214,9 +208,7 @@ class ExprNameNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).name.suffix(suffix),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def to_lowercase(self: Self) -> ExprT:
@@ -262,9 +254,7 @@ class ExprNameNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).name.to_lowercase(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def to_uppercase(self: Self) -> ExprT:
@@ -310,7 +300,5 @@ class ExprNameNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).name.to_uppercase(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )

--- a/narwhals/expr_str.py
+++ b/narwhals/expr_str.py
@@ -77,9 +77,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.len_chars(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def replace(
@@ -146,9 +144,7 @@ class ExprStringNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).str.replace(
                 pattern, value, literal=literal, n=n
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def replace_all(
@@ -214,9 +210,7 @@ class ExprStringNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).str.replace_all(
                 pattern, value, literal=literal
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def strip_chars(self: Self, characters: str | None = None) -> ExprT:
@@ -265,9 +259,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.strip_chars(characters),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def starts_with(self: Self, prefix: str) -> ExprT:
@@ -330,9 +322,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.starts_with(prefix),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def ends_with(self: Self, suffix: str) -> ExprT:
@@ -395,9 +385,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.ends_with(suffix),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def contains(self: Self, pattern: str, *, literal: bool = False) -> ExprT:
@@ -476,9 +464,7 @@ class ExprStringNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).str.contains(
                 pattern, literal=literal
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def slice(self: Self, offset: int, length: int | None = None) -> ExprT:
@@ -581,9 +567,7 @@ class ExprStringNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).str.slice(
                 offset=offset, length=length
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def head(self: Self, n: int = 5) -> ExprT:
@@ -651,9 +635,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.slice(0, n),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def tail(self: Self, n: int = 5) -> ExprT:
@@ -723,9 +705,7 @@ class ExprStringNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).str.slice(
                 offset=-n, length=None
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def to_datetime(self: Self, format: str | None = None) -> ExprT:  # noqa: A002
@@ -795,9 +775,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.to_datetime(format=format),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def to_uppercase(self: Self) -> ExprT:
@@ -862,9 +840,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.to_uppercase(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def to_lowercase(self: Self) -> ExprT:
@@ -924,7 +900,5 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.to_lowercase(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -2140,8 +2140,9 @@ class When:
             msg = "At least one predicate needs to be provided to `narwhals.when`."
             raise TypeError(msg)
         if any(
-            getattr(x, "_aggregates", False) or getattr(x, "_changes_length", False)
+            x._metadata['aggregates'] or x._metadata['changes_length']
             for x in self._predicates
+            if isinstance(x, Expr)
         ):
             msg = "Expressions which aggregate or change length cannot be passed to `filter`."
             raise ShapeError(msg)

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -12,10 +12,9 @@ from typing import TypeVar
 from typing import Union
 from typing import overload
 
-from narwhals._expression_parsing import extract_compliant, combine_metadata
-from narwhals._expression_parsing import operation_aggregates
-from narwhals._expression_parsing import operation_changes_length, ExprMetadata
-from narwhals._expression_parsing import operation_is_order_dependent
+from narwhals._expression_parsing import ExprMetadata
+from narwhals._expression_parsing import combine_metadata
+from narwhals._expression_parsing import extract_compliant
 from narwhals._pandas_like.utils import broadcast_align_and_extract_native
 from narwhals.dataframe import DataFrame
 from narwhals.dataframe import LazyFrame
@@ -1397,7 +1396,15 @@ def col(*names: str | Iterable[str]) -> Expr:
     def func(plx: Any) -> Any:
         return plx.col(*flat_names)
 
-    Expr(func, ExprMetadata(is_order_dependent=False, changes_length=False, aggregates=False, is_multi_output=len(flat_names)>1))
+    return Expr(
+        func,
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=False,
+            is_multi_output=len(flat_names) > 1,
+        ),
+    )
 
 
 def nth(*indices: int | Sequence[int]) -> Expr:
@@ -1460,7 +1467,15 @@ def nth(*indices: int | Sequence[int]) -> Expr:
     def func(plx: Any) -> Any:
         return plx.nth(*flat_indices)
 
-    Expr(func, ExprMetadata(is_order_dependent=False, changes_length=False, aggregates=False, is_multi_output=len(flat_indices)>1))
+    return Expr(
+        func,
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=False,
+            is_multi_output=len(flat_indices) > 1,
+        ),
+    )
 
 
 # Add underscore so it doesn't conflict with builtin `all`
@@ -1517,10 +1532,15 @@ def all_() -> Expr:
         a: [[2,4,6]]
         b: [[8,10,12]]
     """
-    Expr(lambda plx: plx.all(), ExprMetadata(
-                    is_order_dependent=False,
-        changes_length=False,
-        aggregates=False, is_multi_output=True))
+    return Expr(
+        lambda plx: plx.all(),
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=False,
+            is_multi_output=True,
+        ),
+    )
 
 
 # Add underscore so it doesn't conflict with builtin `len`
@@ -1573,7 +1593,15 @@ def len_() -> Expr:
     def func(plx: Any) -> Any:
         return plx.len()
 
-    return Expr(func, is_order_dependent=False, changes_length=False, aggregates=True)
+    return Expr(
+        func,
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=True,
+            is_multi_output=False,
+        ),
+    )
 
 
 def sum(*columns: str) -> Expr:
@@ -1631,10 +1659,12 @@ def sum(*columns: str) -> Expr:
     """
     return Expr(
         lambda plx: plx.col(*columns).sum(),
-            ExprMetadata(
-                    is_order_dependent=False,
-        changes_length=False,
-        aggregates=True, is_multi_output=len(columns)>1)
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=True,
+            is_multi_output=len(columns) > 1,
+        ),
     )
 
 
@@ -1693,10 +1723,12 @@ def mean(*columns: str) -> Expr:
     """
     return Expr(
         lambda plx: plx.col(*columns).mean(),
-            ExprMetadata(
-                    is_order_dependent=False,
-        changes_length=False,
-        aggregates=True, is_multi_output=len(columns)>1)
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=True,
+            is_multi_output=len(columns) > 1,
+        ),
     )
 
 
@@ -1757,10 +1789,12 @@ def median(*columns: str) -> Expr:
     """
     return Expr(
         lambda plx: plx.col(*columns).median(),
-            ExprMetadata(
-                    is_order_dependent=False,
-        changes_length=False,
-        aggregates=True, is_multi_output=len(columns)>1)
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=True,
+            is_multi_output=len(columns) > 1,
+        ),
     )
 
 
@@ -1819,10 +1853,12 @@ def min(*columns: str) -> Expr:
     """
     return Expr(
         lambda plx: plx.col(*columns).min(),
-            ExprMetadata(
-                    is_order_dependent=False,
-        changes_length=False,
-        aggregates=True, is_multi_output=len(columns)>1)
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=True,
+            is_multi_output=len(columns) > 1,
+        ),
     )
 
 
@@ -1881,10 +1917,12 @@ def max(*columns: str) -> Expr:
     """
     return Expr(
         lambda plx: plx.col(*columns).max(),
-            ExprMetadata(
-                    is_order_dependent=False,
-        changes_length=False,
-        aggregates=True, is_multi_output=len(columns)>1)
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=True,
+            is_multi_output=len(columns) > 1,
+        ),
     )
 
 
@@ -1951,7 +1989,7 @@ def sum_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     flat_exprs = flatten(exprs)
     return Expr(
         lambda plx: plx.sum_horizontal(*[extract_compliant(plx, v) for v in flat_exprs]),
-        ExprMetadata({**combine_metadata(*flat_exprs), 'is_multi_output': False})
+        ExprMetadata({**combine_metadata(*flat_exprs), "is_multi_output": False}),
     )
 
 
@@ -2021,7 +2059,7 @@ def min_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     flat_exprs = flatten(exprs)
     return Expr(
         lambda plx: plx.min_horizontal(*[extract_compliant(plx, v) for v in flat_exprs]),
-        ExprMetadata({**combine_metadata(*flat_exprs), 'is_multi_output': False})
+        ExprMetadata({**combine_metadata(*flat_exprs), "is_multi_output": False}),
     )
 
 
@@ -2091,7 +2129,7 @@ def max_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     flat_exprs = flatten(exprs)
     return Expr(
         lambda plx: plx.max_horizontal(*[extract_compliant(plx, v) for v in flat_exprs]),
-        ExprMetadata({**combine_metadata(*flat_exprs), 'is_multi_output': False})
+        ExprMetadata({**combine_metadata(*flat_exprs), "is_multi_output": False}),
     )
 
 
@@ -2116,9 +2154,7 @@ class When:
             lambda plx: plx.when(*self._extract_predicates(plx)).then(
                 extract_compliant(plx, value)
             ),
-            is_order_dependent=operation_is_order_dependent(*self._predicates, value),
-            changes_length=operation_changes_length(*self._predicates, value),
-            aggregates=operation_aggregates(*self._predicates, value),
+            combine_metadata(*self._predicates, value),
         )
 
 
@@ -2128,9 +2164,7 @@ class Then(Expr):
             lambda plx: self._to_compliant_expr(plx).otherwise(
                 extract_compliant(plx, value)
             ),
-            is_order_dependent=operation_is_order_dependent(self, value),
-            changes_length=operation_changes_length(self, value),
-            aggregates=operation_aggregates(self, value),
+            combine_metadata(self, value),
         )
 
 
@@ -2283,7 +2317,7 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     flat_exprs = flatten(exprs)
     return Expr(
         lambda plx: plx.all_horizontal(*[extract_compliant(plx, v) for v in flat_exprs]),
-        ExprMetadata({**combine_metadata(*flat_exprs), 'is_multi_output': False})
+        ExprMetadata({**combine_metadata(*flat_exprs), "is_multi_output": False}),
     )
 
 
@@ -2356,10 +2390,12 @@ def lit(value: Any, dtype: DType | type[DType] | None = None) -> Expr:
 
     return Expr(
         lambda plx: plx.lit(value, dtype),
-            ExprMetadata(
-                    is_order_dependent=False,
-        changes_length=False,
-        aggregates=True, is_multi_output=len(columns)>1)
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=True,
+            is_multi_output=False,
+        ),
     )
 
 
@@ -2437,7 +2473,7 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     flat_exprs = flatten(exprs)
     return Expr(
         lambda plx: plx.any_horizontal(*[extract_compliant(plx, v) for v in flat_exprs]),
-        ExprMetadata({**combine_metadata(*flat_exprs), 'is_multi_output': False})
+        ExprMetadata({**combine_metadata(*flat_exprs), "is_multi_output": False}),
     )
 
 
@@ -2507,7 +2543,7 @@ def mean_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     flat_exprs = flatten(exprs)
     return Expr(
         lambda plx: plx.mean_horizontal(*[extract_compliant(plx, v) for v in flat_exprs]),
-        ExprMetadata({**combine_metadata(*flat_exprs), 'is_multi_output': False})
+        ExprMetadata({**combine_metadata(*flat_exprs), "is_multi_output": False}),
     )
 
 
@@ -2597,7 +2633,5 @@ def concat_str(
             separator=separator,
             ignore_nulls=ignore_nulls,
         ),
-        is_order_dependent=operation_is_order_dependent(*flat_exprs, *more_exprs),
-        changes_length=operation_changes_length(*flat_exprs, *more_exprs),
-        aggregates=operation_aggregates(*flat_exprs, *more_exprs),
+        combine_metadata(*flat_exprs, *more_exprs),
     )

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -1990,7 +1990,7 @@ def sum_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     flat_exprs = flatten(exprs)
     return Expr(
         lambda plx: plx.sum_horizontal(*[extract_compliant(plx, v) for v in flat_exprs]),
-        ExprMetadata({**combine_metadata(*flat_exprs), "is_multi_output": False}),
+        combine_metadata(*exprs, is_multi_output=False),
     )
 
 
@@ -2060,7 +2060,7 @@ def min_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     flat_exprs = flatten(exprs)
     return Expr(
         lambda plx: plx.min_horizontal(*[extract_compliant(plx, v) for v in flat_exprs]),
-        ExprMetadata({**combine_metadata(*flat_exprs), "is_multi_output": False}),
+        combine_metadata(*exprs, is_multi_output=False),
     )
 
 
@@ -2130,7 +2130,7 @@ def max_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     flat_exprs = flatten(exprs)
     return Expr(
         lambda plx: plx.max_horizontal(*[extract_compliant(plx, v) for v in flat_exprs]),
-        ExprMetadata({**combine_metadata(*flat_exprs), "is_multi_output": False}),
+        combine_metadata(*exprs, is_multi_output=False),
     )
 
 
@@ -2319,7 +2319,7 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     flat_exprs = flatten(exprs)
     return Expr(
         lambda plx: plx.all_horizontal(*[extract_compliant(plx, v) for v in flat_exprs]),
-        ExprMetadata({**combine_metadata(*flat_exprs), "is_multi_output": False}),
+        combine_metadata(*exprs, is_multi_output=False),
     )
 
 
@@ -2475,7 +2475,7 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     flat_exprs = flatten(exprs)
     return Expr(
         lambda plx: plx.any_horizontal(*[extract_compliant(plx, v) for v in flat_exprs]),
-        ExprMetadata({**combine_metadata(*flat_exprs), "is_multi_output": False}),
+        combine_metadata(*exprs, is_multi_output=False),
     )
 
 
@@ -2545,7 +2545,7 @@ def mean_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     flat_exprs = flatten(exprs)
     return Expr(
         lambda plx: plx.mean_horizontal(*[extract_compliant(plx, v) for v in flat_exprs]),
-        ExprMetadata({**combine_metadata(*flat_exprs), "is_multi_output": False}),
+        combine_metadata(*exprs, is_multi_output=False),
     )
 
 

--- a/narwhals/group_by.py
+++ b/narwhals/group_by.py
@@ -10,6 +10,7 @@ from typing import cast
 
 from narwhals.dataframe import DataFrame
 from narwhals.dataframe import LazyFrame
+from narwhals.expr import Expr
 from narwhals.exceptions import InvalidOperationError
 from narwhals.utils import tupleify
 
@@ -110,8 +111,8 @@ class GroupBy(Generic[DataFrameT]):
             │ c   ┆ 3   ┆ 1   │
             └─────┴─────┴─────┘
         """
-        if not all(getattr(x, "_aggregates", True) for x in aggs) and all(
-            getattr(x, "_aggregates", True) for x in named_aggs.values()
+        if not all(isinstance(x, Expr) and x._metadata['aggregates'] for x in aggs) and all(
+            isinstance(x, Expr) and x._metadata['aggregates'] for x in named_aggs.values()
         ):
             msg = (
                 "Found expression which does not aggregate.\n\n"
@@ -206,8 +207,8 @@ class LazyGroupBy(Generic[LazyFrameT]):
             │ c   ┆ 3   ┆ 1   │
             └─────┴─────┴─────┘
         """
-        if not all(getattr(x, "_aggregates", True) for x in aggs) and all(
-            getattr(x, "_aggregates", True) for x in named_aggs.values()
+        if not all(isinstance(x, Expr) and x._metadata['aggregates'] for x in aggs) and all(
+            isinstance(x, Expr) and x._metadata['aggregates'] for x in named_aggs.values()
         ):
             msg = (
                 "Found expression which does not aggregate.\n\n"

--- a/narwhals/group_by.py
+++ b/narwhals/group_by.py
@@ -12,7 +12,7 @@ from narwhals.dataframe import DataFrame
 from narwhals.dataframe import LazyFrame
 from narwhals.expr import Expr
 from narwhals.exceptions import InvalidOperationError
-from narwhals.utils import tupleify
+from narwhals.utils import tupleify, flatten
 
 if TYPE_CHECKING:
     from narwhals.typing import IntoExpr
@@ -111,7 +111,8 @@ class GroupBy(Generic[DataFrameT]):
             │ c   ┆ 3   ┆ 1   │
             └─────┴─────┴─────┘
         """
-        if not all(isinstance(x, Expr) and x._metadata['aggregates'] for x in aggs) and all(
+        flat_aggs = flatten(aggs)
+        if not all(isinstance(x, Expr) and x._metadata['aggregates'] for x in flat_aggs) and all(
             isinstance(x, Expr) and x._metadata['aggregates'] for x in named_aggs.values()
         ):
             msg = (
@@ -121,7 +122,7 @@ class GroupBy(Generic[DataFrameT]):
                 "but `df.group_by('a').agg(nw.col('b'))` is not."
             )
             raise InvalidOperationError(msg)
-        aggs, named_aggs = self._df._flatten_and_extract(*aggs, **named_aggs)
+        aggs, named_aggs = self._df._flatten_and_extract(*flat_aggs, **named_aggs)
         return self._df._from_compliant_dataframe(  # type: ignore[return-value]
             self._grouped.agg(*aggs, **named_aggs),
         )
@@ -207,7 +208,8 @@ class LazyGroupBy(Generic[LazyFrameT]):
             │ c   ┆ 3   ┆ 1   │
             └─────┴─────┴─────┘
         """
-        if not all(isinstance(x, Expr) and x._metadata['aggregates'] for x in aggs) and all(
+        flat_aggs = flatten(aggs)
+        if not all(isinstance(x, Expr) and x._metadata['aggregates'] for x in flat_aggs) and all(
             isinstance(x, Expr) and x._metadata['aggregates'] for x in named_aggs.values()
         ):
             msg = (
@@ -217,7 +219,7 @@ class LazyGroupBy(Generic[LazyFrameT]):
                 "but `df.group_by('a').agg(nw.col('b'))` is not."
             )
             raise InvalidOperationError(msg)
-        aggs, named_aggs = self._df._flatten_and_extract(*aggs, **named_aggs)
+        aggs, named_aggs = self._df._flatten_and_extract(*flat_aggs, **named_aggs)
         return self._df._from_compliant_dataframe(  # type: ignore[return-value]
             self._grouped.agg(*aggs, **named_aggs),
         )

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from narwhals._expression_parsing import extract_compliant
 
 from typing import Any
 
@@ -7,7 +8,40 @@ from narwhals.expr import Expr
 from narwhals.utils import flatten
 
 
-class Selector(Expr): ...
+class Selector(Expr):
+    def __or__(self, other):
+        return Selector(
+            lambda plx: self._to_compliant_expr(plx) | extract_compliant(plx, other),
+            ExprMetadata(
+                is_order_dependent=False,
+                changes_length=False,
+                aggregates=False,
+                is_multi_output=True,
+            ),
+        )
+    def __and__(self, other):
+        return Selector(
+            lambda plx: self._to_compliant_expr(plx) & extract_compliant(plx, other),
+            ExprMetadata(
+                is_order_dependent=False,
+                changes_length=False,
+                aggregates=False,
+                is_multi_output=True,
+            ),
+        )
+    def __sub__(self, other):
+        return Selector(
+            lambda plx: self._to_compliant_expr(plx) - extract_compliant(plx, other),
+            ExprMetadata(
+                is_order_dependent=False,
+                changes_length=False,
+                aggregates=False,
+                is_multi_output=True,
+            ),
+        )
+
+
+
 
 
 def by_dtype(*dtypes: Any) -> Expr:

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -32,9 +32,9 @@ class Selector(Expr):
     def __ror__(self: Self, other: Any) -> NoReturn:
         raise NotImplementedError
 
-    def __or__(self, other: Selector | Any) -> Selector:
+    def __and__(self, other: Selector | Any) -> Selector:
         return Selector(
-            lambda plx: self._to_compliant_expr(plx) | extract_compliant(plx, other),
+            lambda plx: self._to_compliant_expr(plx) & extract_compliant(plx, other),
             ExprMetadata(
                 is_order_dependent=False,
                 changes_length=False,
@@ -43,9 +43,9 @@ class Selector(Expr):
             ),
         )
 
-    def __and__(self, other: Selector | Any) -> Selector:
+    def __or__(self, other: Selector | Any) -> Selector:
         return Selector(
-            lambda plx: self._to_compliant_expr(plx) & extract_compliant(plx, other),
+            lambda plx: self._to_compliant_expr(plx) | extract_compliant(plx, other),
             ExprMetadata(
                 is_order_dependent=False,
                 changes_length=False,
@@ -65,8 +65,11 @@ class Selector(Expr):
             ),
         )
 
+    def __invert__(self: Self) -> Selector:
+        return all() - self
 
-def by_dtype(*dtypes: Any) -> Expr:
+
+def by_dtype(*dtypes: Any) -> Selector:
     """Select columns based on their dtype.
 
     Arguments:
@@ -120,7 +123,7 @@ def by_dtype(*dtypes: Any) -> Expr:
     )
 
 
-def numeric() -> Expr:
+def numeric() -> Selector:
     """Select numeric columns.
 
     Returns:
@@ -171,7 +174,7 @@ def numeric() -> Expr:
     )
 
 
-def boolean() -> Expr:
+def boolean() -> Selector:
     """Select boolean columns.
 
     Returns:
@@ -222,7 +225,7 @@ def boolean() -> Expr:
     )
 
 
-def string() -> Expr:
+def string() -> Selector:
     """Select string columns.
 
     Returns:
@@ -273,7 +276,7 @@ def string() -> Expr:
     )
 
 
-def categorical() -> Expr:
+def categorical() -> Selector:
     """Select categorical columns.
 
     Returns:
@@ -324,7 +327,7 @@ def categorical() -> Expr:
     )
 
 
-def all() -> Expr:
+def all() -> Selector:
     """Select all columns.
 
     Returns:

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
-from narwhals._expression_parsing import extract_compliant
 
 from typing import Any
 
 from narwhals._expression_parsing import ExprMetadata
+from narwhals._expression_parsing import extract_compliant
 from narwhals.expr import Expr
 from narwhals.utils import flatten
 
 
 class Selector(Expr):
-    def __or__(self, other):
+    def __or__(self, other: Selector | Any) -> Selector | Any:
         return Selector(
             lambda plx: self._to_compliant_expr(plx) | extract_compliant(plx, other),
             ExprMetadata(
@@ -19,7 +19,8 @@ class Selector(Expr):
                 is_multi_output=True,
             ),
         )
-    def __and__(self, other):
+
+    def __and__(self, other: Selector | Any) -> Selector | Any:
         return Selector(
             lambda plx: self._to_compliant_expr(plx) & extract_compliant(plx, other),
             ExprMetadata(
@@ -29,7 +30,8 @@ class Selector(Expr):
                 is_multi_output=True,
             ),
         )
-    def __sub__(self, other):
+
+    def __sub__(self, other: Selector | Any) -> Selector | Any:
         return Selector(
             lambda plx: self._to_compliant_expr(plx) - extract_compliant(plx, other),
             ExprMetadata(
@@ -39,9 +41,6 @@ class Selector(Expr):
                 is_multi_output=True,
             ),
         )
-
-
-
 
 
 def by_dtype(*dtypes: Any) -> Expr:

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from narwhals._expression_parsing import ExprMetadata
 from narwhals.expr import Expr
 from narwhals.utils import flatten
 
@@ -54,9 +55,12 @@ def by_dtype(*dtypes: Any) -> Expr:
     """
     return Selector(
         lambda plx: plx.selectors.by_dtype(flatten(dtypes)),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=False,
+            is_multi_output=True,
+        ),
     )
 
 
@@ -102,9 +106,12 @@ def numeric() -> Expr:
     """
     return Selector(
         lambda plx: plx.selectors.numeric(),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=False,
+            is_multi_output=True,
+        ),
     )
 
 
@@ -150,9 +157,12 @@ def boolean() -> Expr:
     """
     return Selector(
         lambda plx: plx.selectors.boolean(),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=False,
+            is_multi_output=True,
+        ),
     )
 
 
@@ -198,9 +208,12 @@ def string() -> Expr:
     """
     return Selector(
         lambda plx: plx.selectors.string(),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=False,
+            is_multi_output=True,
+        ),
     )
 
 
@@ -246,9 +259,12 @@ def categorical() -> Expr:
     """
     return Selector(
         lambda plx: plx.selectors.categorical(),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=False,
+            is_multi_output=True,
+        ),
     )
 
 
@@ -294,9 +310,12 @@ def all() -> Expr:
     """
     return Selector(
         lambda plx: plx.selectors.all(),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(
+            is_order_dependent=False,
+            changes_length=False,
+            aggregates=False,
+            is_multi_output=True,
+        ),
     )
 
 

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -15,6 +15,7 @@ import narwhals as nw
 from narwhals import dependencies
 from narwhals import exceptions
 from narwhals import selectors
+from narwhals._expression_parsing import ExprMetadata
 from narwhals.dataframe import DataFrame as NwDataFrame
 from narwhals.dataframe import LazyFrame as NwLazyFrame
 from narwhals.dependencies import get_polars
@@ -885,7 +886,9 @@ class Expr(NwExpr):
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).head(n),
-            ExprMetadata({**self._metadata, 'changes_length': True, 'is_order_dependent': True})
+            ExprMetadata(
+                {**self._metadata, "changes_length": True, "is_order_dependent": True}
+            ),
         )
 
     def tail(self, n: int = 10) -> Self:
@@ -899,7 +902,9 @@ class Expr(NwExpr):
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).tail(n),
-            ExprMetadata({**self._metadata, 'changes_length': True, 'is_order_dependent': True})
+            ExprMetadata(
+                {**self._metadata, "changes_length": True, "is_order_dependent": True}
+            ),
         )
 
     def gather_every(self: Self, n: int, offset: int = 0) -> Self:
@@ -914,7 +919,9 @@ class Expr(NwExpr):
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).gather_every(n=n, offset=offset),
-            ExprMetadata({**self._metadata, 'changes_length': True, 'is_order_dependent': True})
+            ExprMetadata(
+                {**self._metadata, "changes_length": True, "is_order_dependent": True}
+            ),
         )
 
     def unique(self, *, maintain_order: bool | None = None) -> Self:
@@ -936,7 +943,7 @@ class Expr(NwExpr):
             warn(message=msg, category=UserWarning, stacklevel=find_stacklevel())
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).unique(),
-            ExprMetadata({**self._metadata, 'changes_length': True})
+            ExprMetadata({**self._metadata, "changes_length": True}),
         )
 
     def sort(self, *, descending: bool = False, nulls_last: bool = False) -> Self:
@@ -953,7 +960,7 @@ class Expr(NwExpr):
             lambda plx: self._to_compliant_expr(plx).sort(
                 descending=descending, nulls_last=nulls_last
             ),
-            metadata=ExprMetadata({**self._metadata, 'is_order_dependent': True})
+            metadata=ExprMetadata({**self._metadata, "is_order_dependent": True}),
         )
 
     def arg_true(self) -> Self:
@@ -964,7 +971,9 @@ class Expr(NwExpr):
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).arg_true(),
-            ExprMetadata({**self._metadata, 'changes_length': True, 'is_order_dependent': True})
+            ExprMetadata(
+                {**self._metadata, "changes_length": True, "is_order_dependent": True}
+            ),
         )
 
     def sample(
@@ -998,7 +1007,9 @@ class Expr(NwExpr):
             lambda plx: self._to_compliant_expr(plx).sample(
                 n, fraction=fraction, with_replacement=with_replacement, seed=seed
             ),
-            ExprMetadata({**self._metadata, 'changes_length': True, 'is_order_dependent': True})
+            ExprMetadata(
+                {**self._metadata, "changes_length": True, "is_order_dependent": True}
+            ),
         )
 
 
@@ -1043,12 +1054,7 @@ def _stableify(
             level=obj._level,
         )
     if isinstance(obj, NwExpr):
-        return Expr(
-            obj._to_compliant_expr,
-            is_order_dependent=obj._is_order_dependent,
-            changes_length=obj._changes_length,
-            aggregates=obj._aggregates,
-        )
+        return Expr(obj._to_compliant_expr, obj._metadata)
     return obj
 
 
@@ -2006,12 +2012,7 @@ class When(NwWhen):
 class Then(NwThen, Expr):
     @classmethod
     def from_then(cls, then: NwThen) -> Self:
-        return cls(
-            then._to_compliant_expr,
-            is_order_dependent=then._is_order_dependent,
-            changes_length=then._changes_length,
-            aggregates=then._aggregates,
-        )
+        return cls(then._to_compliant_expr, then._metadata)
 
     def otherwise(self, value: Any) -> Expr:
         return _stableify(super().otherwise(value))

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -885,9 +885,7 @@ class Expr(NwExpr):
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).head(n),
-            is_order_dependent=True,
-            changes_length=True,
-            aggregates=self._aggregates,
+            ExprMetadata({**self._metadata, 'changes_length': True, 'is_order_dependent': True})
         )
 
     def tail(self, n: int = 10) -> Self:
@@ -901,9 +899,7 @@ class Expr(NwExpr):
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).tail(n),
-            is_order_dependent=True,
-            changes_length=True,
-            aggregates=self._aggregates,
+            ExprMetadata({**self._metadata, 'changes_length': True, 'is_order_dependent': True})
         )
 
     def gather_every(self: Self, n: int, offset: int = 0) -> Self:
@@ -918,9 +914,7 @@ class Expr(NwExpr):
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).gather_every(n=n, offset=offset),
-            is_order_dependent=True,
-            changes_length=True,
-            aggregates=self._aggregates,
+            ExprMetadata({**self._metadata, 'changes_length': True, 'is_order_dependent': True})
         )
 
     def unique(self, *, maintain_order: bool | None = None) -> Self:
@@ -942,9 +936,7 @@ class Expr(NwExpr):
             warn(message=msg, category=UserWarning, stacklevel=find_stacklevel())
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).unique(),
-            self._is_order_dependent,
-            changes_length=True,
-            aggregates=self._aggregates,
+            ExprMetadata({**self._metadata, 'changes_length': True})
         )
 
     def sort(self, *, descending: bool = False, nulls_last: bool = False) -> Self:
@@ -961,9 +953,7 @@ class Expr(NwExpr):
             lambda plx: self._to_compliant_expr(plx).sort(
                 descending=descending, nulls_last=nulls_last
             ),
-            is_order_dependent=True,
-            changes_length=self._changes_length,
-            aggregates=self._aggregates,
+            metadata=ExprMetadata({**self._metadata, 'is_order_dependent': True})
         )
 
     def arg_true(self) -> Self:
@@ -974,9 +964,7 @@ class Expr(NwExpr):
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).arg_true(),
-            is_order_dependent=True,
-            changes_length=True,
-            aggregates=self._aggregates,
+            ExprMetadata({**self._metadata, 'changes_length': True, 'is_order_dependent': True})
         )
 
     def sample(
@@ -1010,9 +998,7 @@ class Expr(NwExpr):
             lambda plx: self._to_compliant_expr(plx).sample(
                 n, fraction=fraction, with_replacement=with_replacement, seed=seed
             ),
-            is_order_dependent=True,
-            changes_length=True,
-            aggregates=self._aggregates,
+            ExprMetadata({**self._metadata, 'changes_length': True, 'is_order_dependent': True})
         )
 
 

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -2014,7 +2014,7 @@ class When(NwWhen):
 class Then(NwThen, Expr):
     @classmethod
     def from_then(cls: type, then: NwThen) -> Then:
-        return cls(then._to_compliant_expr, then._metadata)
+        return cls(then._to_compliant_expr, then._metadata)  # type: ignore[no-any-return]
 
     def otherwise(self: Self, value: Any) -> Expr:
         return _stableify(super().otherwise(value))

--- a/tests/expr_and_series/double_selected_test.py
+++ b/tests/expr_and_series/double_selected_test.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 import narwhals.stable.v1 as nw
+from narwhals.exceptions import MultiOutputExprError
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
@@ -17,6 +20,5 @@ def test_double_selected(constructor: Constructor) -> None:
     expected = {"z": [7, 8, 9], "a": [2, 6, 4], "b": [8, 8, 12]}
     assert_equal_data(result, expected)
 
-    result = df.select("a").select(nw.col("a") + nw.all())
-    expected = {"a": [2, 6, 4]}
-    assert_equal_data(result, expected)
+    with pytest.raises(MultiOutputExprError):
+        df.select("a").select(nw.col("a") + nw.all())

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -6,6 +6,7 @@ import sys
 import polars as pl
 
 import narwhals as nw
+from narwhals._expression_parsing import ExprMetadata
 from narwhals.utils import remove_prefix
 from narwhals.utils import remove_suffix
 
@@ -44,6 +45,12 @@ BASE_DTYPES = {
     "OrderedDict",
     "Mapping",
 }
+PLACEHOLDER_EXPR_METADATA = ExprMetadata(
+    is_order_dependent=False,
+    aggregates=False,
+    changes_length=False,
+    is_multi_output=False,
+)
 
 files = {remove_suffix(i, ".py") for i in os.listdir("narwhals")}
 
@@ -161,9 +168,7 @@ for namespace in NAMESPACES.difference({"name"}):
 # Expr methods
 expr_methods = [
     i
-    for i in nw.Expr(
-        lambda: 0, is_order_dependent=False, changes_length=False, aggregates=False
-    ).__dir__()
+    for i in nw.Expr(lambda: 0, PLACEHOLDER_EXPR_METADATA).__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
 with open("docs/api-reference/expr.md") as fd:
@@ -187,12 +192,7 @@ for namespace in NAMESPACES:
     expr_methods = [
         i
         for i in getattr(
-            nw.Expr(
-                lambda: 0,
-                is_order_dependent=False,
-                changes_length=False,
-                aggregates=False,
-            ),
+            nw.Expr(lambda: 0, PLACEHOLDER_EXPR_METADATA),
             namespace,
         ).__dir__()
         if not i[0].isupper() and i[0] != "_"
@@ -236,9 +236,7 @@ if extra := set(documented).difference(dtypes):
 # Check Expr vs Series
 expr = [
     i
-    for i in nw.Expr(
-        lambda: 0, is_order_dependent=False, changes_length=False, aggregates=False
-    ).__dir__()
+    for i in nw.Expr(lambda: 0, PLACEHOLDER_EXPR_METADATA).__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
 series = [
@@ -260,12 +258,7 @@ for namespace in NAMESPACES.difference({"name"}):
     expr_internal = [
         i
         for i in getattr(
-            nw.Expr(
-                lambda: 0,
-                is_order_dependent=False,
-                changes_length=False,
-                aggregates=False,
-            ),
+            nw.Expr(lambda: 0, PLACEHOLDER_EXPR_METADATA),
             namespace,
         ).__dir__()
         if not i[0].isupper() and i[0] != "_"


### PR DESCRIPTION
One step closer to #1780.

Next steps:
- in the metadata, store a callable which determines the root names
- only set aliases when necessary, as opposed to renaming after each operation. PySpark / SQL don't let us set as many aliases as we do now, e.g. `'select (a - mean(a) over () as a) as a from rel'` raises

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
