### PR TITLE
fix: address `&` / `|` operator errors for PySpark / chore: use F.lit in maybe_evaluate for pyspark, like we do for duckdb

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -151,47 +151,48 @@ jobs:
           cd scikit-lego
           pytest -n auto --disable-warnings --cov=sklego -m "not cvxpy and not formulaic and not umap"
 
-  shiny:
-    strategy:
-      matrix:
-        python-version: ["3.12"]
-        os: [ubuntu-latest]
+  # temporarily un-enabled as it's been failing for some time due to unrelated reasons
+  # shiny:
+  #   strategy:
+  #     matrix:
+  #       python-version: ["3.12"]
+  #       os: [ubuntu-latest]
 
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: "true"
-          cache-suffix: ${{ matrix.python-version }}
-          cache-dependency-glob: "pyproject.toml"
-      - name: clone-shiny
-        run: |
-          git clone https://github.com/posit-dev/py-shiny.git
-          cd py-shiny
-          git log
-      - name: install-basics
-        run: uv pip install --upgrade tox virtualenv setuptools --system
-      - name: install-shiny-dev
-        env:
-          UV_SYSTEM_PYTHON: 1
-        run: |
-          cd py-shiny
-          make narwhals-install-shiny
-      - name: install-narwhals-dev
-        run: |
-          uv pip uninstall narwhals --system
-          uv pip install -e . --system
-      - name: show-deps
-        run: uv pip freeze
-      - name: Run `make narwhals-test-integration`
-        run: |
-          cd py-shiny
-          make narwhals-test-integration
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: Install uv
+  #       uses: astral-sh/setup-uv@v5
+  #       with:
+  #         enable-cache: "true"
+  #         cache-suffix: ${{ matrix.python-version }}
+  #         cache-dependency-glob: "pyproject.toml"
+  #     - name: clone-shiny
+  #       run: |
+  #         git clone https://github.com/posit-dev/py-shiny.git
+  #         cd py-shiny
+  #         git log
+  #     - name: install-basics
+  #       run: uv pip install --upgrade tox virtualenv setuptools --system
+  #     - name: install-shiny-dev
+  #       env:
+  #         UV_SYSTEM_PYTHON: 1
+  #       run: |
+  #         cd py-shiny
+  #         make narwhals-install-shiny
+  #     - name: install-narwhals-dev
+  #       run: |
+  #         uv pip uninstall narwhals --system
+  #         uv pip install -e . --system
+  #     - name: show-deps
+  #       run: uv pip freeze
+  #     - name: Run `make narwhals-test-integration`
+  #       run: |
+  #         cd py-shiny
+  #         make narwhals-test-integration
 
   tea-tasting:
     strategy:

--- a/narwhals/_dask/group_by.py
+++ b/narwhals/_dask/group_by.py
@@ -147,7 +147,7 @@ def agg_dask(
             # e.g. agg(nw.mean('a')) # noqa: ERA001
             function_name = re.sub(r"(\w+->)", "", expr._function_name)
             kwargs = (
-                {"ddof": expr._kwargs["ddof"]} if function_name in {"std", "var"} else {}
+                {"ddof": expr._kwargs["ddof"]} if function_name in {"std", "var"} else {}  # type: ignore[attr-defined]
             )
 
             agg_function = POLARS_TO_DASK_AGGREGATIONS.get(function_name, function_name)

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -48,7 +48,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         returns_scalar: bool,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any],
     ) -> None:
         self._call = call
         self._depth = depth
@@ -58,7 +57,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         self._returns_scalar = returns_scalar
         self._backend_version = backend_version
         self._version = version
-        self._kwargs = kwargs
 
     def __call__(self: Self, df: DuckDBLazyFrame) -> Sequence[duckdb.Expression]:
         return self._call(df)
@@ -92,7 +90,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
             returns_scalar=False,
             backend_version=backend_version,
             version=version,
-            kwargs={},
         )
 
     @classmethod
@@ -116,7 +113,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
             returns_scalar=False,
             backend_version=backend_version,
             version=version,
-            kwargs={},
         )
 
     def _from_call(
@@ -147,7 +143,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
             returns_scalar=returns_scalar,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs=expressifiable_args,
         )
 
     def __and__(self: Self, other: DuckDBExpr) -> Self:
@@ -295,7 +290,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
             returns_scalar=self._returns_scalar,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={**self._kwargs, "name": name},
         )
 
     def abs(self: Self) -> Self:

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -538,16 +538,13 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):
         )
 
     def cast(self: Self, dtype: DType | type[DType]) -> Self:
-        def func(
-            _input: duckdb.Expression, dtype: DType | type[DType]
-        ) -> duckdb.Expression:
+        def func(_input: duckdb.Expression) -> duckdb.Expression:
             native_dtype = narwhals_to_native_dtype(dtype, self._version)
             return _input.cast(native_dtype)
 
         return self._from_call(
             func,
             "cast",
-            dtype=dtype,
             returns_scalar=self._returns_scalar,
         )
 

--- a/narwhals/_duckdb/expr_name.py
+++ b/narwhals/_duckdb/expr_name.py
@@ -23,7 +23,6 @@ class DuckDBExprNameNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs=self._compliant_expr._kwargs,
         )
 
     def map(self: Self, function: Callable[[str], str]) -> DuckDBExpr:
@@ -38,7 +37,6 @@ class DuckDBExprNameNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs={**self._compliant_expr._kwargs, "function": function},
         )
 
     def prefix(self: Self, prefix: str) -> DuckDBExpr:
@@ -53,7 +51,6 @@ class DuckDBExprNameNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs={**self._compliant_expr._kwargs, "prefix": prefix},
         )
 
     def suffix(self: Self, suffix: str) -> DuckDBExpr:
@@ -68,7 +65,6 @@ class DuckDBExprNameNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs={**self._compliant_expr._kwargs, "suffix": suffix},
         )
 
     def to_lowercase(self: Self) -> DuckDBExpr:
@@ -83,7 +79,6 @@ class DuckDBExprNameNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs=self._compliant_expr._kwargs,
         )
 
     def to_uppercase(self: Self) -> DuckDBExpr:
@@ -98,5 +93,4 @@ class DuckDBExprNameNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs=self._compliant_expr._kwargs,
         )

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -58,7 +58,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def concat(
@@ -142,11 +141,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={
-                "exprs": exprs,
-                "separator": separator,
-                "ignore_nulls": ignore_nulls,
-            },
         )
 
     def all_horizontal(self: Self, *exprs: DuckDBExpr) -> DuckDBExpr:
@@ -163,7 +157,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def any_horizontal(self: Self, *exprs: DuckDBExpr) -> DuckDBExpr:
@@ -180,7 +173,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def max_horizontal(self: Self, *exprs: DuckDBExpr) -> DuckDBExpr:
@@ -197,7 +189,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def min_horizontal(self: Self, *exprs: DuckDBExpr) -> DuckDBExpr:
@@ -214,7 +205,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def sum_horizontal(self: Self, *exprs: DuckDBExpr) -> DuckDBExpr:
@@ -236,7 +226,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def mean_horizontal(self: Self, *exprs: DuckDBExpr) -> DuckDBExpr:
@@ -261,7 +250,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def when(
@@ -303,7 +291,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
             returns_scalar=True,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def len(self: Self) -> DuckDBExpr:
@@ -319,7 +306,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
             returns_scalar=True,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
 
@@ -378,7 +364,6 @@ class DuckDBWhen:
             returns_scalar=self._returns_scalar,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"value": value},
         )
 
 
@@ -394,7 +379,6 @@ class DuckDBThen(DuckDBExpr):
         returns_scalar: bool,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any],
     ) -> None:
         self._backend_version = backend_version
         self._version = version
@@ -404,7 +388,6 @@ class DuckDBThen(DuckDBExpr):
         self._evaluate_output_names = evaluate_output_names
         self._alias_output_names = alias_output_names
         self._returns_scalar = returns_scalar
-        self._kwargs = kwargs
 
     def otherwise(self: Self, value: DuckDBExpr | Any) -> DuckDBExpr:
         # type ignore because we are setting the `_call` attribute to a

--- a/narwhals/_duckdb/selectors.py
+++ b/narwhals/_duckdb/selectors.py
@@ -43,7 +43,6 @@ class DuckDBSelectorNamespace:
             backend_version=self._backend_version,
             returns_scalar=False,
             version=self._version,
-            kwargs={},
         )
 
     def numeric(self: Self) -> DuckDBSelector:
@@ -90,7 +89,6 @@ class DuckDBSelectorNamespace:
             backend_version=self._backend_version,
             returns_scalar=False,
             version=self._version,
-            kwargs={},
         )
 
 
@@ -112,7 +110,6 @@ class DuckDBSelector(DuckDBExpr):
             backend_version=self._backend_version,
             returns_scalar=self._returns_scalar,
             version=self._version,
-            kwargs={},
         )
 
     def __sub__(self: Self, other: DuckDBSelector | Any) -> DuckDBSelector | Any:
@@ -138,7 +135,6 @@ class DuckDBSelector(DuckDBExpr):
                 backend_version=self._backend_version,
                 returns_scalar=self._returns_scalar,
                 version=self._version,
-                kwargs={},
             )
         else:
             return self._to_expr() - other
@@ -170,7 +166,6 @@ class DuckDBSelector(DuckDBExpr):
                 backend_version=self._backend_version,
                 returns_scalar=self._returns_scalar,
                 version=self._version,
-                kwargs={},
             )
         else:
             return self._to_expr() | other
@@ -198,7 +193,6 @@ class DuckDBSelector(DuckDBExpr):
                 backend_version=self._backend_version,
                 returns_scalar=self._returns_scalar,
                 version=self._version,
-                kwargs={},
             )
         else:
             return self._to_expr() & other

--- a/narwhals/_duckdb/utils.py
+++ b/narwhals/_duckdb/utils.py
@@ -8,13 +8,13 @@ from typing import Callable
 
 import duckdb
 
-from narwhals.dtypes import DType
 from narwhals.utils import import_dtypes_module
 from narwhals.utils import isinstance_or_issubclass
 
 if TYPE_CHECKING:
     from narwhals._duckdb.dataframe import DuckDBLazyFrame
     from narwhals._duckdb.expr import DuckDBExpr
+    from narwhals.dtypes import DType
     from narwhals.utils import Version
 
 
@@ -31,8 +31,6 @@ def maybe_evaluate(df: DuckDBLazyFrame, obj: Any) -> Any:
             msg = "Reductions are not yet supported for DuckDB, at least until they implement duckdb.WindowExpression"
             raise NotImplementedError(msg)
         return column_result
-    if isinstance_or_issubclass(obj, DType):
-        return obj
     return duckdb.ConstantExpression(obj)
 
 

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -623,10 +623,13 @@ class PandasLikeSeries(CompliantSeries):
         self: Self, old: Sequence[Any], new: Sequence[Any], *, return_dtype: DType | None
     ) -> PandasLikeSeries:
         tmp_name = f"{self.name}_tmp"
+        dtype_backend = get_dtype_backend(
+            dtype=self._native_series.dtype, implementation=self._implementation
+        )
         dtype = (
             narwhals_to_native_dtype(
                 return_dtype,
-                self._native_series.dtype,
+                dtype_backend,
                 self._implementation,
                 self._backend_version,
                 self._version,

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -45,7 +45,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         returns_scalar: bool,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any],
     ) -> None:
         self._call = call
         self._depth = depth
@@ -55,7 +54,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         self._returns_scalar = returns_scalar
         self._backend_version = backend_version
         self._version = version
-        self._kwargs = kwargs
 
     def __call__(self: Self, df: SparkLikeLazyFrame) -> Sequence[Column]:
         return self._call(df)
@@ -89,7 +87,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             returns_scalar=False,
             backend_version=backend_version,
             version=version,
-            kwargs={},
         )
 
     @classmethod
@@ -112,7 +109,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             returns_scalar=False,
             backend_version=backend_version,
             version=version,
-            kwargs={},
         )
 
     def _from_call(
@@ -143,7 +139,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             returns_scalar=self._returns_scalar or returns_scalar,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs=expressifiable_args,
         )
 
     def __eq__(self: Self, other: SparkLikeExpr) -> Self:  # type: ignore[override]
@@ -297,7 +292,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             returns_scalar=self._returns_scalar,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={**self._kwargs, "name": name},
         )
 
     def all(self: Self) -> Self:
@@ -355,7 +349,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
         func = partial(_std, ddof=ddof, np_version=parse_version(np.__version__))
 
-        return self._from_call(func, "std", returns_scalar=True)
+        return self._from_call(func, f"std[{ddof}]", returns_scalar=True)
 
     def var(self: Self, ddof: int) -> Self:
         from functools import partial
@@ -364,9 +358,9 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
         from narwhals._spark_like.utils import _var
 
-        func = partial(_var, ddof=ddof, np_version=parse_version(np.__version__))
+        func = partial(_var, ddof=F.lit(ddof), np_version=parse_version(np.__version__))
 
-        return self._from_call(func, "var", returns_scalar=True)
+        return self._from_call(func, f"var[{ddof}]", returns_scalar=True)
 
     def clip(
         self: Self,
@@ -500,7 +494,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             backend_version=self._backend_version,
             version=self._version,
             returns_scalar=False,
-            kwargs={**self._kwargs, "keys": keys},
         )
 
     def is_null(self: Self) -> Self:

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -307,13 +307,11 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         return self._from_call(F.bool_or, "any", returns_scalar=True)
 
     def cast(self: Self, dtype: DType | type[DType]) -> Self:
-        def _cast(_input: Column, dtype: DType | type[DType]) -> Column:
+        def _cast(_input: Column) -> Column:
             spark_dtype = narwhals_to_native_dtype(dtype, self._version)
             return _input.cast(spark_dtype)
 
-        return self._from_call(
-            _cast, "cast", dtype=dtype, returns_scalar=self._returns_scalar
-        )
+        return self._from_call(_cast, "cast", returns_scalar=self._returns_scalar)
 
     def count(self: Self) -> Self:
         return self._from_call(F.count, "count", returns_scalar=True)
@@ -357,7 +355,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
         func = partial(_std, ddof=ddof, np_version=parse_version(np.__version__))
 
-        return self._from_call(func, "std", returns_scalar=True, ddof=ddof)
+        return self._from_call(func, "std", returns_scalar=True)
 
     def var(self: Self, ddof: int) -> Self:
         from functools import partial
@@ -368,7 +366,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
         func = partial(_var, ddof=ddof, np_version=parse_version(np.__version__))
 
-        return self._from_call(func, "var", returns_scalar=True, ddof=ddof)
+        return self._from_call(func, "var", returns_scalar=True)
 
     def clip(
         self: Self,
@@ -443,13 +441,12 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         )
 
     def is_in(self: Self, values: Sequence[Any]) -> Self:
-        def _is_in(_input: Column, values: Sequence[Any]) -> Column:
+        def _is_in(_input: Column) -> Column:
             return _input.isin(values)
 
         return self._from_call(
             _is_in,
             "is_in",
-            values=values,
             returns_scalar=self._returns_scalar,
         )
 
@@ -470,13 +467,12 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         return self._from_call(_len, "len", returns_scalar=True)
 
     def round(self: Self, decimals: int) -> Self:
-        def _round(_input: Column, decimals: int) -> Column:
+        def _round(_input: Column) -> Column:
             return F.round(_input, decimals)
 
         return self._from_call(
             _round,
             "round",
-            decimals=decimals,
             returns_scalar=self._returns_scalar,
         )
 

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -358,7 +358,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
         from narwhals._spark_like.utils import _var
 
-        func = partial(_var, ddof=F.lit(ddof), np_version=parse_version(np.__version__))
+        func = partial(_var, ddof=ddof, np_version=parse_version(np.__version__))
 
         return self._from_call(func, f"var[{ddof}]", returns_scalar=True)
 

--- a/narwhals/_spark_like/expr_name.py
+++ b/narwhals/_spark_like/expr_name.py
@@ -23,7 +23,6 @@ class SparkLikeExprNameNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs=self._compliant_expr._kwargs,
         )
 
     def map(self: Self, function: Callable[[str], str]) -> SparkLikeExpr:
@@ -38,7 +37,6 @@ class SparkLikeExprNameNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs={**self._compliant_expr._kwargs, "function": function},
         )
 
     def prefix(self: Self, prefix: str) -> SparkLikeExpr:
@@ -53,7 +51,6 @@ class SparkLikeExprNameNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs={**self._compliant_expr._kwargs, "prefix": prefix},
         )
 
     def suffix(self: Self, suffix: str) -> SparkLikeExpr:
@@ -68,7 +65,6 @@ class SparkLikeExprNameNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs={**self._compliant_expr._kwargs, "suffix": suffix},
         )
 
     def to_lowercase(self: Self) -> SparkLikeExpr:
@@ -83,7 +79,6 @@ class SparkLikeExprNameNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs=self._compliant_expr._kwargs,
         )
 
     def to_uppercase(self: Self) -> SparkLikeExpr:
@@ -98,5 +93,4 @@ class SparkLikeExprNameNamespace:
             returns_scalar=self._compliant_expr._returns_scalar,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs=self._compliant_expr._kwargs,
         )

--- a/narwhals/_spark_like/expr_str.py
+++ b/narwhals/_spark_like/expr_str.py
@@ -26,66 +26,58 @@ class SparkLikeExprStringNamespace:
     def replace_all(
         self: Self, pattern: str, value: str, *, literal: bool
     ) -> SparkLikeExpr:
-        def func(_input: Column, pattern: str, value: str, *, literal: bool) -> Column:
+        def func(_input: Column) -> Column:
             replace_all_func = F.replace if literal else F.regexp_replace
             return replace_all_func(_input, F.lit(pattern), F.lit(value))
 
         return self._compliant_expr._from_call(
             func,
             "replace",
-            pattern=pattern,
-            value=value,
-            literal=literal,
             returns_scalar=self._compliant_expr._returns_scalar,
         )
 
     def strip_chars(self: Self, characters: str | None) -> SparkLikeExpr:
         import string
 
-        def func(_input: Column, characters: str | None) -> Column:
+        def func(_input: Column) -> Column:
             to_remove = characters if characters is not None else string.whitespace
             return F.btrim(_input, F.lit(to_remove))
 
         return self._compliant_expr._from_call(
             func,
             "strip",
-            characters=characters,
             returns_scalar=self._compliant_expr._returns_scalar,
         )
 
     def starts_with(self: Self, prefix: str) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            lambda _input, prefix: F.startswith(_input, F.lit(prefix)),
+            lambda _input: F.startswith(_input, F.lit(prefix)),
             "starts_with",
-            prefix=prefix,
             returns_scalar=self._compliant_expr._returns_scalar,
         )
 
     def ends_with(self: Self, suffix: str) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            lambda _input, suffix: F.endswith(_input, F.lit(suffix)),
+            lambda _input: F.endswith(_input, F.lit(suffix)),
             "ends_with",
-            suffix=suffix,
             returns_scalar=self._compliant_expr._returns_scalar,
         )
 
     def contains(self: Self, pattern: str, *, literal: bool) -> SparkLikeExpr:
-        def func(_input: Column, pattern: str, *, literal: bool) -> Column:
+        def func(_input: Column) -> Column:
             contains_func = F.contains if literal else F.regexp
             return contains_func(_input, F.lit(pattern))
 
         return self._compliant_expr._from_call(
             func,
             "contains",
-            pattern=pattern,
-            literal=literal,
             returns_scalar=self._compliant_expr._returns_scalar,
         )
 
     def slice(self: Self, offset: int, length: int | None) -> SparkLikeExpr:
         # From the docs: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.substring.html
         # The position is not zero based, but 1 based index.
-        def func(_input: Column, offset: int, length: int | None) -> Column:
+        def func(_input: Column) -> Column:
             col_length = F.char_length(_input)
 
             _offset = col_length + F.lit(offset + 1) if offset < 0 else F.lit(offset + 1)
@@ -95,8 +87,6 @@ class SparkLikeExprStringNamespace:
         return self._compliant_expr._from_call(
             func,
             "slice",
-            offset=offset,
-            length=length,
             returns_scalar=self._compliant_expr._returns_scalar,
         )
 

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -54,7 +54,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def col(self: Self, *column_names: str) -> SparkLikeExpr:
@@ -86,7 +85,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             returns_scalar=True,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def len(self: Self) -> SparkLikeExpr:
@@ -102,7 +100,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             returns_scalar=True,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def all_horizontal(self: Self, *exprs: SparkLikeExpr) -> SparkLikeExpr:
@@ -119,7 +116,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def any_horizontal(self: Self, *exprs: SparkLikeExpr) -> SparkLikeExpr:
@@ -136,7 +132,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def sum_horizontal(self: Self, *exprs: SparkLikeExpr) -> SparkLikeExpr:
@@ -158,7 +153,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def mean_horizontal(self: Self, *exprs: SparkLikeExpr) -> SparkLikeExpr:
@@ -183,7 +177,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def max_horizontal(self: Self, *exprs: SparkLikeExpr) -> SparkLikeExpr:
@@ -200,7 +193,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def min_horizontal(self: Self, *exprs: SparkLikeExpr) -> SparkLikeExpr:
@@ -217,7 +209,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def concat(
@@ -311,11 +302,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             returns_scalar=False,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={
-                "exprs": exprs,
-                "separator": separator,
-                "ignore_nulls": ignore_nulls,
-            },
         )
 
     def when(self: Self, *predicates: SparkLikeExpr) -> SparkLikeWhen:
@@ -375,7 +361,6 @@ class SparkLikeWhen:
             returns_scalar=self._returns_scalar,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"value": value},
         )
 
 
@@ -391,7 +376,6 @@ class SparkLikeThen(SparkLikeExpr):
         returns_scalar: bool,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any],
     ) -> None:
         self._backend_version = backend_version
         self._version = version
@@ -401,7 +385,6 @@ class SparkLikeThen(SparkLikeExpr):
         self._evaluate_output_names = evaluate_output_names
         self._alias_output_names = alias_output_names
         self._returns_scalar = returns_scalar
-        self._kwargs = kwargs
 
     def otherwise(self: Self, value: SparkLikeExpr | Any) -> SparkLikeExpr:
         # type ignore because we are setting the `_call` attribute to a

--- a/narwhals/_spark_like/selectors.py
+++ b/narwhals/_spark_like/selectors.py
@@ -41,7 +41,6 @@ class SparkLikeSelectorNamespace:
             backend_version=self._backend_version,
             returns_scalar=False,
             version=self._version,
-            kwargs={},
         )
 
     def numeric(self: Self) -> SparkLikeSelector:
@@ -88,7 +87,6 @@ class SparkLikeSelectorNamespace:
             backend_version=self._backend_version,
             returns_scalar=False,
             version=self._version,
-            kwargs={},
         )
 
 
@@ -110,7 +108,6 @@ class SparkLikeSelector(SparkLikeExpr):
             backend_version=self._backend_version,
             returns_scalar=self._returns_scalar,
             version=self._version,
-            kwargs={},
         )
 
     def __sub__(self: Self, other: SparkLikeSelector | Any) -> SparkLikeSelector | Any:
@@ -136,7 +133,6 @@ class SparkLikeSelector(SparkLikeExpr):
                 backend_version=self._backend_version,
                 returns_scalar=self._returns_scalar,
                 version=self._version,
-                kwargs={},
             )
         else:
             return self._to_expr() - other
@@ -168,7 +164,6 @@ class SparkLikeSelector(SparkLikeExpr):
                 backend_version=self._backend_version,
                 returns_scalar=self._returns_scalar,
                 version=self._version,
-                kwargs={},
             )
         else:
             return self._to_expr() | other
@@ -196,7 +191,6 @@ class SparkLikeSelector(SparkLikeExpr):
                 backend_version=self._backend_version,
                 returns_scalar=self._returns_scalar,
                 version=self._version,
-                kwargs={},
             )
         else:
             return self._to_expr() & other

--- a/narwhals/_spark_like/selectors.py
+++ b/narwhals/_spark_like/selectors.py
@@ -139,9 +139,7 @@ class SparkLikeSelector(SparkLikeExpr):
                 kwargs={},
             )
         else:
-            return self._to_expr() - (
-                other if isinstance(other, SparkLikeExpr) else F.lit(other)
-            )
+            return self._to_expr() - other
 
     def __or__(self: Self, other: SparkLikeSelector | Any) -> SparkLikeSelector | Any:
         if isinstance(other, SparkLikeSelector):
@@ -173,9 +171,7 @@ class SparkLikeSelector(SparkLikeExpr):
                 kwargs={},
             )
         else:
-            return self._to_expr() | (
-                other if isinstance(other, SparkLikeExpr) else F.lit(other)
-            )
+            return self._to_expr() | other
 
     def __and__(self: Self, other: SparkLikeSelector | Any) -> SparkLikeSelector | Any:
         if isinstance(other, SparkLikeSelector):
@@ -203,9 +199,7 @@ class SparkLikeSelector(SparkLikeExpr):
                 kwargs={},
             )
         else:
-            return self._to_expr() & (
-                other if isinstance(other, SparkLikeExpr) else F.lit(other)
-            )
+            return self._to_expr() & other
 
     def __invert__(self: Self) -> SparkLikeSelector:
         return (

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -6,18 +6,19 @@ from typing import Any
 from typing import Callable
 
 from pyspark.sql import functions as F  # noqa: N812
+from pyspark.sql import types as pyspark_types
+from pyspark.sql.window import Window
 
+from narwhals.dtypes import DType
 from narwhals.exceptions import UnsupportedDTypeError
 from narwhals.utils import import_dtypes_module
 from narwhals.utils import isinstance_or_issubclass
 
 if TYPE_CHECKING:
     from pyspark.sql import Column
-    from pyspark.sql import types as pyspark_types
 
     from narwhals._spark_like.dataframe import SparkLikeLazyFrame
     from narwhals._spark_like.expr import SparkLikeExpr
-    from narwhals.dtypes import DType
     from narwhals.utils import Version
 
 
@@ -26,8 +27,6 @@ def native_to_narwhals_dtype(
     dtype: pyspark_types.DataType,
     version: Version,
 ) -> DType:  # pragma: no cover
-    from pyspark.sql import types as pyspark_types
-
     dtypes = import_dtypes_module(version=version)
 
     if isinstance(dtype, pyspark_types.DoubleType):
@@ -68,8 +67,6 @@ def native_to_narwhals_dtype(
 def narwhals_to_native_dtype(
     dtype: DType | type[DType], version: Version
 ) -> pyspark_types.DataType:
-    from pyspark.sql import types as pyspark_types
-
     dtypes = import_dtypes_module(version)
 
     if isinstance_or_issubclass(dtype, dtypes.Float64):
@@ -146,11 +143,11 @@ def maybe_evaluate(df: SparkLikeLazyFrame, obj: Any) -> Any:
         column_result = column_results[0]
         if obj._returns_scalar:
             # Return scalar, let PySpark do its broadcasting
-            from pyspark.sql.window import Window
-
             return column_result.over(Window.partitionBy(F.lit(1)))
         return column_result
-    return obj
+    if isinstance_or_issubclass(obj, DType):
+        return obj
+    return F.lit(obj)
 
 
 def _std(_input: Column | str, ddof: int, np_version: tuple[int, ...]) -> Column:

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -9,7 +9,6 @@ from pyspark.sql import functions as F  # noqa: N812
 from pyspark.sql import types as pyspark_types
 from pyspark.sql.window import Window
 
-from narwhals.dtypes import DType
 from narwhals.exceptions import UnsupportedDTypeError
 from narwhals.utils import import_dtypes_module
 from narwhals.utils import isinstance_or_issubclass
@@ -19,6 +18,7 @@ if TYPE_CHECKING:
 
     from narwhals._spark_like.dataframe import SparkLikeLazyFrame
     from narwhals._spark_like.expr import SparkLikeExpr
+    from narwhals.dtypes import DType
     from narwhals.utils import Version
 
 
@@ -145,8 +145,6 @@ def maybe_evaluate(df: SparkLikeLazyFrame, obj: Any) -> Any:
             # Return scalar, let PySpark do its broadcasting
             return column_result.over(Window.partitionBy(F.lit(1)))
         return column_result
-    if isinstance_or_issubclass(obj, DType):
-        return obj
     return F.lit(obj)
 
 

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -87,7 +87,6 @@ class CompliantExpr(Protocol, Generic[CompliantSeriesT_co]):
     _alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None
     _depth: int
     _function_name: str
-    _kwargs: dict[str, Any]
 
     def __call__(self, df: Any) -> Sequence[CompliantSeriesT_co]: ...
     def __narwhals_expr__(self) -> None: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,7 +224,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         if (
             constructor in ("pandas[nullable]", "pandas[pyarrow]")
             and MIN_PANDAS_NULLABLE_VERSION > PANDAS_VERSION
-        ):
+        ):  # pragma: no cover
             continue
         if constructor in EAGER_CONSTRUCTORS:
             eager_constructors.append(EAGER_CONSTRUCTORS[constructor])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,9 +219,10 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     constructors_ids: list[str] = []
 
     for constructor in selected_constructors:
-        if constructor in ("pandas[nullable]", "pandas[pyarrow]") and PANDAS_VERSION < (
-            1,
-            5,
+        min_pandas_nullable_version = (1, 5)
+        if (
+            constructor in ("pandas[nullable]", "pandas[pyarrow]")
+            and min_pandas_nullable_version > PANDAS_VERSION
         ):
             continue
         if constructor in EAGER_CONSTRUCTORS:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     from narwhals.typing import IntoDataFrame
     from narwhals.typing import IntoFrame
 
+MIN_PANDAS_NULLABLE_VERSION = (1, 5)
+
 # When testing cudf.pandas in Kaggle, we get an error if we try to run
 # python -m cudf.pandas -m pytest --constructors=pandas. This gives us
 # a way to run `python -m cudf.pandas -m pytest` and control which constructors
@@ -219,10 +221,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     constructors_ids: list[str] = []
 
     for constructor in selected_constructors:
-        min_pandas_nullable_version = (1, 5)
         if (
             constructor in ("pandas[nullable]", "pandas[pyarrow]")
-            and min_pandas_nullable_version > PANDAS_VERSION
+            and MIN_PANDAS_NULLABLE_VERSION > PANDAS_VERSION
         ):
             continue
         if constructor in EAGER_CONSTRUCTORS:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ import pyarrow as pa
 import pytest
 
 from narwhals.utils import generate_temporary_column_name
+from tests.utils import PANDAS_VERSION
 
 if TYPE_CHECKING:
     import duckdb
@@ -218,6 +219,11 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     constructors_ids: list[str] = []
 
     for constructor in selected_constructors:
+        if constructor in ("pandas[nullable]", "pandas[pyarrow]") and PANDAS_VERSION < (
+            1,
+            5,
+        ):
+            continue
         if constructor in EAGER_CONSTRUCTORS:
             eager_constructors.append(EAGER_CONSTRUCTORS[constructor])
             eager_constructors_ids.append(constructor)

--- a/tests/expr_and_series/operators_test.py
+++ b/tests/expr_and_series/operators_test.py
@@ -91,7 +91,7 @@ def test_logic_operators_expr_scalar(
         "dask" in str(constructor)
         and DASK_VERSION < (2024, 10)
         and operator in ("__rand__", "__ror__")
-    ) or ("pyspark" in str(constructor) and operator in ("__and__", "__or__")):
+    ):
         request.applymarker(pytest.mark.xfail)
     data = {"a": [True, True, False, False]}
     df = nw.from_native(constructor(data))


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
