### PR TITLE
feat: start (silently) adding support for SQLFrame

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -29,6 +29,6 @@ jobs:
       - name: griffe
         # hopefully temporary until https://github.com/mkdocstrings/mkdocstrings/issues/716
         run: pip install git+https://github.com/MarcoGorelli/griffe.git@no-overloads
-      - run: pip install -e .[docs,pyspark,dask,duckdb]
+      - run: pip install -e .[docs,dask,duckdb]
 
       - run: mkdocs gh-deploy --force

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -76,11 +76,7 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
         return Window
 
     def __native_namespace__(self: Self) -> ModuleType:  # pragma: no cover
-        if self._implementation in (Implementation.PYSPARK, Implementation.SQLFRAME):
-            return self._implementation.to_native_namespace()
-
-        msg = f"Expected pyspark, got: {type(self._implementation)}"  # pragma: no cover
-        raise AssertionError(msg)
+        return self._implementation.to_native_namespace()
 
     def __narwhals_namespace__(self: Self) -> SparkLikeNamespace:
         from narwhals._spark_like.namespace import SparkLikeNamespace
@@ -138,11 +134,10 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
 
         if not new_columns:
             # return empty dataframe, like Polars does
-            raise AssertionError
-            from pyspark.sql.types import StructType
-
             spark_session = self._native_frame.sparkSession
-            spark_df = spark_session.createDataFrame([], StructType([]))
+            spark_df = spark_session.createDataFrame(
+                [], self._native_dtypes.StructType([])
+            )
 
             return self._from_native_frame(spark_df)
 

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -186,7 +186,7 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
             field.name: native_to_narwhals_dtype(
                 dtype=field.dataType,
                 version=self._version,
-                spark_types=self._native_dtypes(),
+                spark_types=self._native_dtypes,
             )
             for field in self._native_frame.schema
         }

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -37,7 +37,7 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
         *,
         backend_version: tuple[int, ...],
         version: Version,
-        implementation: Implementation = Implementation.SQLFRAME,
+        implementation: Implementation,
     ) -> None:
         self._native_frame = native_dataframe
         self._backend_version = backend_version
@@ -86,7 +86,9 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
         from narwhals._spark_like.namespace import SparkLikeNamespace
 
         return SparkLikeNamespace(
-            backend_version=self._backend_version, version=self._version
+            backend_version=self._backend_version,
+            version=self._version,
+            implementation=self._implementation,
         )
 
     def __narwhals_lazyframe__(self: Self) -> Self:
@@ -94,12 +96,18 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
 
     def _change_version(self: Self, version: Version) -> Self:
         return self.__class__(
-            self._native_frame, backend_version=self._backend_version, version=version
+            self._native_frame,
+            backend_version=self._backend_version,
+            version=version,
+            implementation=self._implementation,
         )
 
     def _from_native_frame(self: Self, df: DataFrame) -> Self:
         return self.__class__(
-            df, backend_version=self._backend_version, version=self._version
+            df,
+            backend_version=self._backend_version,
+            version=self._version,
+            implementation=self._implementation,
         )
 
     @property

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -51,7 +51,9 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
             from sqlframe.duckdb import functions
 
             return functions
-        raise AssertionError
+        from pyspark.sql import functions
+
+        return functions
 
     @property
     def _native_dtypes(self) -> Any:
@@ -59,7 +61,9 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
             from sqlframe.duckdb import types
 
             return types
-        raise AssertionError
+        from pyspark.sql import types
+
+        return types
 
     @property
     def _Window(self) -> Any:  # noqa: N802
@@ -67,7 +71,9 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
             from sqlframe.duckdb import Window
 
             return Window
-        raise AssertionError
+        from pyspark.sql import Window
+
+        return Window
 
     def __native_namespace__(self: Self) -> ModuleType:  # pragma: no cover
         if self._implementation in (Implementation.PYSPARK, Implementation.SQLFRAME):

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -70,7 +70,7 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
         raise AssertionError
 
     def __native_namespace__(self: Self) -> ModuleType:  # pragma: no cover
-        if self._implementation in (Implementation.PYSPARK, Implementation.SQLFrame):
+        if self._implementation in (Implementation.PYSPARK, Implementation.SQLFRAME):
             return self._implementation.to_native_namespace()
 
         msg = f"Expected pyspark, got: {type(self._implementation)}"  # pragma: no cover
@@ -320,5 +320,5 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
             )
 
         return self._from_native_frame(
-            self_native.join(other=other, on=left_on, how=how).select(col_order)
+            self_native.join(other, on=left_on, how=how).select(col_order)
         )

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -331,7 +331,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
     def cast(self: Self, dtype: DType | type[DType]) -> Self:
         def _cast(_input: Column) -> Column:
             spark_dtype = narwhals_to_native_dtype(
-                dtype, self._version, self._native_types()
+                dtype, self._version, self._native_types
             )
             return _input.cast(spark_dtype)
 
@@ -514,7 +514,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
     def n_unique(self: Self) -> Self:
         def _n_unique(_input: Column) -> Column:
             return self._F.count_distinct(_input) + self._F.max(
-                self._F.isnull(_input).cast(self._native_types().IntegerType())
+                self._F.isnull(_input).cast(self._native_types.IntegerType())
             )
 
         return self._from_call(_n_unique, "n_unique", expr_kind=ExprKind.AGGREGATION)

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -471,13 +471,14 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         return self._from_call(_is_duplicated, "is_duplicated", expr_kind=self._expr_kind)
 
     def is_finite(self: Self) -> Self:
+        F = self._get_functions()
         def _is_finite(_input: Column) -> Column:
             # A value is finite if it's not NaN, and not infinite, while NULLs should be
             # preserved
             is_finite_condition = (
                 ~self._get_functions().isnan(_input)
-                & (_input != float("inf"))
-                & (_input != float("-inf"))
+                & (_input != F.lit(float("inf")))
+                & (_input != F.lit(float("-inf")))
             )
             return (
                 self._get_functions()

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -40,7 +40,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         expr_kind: ExprKind,
         backend_version: tuple[int, ...],
         version: Version,
-        implementation: Implementation = Implementation.SQLFRAME,
+        implementation: Implementation,
     ) -> None:
         self._call = call
         self._function_name = function_name
@@ -91,7 +91,9 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         from narwhals._spark_like.namespace import SparkLikeNamespace
 
         return SparkLikeNamespace(
-            backend_version=self._backend_version, version=self._version
+            backend_version=self._backend_version,
+            version=self._version,
+            implementation=self._implementation,
         )
 
     @classmethod
@@ -100,6 +102,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         *column_names: str,
         backend_version: tuple[int, ...],
         version: Version,
+        implementation: Implementation,
     ) -> Self:
         def func(df: SparkLikeLazyFrame) -> list[Column]:
             return [df._F.col(col_name) for col_name in column_names]
@@ -112,6 +115,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             expr_kind=ExprKind.TRANSFORM,
             backend_version=backend_version,
             version=version,
+            implementation=implementation,
         )
 
     @classmethod
@@ -120,6 +124,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
         *column_indices: int,
         backend_version: tuple[int, ...],
         version: Version,
+        implementation: Implementation,
     ) -> Self:
         def func(df: SparkLikeLazyFrame) -> list[Column]:
             columns = df.columns
@@ -133,6 +138,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             expr_kind=ExprKind.TRANSFORM,
             backend_version=backend_version,
             version=version,
+            implementation=implementation,
         )
 
     def _from_call(
@@ -162,6 +168,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             expr_kind=expr_kind,
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def __eq__(self: Self, other: SparkLikeExpr) -> Self:  # type: ignore[override]
@@ -312,6 +319,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             expr_kind=self._expr_kind,
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def all(self: Self) -> Self:
@@ -528,6 +536,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
             expr_kind=ExprKind.TRANSFORM,
         )
 

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -60,7 +60,9 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             from sqlframe.duckdb import functions
 
             return functions
-        raise AssertionError
+        from pyspark.sql import functions
+
+        return functions
 
     @property
     def _native_types(self) -> Any:
@@ -68,7 +70,9 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             from sqlframe.duckdb import types
 
             return types
-        raise AssertionError
+        from pyspark.sql import types
+
+        return types
 
     @property
     def _Window(self) -> Any:  # noqa: N802
@@ -76,7 +80,9 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             from sqlframe.duckdb import Window
 
             return Window
-        raise AssertionError
+        from pyspark.sql import Window
+
+        return Window
 
     def __narwhals_expr__(self: Self) -> None: ...
 

--- a/narwhals/_spark_like/expr_dt.py
+++ b/narwhals/_spark_like/expr_dt.py
@@ -15,56 +15,56 @@ class SparkLikeExprDateTimeNamespace:
 
     def date(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            F.to_date,
+            self._compliant_expr._get_functions().to_date,
             "date",
             expr_kind=self._compliant_expr._expr_kind,
         )
 
     def year(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            F.year,
+            self._compliant_expr._get_functions().year,
             "year",
             expr_kind=self._compliant_expr._expr_kind,
         )
 
     def month(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            F.month,
+            self._compliant_expr._get_functions().month,
             "month",
             expr_kind=self._compliant_expr._expr_kind,
         )
 
     def day(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            F.day,
+            self._compliant_expr._get_functions().day,
             "day",
             expr_kind=self._compliant_expr._expr_kind,
         )
 
     def hour(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            F.hour,
+            self._compliant_expr._get_functions().hour,
             "hour",
             expr_kind=self._compliant_expr._expr_kind,
         )
 
     def minute(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            F.minute,
+            self._compliant_expr._get_functions().minute,
             "minute",
             expr_kind=self._compliant_expr._expr_kind,
         )
 
     def second(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            F.second,
+            self._compliant_expr._get_functions().second,
             "second",
             expr_kind=self._compliant_expr._expr_kind,
         )
 
     def millisecond(self: Self) -> SparkLikeExpr:
         def _millisecond(_input: Column) -> Column:
-            return F.floor((F.unix_micros(_input) % 1_000_000) / 1000)
+            return self._compliant_expr._get_functions().floor((self._compliant_expr._get_functions().unix_micros(_input) % 1_000_000) / 1000)
 
         return self._compliant_expr._from_call(
             _millisecond,
@@ -74,7 +74,7 @@ class SparkLikeExprDateTimeNamespace:
 
     def microsecond(self: Self) -> SparkLikeExpr:
         def _microsecond(_input: Column) -> Column:
-            return F.unix_micros(_input) % 1_000_000
+            return self._compliant_expr._get_functions().unix_micros(_input) % 1_000_000
 
         return self._compliant_expr._from_call(
             _microsecond,
@@ -84,7 +84,7 @@ class SparkLikeExprDateTimeNamespace:
 
     def nanosecond(self: Self) -> SparkLikeExpr:
         def _nanosecond(_input: Column) -> Column:
-            return (F.unix_micros(_input) % 1_000_000) * 1000
+            return (self._compliant_expr._get_functions().unix_micros(_input) % 1_000_000) * 1000
 
         return self._compliant_expr._from_call(
             _nanosecond,
@@ -94,7 +94,7 @@ class SparkLikeExprDateTimeNamespace:
 
     def ordinal_day(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            F.dayofyear,
+            self._compliant_expr._get_functions().dayofyear,
             "ordinal_day",
             expr_kind=self._compliant_expr._expr_kind,
         )
@@ -102,7 +102,7 @@ class SparkLikeExprDateTimeNamespace:
     def weekday(self: Self) -> SparkLikeExpr:
         def _weekday(_input: Column) -> Column:
             # PySpark's dayofweek returns 1-7 for Sunday-Saturday
-            return (F.dayofweek(_input) + 6) % 7
+            return (self._compliant_expr._get_functions().dayofweek(_input) + 6) % 7
 
         return self._compliant_expr._from_call(
             _weekday,

--- a/narwhals/_spark_like/expr_dt.py
+++ b/narwhals/_spark_like/expr_dt.py
@@ -19,49 +19,49 @@ class SparkLikeExprDateTimeNamespace:
         return self._compliant_expr._from_call(
             F.to_date,
             "date",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def year(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
             F.year,
             "year",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def month(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
             F.month,
             "month",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def day(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
             F.day,
             "day",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def hour(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
             F.hour,
             "hour",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def minute(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
             F.minute,
             "minute",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def second(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
             F.second,
             "second",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def millisecond(self: Self) -> SparkLikeExpr:
@@ -71,7 +71,7 @@ class SparkLikeExprDateTimeNamespace:
         return self._compliant_expr._from_call(
             _millisecond,
             "millisecond",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def microsecond(self: Self) -> SparkLikeExpr:
@@ -81,7 +81,7 @@ class SparkLikeExprDateTimeNamespace:
         return self._compliant_expr._from_call(
             _microsecond,
             "microsecond",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def nanosecond(self: Self) -> SparkLikeExpr:
@@ -91,14 +91,14 @@ class SparkLikeExprDateTimeNamespace:
         return self._compliant_expr._from_call(
             _nanosecond,
             "nanosecond",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def ordinal_day(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
             F.dayofyear,
             "ordinal_day",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def weekday(self: Self) -> SparkLikeExpr:
@@ -109,5 +109,5 @@ class SparkLikeExprDateTimeNamespace:
         return self._compliant_expr._from_call(
             _weekday,
             "weekday",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )

--- a/narwhals/_spark_like/expr_dt.py
+++ b/narwhals/_spark_like/expr_dt.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pyspark.sql import functions as F  # noqa: N812
-
 if TYPE_CHECKING:
     from pyspark.sql import Column
     from typing_extensions import Self

--- a/narwhals/_spark_like/expr_name.py
+++ b/narwhals/_spark_like/expr_name.py
@@ -64,4 +64,5 @@ class SparkLikeExprNameNamespace:
             expr_kind=self._compliant_expr._expr_kind,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
+            implementation=self._compliant_expr._implementation,
         )

--- a/narwhals/_spark_like/expr_name.py
+++ b/narwhals/_spark_like/expr_name.py
@@ -61,7 +61,7 @@ class SparkLikeExprNameNamespace:
             function_name=self._compliant_expr._function_name,
             evaluate_output_names=self._compliant_expr._evaluate_output_names,
             alias_output_names=alias_output_names,
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
         )

--- a/narwhals/_spark_like/expr_str.py
+++ b/narwhals/_spark_like/expr_str.py
@@ -20,7 +20,7 @@ class SparkLikeExprStringNamespace:
         return self._compliant_expr._from_call(
             F.char_length,
             "len",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def replace_all(
@@ -33,7 +33,7 @@ class SparkLikeExprStringNamespace:
         return self._compliant_expr._from_call(
             func,
             "replace",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def strip_chars(self: Self, characters: str | None) -> SparkLikeExpr:
@@ -46,21 +46,21 @@ class SparkLikeExprStringNamespace:
         return self._compliant_expr._from_call(
             func,
             "strip",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def starts_with(self: Self, prefix: str) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
             lambda _input: F.startswith(_input, F.lit(prefix)),
             "starts_with",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def ends_with(self: Self, suffix: str) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
             lambda _input: F.endswith(_input, F.lit(suffix)),
             "ends_with",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def contains(self: Self, pattern: str, *, literal: bool) -> SparkLikeExpr:
@@ -71,7 +71,7 @@ class SparkLikeExprStringNamespace:
         return self._compliant_expr._from_call(
             func,
             "contains",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def slice(self: Self, offset: int, length: int | None) -> SparkLikeExpr:
@@ -87,21 +87,21 @@ class SparkLikeExprStringNamespace:
         return self._compliant_expr._from_call(
             func,
             "slice",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def to_uppercase(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
             F.upper,
             "to_uppercase",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def to_lowercase(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
             F.lower,
             "to_lowercase",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
     def to_datetime(self: Self, format: str | None) -> SparkLikeExpr:  # noqa: A002
@@ -111,7 +111,7 @@ class SparkLikeExprStringNamespace:
                 format=strptime_to_pyspark_format(format),
             ),
             "to_datetime",
-            returns_scalar=self._compliant_expr._returns_scalar,
+            expr_kind=self._compliant_expr._expr_kind,
         )
 
 

--- a/narwhals/_spark_like/expr_str.py
+++ b/narwhals/_spark_like/expr_str.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import overload
 
-from pyspark.sql import functions as F  # noqa: N812
-
 if TYPE_CHECKING:
     from pyspark.sql import Column
     from typing_extensions import Self
@@ -18,7 +16,7 @@ class SparkLikeExprStringNamespace:
 
     def len_chars(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            F.char_length,
+            self._compliant_expr._get_functions().char_length,
             "len",
             expr_kind=self._compliant_expr._expr_kind,
         )
@@ -27,8 +25,16 @@ class SparkLikeExprStringNamespace:
         self: Self, pattern: str, value: str, *, literal: bool
     ) -> SparkLikeExpr:
         def func(_input: Column) -> Column:
-            replace_all_func = F.replace if literal else F.regexp_replace
-            return replace_all_func(_input, F.lit(pattern), F.lit(value))
+            replace_all_func = (
+                self._compliant_expr._get_functions().replace
+                if literal
+                else self._compliant_expr._get_functions().regexp_replace
+            )
+            return replace_all_func(
+                _input,
+                self._compliant_expr._get_functions().lit(pattern),
+                self._compliant_expr._get_functions().lit(value),
+            )
 
         return self._compliant_expr._from_call(
             func,
@@ -41,7 +47,9 @@ class SparkLikeExprStringNamespace:
 
         def func(_input: Column) -> Column:
             to_remove = characters if characters is not None else string.whitespace
-            return F.btrim(_input, F.lit(to_remove))
+            return self._compliant_expr._get_functions().btrim(
+                _input, self._compliant_expr._get_functions().lit(to_remove)
+            )
 
         return self._compliant_expr._from_call(
             func,
@@ -51,22 +59,32 @@ class SparkLikeExprStringNamespace:
 
     def starts_with(self: Self, prefix: str) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            lambda _input: F.startswith(_input, F.lit(prefix)),
+            lambda _input: self._compliant_expr._get_functions().startswith(
+                _input, self._compliant_expr._get_functions().lit(prefix)
+            ),
             "starts_with",
             expr_kind=self._compliant_expr._expr_kind,
         )
 
     def ends_with(self: Self, suffix: str) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            lambda _input: F.endswith(_input, F.lit(suffix)),
+            lambda _input: self._compliant_expr._get_functions().endswith(
+                _input, self._compliant_expr._get_functions().lit(suffix)
+            ),
             "ends_with",
             expr_kind=self._compliant_expr._expr_kind,
         )
 
     def contains(self: Self, pattern: str, *, literal: bool) -> SparkLikeExpr:
         def func(_input: Column) -> Column:
-            contains_func = F.contains if literal else F.regexp
-            return contains_func(_input, F.lit(pattern))
+            contains_func = (
+                self._compliant_expr._get_functions().contains
+                if literal
+                else self._compliant_expr._get_functions().regexp
+            )
+            return contains_func(
+                _input, self._compliant_expr._get_functions().lit(pattern)
+            )
 
         return self._compliant_expr._from_call(
             func,
@@ -78,10 +96,18 @@ class SparkLikeExprStringNamespace:
         # From the docs: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.substring.html
         # The position is not zero based, but 1 based index.
         def func(_input: Column) -> Column:
-            col_length = F.char_length(_input)
+            col_length = self._compliant_expr._get_functions().char_length(_input)
 
-            _offset = col_length + F.lit(offset + 1) if offset < 0 else F.lit(offset + 1)
-            _length = F.lit(length) if length is not None else col_length
+            _offset = (
+                col_length + self._compliant_expr._get_functions().lit(offset + 1)
+                if offset < 0
+                else self._compliant_expr._get_functions().lit(offset + 1)
+            )
+            _length = (
+                self._compliant_expr._get_functions().lit(length)
+                if length is not None
+                else col_length
+            )
             return _input.substr(_offset, _length)
 
         return self._compliant_expr._from_call(
@@ -92,22 +118,26 @@ class SparkLikeExprStringNamespace:
 
     def to_uppercase(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            F.upper,
+            self._compliant_expr._get_functions().upper,
             "to_uppercase",
             expr_kind=self._compliant_expr._expr_kind,
         )
 
     def to_lowercase(self: Self) -> SparkLikeExpr:
         return self._compliant_expr._from_call(
-            F.lower,
+            self._compliant_expr._get_functions().lower,
             "to_lowercase",
             expr_kind=self._compliant_expr._expr_kind,
         )
 
     def to_datetime(self: Self, format: str | None) -> SparkLikeExpr:  # noqa: A002
         return self._compliant_expr._from_call(
-            lambda _input: F.to_timestamp(
-                F.replace(_input, F.lit("T"), F.lit(" ")),
+            lambda _input: self._compliant_expr._get_functions().to_timestamp(
+                self._compliant_expr._get_functions().replace(
+                    _input,
+                    self._compliant_expr._get_functions().lit("T"),
+                    self._compliant_expr._get_functions().lit(" "),
+                ),
                 format=strptime_to_pyspark_format(format),
             ),
             "to_datetime",

--- a/narwhals/_spark_like/group_by.py
+++ b/narwhals/_spark_like/group_by.py
@@ -52,7 +52,6 @@ class SparkLikeLazyGroupBy:
             return self._compliant_frame._from_native_frame(
                 self._compliant_frame._native_frame.select(*self._keys).dropDuplicates()
             )
-
         return self._compliant_frame._from_native_frame(
-            self._compliant_frame._native_frame.groupBy(self._keys).agg(*agg_columns)
+            self._compliant_frame._native_frame.groupBy(*self._keys).agg(*agg_columns)
         )

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -24,20 +24,28 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from narwhals.dtypes import DType
+    from narwhals.utils import Implementation
     from narwhals.utils import Version
 
 
 class SparkLikeNamespace(CompliantNamespace["Column"]):
     def __init__(
-        self: Self, *, backend_version: tuple[int, ...], version: Version
+        self: Self,
+        *,
+        backend_version: tuple[int, ...],
+        version: Version,
+        implementation: Implementation,
     ) -> None:
         self._backend_version = backend_version
         self._version = version
+        self._implementation = implementation
 
     @property
     def selectors(self: Self) -> SparkLikeSelectorNamespace:
         return SparkLikeSelectorNamespace(
-            backend_version=self._backend_version, version=self._version
+            backend_version=self._backend_version,
+            version=self._version,
+            implementation=self._implementation,
         )
 
     def all(self: Self) -> SparkLikeExpr:
@@ -52,16 +60,23 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             expr_kind=ExprKind.TRANSFORM,
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def col(self: Self, *column_names: str) -> SparkLikeExpr:
         return SparkLikeExpr.from_column_names(
-            *column_names, backend_version=self._backend_version, version=self._version
+            *column_names,
+            backend_version=self._backend_version,
+            version=self._version,
+            implementation=self._implementation,
         )
 
     def nth(self: Self, *column_indices: int) -> SparkLikeExpr:
         return SparkLikeExpr.from_column_indices(
-            *column_indices, backend_version=self._backend_version, version=self._version
+            *column_indices,
+            backend_version=self._backend_version,
+            version=self._version,
+            implementation=self._implementation,
         )
 
     def lit(self: Self, value: object, dtype: DType | None) -> SparkLikeExpr:
@@ -80,6 +95,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             expr_kind=ExprKind.LITERAL,
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def len(self: Self) -> SparkLikeExpr:
@@ -94,6 +110,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             expr_kind=ExprKind.AGGREGATION,
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def all_horizontal(self: Self, *exprs: SparkLikeExpr) -> SparkLikeExpr:
@@ -109,6 +126,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def any_horizontal(self: Self, *exprs: SparkLikeExpr) -> SparkLikeExpr:
@@ -124,6 +142,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def sum_horizontal(self: Self, *exprs: SparkLikeExpr) -> SparkLikeExpr:
@@ -144,6 +163,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def mean_horizontal(self: Self, *exprs: SparkLikeExpr) -> SparkLikeExpr:
@@ -173,6 +193,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def max_horizontal(self: Self, *exprs: SparkLikeExpr) -> SparkLikeExpr:
@@ -188,6 +209,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def min_horizontal(self: Self, *exprs: SparkLikeExpr) -> SparkLikeExpr:
@@ -203,6 +225,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def concat(
@@ -235,6 +258,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
                 native_dataframe=reduce(lambda x, y: x.union(y), dfs),
                 backend_version=self._backend_version,
                 version=self._version,
+                implementation=self._implementation,
             )
 
         if how == "diagonal":
@@ -244,6 +268,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
                 ),
                 backend_version=self._backend_version,
                 version=self._version,
+                implementation=self._implementation,
             )
         raise NotImplementedError
 
@@ -300,16 +325,22 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def when(self: Self, *predicates: SparkLikeExpr) -> SparkLikeWhen:
-        plx = self.__class__(backend_version=self._backend_version, version=self._version)
+        plx = self.__class__(
+            backend_version=self._backend_version,
+            version=self._version,
+            implementation=self._implementation,
+        )
         condition = plx.all_horizontal(*predicates)
         return SparkLikeWhen(
             condition,
             self._backend_version,
             expr_kind=ExprKind.TRANSFORM,
             version=self._version,
+            implementation=self._implementation,
         )
 
 
@@ -323,6 +354,7 @@ class SparkLikeWhen:
         *,
         expr_kind: ExprKind,
         version: Version,
+        implementation: Implementation,
     ) -> None:
         self._backend_version = backend_version
         self._condition = condition
@@ -330,6 +362,7 @@ class SparkLikeWhen:
         self._otherwise_value = otherwise_value
         self._expr_kind = expr_kind
         self._version = version
+        self._implementation = implementation
 
     def __call__(self: Self, df: SparkLikeLazyFrame) -> list[Column]:
         condition = self._condition(df)[0]
@@ -361,6 +394,7 @@ class SparkLikeWhen:
             expr_kind=self._expr_kind,
             backend_version=self._backend_version,
             version=self._version,
+            implementation=self._implementation,
         )
 
 
@@ -375,6 +409,7 @@ class SparkLikeThen(SparkLikeExpr):
         expr_kind: ExprKind,
         backend_version: tuple[int, ...],
         version: Version,
+        implementation: Implementation,
     ) -> None:
         self._backend_version = backend_version
         self._version = version
@@ -383,6 +418,7 @@ class SparkLikeThen(SparkLikeExpr):
         self._evaluate_output_names = evaluate_output_names
         self._alias_output_names = alias_output_names
         self._expr_kind = expr_kind
+        self._implementation = implementation
 
     def otherwise(self: Self, value: SparkLikeExpr | Any) -> SparkLikeExpr:
         # type ignore because we are setting the `_call` attribute to a

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -164,7 +164,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
                     / reduce(
                         operator.add,
                         (
-                            col.isNotNull().cast(df._get_spark_dtypes().IntegerType())
+                            col.isNotNull().cast(df._get_spark_types().IntegerType())
                             for col in cols
                         ),
                     )
@@ -259,11 +259,9 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
         separator: str,
         ignore_nulls: bool,
     ) -> SparkLikeExpr:
-        from pyspark.sql.types import StringType
-
         def func(df: SparkLikeLazyFrame) -> list[Column]:
             cols = [s for _expr in exprs for s in _expr(df)]
-            cols_casted = [s.cast(StringType()) for s in cols]
+            cols_casted = [s.cast(df._get_spark_types().StringType()) for s in cols]
             null_mask = [
                 df._get_functions().isnull(s) for _expr in exprs for s in _expr(df)
             ]

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -18,6 +18,7 @@ from narwhals._spark_like.dataframe import SparkLikeLazyFrame
 from narwhals._spark_like.expr import SparkLikeExpr
 from narwhals._spark_like.selectors import SparkLikeSelectorNamespace
 from narwhals._spark_like.utils import ExprKind
+from narwhals._spark_like.utils import n_ary_operation_expr_kind
 from narwhals.typing import CompliantNamespace
 
 if TYPE_CHECKING:
@@ -81,7 +82,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             function_name="lit",
             evaluate_output_names=lambda _df: ["literal"],
             alias_output_names=None,
-            expr_kind=ExprKind.AGGREGATION,
+            expr_kind=ExprKind.LITERAL,
             backend_version=self._backend_version,
             version=self._version,
         )
@@ -110,7 +111,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             function_name="all_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            expr_kind=ExprKind.TRANSFORM,
+            expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
         )
@@ -125,7 +126,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             function_name="any_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            expr_kind=ExprKind.TRANSFORM,
+            expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
         )
@@ -145,7 +146,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             function_name="sum_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            expr_kind=ExprKind.TRANSFORM,
+            expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
         )
@@ -168,7 +169,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             function_name="mean_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            expr_kind=ExprKind.TRANSFORM,
+            expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
         )
@@ -183,7 +184,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             function_name="max_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            expr_kind=ExprKind.TRANSFORM,
+            expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
         )
@@ -198,7 +199,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             function_name="min_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            expr_kind=ExprKind.TRANSFORM,
+            expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
         )
@@ -290,7 +291,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
             function_name="concat_str",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            expr_kind=ExprKind.TRANSFORM,
+            expr_kind=n_ary_operation_expr_kind(*exprs),
             backend_version=self._backend_version,
             version=self._version,
         )

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -285,25 +285,21 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
 
             if not ignore_nulls:
                 null_mask_result = reduce(lambda x, y: x | y, null_mask)
-                result = (
-                    df._F()
-                    .when(
-                        ~null_mask_result,
-                        reduce(
-                            lambda x, y: df._F.format_string(f"%s{separator}%s", x, y),
-                            cols_casted,
-                        ),
-                    )
-                    .otherwise(df._F.lit(None))
-                )
+                result = df._F.when(
+                    ~null_mask_result,
+                    reduce(
+                        lambda x, y: df._F.format_string(f"%s{separator}%s", x, y),
+                        cols_casted,
+                    ),
+                ).otherwise(df._F.lit(None))
             else:
                 init_value, *values = [
-                    df._F().when(~nm, col).otherwise(df._F.lit(""))
+                    df._F.when(~nm, col).otherwise(df._F.lit(""))
                     for col, nm in zip(cols_casted, null_mask)
                 ]
 
                 separators = (
-                    df._F().when(nm, df._F.lit("")).otherwise(df._F.lit(separator))
+                    df._F.when(nm, df._F.lit("")).otherwise(df._F.lit(separator))
                     for nm in null_mask[:-1]
                 )
                 result = reduce(
@@ -379,7 +375,7 @@ class SparkLikeWhen:
             # `self._otherwise_value` is a scalar
             other_ = df._F.lit(self._otherwise_value)
 
-        return [df._F().when(condition=condition, value=value_).otherwise(value=other_)]
+        return [df._F.when(condition=condition, value=value_).otherwise(value=other_)]
 
     def then(self: Self, value: SparkLikeExpr | Any) -> SparkLikeThen:
         self._then_value = value

--- a/narwhals/_spark_like/selectors.py
+++ b/narwhals/_spark_like/selectors.py
@@ -7,6 +7,7 @@ from typing import Sequence
 
 from narwhals._spark_like.expr import SparkLikeExpr
 from narwhals._spark_like.utils import ExprKind
+from narwhals.utils import Implementation
 from narwhals.utils import import_dtypes_module
 
 if TYPE_CHECKING:
@@ -20,10 +21,15 @@ if TYPE_CHECKING:
 
 class SparkLikeSelectorNamespace:
     def __init__(
-        self: Self, *, backend_version: tuple[int, ...], version: Version
+        self: Self,
+        *,
+        backend_version: tuple[int, ...],
+        version: Version,
+        implementation: Implementation,
     ) -> None:
         self._backend_version = backend_version
         self._version = version
+        self._implementation = implementation
 
     def by_dtype(self: Self, dtypes: list[DType | type[DType]]) -> SparkLikeSelector:
         def func(df: SparkLikeLazyFrame) -> list[Column]:
@@ -40,6 +46,7 @@ class SparkLikeSelectorNamespace:
             backend_version=self._backend_version,
             expr_kind=ExprKind.TRANSFORM,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def matches(self: Self, pattern: str) -> SparkLikeSelector:
@@ -57,6 +64,7 @@ class SparkLikeSelectorNamespace:
             backend_version=self._backend_version,
             expr_kind=ExprKind.TRANSFORM,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def numeric(self: Self) -> SparkLikeSelector:
@@ -102,6 +110,7 @@ class SparkLikeSelectorNamespace:
             backend_version=self._backend_version,
             expr_kind=ExprKind.TRANSFORM,
             version=self._version,
+            implementation=self._implementation,
         )
 
 
@@ -118,6 +127,7 @@ class SparkLikeSelector(SparkLikeExpr):
             backend_version=self._backend_version,
             expr_kind=self._expr_kind,
             version=self._version,
+            implementation=self._implementation,
         )
 
     def __sub__(self: Self, other: SparkLikeSelector | Any) -> SparkLikeSelector | Any:
@@ -142,6 +152,7 @@ class SparkLikeSelector(SparkLikeExpr):
                 backend_version=self._backend_version,
                 expr_kind=self._expr_kind,
                 version=self._version,
+                implementation=self._implementation,
             )
         else:
             return self._to_expr() - other
@@ -172,6 +183,7 @@ class SparkLikeSelector(SparkLikeExpr):
                 backend_version=self._backend_version,
                 expr_kind=self._expr_kind,
                 version=self._version,
+                implementation=self._implementation,
             )
         else:
             return self._to_expr() | other
@@ -198,6 +210,7 @@ class SparkLikeSelector(SparkLikeExpr):
                 backend_version=self._backend_version,
                 expr_kind=self._expr_kind,
                 version=self._version,
+                implementation=self._implementation,
             )
         else:
             return self._to_expr() & other
@@ -205,7 +218,9 @@ class SparkLikeSelector(SparkLikeExpr):
     def __invert__(self: Self) -> SparkLikeSelector:
         return (
             SparkLikeSelectorNamespace(
-                backend_version=self._backend_version, version=self._version
+                backend_version=self._backend_version,
+                version=self._version,
+                implementation=self._implementation,
             ).all()
             - self
         )

--- a/narwhals/_spark_like/selectors.py
+++ b/narwhals/_spark_like/selectors.py
@@ -26,7 +26,7 @@ class SparkLikeSelectorNamespace:
 
     def by_dtype(self: Self, dtypes: list[DType | type[DType]]) -> SparkLikeSelector:
         def func(df: SparkLikeLazyFrame) -> list[Column]:
-            return [F.col(col) for col in df.columns if df.schema[col] in dtypes]
+            return [df._get_functions().col(col) for col in df.columns if df.schema[col] in dtypes]
 
         def evalute_output_names(df: SparkLikeLazyFrame) -> Sequence[str]:
             return [col for col in df.columns if df.schema[col] in dtypes]
@@ -74,7 +74,7 @@ class SparkLikeSelectorNamespace:
 
     def all(self: Self) -> SparkLikeSelector:
         def func(df: SparkLikeLazyFrame) -> list[Column]:
-            return [F.col(col) for col in df.columns]
+            return [df._get_functions().col(col) for col in df.columns]
 
         return SparkLikeSelector(
             func,

--- a/narwhals/_spark_like/selectors.py
+++ b/narwhals/_spark_like/selectors.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Sequence
 
-from pyspark.sql import functions as F  # noqa: N812
-
 from narwhals._spark_like.expr import SparkLikeExpr
 from narwhals._spark_like.utils import ExprKind
 from narwhals.utils import import_dtypes_module

--- a/narwhals/_spark_like/selectors.py
+++ b/narwhals/_spark_like/selectors.py
@@ -7,6 +7,7 @@ from typing import Sequence
 from pyspark.sql import functions as F  # noqa: N812
 
 from narwhals._spark_like.expr import SparkLikeExpr
+from narwhals._spark_like.utils import ExprKind
 from narwhals.utils import import_dtypes_module
 
 if TYPE_CHECKING:
@@ -38,7 +39,7 @@ class SparkLikeSelectorNamespace:
             evaluate_output_names=evalute_output_names,
             alias_output_names=None,
             backend_version=self._backend_version,
-            returns_scalar=False,
+            expr_kind=ExprKind.TRANSFORM,
             version=self._version,
         )
 
@@ -83,7 +84,7 @@ class SparkLikeSelectorNamespace:
             evaluate_output_names=lambda df: df.columns,
             alias_output_names=None,
             backend_version=self._backend_version,
-            returns_scalar=False,
+            expr_kind=ExprKind.TRANSFORM,
             version=self._version,
         )
 
@@ -99,7 +100,7 @@ class SparkLikeSelector(SparkLikeExpr):
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
-            returns_scalar=self._returns_scalar,
+            expr_kind=self._expr_kind,
             version=self._version,
         )
 
@@ -123,7 +124,7 @@ class SparkLikeSelector(SparkLikeExpr):
                 evaluate_output_names=evaluate_output_names,
                 alias_output_names=None,
                 backend_version=self._backend_version,
-                returns_scalar=self._returns_scalar,
+                expr_kind=self._expr_kind,
                 version=self._version,
             )
         else:
@@ -153,7 +154,7 @@ class SparkLikeSelector(SparkLikeExpr):
                 evaluate_output_names=evaluate_output_names,
                 alias_output_names=None,
                 backend_version=self._backend_version,
-                returns_scalar=self._returns_scalar,
+                expr_kind=self._expr_kind,
                 version=self._version,
             )
         else:
@@ -179,7 +180,7 @@ class SparkLikeSelector(SparkLikeExpr):
                 evaluate_output_names=evaluate_output_names,
                 alias_output_names=None,
                 backend_version=self._backend_version,
-                returns_scalar=self._returns_scalar,
+                expr_kind=self._expr_kind,
                 version=self._version,
             )
         else:

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -172,14 +172,14 @@ def _std(
     F = functions
     if np_version > (2, 0):
         if ddof == 1:
-            return F.stddev_samp(_input)
+            return functions.stddev_samp(_input)
 
-        n_rows = F.count(_input)
-        return F.stddev_samp(_input) * F.sqrt((n_rows - 1) / (n_rows - ddof))
+        n_rows = functions.count(_input)
+        return functions.stddev_samp(_input) * functions.sqrt((n_rows - 1) / (n_rows - ddof))
 
     from pyspark.pandas.spark.functions import stddev
 
-    input_col = F.col(_input) if isinstance(_input, str) else _input
+    input_col = functions.col(_input) if isinstance(_input, str) else _input
     return stddev(input_col, ddof=ddof)
 
 
@@ -189,14 +189,14 @@ def _var(
     F = functions
     if np_version > (2, 0):
         if ddof == 1:
-            return F.var_samp(_input)
+            return functions.var_samp(_input)
 
-        n_rows = F.count(_input)
-        return F.var_samp(_input) * (n_rows - 1) / (n_rows - ddof)
+        n_rows = functions.count(_input)
+        return functions.var_samp(_input) * (n_rows - 1) / (n_rows - ddof)
 
     from pyspark.pandas.spark.functions import var
 
-    input_col = F.col(_input) if isinstance(_input, str) else _input
+    input_col = functions.col(_input) if isinstance(_input, str) else _input
     return var(input_col, ddof=ddof)
 
 

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -6,11 +6,6 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 from typing import Any
 
-from pyspark.sql import Column
-from pyspark.sql import Window
-from pyspark.sql import functions as F  # noqa: N812
-from pyspark.sql import types as pyspark_types
-
 from narwhals.exceptions import UnsupportedDTypeError
 from narwhals.utils import import_dtypes_module
 from narwhals.utils import isinstance_or_issubclass
@@ -43,65 +38,66 @@ class ExprKind(Enum):
 def native_to_narwhals_dtype(
     dtype: pyspark_types.DataType,
     version: Version,
+    spark_types,
 ) -> DType:  # pragma: no cover
     dtypes = import_dtypes_module(version=version)
 
-    if isinstance(dtype, pyspark_types.DoubleType):
+    if isinstance(dtype, spark_types.DoubleType):
         return dtypes.Float64()
-    if isinstance(dtype, pyspark_types.FloatType):
+    if isinstance(dtype, spark_types.FloatType):
         return dtypes.Float32()
-    if isinstance(dtype, pyspark_types.LongType):
+    if isinstance(dtype, spark_types.LongType):
         return dtypes.Int64()
-    if isinstance(dtype, pyspark_types.IntegerType):
+    if isinstance(dtype, spark_types.IntegerType):
         return dtypes.Int32()
-    if isinstance(dtype, pyspark_types.ShortType):
+    if isinstance(dtype, spark_types.ShortType):
         return dtypes.Int16()
-    if isinstance(dtype, pyspark_types.ByteType):
+    if isinstance(dtype, spark_types.ByteType):
         return dtypes.Int8()
     string_types = [
-        pyspark_types.StringType,
-        pyspark_types.VarcharType,
-        pyspark_types.CharType,
+        spark_types.StringType,
+        spark_types.VarcharType,
+        spark_types.CharType,
     ]
     if any(isinstance(dtype, t) for t in string_types):
         return dtypes.String()
-    if isinstance(dtype, pyspark_types.BooleanType):
+    if isinstance(dtype, spark_types.BooleanType):
         return dtypes.Boolean()
-    if isinstance(dtype, pyspark_types.DateType):
+    if isinstance(dtype, spark_types.DateType):
         return dtypes.Date()
     datetime_types = [
-        pyspark_types.TimestampType,
-        pyspark_types.TimestampNTZType,
+        spark_types.TimestampType,
+        spark_types.TimestampNTZType,
     ]
     if any(isinstance(dtype, t) for t in datetime_types):
         return dtypes.Datetime()
-    if isinstance(dtype, pyspark_types.DecimalType):  # pragma: no cover
+    if isinstance(dtype, spark_types.DecimalType):  # pragma: no cover
         # TODO(unassigned): cover this in dtypes_test.py
         return dtypes.Decimal()
     return dtypes.Unknown()
 
 
 def narwhals_to_native_dtype(
-    dtype: DType | type[DType], version: Version
+    dtype: DType | type[DType], version: Version, spark_types
 ) -> pyspark_types.DataType:
     dtypes = import_dtypes_module(version)
 
     if isinstance_or_issubclass(dtype, dtypes.Float64):
-        return pyspark_types.DoubleType()
+        return spark_types.DoubleType()
     if isinstance_or_issubclass(dtype, dtypes.Float32):
-        return pyspark_types.FloatType()
+        return spark_types.FloatType()
     if isinstance_or_issubclass(dtype, dtypes.Int64):
-        return pyspark_types.LongType()
+        return spark_types.LongType()
     if isinstance_or_issubclass(dtype, dtypes.Int32):
-        return pyspark_types.IntegerType()
+        return spark_types.IntegerType()
     if isinstance_or_issubclass(dtype, dtypes.Int16):
-        return pyspark_types.ShortType()
+        return spark_types.ShortType()
     if isinstance_or_issubclass(dtype, dtypes.Int8):
-        return pyspark_types.ByteType()
+        return spark_types.ByteType()
     if isinstance_or_issubclass(dtype, dtypes.String):
-        return pyspark_types.StringType()
+        return spark_types.StringType()
     if isinstance_or_issubclass(dtype, dtypes.Boolean):
-        return pyspark_types.BooleanType()
+        return spark_types.BooleanType()
     if isinstance_or_issubclass(dtype, (dtypes.Date, dtypes.Datetime)):
         msg = "Converting to Date or Datetime dtype is not supported yet"
         raise NotImplementedError(msg)
@@ -163,12 +159,17 @@ def maybe_evaluate(df: SparkLikeLazyFrame, obj: Any, *, expr_kind: ExprKind) -> 
         if obj._expr_kind is ExprKind.AGGREGATION and expr_kind is ExprKind.TRANSFORM:
             # Returns scalar, but overall expression doesn't.
             # Let PySpark do its broadcasting
-            return column_result.over(Window.partitionBy(F.lit(1)))
+            return column_result.over(
+                df._get_window().partitionBy(df._get_functions().lit(1))
+            )
         return column_result
-    return F.lit(obj)
+    return df._get_functions().lit(obj)
 
 
-def _std(_input: Column | str, ddof: int, np_version: tuple[int, ...]) -> Column:
+def _std(
+    _input: Column | str, ddof: int, np_version: tuple[int, ...], functions
+) -> Column:
+    F = functions
     if np_version > (2, 0):
         if ddof == 1:
             return F.stddev_samp(_input)
@@ -182,7 +183,10 @@ def _std(_input: Column | str, ddof: int, np_version: tuple[int, ...]) -> Column
     return stddev(input_col, ddof=ddof)
 
 
-def _var(_input: Column | str, ddof: int, np_version: tuple[int, ...]) -> Column:
+def _var(
+    _input: Column | str, ddof: int, np_version: tuple[int, ...], functions
+) -> Column:
+    F = functions
     if np_version > (2, 0):
         if ddof == 1:
             return F.var_samp(_input)

--- a/narwhals/dependencies.py
+++ b/narwhals/dependencies.py
@@ -107,6 +107,11 @@ def get_pyspark_sql() -> Any:
     return sys.modules.get("pyspark.sql", None)
 
 
+def get_sqlframe() -> Any:
+    """Get sqlframe module (if already imported - else return None)."""
+    return sys.modules.get("sqlframe", None)
+
+
 def is_pandas_dataframe(df: Any) -> TypeGuard[pd.DataFrame]:
     """Check whether `df` is a pandas DataFrame without importing pandas."""
     return ((pd := get_pandas()) is not None and isinstance(df, pd.DataFrame)) or any(
@@ -215,6 +220,14 @@ def is_pyspark_dataframe(df: Any) -> TypeGuard[pyspark_sql.DataFrame]:
     return bool(
         (pyspark_sql := get_pyspark_sql()) is not None
         and isinstance(df, pyspark_sql.DataFrame)
+    )
+
+
+def is_sqlframe_dataframe(df: Any) -> TypeGuard[pyspark_sql.DataFrame]:
+    """Check whether `df` is a SQLFrame DataFrame without importing SQLFrame."""
+    return bool(
+        (sqlframe := get_sqlframe()) is not None
+        and isinstance(df, sqlframe.base.dataframe.BaseDataFrame)
     )
 
 

--- a/narwhals/dependencies.py
+++ b/narwhals/dependencies.py
@@ -9,6 +9,7 @@ from typing import Any
 
 if TYPE_CHECKING:
     import numpy as np
+    import sqlframe
 
     if sys.version_info >= (3, 10):
         from typing import TypeGuard
@@ -223,7 +224,7 @@ def is_pyspark_dataframe(df: Any) -> TypeGuard[pyspark_sql.DataFrame]:
     )
 
 
-def is_sqlframe_dataframe(df: Any) -> TypeGuard[pyspark_sql.DataFrame]:
+def is_sqlframe_dataframe(df: Any) -> TypeGuard[sqlframe.base.dataframe.BaseDataFrame]:
     """Check whether `df` is a SQLFrame DataFrame without importing SQLFrame."""
     return bool(
         (sqlframe := get_sqlframe()) is not None

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -380,6 +380,7 @@ def _from_native_impl(  # noqa: PLR0915
         raise ValueError(msg)
 
     # SQLFrame
+    # This one needs checking before extensions as just `hasattr` seems to raise.
     if is_sqlframe_dataframe(native_object):  # pragma: no cover
         from narwhals._spark_like.dataframe import SparkLikeLazyFrame
 
@@ -397,6 +398,7 @@ def _from_native_impl(  # noqa: PLR0915
                 native_object,
                 backend_version=backend_version,
                 version=version,
+                implementation=Implementation.SQLFRAME,
             ),
             level="lazy",
         )
@@ -750,6 +752,7 @@ def _from_native_impl(  # noqa: PLR0915
                 native_object,
                 backend_version=parse_version(get_pyspark().__version__),
                 version=version,
+                implementation=Implementation.PYSPARK,
             ),
             level="lazy",
         )

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -380,7 +380,7 @@ def _from_native_impl(  # noqa: PLR0915
         raise ValueError(msg)
 
     # SQLFrame
-    # This one needs checking before extensions as just `hasattr` seems to raise.
+    # This one needs checking before extensions as `hasattr` always returns `True`.
     if is_sqlframe_dataframe(native_object):  # pragma: no cover
         from narwhals._spark_like.dataframe import SparkLikeLazyFrame
 

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -302,7 +302,7 @@ MIN_VERSIONS: dict[Implementation, tuple[int, ...]] = {
     Implementation.DASK: (2024, 8),
     Implementation.DUCKDB: (1,),
     Implementation.IBIS: (6,),
-    Implementation.SQLFRAME: (0, 0, 0),
+    Implementation.SQLFRAME: (3, 14, 2),
 }
 
 

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -79,6 +79,8 @@ class Implementation(Enum):
     """DuckDB implementation."""
     IBIS = auto()
     """Ibis implementation."""
+    SQLFRAME = auto()
+    """SQLFrame implementation."""
 
     UNKNOWN = auto()
     """Unknown implementation."""
@@ -300,6 +302,7 @@ MIN_VERSIONS: dict[Implementation, tuple[int, ...]] = {
     Implementation.DASK: (2024, 8),
     Implementation.DUCKDB: (1,),
     Implementation.IBIS: (6,),
+    Implementation.SQLFRAME: (0, 0, 0),
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,8 +169,8 @@ filterwarnings = [
   'ignore:.*distutils Version classes are deprecated. Use packaging.version instead.*:DeprecationWarning:pyspark',
   'ignore:.*is_datetime64tz_dtype is deprecated and will be removed in a future version.*:DeprecationWarning:pyspark',
   # Warning raised by PyArrow nightly just by importing pandas
-  'ignore:.*Python binding for RankQuantileOptions not exposed:RuntimeWarning:pyarrow'
-
+  'ignore:.*Python binding for RankQuantileOptions not exposed:RuntimeWarning:pyarrow',
+  'ignore:.*pandas only supports SQLAlchemy:UserWarning'
 ]
 xfail_strict = true
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,7 +183,7 @@ def pyspark_lazy_constructor() -> Callable[[Any], IntoFrame]:  # pragma: no cove
 
 
 def sqlframe_pyspark_lazy_constructor(
-    obj,
+    obj: dict[str, Any],
 ) -> Callable[[Any], IntoFrame]:  # pragma: no cover
     from sqlframe.duckdb import DuckDBSession
 
@@ -207,8 +207,10 @@ LAZY_CONSTRUCTORS: dict[str, Callable[[Any], IntoFrame]] = {
     "dask": dask_lazy_p2_constructor,
     "polars[lazy]": polars_lazy_constructor,
     "duckdb": duckdb_lazy_constructor,
-    # "pyspark": pyspark_lazy_constructor,  # type: ignore[dict-item]
-    "pyspark": sqlframe_pyspark_lazy_constructor,  # type: ignore[dict-item]
+    "pyspark": pyspark_lazy_constructor,  # type: ignore[dict-item]
+    # We've reported several bugs to sqlframe - once they address
+    # them, we can start testing them as part of our CI.
+    # "sqlframe": pyspark_lazy_constructor,  # noqa: ERA001
 }
 GPU_CONSTRUCTORS: dict[str, Callable[[Any], IntoFrame]] = {"cudf": cudf_constructor}
 
@@ -245,8 +247,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             constructors_ids.append(constructor)
         elif constructor in LAZY_CONSTRUCTORS:
             if constructor == "pyspark":
-                if sys.version_info < (3, 13):  # pragma: no cover
-                    constructors.append(sqlframe_pyspark_lazy_constructor)
+                if sys.version_info < (3, 12):  # pragma: no cover
+                    constructors.append(pyspark_lazy_constructor())
                 else:  # pragma: no cover
                     continue
             else:

--- a/tests/expr_and_series/is_finite_test.py
+++ b/tests/expr_and_series/is_finite_test.py
@@ -25,6 +25,8 @@ def test_is_finite_expr(constructor: Constructor) -> None:
 
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a").is_finite())
+    breakpoint()
+    result.to_native().show()
     assert_equal_data(result, expected)
 
 

--- a/tests/expr_and_series/is_finite_test.py
+++ b/tests/expr_and_series/is_finite_test.py
@@ -25,8 +25,6 @@ def test_is_finite_expr(constructor: Constructor) -> None:
 
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a").is_finite())
-    breakpoint()
-    result.to_native().show()
     assert_equal_data(result, expected)
 
 


### PR DESCRIPTION
At the moment there's quite a few bugs failing for SQLFrame. But it's a start

Plus, it means:
- we can build the API completeness pages without needing PySpark installed
- we'll later have a way to run PySpark tests via SQLFrame in newer Python versions
- it may open the door for #1419 

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
