### PR TITLE
feat: catch Polars exceptions, unify exception raising more

### DIFF
--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -125,7 +125,7 @@ class PolarsDataFrame:
                 msg = f"{e!s}\n\nHint: Did you mean one of these columns: {self.columns}?"
                 raise ColumnNotFoundError(msg) from e
             except Exception as e:  # noqa: BLE001
-                raise catch_polars_exception(e) from None
+                raise catch_polars_exception(e, self._backend_version) from None
 
         return func
 
@@ -368,7 +368,7 @@ class PolarsDataFrame:
                 separator=separator,
             )
         except Exception as e:  # noqa: BLE001
-            raise catch_polars_exception(e) from None
+            raise catch_polars_exception(e, self._backend_version) from None
         return self._from_native_object(result)
 
     def to_polars(self: Self) -> pl.DataFrame:
@@ -453,7 +453,7 @@ class PolarsLazyFrame:
             try:
                 collected_schema = self._native_frame.collect_schema()
             except Exception as e:  # noqa: BLE001
-                raise catch_polars_exception(e) from None
+                raise catch_polars_exception(e, self._backend_version) from None
             return {
                 name: native_to_narwhals_dtype(
                     dtype, self._version, self._backend_version
@@ -469,7 +469,7 @@ class PolarsLazyFrame:
         try:
             result = self._native_frame.collect(**kwargs)
         except Exception as e:  # noqa: BLE001
-            raise catch_polars_exception(e) from None
+            raise catch_polars_exception(e, self._backend_version) from None
 
         if backend is None or backend is Implementation.POLARS:
             from narwhals._polars.dataframe import PolarsDataFrame

--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -139,10 +139,7 @@ class PolarsDataFrame:
                 for name, dtype in self._native_frame.schema.items()
             }
         else:
-            try:
-                collected_schema = self._native_frame.collect_schema()
-            except Exception as e:  # noqa: BLE001
-                raise catch_polars_exception(e) from None
+            collected_schema = self._native_frame.collect_schema()
             return {
                 name: native_to_narwhals_dtype(
                     dtype, self._version, self._backend_version

--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -115,7 +115,7 @@ class PolarsDataFrame:
             except pl.exceptions.ColumnNotFoundError as e:  # pragma: no cover
                 msg = f"{e!s}\n\nHint: Did you mean one of these columns: {self.columns}?"
                 raise ColumnNotFoundError(msg) from e
-            except pl.exceptions.PolarsError as e:
+            except Exception as e:  # noqa: BLE001
                 raise catch_polars_exception(e) from None
 
         return func
@@ -141,7 +141,7 @@ class PolarsDataFrame:
         else:
             try:
                 collected_schema = self._native_frame.collect_schema()
-            except pl.exceptions.PolarsError as e:
+            except Exception as e:  # noqa: BLE001
                 raise catch_polars_exception(e) from None
             return {
                 name: native_to_narwhals_dtype(
@@ -362,7 +362,7 @@ class PolarsDataFrame:
                 sort_columns=sort_columns,
                 separator=separator,
             )
-        except pl.exceptions.PolarsError as e:
+        except Exception as e:  # noqa: BLE001
             raise catch_polars_exception(e) from None
         return self._from_native_object(result)
 
@@ -447,7 +447,7 @@ class PolarsLazyFrame:
         else:
             try:
                 collected_schema = self._native_frame.collect_schema()
-            except pl.exceptions.PolarsError as e:
+            except Exception as e:  # noqa: BLE001
                 raise catch_polars_exception(e) from None
             return {
                 name: native_to_narwhals_dtype(
@@ -461,11 +461,9 @@ class PolarsLazyFrame:
         backend: Implementation | None,
         **kwargs: Any,
     ) -> CompliantDataFrame:
-        import polars as pl
-
         try:
             result = self._native_frame.collect(**kwargs)
-        except pl.exceptions.PolarsError as e:
+        except Exception as e:  # noqa: BLE001
             raise catch_polars_exception(e) from None
 
         if backend is None or backend is Implementation.POLARS:

--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -103,6 +103,15 @@ class PolarsDataFrame:
         # scalar
         return obj
 
+    def __len__(self) -> int:
+        return len(self._native_frame)
+
+    def head(self, n: int) -> Self:
+        return self._from_native_frame(self._native_frame.head(n))
+
+    def tail(self, n: int) -> Self:
+        return self._from_native_frame(self._native_frame.tail(n))
+
     def __getattr__(self: Self, attr: str) -> Any:
         def func(*args: Any, **kwargs: Any) -> Any:
             import polars as pl

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -229,7 +229,7 @@ class PolarsSeries:
         try:
             native_is_nan = native.is_nan()
         except Exception as e:  # noqa: BLE001
-            raise catch_polars_exception(e) from None
+            raise catch_polars_exception(e, self._backend_version) from None
         if self._backend_version < (1, 18):  # pragma: no cover
             return self._from_native_series(
                 pl.select(pl.when(native.is_not_null()).then(native_is_nan))[native.name]
@@ -471,7 +471,7 @@ class PolarsSeries:
         try:
             return self._native_series.__contains__(other)
         except Exception as e:  # noqa: BLE001
-            raise catch_polars_exception(e) from None
+            raise catch_polars_exception(e, self._backend_version) from None
 
     def to_polars(self: Self) -> pl.Series:
         return self._native_series

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -226,17 +226,15 @@ class PolarsSeries:
 
     def is_nan(self: Self) -> Self:
         native = self._native_series
-
-        if self._backend_version < (1, 18):  # pragma: no cover
-            return self._from_native_series(
-                pl.select(pl.when(native.is_not_null()).then(native.is_nan()))[
-                    native.name
-                ]
-            )
         try:
-            return self._from_native_series(native.is_nan())
+            native_is_nan = native.is_nan()
         except pl.exceptions.PolarsError as e:
             raise catch_polars_exception(e) from None
+        if self._backend_version < (1, 18):  # pragma: no cover
+            return self._from_native_series(
+                pl.select(pl.when(native.is_not_null()).then(native_is_nan))[native.name]
+            )
+        return self._from_native_series(native_is_nan)
 
     def median(self: Self) -> Any:
         from narwhals.exceptions import InvalidOperationError

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -228,7 +228,7 @@ class PolarsSeries:
         native = self._native_series
         try:
             native_is_nan = native.is_nan()
-        except pl.exceptions.PolarsError as e:
+        except Exception as e:  # noqa: BLE001
             raise catch_polars_exception(e) from None
         if self._backend_version < (1, 18):  # pragma: no cover
             return self._from_native_series(
@@ -470,7 +470,7 @@ class PolarsSeries:
     def __contains__(self: Self, other: Any) -> bool:
         try:
             return self._native_series.__contains__(other)
-        except pl.exceptions.PolarsError as e:
+        except Exception as e:  # noqa: BLE001
             raise catch_polars_exception(e) from None
 
     def to_polars(self: Self) -> pl.Series:

--- a/narwhals/_polars/utils.py
+++ b/narwhals/_polars/utils.py
@@ -9,6 +9,10 @@ from typing import overload
 
 import polars as pl
 
+from narwhals.exceptions import ColumnNotFoundError
+from narwhals.exceptions import InvalidOperationError
+from narwhals.exceptions import NarwhalsError
+from narwhals.exceptions import ShapeError
 from narwhals.utils import import_dtypes_module
 
 if TYPE_CHECKING:
@@ -217,3 +221,13 @@ def convert_str_slice_to_int_slice(
     stop = columns.index(str_slice.stop) + 1 if str_slice.stop is not None else None
     step = str_slice.step
     return (start, stop, step)
+
+
+def catch_polars_exception(exception: pl.exceptions.PolarsError) -> NarwhalsError:
+    if isinstance(exception, pl.exceptions.ColumnNotFoundError):
+        return ColumnNotFoundError(str(exception))
+    elif isinstance(exception, pl.exceptions.ShapeError):
+        return ShapeError(str(exception))
+    elif isinstance(exception, pl.exceptions.InvalidOperationError):
+        return InvalidOperationError(str(exception))
+    return NarwhalsError(str(exception))

--- a/narwhals/_polars/utils.py
+++ b/narwhals/_polars/utils.py
@@ -223,11 +223,19 @@ def convert_str_slice_to_int_slice(
     return (start, stop, step)
 
 
-def catch_polars_exception(exception: pl.exceptions.PolarsError) -> NarwhalsError:
+def catch_polars_exception(exception: Exception) -> NarwhalsError | Exception:
     if isinstance(exception, pl.exceptions.ColumnNotFoundError):
         return ColumnNotFoundError(str(exception))
     elif isinstance(exception, pl.exceptions.ShapeError):
         return ShapeError(str(exception))
     elif isinstance(exception, pl.exceptions.InvalidOperationError):
         return InvalidOperationError(str(exception))
-    return NarwhalsError(str(exception))
+    elif isinstance(exception, pl.exceptions.ComputeError):
+        # We don't (yet?) have a Narwhals ComputeError.
+        return NarwhalsError(str(exception))
+    if hasattr(pl.exceptions, "PolarsError") and isinstance(
+        exception, pl.exceptions.PolarsError
+    ):
+        # Old versions of Polars didn't have PolarsError.
+        return NarwhalsError(str(exception))
+    return exception

--- a/narwhals/_polars/utils.py
+++ b/narwhals/_polars/utils.py
@@ -238,4 +238,8 @@ def catch_polars_exception(exception: Exception) -> NarwhalsError | Exception:
     ):
         # Old versions of Polars didn't have PolarsError.
         return NarwhalsError(str(exception))
+    if "polars.exceptions" in str(type(exception)):
+        # Last attempt...
+        return NarwhalsError(str(exception))
+    # Just return exception as-is.
     return exception

--- a/narwhals/_polars/utils.py
+++ b/narwhals/_polars/utils.py
@@ -238,8 +238,8 @@ def catch_polars_exception(exception: Exception) -> NarwhalsError | Exception:
     ):
         # Old versions of Polars didn't have PolarsError.
         return NarwhalsError(str(exception))
-    if "polars.exceptions" in str(type(exception)):
-        # Last attempt...
+    elif "polars.exceptions" in str(type(exception)):  # pragma: no cover
+        # Last attempt, for old Polars versions.
         return NarwhalsError(str(exception))
     # Just return exception as-is.
     return exception

--- a/narwhals/exceptions.py
+++ b/narwhals/exceptions.py
@@ -6,6 +6,10 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
+class NarwhalsError(ValueError):
+    """Base class for all Narwhals exceptions."""
+
+
 class FormattedKeyError(KeyError):
     """KeyError with formatted error message.
 
@@ -22,7 +26,7 @@ class FormattedKeyError(KeyError):
         return self.message
 
 
-class ColumnNotFoundError(FormattedKeyError):
+class ColumnNotFoundError(FormattedKeyError, NarwhalsError):
     """Exception raised when column name isn't present."""
 
     def __init__(self: Self, message: str) -> None:
@@ -40,15 +44,15 @@ class ColumnNotFoundError(FormattedKeyError):
         return ColumnNotFoundError(message)
 
 
-class ShapeError(Exception):
+class ShapeError(NarwhalsError):
     """Exception raised when trying to perform operations on data structures with incompatible shapes."""
 
 
-class InvalidOperationError(Exception):
+class InvalidOperationError(NarwhalsError):
     """Exception raised during invalid operations."""
 
 
-class InvalidIntoExprError(TypeError):
+class InvalidIntoExprError(NarwhalsError):
     """Exception raised when object can't be converted to expression."""
 
     def __init__(self: Self, message: str) -> None:
@@ -71,7 +75,7 @@ class InvalidIntoExprError(TypeError):
         return InvalidIntoExprError(message)
 
 
-class AnonymousExprError(ValueError):  # pragma: no cover
+class AnonymousExprError(NarwhalsError):  # pragma: no cover
     """Exception raised when trying to perform operations on anonymous expressions."""
 
     def __init__(self: Self, message: str) -> None:
@@ -88,7 +92,7 @@ class AnonymousExprError(ValueError):  # pragma: no cover
         return AnonymousExprError(message)
 
 
-class OrderDependentExprError(ValueError):
+class OrderDependentExprError(NarwhalsError):
     """Exception raised when trying to use an order-dependent expressions with LazyFrames."""
 
     def __init__(self: Self, message: str) -> None:
@@ -96,7 +100,7 @@ class OrderDependentExprError(ValueError):
         super().__init__(self.message)
 
 
-class LengthChangingExprError(ValueError):
+class LengthChangingExprError(NarwhalsError):
     """Exception raised when trying to use an expression which changes length with LazyFrames."""
 
     def __init__(self: Self, message: str) -> None:
@@ -104,7 +108,7 @@ class LengthChangingExprError(ValueError):
         super().__init__(self.message)
 
 
-class UnsupportedDTypeError(ValueError):
+class UnsupportedDTypeError(NarwhalsError):
     """Exception raised when trying to convert to a DType which is not supported by the given backend."""
 
 

--- a/narwhals/exceptions.py
+++ b/narwhals/exceptions.py
@@ -52,7 +52,7 @@ class InvalidOperationError(NarwhalsError):
     """Exception raised during invalid operations."""
 
 
-class InvalidIntoExprError(NarwhalsError):
+class InvalidIntoExprError(TypeError, NarwhalsError):
     """Exception raised when object can't be converted to expression."""
 
     def __init__(self: Self, message: str) -> None:

--- a/tests/expr_and_series/is_nan_test.py
+++ b/tests/expr_and_series/is_nan_test.py
@@ -5,9 +5,9 @@ from contextlib import nullcontext as does_not_raise
 from typing import Any
 
 import pytest
-from polars.exceptions import ComputeError
 
 import narwhals.stable.v1 as nw
+from narwhals.exceptions import NarwhalsError
 from tests.conftest import dask_lazy_p1_constructor
 from tests.conftest import dask_lazy_p2_constructor
 from tests.conftest import modin_constructor
@@ -53,7 +53,8 @@ def test_nan(constructor: Constructor) -> None:
 
     context = (
         pytest.raises(
-            ComputeError, match="NAN is not supported in a Non-floating point type column"
+            NarwhalsError,
+            match="NAN is not supported in a Non-floating point type column",
         )
         if "polars_lazy" in str(constructor)
         and os.environ.get("NARWHALS_POLARS_GPU", False)
@@ -96,18 +97,15 @@ def test_nan_series(constructor_eager: ConstructorEager) -> None:
 def test_nan_non_float(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    from polars.exceptions import InvalidOperationError as PlInvalidOperationError
     from pyarrow.lib import ArrowNotImplementedError
 
-    from narwhals.exceptions import InvalidOperationError as NwInvalidOperationError
+    from narwhals.exceptions import InvalidOperationError
 
     data = {"a": ["x", "y"]}
     df = nw.from_native(constructor(data))
 
-    exc = NwInvalidOperationError
-    if "polars" in str(constructor):
-        exc = PlInvalidOperationError
-    elif "pyarrow_table" in str(constructor):
+    exc = InvalidOperationError
+    if "pyarrow_table" in str(constructor):
         exc = ArrowNotImplementedError
 
     with pytest.raises(exc):
@@ -115,18 +113,15 @@ def test_nan_non_float(constructor: Constructor, request: pytest.FixtureRequest)
 
 
 def test_nan_non_float_series(constructor_eager: ConstructorEager) -> None:
-    from polars.exceptions import InvalidOperationError as PlInvalidOperationError
     from pyarrow.lib import ArrowNotImplementedError
 
-    from narwhals.exceptions import InvalidOperationError as NwInvalidOperationError
+    from narwhals.exceptions import InvalidOperationError
 
     data = {"a": ["x", "y"]}
     df = nw.from_native(constructor_eager(data), eager_only=True)
 
-    exc = NwInvalidOperationError
-    if "polars" in str(constructor_eager):
-        exc = PlInvalidOperationError
-    elif "pyarrow_table" in str(constructor_eager):
+    exc = InvalidOperationError
+    if "pyarrow_table" in str(constructor_eager):
         exc = ArrowNotImplementedError
 
     with pytest.raises(exc):

--- a/tests/expr_and_series/median_test.py
+++ b/tests/expr_and_series/median_test.py
@@ -45,18 +45,17 @@ def test_median_expr_raises_on_str(
 ) -> None:
     if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    from polars.exceptions import InvalidOperationError as PlInvalidOperationError
 
     df = nw.from_native(constructor(data))
     if isinstance(df, nw.LazyFrame):
         with pytest.raises(
-            (InvalidOperationError, PlInvalidOperationError),
+            InvalidOperationError,
             match="`median` operation not supported",
         ):
             df.select(expr).lazy().collect()
     else:
         with pytest.raises(
-            (InvalidOperationError, PlInvalidOperationError),
+            InvalidOperationError,
             match="`median` operation not supported",
         ):
             df.select(expr)

--- a/tests/expr_and_series/replace_strict_test.py
+++ b/tests/expr_and_series/replace_strict_test.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import narwhals.stable.v1 as nw
+from narwhals.exceptions import NarwhalsError
 from tests.utils import POLARS_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
@@ -56,20 +57,18 @@ def test_replace_strict_series(
 def test_replace_non_full(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
-    from polars.exceptions import PolarsError
-
     if "dask" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     if ("pyspark" in str(constructor)) or "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor({"a": [1, 2, 3]}))
     if isinstance(df, nw.LazyFrame):
-        with pytest.raises((ValueError, PolarsError)):
+        with pytest.raises((ValueError, NarwhalsError)):
             df.select(
                 nw.col("a").replace_strict([1, 3], [3, 4], return_dtype=nw.Int64)
             ).collect()
     else:
-        with pytest.raises((ValueError, PolarsError)):
+        with pytest.raises((ValueError, NarwhalsError)):
             df.select(nw.col("a").replace_strict([1, 3], [3, 4], return_dtype=nw.Int64))
 
 

--- a/tests/frame/drop_test.py
+++ b/tests/frame/drop_test.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 import pytest
-from polars.exceptions import ColumnNotFoundError as PlColumnNotFoundError
 
 import narwhals.stable.v1 as nw
 from narwhals.exceptions import ColumnNotFoundError
@@ -36,7 +35,7 @@ def test_drop(constructor: Constructor, to_drop: list[str], expected: list[str])
     [
         (
             True,
-            pytest.raises((ColumnNotFoundError, PlColumnNotFoundError), match="z"),
+            pytest.raises(ColumnNotFoundError, match="z"),
         ),
         (False, does_not_raise()),
     ],

--- a/tests/frame/explode_test.py
+++ b/tests/frame/explode_test.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from typing import Sequence
 
 import pytest
-from polars.exceptions import InvalidOperationError as PlInvalidOperationError
-from polars.exceptions import ShapeError as PlShapeError
 
 import narwhals.stable.v1 as nw
 from narwhals.exceptions import InvalidOperationError
@@ -118,7 +116,7 @@ def test_explode_shape_error(
         request.applymarker(pytest.mark.xfail)
 
     with pytest.raises(
-        (ShapeError, PlShapeError, NotImplementedError),
+        (ShapeError, NotImplementedError),
         match=r".*exploded columns (must )?have matching element counts",
     ):
         _ = (
@@ -140,7 +138,7 @@ def test_explode_invalid_operation_error(
         request.applymarker(pytest.mark.xfail)
 
     with pytest.raises(
-        (InvalidOperationError, PlInvalidOperationError),
+        InvalidOperationError,
         match="`explode` operation not supported for dtype",
     ):
         _ = nw.from_native(constructor(data)).lazy().explode("a").collect()

--- a/tests/frame/filter_test.py
+++ b/tests/frame/filter_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from contextlib import nullcontext as does_not_raise
 
 import pytest
-from polars.exceptions import ShapeError as PlShapeError
 
 import narwhals as nw
 from narwhals.exceptions import LengthChangingExprError
@@ -44,5 +43,5 @@ def test_filter_raise_on_agg_predicate(constructor: Constructor) -> None:
 def test_filter_raise_on_shape_mismatch(constructor: Constructor) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df = nw.from_native(constructor(data))
-    with pytest.raises((LengthChangingExprError, ShapeError, PlShapeError)):
+    with pytest.raises((LengthChangingExprError, ShapeError)):
         df.filter(nw.col("b").unique() > 2).lazy().collect()

--- a/tests/frame/pivot_test.py
+++ b/tests/frame/pivot_test.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from contextlib import nullcontext as does_not_raise
 from typing import Any
 
-import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
+from narwhals.exceptions import NarwhalsError
 from tests.utils import PANDAS_VERSION
 from tests.utils import POLARS_VERSION
 from tests.utils import ConstructorEager
@@ -147,7 +147,7 @@ def test_pivot(
     ("data_", "context"),
     [
         (data_no_dups, does_not_raise()),
-        (data, pytest.raises((ValueError, pl.exceptions.ComputeError))),
+        (data, pytest.raises((ValueError, NarwhalsError))),
     ],
 )
 def test_pivot_no_agg(

--- a/tests/frame/select_test.py
+++ b/tests/frame/select_test.py
@@ -5,11 +5,11 @@ from typing import Any
 import pandas as pd
 import pyarrow as pa
 import pytest
-from polars.exceptions import DuplicateError
 
 import narwhals.stable.v1 as nw
 from narwhals.exceptions import ColumnNotFoundError
 from narwhals.exceptions import InvalidIntoExprError
+from narwhals.exceptions import NarwhalsError
 from tests.utils import DASK_VERSION
 from tests.utils import PANDAS_VERSION
 from tests.utils import POLARS_VERSION
@@ -138,5 +138,5 @@ def test_left_to_right_broadcasting(
 
 def test_alias_invalid(constructor: Constructor) -> None:
     df = nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]}))
-    with pytest.raises((DuplicateError, ValueError)):
+    with pytest.raises((NarwhalsError, ValueError)):
         df.lazy().select(nw.all().alias("c")).collect()


### PR DESCRIPTION
Unify exceptions, and re-raise Polars ones as Narwhals ones

This doesn't unify _everything_...but I think it's a nice step forwards, and should be ~~totally backwards-compatible~~ mostly backwards-compatible (unless anyone catches Polars exceptions specifically in tests)

Towards #1373 