### PR TITLE
chore: remove unused `_depth` from `DuckDBExpr` and `SparkLikeExpr`

### DIFF
--- a/narwhals/_duckdb/expr_name.py
+++ b/narwhals/_duckdb/expr_name.py
@@ -58,7 +58,6 @@ class DuckDBExprNameNamespace:
     ) -> DuckDBExpr:
         return self._compliant_expr.__class__(
             call=self._compliant_expr._call,
-            depth=self._compliant_expr._depth,
             function_name=self._compliant_expr._function_name,
             evaluate_output_names=self._compliant_expr._evaluate_output_names,
             alias_output_names=alias_output_names,

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -53,7 +53,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
 
         return DuckDBExpr(
             call=_all,
-            depth=0,
             function_name="all",
             evaluate_output_names=lambda df: df.columns,
             alias_output_names=None,
@@ -136,7 +135,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
 
         return DuckDBExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="concat_str",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -152,7 +150,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
 
         return DuckDBExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="all_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -168,7 +165,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
 
         return DuckDBExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="or_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -184,7 +180,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
 
         return DuckDBExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="max_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -200,7 +195,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
 
         return DuckDBExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="min_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -221,7 +215,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
 
         return DuckDBExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="sum_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -245,7 +238,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
 
         return DuckDBExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="mean_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -289,7 +281,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
 
         return DuckDBExpr(
             func,
-            depth=0,
             function_name="lit",
             evaluate_output_names=lambda _df: ["literal"],
             alias_output_names=None,
@@ -304,7 +295,6 @@ class DuckDBNamespace(CompliantNamespace["duckdb.Expression"]):
 
         return DuckDBExpr(
             call=func,
-            depth=0,
             function_name="len",
             evaluate_output_names=lambda _df: ["len"],
             alias_output_names=None,
@@ -360,7 +350,6 @@ class DuckDBWhen:
 
         return DuckDBThen(
             self,
-            depth=0,
             function_name="whenthen",
             evaluate_output_names=getattr(
                 value, "_evaluate_output_names", lambda _df: ["literal"]
@@ -377,7 +366,6 @@ class DuckDBThen(DuckDBExpr):
         self: Self,
         call: DuckDBWhen,
         *,
-        depth: int,
         function_name: str,
         evaluate_output_names: Callable[[DuckDBLazyFrame], Sequence[str]],
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
@@ -388,7 +376,6 @@ class DuckDBThen(DuckDBExpr):
         self._backend_version = backend_version
         self._version = version
         self._call = call
-        self._depth = depth
         self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names
         self._alias_output_names = alias_output_names

--- a/narwhals/_duckdb/selectors.py
+++ b/narwhals/_duckdb/selectors.py
@@ -37,7 +37,6 @@ class DuckDBSelectorNamespace:
 
         return DuckDBSelector(
             func,
-            depth=0,
             function_name="selector",
             evaluate_output_names=evalute_output_names,
             alias_output_names=None,
@@ -83,7 +82,6 @@ class DuckDBSelectorNamespace:
 
         return DuckDBSelector(
             func,
-            depth=0,
             function_name="selector",
             evaluate_output_names=lambda df: df.columns,
             alias_output_names=None,
@@ -95,16 +93,11 @@ class DuckDBSelectorNamespace:
 
 class DuckDBSelector(DuckDBExpr):
     def __repr__(self: Self) -> str:  # pragma: no cover
-        return (
-            f"DuckDBSelector("
-            f"depth={self._depth}, "
-            f"function_name={self._function_name})"
-        )
+        return f"DuckDBSelector(" f"function_name={self._function_name})"
 
     def _to_expr(self: Self) -> DuckDBExpr:
         return DuckDBExpr(
             self._call,
-            depth=self._depth,
             function_name=self._function_name,
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=self._alias_output_names,
@@ -129,7 +122,6 @@ class DuckDBSelector(DuckDBExpr):
 
             return DuckDBSelector(
                 call,
-                depth=0,
                 function_name="selector",
                 evaluate_output_names=evaluate_output_names,
                 alias_output_names=None,
@@ -160,7 +152,6 @@ class DuckDBSelector(DuckDBExpr):
 
             return DuckDBSelector(
                 call,
-                depth=0,
                 function_name="selector",
                 evaluate_output_names=evaluate_output_names,
                 alias_output_names=None,
@@ -187,7 +178,6 @@ class DuckDBSelector(DuckDBExpr):
 
             return DuckDBSelector(
                 call,
-                depth=0,
                 function_name="selector",
                 evaluate_output_names=evaluate_output_names,
                 alias_output_names=None,

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -31,12 +31,12 @@ if TYPE_CHECKING:
 
 class SparkLikeExpr(CompliantExpr["Column"]):
     _implementation = Implementation.PYSPARK
+    _depth = 0  # Unused, just for compatibility with CompliantExpr
 
     def __init__(
         self: Self,
         call: Callable[[SparkLikeLazyFrame], list[Column]],
         *,
-        depth: int,
         function_name: str,
         evaluate_output_names: Callable[[SparkLikeLazyFrame], Sequence[str]],
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
@@ -47,7 +47,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         version: Version,
     ) -> None:
         self._call = call
-        self._depth = depth
         self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names
         self._alias_output_names = alias_output_names
@@ -80,7 +79,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
         return cls(
             func,
-            depth=0,
             function_name="col",
             evaluate_output_names=lambda _df: list(column_names),
             alias_output_names=None,
@@ -102,7 +100,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
         return cls(
             func,
-            depth=0,
             function_name="nth",
             evaluate_output_names=lambda df: [df.columns[i] for i in column_indices],
             alias_output_names=None,
@@ -132,7 +129,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
         return self.__class__(
             func,
-            depth=self._depth + 1,
             function_name=f"{self._function_name}->{expr_name}",
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=self._alias_output_names,
@@ -281,11 +277,8 @@ class SparkLikeExpr(CompliantExpr["Column"]):
                 raise ValueError(msg)
             return [name]
 
-        # Define this one manually, so that we can
-        # override `output_names` and not increase depth
         return self.__class__(
             self._call,
-            depth=self._depth,
             function_name=self._function_name,
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=alias_output_names,
@@ -487,7 +480,6 @@ class SparkLikeExpr(CompliantExpr["Column"]):
 
         return self.__class__(
             func,
-            depth=self._depth + 1,
             function_name=self._function_name + "->over",
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=self._alias_output_names,

--- a/narwhals/_spark_like/expr_name.py
+++ b/narwhals/_spark_like/expr_name.py
@@ -58,7 +58,6 @@ class SparkLikeExprNameNamespace:
     ) -> SparkLikeExpr:
         return self._compliant_expr.__class__(
             self._compliant_expr._call,
-            depth=self._compliant_expr._depth,
             function_name=self._compliant_expr._function_name,
             evaluate_output_names=self._compliant_expr._evaluate_output_names,
             alias_output_names=alias_output_names,

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -47,7 +47,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
 
         return SparkLikeExpr(
             call=_all,
-            depth=0,
             function_name="all",
             evaluate_output_names=lambda df: df.columns,
             alias_output_names=None,
@@ -78,7 +77,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
 
         return SparkLikeExpr(
             call=_lit,
-            depth=0,
             function_name="lit",
             evaluate_output_names=lambda _df: ["literal"],
             alias_output_names=None,
@@ -93,7 +91,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
 
         return SparkLikeExpr(
             func,
-            depth=0,
             function_name="len",
             evaluate_output_names=lambda _df: ["len"],
             alias_output_names=None,
@@ -109,7 +106,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
 
         return SparkLikeExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="all_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -125,7 +121,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
 
         return SparkLikeExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="any_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -146,7 +141,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
 
         return SparkLikeExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="sum_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -170,7 +164,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
 
         return SparkLikeExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="mean_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -186,7 +179,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
 
         return SparkLikeExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="max_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -202,7 +194,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
 
         return SparkLikeExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="min_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -295,7 +286,6 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
 
         return SparkLikeExpr(
             call=func,
-            depth=max(x._depth for x in exprs) + 1,
             function_name="concat_str",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
@@ -352,7 +342,6 @@ class SparkLikeWhen:
 
         return SparkLikeThen(
             self,
-            depth=0,
             function_name="whenthen",
             evaluate_output_names=getattr(
                 value, "_evaluate_output_names", lambda _df: ["literal"]
@@ -369,7 +358,6 @@ class SparkLikeThen(SparkLikeExpr):
         self: Self,
         call: SparkLikeWhen,
         *,
-        depth: int,
         function_name: str,
         evaluate_output_names: Callable[[SparkLikeLazyFrame], Sequence[str]],
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
@@ -380,7 +368,6 @@ class SparkLikeThen(SparkLikeExpr):
         self._backend_version = backend_version
         self._version = version
         self._call = call
-        self._depth = depth
         self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names
         self._alias_output_names = alias_output_names

--- a/narwhals/_spark_like/selectors.py
+++ b/narwhals/_spark_like/selectors.py
@@ -34,7 +34,6 @@ class SparkLikeSelectorNamespace:
 
         return SparkLikeSelector(
             func,
-            depth=0,
             function_name="selector",
             evaluate_output_names=evalute_output_names,
             alias_output_names=None,
@@ -80,7 +79,6 @@ class SparkLikeSelectorNamespace:
 
         return SparkLikeSelector(
             func,
-            depth=0,
             function_name="selector",
             evaluate_output_names=lambda df: df.columns,
             alias_output_names=None,
@@ -92,16 +90,11 @@ class SparkLikeSelectorNamespace:
 
 class SparkLikeSelector(SparkLikeExpr):
     def __repr__(self: Self) -> str:  # pragma: no cover
-        return (
-            f"SparkLikeSelector("
-            f"depth={self._depth}, "
-            f"function_name={self._function_name})"
-        )
+        return f"SparkLikeSelector(" f"function_name={self._function_name})"
 
     def _to_expr(self: Self) -> SparkLikeExpr:
         return SparkLikeExpr(
             self._call,
-            depth=self._depth,
             function_name=self._function_name,
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=self._alias_output_names,
@@ -126,7 +119,6 @@ class SparkLikeSelector(SparkLikeExpr):
 
             return SparkLikeSelector(
                 call,
-                depth=0,
                 function_name="selector",
                 evaluate_output_names=evaluate_output_names,
                 alias_output_names=None,
@@ -157,7 +149,6 @@ class SparkLikeSelector(SparkLikeExpr):
 
             return SparkLikeSelector(
                 call,
-                depth=0,
                 function_name="selector",
                 evaluate_output_names=evaluate_output_names,
                 alias_output_names=None,
@@ -184,7 +175,6 @@ class SparkLikeSelector(SparkLikeExpr):
 
             return SparkLikeSelector(
                 call,
-                depth=0,
                 function_name="selector",
                 evaluate_output_names=evaluate_output_names,
                 alias_output_names=None,


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
