### PR TITLE
feat: spark `date` and `datetime`data types.

### DIFF
--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -91,7 +91,7 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
                 )
                 column = column.cast(native_dtype)
 
-            return [column.alias("literal")]
+            return [column]
 
         return SparkLikeExpr(
             call=_lit,

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -84,10 +84,8 @@ class SparkLikeNamespace(CompliantNamespace["Column"]):
         def _lit(df: SparkLikeLazyFrame) -> list[Column]:
             column = df._F.lit(value)
             if dtype:
-                import pyspark.sql.types as pyspark_types
-
                 native_dtype = narwhals_to_native_dtype(
-                    dtype, self._version, pyspark_types
+                    dtype, version=self._version, spark_types=df._native_dtypes
                 )
                 column = column.cast(native_dtype)
 

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -104,6 +104,9 @@ def narwhals_to_native_dtype(
     if isinstance_or_issubclass(dtype, dtypes.Date):
         return spark_types.DateType()
     if isinstance_or_issubclass(dtype, dtypes.Datetime):
+        dt_time_zone = getattr(dtype, "time_zone", None)
+        if dt_time_zone is None:
+            return spark_types.TimestampNTZType()
         return spark_types.TimestampType()
     if isinstance_or_issubclass(dtype, dtypes.List):  # pragma: no cover
         msg = "Converting to List dtype is not supported yet"

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -101,9 +101,10 @@ def narwhals_to_native_dtype(
         return spark_types.StringType()
     if isinstance_or_issubclass(dtype, dtypes.Boolean):
         return spark_types.BooleanType()
-    if isinstance_or_issubclass(dtype, (dtypes.Date, dtypes.Datetime)):
-        msg = "Converting to Date or Datetime dtype is not supported yet"
-        raise NotImplementedError(msg)
+    if isinstance_or_issubclass(dtype, dtypes.Date):
+        return spark_types.DateType()
+    if isinstance_or_issubclass(dtype, dtypes.Datetime):
+        return spark_types.TimestampType()
     if isinstance_or_issubclass(dtype, dtypes.List):  # pragma: no cover
         msg = "Converting to List dtype is not supported yet"
         raise NotImplementedError(msg)

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -87,9 +87,10 @@ def narwhals_to_native_dtype(
         return pyspark_types.StringType()
     if isinstance_or_issubclass(dtype, dtypes.Boolean):
         return pyspark_types.BooleanType()
-    if isinstance_or_issubclass(dtype, (dtypes.Date, dtypes.Datetime)):
-        msg = "Converting to Date or Datetime dtype is not supported yet"
-        raise NotImplementedError(msg)
+    if isinstance_or_issubclass(dtype, dtypes.Date):
+        return pyspark_types.DateType()
+    if isinstance_or_issubclass(dtype, dtypes.Datetime):
+        return pyspark_types.TimestampType()
     if isinstance_or_issubclass(dtype, dtypes.List):  # pragma: no cover
         msg = "Converting to List dtype is not supported yet"
         raise NotImplementedError(msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
 from copy import deepcopy
 from typing import TYPE_CHECKING
 from typing import Any
@@ -247,10 +246,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             constructors_ids.append(constructor)
         elif constructor in LAZY_CONSTRUCTORS:
             if constructor == "pyspark":
-                if sys.version_info < (3, 12):  # pragma: no cover
-                    constructors.append(pyspark_lazy_constructor())
-                else:  # pragma: no cover
-                    continue
+                constructors.append(pyspark_lazy_constructor())
             else:
                 constructors.append(LAZY_CONSTRUCTORS[constructor])
             constructors_ids.append(constructor)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from copy import deepcopy
 from typing import TYPE_CHECKING
 from typing import Any
@@ -246,7 +247,10 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             constructors_ids.append(constructor)
         elif constructor in LAZY_CONSTRUCTORS:
             if constructor == "pyspark":
-                constructors.append(pyspark_lazy_constructor())
+                if sys.version_info < (3, 12):  # pragma: no cover
+                    constructors.append(pyspark_lazy_constructor())
+                else:  # pragma: no cover
+                    continue
             else:
                 constructors.append(LAZY_CONSTRUCTORS[constructor])
             constructors_ids.append(constructor)

--- a/tests/expr_and_series/lit_test.py
+++ b/tests/expr_and_series/lit_test.py
@@ -22,13 +22,10 @@ if TYPE_CHECKING:
     [(None, [2, 2, 2]), (nw.String, ["2", "2", "2"]), (nw.Float32, [2.0, 2.0, 2.0])],
 )
 def test_lit(
-    request: pytest.FixtureRequest,
     constructor: Constructor,
     dtype: DType | None,
     expected_lit: list[Any],
 ) -> None:
-    if "pyspark" in str(constructor) and dtype is not None:
-        request.applymarker(pytest.mark.xfail)
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df_raw = constructor(data)
     df = nw.from_native(df_raw).lazy()
@@ -83,6 +80,7 @@ def test_lit_out_name(constructor: Constructor) -> None:
         ("right_scalar", nw.col("a") + 1, [2, 4, 3]),
         ("left_scalar_with_agg", 1 + nw.col("a").mean(), [3]),
         ("right_scalar_with_agg", nw.col("a").mean() - 1, [1]),
+        ("lit_compare", nw.col("a") == nw.lit(3), [False, True, False]),
     ],
 )
 def test_lit_operation_in_select(
@@ -130,7 +128,7 @@ def test_lit_operation_in_with_columns(
 
 @pytest.mark.skipif(PANDAS_VERSION < (1, 5), reason="too old for pyarrow")
 def test_date_lit(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if "dask" in str(constructor) or "pyspark" in str(constructor):
+    if "dask" in str(constructor):
         # https://github.com/dask/dask/issues/11637
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor({"a": [1]}))


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Implemented `date` and `datetime` data types for pyspark and enabled tests to validate implementation. 

Enabled setting `dtype` on spark `lit` expression. I have seen the some areas where `_native_types` is used, but I did not see how I could make it work in the context of `lit` namespace.

I was working on fixing some of the issues with the `lit` namespace as well, but when I was about the open the PR, I realized fixes for the same issue have already been merged in the main branch. I left an additional parametrization in (`test_lit`) that could be helpful in the future.

Also, was there any specific reason why spark tests were disabled on python 3.12?