### PR TITLE
chore: simplify duckdb group-by

### DIFF
--- a/narwhals/_duckdb/group_by.py
+++ b/narwhals/_duckdb/group_by.py
@@ -49,7 +49,5 @@ class DuckDBGroupBy:
             )
 
         return self._compliant_frame._from_native_frame(
-            self._compliant_frame._native_frame.aggregate(
-                agg_columns, group_expr=",".join(f'"{key}"' for key in self._keys)
-            )
+            self._compliant_frame._native_frame.aggregate(agg_columns)
         )


### PR DESCRIPTION
duckdb auto-infers the groups in `aggregate`, so can remove this string-hacking (in general, the less manual string construction we do, better, though in some places it's inevitable)

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
