### PR TITLE
feat: allow for tests to be run without Polars installed, unify exceptions more

### DIFF
--- a/tests/expr_and_series/dt/ordinal_day_test.py
+++ b/tests/expr_and_series/dt/ordinal_day_test.py
@@ -38,5 +38,7 @@ def test_ordinal_day(dates: datetime) -> None:
     except ImportError:
         pass
     else:
-        result_pl = nw.from_native(pl.Series([dates]), series_only=True).dt.ordinal_day()[0]
+        result_pl = nw.from_native(pl.Series([dates]), series_only=True).dt.ordinal_day()[
+            0
+        ]
         assert result_pl == result_pd

--- a/tests/expr_and_series/dt/ordinal_day_test.py
+++ b/tests/expr_and_series/dt/ordinal_day_test.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 import hypothesis.strategies as st
 import pandas as pd
-import polars as pl
 import pytest
 from hypothesis import given
 
@@ -30,8 +29,14 @@ def test_ordinal_day(dates: datetime) -> None:
         pd.Series([dates]).convert_dtypes(dtype_backend="numpy_nullable"),
         series_only=True,
     ).dt.ordinal_day()[0]
-    result_pl = nw.from_native(pl.Series([dates]), series_only=True).dt.ordinal_day()[0]
-    assert result_pd == result_pl
-    assert result_pda == result_pl
-    assert result_pdn == result_pl
-    assert result_pdms == result_pl
+    assert result_pda == result_pd
+    assert result_pdn == result_pd
+    assert result_pdms == result_pd
+
+    try:
+        import polars as pl
+    except ImportError:
+        pass
+    else:
+        result_pl = nw.from_native(pl.Series([dates]), series_only=True).dt.ordinal_day()[0]
+        assert result_pl == result_pd

--- a/tests/expr_and_series/dt/total_minutes_test.py
+++ b/tests/expr_and_series/dt/total_minutes_test.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 import hypothesis.strategies as st
 import pandas as pd
-import polars as pl
 import pytest
 from hypothesis import given
 
@@ -37,10 +36,16 @@ def test_total_minutes(timedeltas: timedelta) -> None:
         pd.Series([timedeltas]).convert_dtypes(dtype_backend="numpy_nullable"),
         series_only=True,
     ).dt.total_minutes()[0]
-    result_pl = nw.from_native(
-        pl.Series([timedeltas]), series_only=True
-    ).dt.total_minutes()[0]
-    assert result_pd == result_pl
-    assert result_pda == result_pl
-    assert result_pdn == result_pl
-    assert result_pdns == result_pl
+    assert result_pda == result_pd
+    assert result_pdn == result_pd
+    assert result_pdns == result_pd
+
+    try:
+        import polars as pl
+    except ImportError:
+        pass
+    else:
+        result_pl = nw.from_native(
+            pl.Series([timedeltas]), series_only=True
+        ).dt.total_minutes()[0]
+        assert result_pl == result_pd

--- a/tests/expr_and_series/is_nan_test.py
+++ b/tests/expr_and_series/is_nan_test.py
@@ -52,10 +52,9 @@ def test_nan(constructor: Constructor) -> None:
 
     if "polars_lazy" in str(constructor) and os.environ.get("NARWHALS_POLARS_GPU", False):
         from polars.exceptions import ComputeError
-        context = (
-            pytest.raises(
-                ComputeError, match="NAN is not supported in a Non-floating point type column"
-            )
+
+        context = pytest.raises(
+            ComputeError, match="NAN is not supported in a Non-floating point type column"
         )
     else:
         context = does_not_raise()
@@ -105,9 +104,11 @@ def test_nan_non_float(constructor: Constructor, request: pytest.FixtureRequest)
     exc = NwInvalidOperationError
     if "polars" in str(constructor):
         from polars.exceptions import InvalidOperationError as PlInvalidOperationError
+
         exc = PlInvalidOperationError
     elif "pyarrow_table" in str(constructor):
         from pyarrow.lib import ArrowNotImplementedError
+
         exc = ArrowNotImplementedError
 
     with pytest.raises(exc):
@@ -123,9 +124,11 @@ def test_nan_non_float_series(constructor_eager: ConstructorEager) -> None:
     exc = NwInvalidOperationError
     if "polars" in str(constructor_eager):
         from polars.exceptions import InvalidOperationError as PlInvalidOperationError
+
         exc = PlInvalidOperationError
     elif "pyarrow_table" in str(constructor_eager):
         from pyarrow.lib import ArrowNotImplementedError
+
         exc = ArrowNotImplementedError
 
     with pytest.raises(exc):

--- a/tests/expr_and_series/nth_test.py
+++ b/tests/expr_and_series/nth_test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
@@ -37,6 +36,7 @@ def test_nth(
     reason="1.0.0",
 )
 def test_nth_not_supported() -> None:  # pragma: no cover
+    pl = pytest.importorskip("polars")
     df = nw.from_native(pl.DataFrame(data))
     with pytest.raises(
         AttributeError, match="`nth` is only supported for Polars>=1.0.0."

--- a/tests/expr_and_series/rolling_var_test.py
+++ b/tests/expr_and_series/rolling_var_test.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import hypothesis.strategies as st
 import pandas as pd
-import polars as pl
 import pyarrow as pa
 import pytest
 from hypothesis import given
@@ -130,10 +129,15 @@ def test_rolling_var_hypothesis(center: bool, values: list[float]) -> None:  # n
     expected_dict = nw.from_native(expected, eager_only=True).to_dict(as_series=False)
     assert_equal_data(result, expected_dict)
 
-    result = nw.from_native(pl.from_pandas(df)).select(
-        nw.col("a").rolling_var(
-            window_size, center=center, min_samples=min_samples, ddof=ddof
+    try:
+        import polars as pl
+    except ImportError:
+        pass
+    else:
+        result = nw.from_native(pl.from_pandas(df)).select(
+            nw.col("a").rolling_var(
+                window_size, center=center, min_samples=min_samples, ddof=ddof
+            )
         )
-    )
-    expected_dict = nw.from_native(expected, eager_only=True).to_dict(as_series=False)
-    assert_equal_data(result, expected_dict)
+        expected_dict = nw.from_native(expected, eager_only=True).to_dict(as_series=False)
+        assert_equal_data(result, expected_dict)

--- a/tests/frame/arrow_c_stream_test.py
+++ b/tests/frame/arrow_c_stream_test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import polars as pl
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
@@ -8,6 +7,8 @@ import pytest
 import narwhals.stable.v1 as nw
 from tests.utils import POLARS_VERSION
 from tests.utils import PYARROW_VERSION
+
+pl = pytest.importorskip("polars")
 
 
 @pytest.mark.skipif(POLARS_VERSION < (1, 3), reason="too old for pycapsule in Polars")

--- a/tests/frame/explode_test.py
+++ b/tests/frame/explode_test.py
@@ -117,6 +117,7 @@ def test_explode_shape_error(
     expected_exceptions = (ShapeError,)
     if "polars" in str(constructor):
         from polars.exceptions import ShapeError as PlShapeError
+
         expected_exceptions = expected_exceptions + (PlShapeError,)
     with pytest.raises(
         expected_exceptions,
@@ -143,6 +144,7 @@ def test_explode_invalid_operation_error(
     expected_exceptions = (InvalidOperationError,)
     if "polars" in str(constructor):
         from polars.exceptions import InvalidOperationError as PlInvalidOperationError
+
         expected_exceptions = expected_exceptions + (PlInvalidOperationError,)
     with pytest.raises(
         expected_exceptions,

--- a/tests/frame/filter_test.py
+++ b/tests/frame/filter_test.py
@@ -46,6 +46,7 @@ def test_filter_raise_on_shape_mismatch(constructor: Constructor) -> None:
     expected_exceptions = (LengthChangingExprError, ShapeError)
     if "polars" in str(constructor):
         from polars.exceptions import ShapeError as PlShapeError
+
         expected_exceptions = expected_exceptions + (PlShapeError,)
     with pytest.raises(expected_exceptions):
         df.filter(nw.col("b").unique() > 2).lazy().collect()

--- a/tests/frame/filter_test.py
+++ b/tests/frame/filter_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from contextlib import nullcontext as does_not_raise
 
 import pytest
-from polars.exceptions import ShapeError as PlShapeError
 
 import narwhals as nw
 from narwhals.exceptions import LengthChangingExprError
@@ -44,5 +43,9 @@ def test_filter_raise_on_agg_predicate(constructor: Constructor) -> None:
 def test_filter_raise_on_shape_mismatch(constructor: Constructor) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
-    with pytest.raises((LengthChangingExprError, ShapeError, PlShapeError)):
+    expected_exceptions = (LengthChangingExprError, ShapeError)
+    if "polars" in str(constructor):
+        from polars.exceptions import ShapeError as PlShapeError
+        expected_exceptions = expected_exceptions + (PlShapeError,)
+    with pytest.raises(expected_exceptions):
         df.filter(nw.col("b").unique() > 2).lazy().collect()

--- a/tests/frame/getitem_test.py
+++ b/tests/frame/getitem_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
-import polars as pl
 import pyarrow as pa
 import pytest
 
@@ -48,6 +47,7 @@ def test_slice_rows_with_step_pyarrow() -> None:
 
 
 def test_slice_lazy_fails() -> None:
+    pl = pytest.importorskip("polars")
     with pytest.raises(TypeError, match="Slicing is not supported on LazyFrame"):
         _ = nw.from_native(pl.LazyFrame(data))[1:]
 

--- a/tests/frame/interchange_native_namespace_test.py
+++ b/tests/frame/interchange_native_namespace_test.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
+
+pl = pytest.importorskip("polars")
 
 data = {"a": [1, 2, 3], "b": [4.5, 6.7, 8.9], "z": ["x", "y", "w"]}
 

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -4,11 +4,12 @@ from datetime import date
 from datetime import datetime
 from datetime import timedelta
 
-import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import IBIS_VERSION
+
+pl = pytest.importorskip("polars")
 
 
 def test_interchange_schema() -> None:

--- a/tests/frame/interchange_select_test.py
+++ b/tests/frame/interchange_select_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 
-import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
@@ -54,6 +53,7 @@ def test_interchange_ibis(
         ibis.set_backend("duckdb")
     except ImportError:
         request.applymarker(pytest.mark.xfail)
+    pl = pytest.importorskip("polars")
     df_pl = pl.DataFrame(data)
 
     filepath = str(tmpdir / "file.parquet")  # type: ignore[operator]
@@ -69,6 +69,7 @@ def test_interchange_ibis(
 
 def test_interchange_duckdb() -> None:
     duckdb = pytest.importorskip("duckdb")
+    pl = pytest.importorskip("polars")
     df_pl = pl.DataFrame(data)  # noqa: F841
     rel = duckdb.sql("select * from df_pl")
     df = nw.from_native(rel, eager_or_interchange_only=True)

--- a/tests/frame/interchange_to_arrow_test.py
+++ b/tests/frame/interchange_to_arrow_test.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import polars as pl
 import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
+
+pl = pytest.importorskip("polars")
 
 data = {"a": [1, 2, 3], "b": [4.0, 5.0, 6.1], "z": ["x", "y", "z"]}
 


### PR DESCRIPTION
CC @MarcoGorelli 

Sending early to get feedback on the approaches used.

I went for:

1. `pytest.importorskip()` if the whole test (or module) seemed to rely on `polars`.
2. Explicit `try/except ImportError:` for tests that partially rely on `polars` — figured it would be weird to have them reported as "skipped" when the other part passed.
3. An explicit tuple variable for expected exceptions for `pytest.raises()`, with appending the `polars` exception when `polars` constructor is used.

Issue #1726 