### PR TITLE
fix(typing): Ensure `LazyFrame` has a unique `TypeVar`

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -54,12 +54,13 @@ if TYPE_CHECKING:
 
     PS = ParamSpec("PS")
 
+_FrameT = TypeVar("_FrameT", bound="IntoFrame")
 FrameT = TypeVar("FrameT", bound="IntoFrame")
 DataFrameT = TypeVar("DataFrameT", bound="IntoDataFrame")
 R = TypeVar("R")
 
 
-class BaseFrame(Generic[FrameT]):
+class BaseFrame(Generic[_FrameT]):
     _compliant_frame: Any
     _level: Literal["full", "lazy", "interchange"]
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Resolves an issue mentioned in (https://discord.com/channels/1235257048170762310/1237430779584446546/1335943538352848928)

**Every site** that `LazyFrame` was specialised (`LazyFrame[<some>]`) it created a warning for `pyright`/`Pylance`.

The simplest explanation is you need to use a different `TypeVar` when subclassing to preserve the generic behavior.
It doesn't matter that `_FrameT` and `FrameT` are functionally equivalent.

Also `_FrameT` is never exposed to the user, or anywhere AFAICT - so I just prefixed the existing name.

### Examples

**Before** / **After**
<img src="https://github.com/user-attachments/assets/aba93081-2852-4d51-8476-681a452fcc3c" width="500"> <img src="https://github.com/user-attachments/assets/f08ba7ba-e647-4b0a-86f0-38594af7a3c0" width="478">


