### PR TITLE
fix: allow any name in expression parsing

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -294,7 +294,7 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         return self._from_native_frame(self._native_frame.select(list(column_names)))
 
     def select(self: Self, *exprs: IntoArrowExpr, **named_exprs: IntoArrowExpr) -> Self:
-        new_series = evaluate_into_exprs(self, *exprs, **named_exprs)
+        new_series: list[ArrowSeries] = evaluate_into_exprs(self)(*exprs, **named_exprs)
         if not new_series:
             # return empty dataframe, like Polars does
             return self._from_native_frame(self._native_frame.__class__.from_arrays([]))
@@ -306,7 +306,7 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         self: Self, *exprs: IntoArrowExpr, **named_exprs: IntoArrowExpr
     ) -> Self:
         native_frame = self._native_frame
-        new_columns = evaluate_into_exprs(self, *exprs, **named_exprs)
+        new_columns: list[ArrowSeries] = evaluate_into_exprs(self)(*exprs, **named_exprs)
 
         length = len(self)
         columns = self.columns

--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -75,7 +75,7 @@ class DaskLazyFrame(CompliantLazyFrame):
 
     def with_columns(self: Self, *exprs: DaskExpr, **named_exprs: DaskExpr) -> Self:
         df = self._native_frame
-        new_series = parse_exprs_and_named_exprs(self, *exprs, **named_exprs)
+        new_series = parse_exprs_and_named_exprs(self)(*exprs, **named_exprs)
         df = df.assign(**new_series)
         return self._from_native_frame(df)
 
@@ -115,7 +115,7 @@ class DaskLazyFrame(CompliantLazyFrame):
         )
 
     def select(self: Self, *exprs: DaskExpr, **named_exprs: DaskExpr) -> Self:
-        new_series = parse_exprs_and_named_exprs(self, *exprs, **named_exprs)
+        new_series = parse_exprs_and_named_exprs(self)(*exprs, **named_exprs)
 
         if not new_series:
             # return empty dataframe, like Polars does

--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -104,7 +104,7 @@ class DuckDBLazyFrame(CompliantLazyFrame):
         *exprs: DuckDBExpr,
         **named_exprs: DuckDBExpr,
     ) -> Self:
-        new_columns_map = parse_exprs_and_named_exprs(self, *exprs, **named_exprs)
+        new_columns_map = parse_exprs_and_named_exprs(self)(*exprs, **named_exprs)
         if not new_columns_map:
             # TODO(marco): return empty relation with 0 columns?
             return self._from_native_frame(self._native_frame.limit(0))
@@ -139,7 +139,7 @@ class DuckDBLazyFrame(CompliantLazyFrame):
         *exprs: DuckDBExpr,
         **named_exprs: DuckDBExpr,
     ) -> Self:
-        new_columns_map = parse_exprs_and_named_exprs(self, *exprs, **named_exprs)
+        new_columns_map = parse_exprs_and_named_exprs(self)(*exprs, **named_exprs)
         result = []
         for col in self._native_frame.columns:
             if col in new_columns_map:

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -62,23 +62,28 @@ def evaluate_into_expr(
 
 def evaluate_into_exprs(
     df: CompliantDataFrame,
-    *exprs: IntoCompliantExpr[CompliantSeriesT_co],
-    **named_exprs: IntoCompliantExpr[CompliantSeriesT_co],
-) -> Sequence[CompliantSeriesT_co]:
+) -> Callable[..., list[CompliantSeriesT_co]]:
     """Evaluate each expr into Series."""
-    series = [
-        item
-        for sublist in (evaluate_into_expr(df, into_expr) for into_expr in exprs)
-        for item in sublist
-    ]
-    for name, expr in named_exprs.items():
-        evaluated_expr = evaluate_into_expr(df, expr)
-        if len(evaluated_expr) > 1:
-            msg = "Named expressions must return a single column"  # pragma: no cover
-            raise AssertionError(msg)
-        to_append = evaluated_expr[0].alias(name)
-        series.append(to_append)
-    return series
+
+    def func(
+        *exprs: IntoCompliantExpr[CompliantSeriesT_co],
+        **named_exprs: IntoCompliantExpr[CompliantSeriesT_co],
+    ) -> list[CompliantSeriesT_co]:
+        series = [
+            item
+            for sublist in (evaluate_into_expr(df, into_expr) for into_expr in exprs)
+            for item in sublist
+        ]
+        for name, expr in named_exprs.items():
+            evaluated_expr = evaluate_into_expr(df, expr)
+            if len(evaluated_expr) > 1:
+                msg = "Named expressions must return a single column"  # pragma: no cover
+                raise AssertionError(msg)
+            to_append = evaluated_expr[0].alias(name)
+            series.append(to_append)
+        return series
+
+    return func
 
 
 def maybe_evaluate_expr(

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -363,7 +363,9 @@ class PandasLikeDataFrame(CompliantDataFrame, CompliantLazyFrame):
         *exprs: IntoPandasLikeExpr,
         **named_exprs: IntoPandasLikeExpr,
     ) -> Self:
-        new_series = evaluate_into_exprs(self, *exprs, **named_exprs)
+        new_series: list[PandasLikeSeries] = evaluate_into_exprs(self)(
+            *exprs, **named_exprs
+        )
         if not new_series:
             # return empty dataframe, like Polars does
             return self._from_native_frame(self._native_frame.__class__())
@@ -433,7 +435,9 @@ class PandasLikeDataFrame(CompliantDataFrame, CompliantLazyFrame):
         **named_exprs: IntoPandasLikeExpr,
     ) -> Self:
         index = self._native_frame.index
-        new_columns = evaluate_into_exprs(self, *exprs, **named_exprs)
+        new_columns: list[PandasLikeSeries] = evaluate_into_exprs(self)(
+            *exprs, **named_exprs
+        )
         if not new_columns and len(self) == 0:
             return self
 

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -94,7 +94,7 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
         *exprs: SparkLikeExpr,
         **named_exprs: SparkLikeExpr,
     ) -> Self:
-        new_columns = parse_exprs_and_named_exprs(self, *exprs, **named_exprs)
+        new_columns = parse_exprs_and_named_exprs(self)(*exprs, **named_exprs)
 
         if not new_columns:
             # return empty dataframe, like Polars does
@@ -135,7 +135,7 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
         *exprs: SparkLikeExpr,
         **named_exprs: SparkLikeExpr,
     ) -> Self:
-        new_columns_map = parse_exprs_and_named_exprs(self, *exprs, **named_exprs)
+        new_columns_map = parse_exprs_and_named_exprs(self)(*exprs, **named_exprs)
         return self._from_native_frame(self._native_frame.withColumns(new_columns_map))
 
     def drop(self: Self, columns: list[str], strict: bool) -> Self:  # noqa: FBT001


### PR DESCRIPTION
Currently if we do:

```py
@nw.narwhalify
def func(df):
    return df.with_columns(df=nw.col("a")+1)
```
with any backend except polars, we get an error:

> TypeError: evaluate_into_exprs() got multiple values for argument 'df'

This PR fixes this issue

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

