### PR TITLE
fix: Always collect `Iterator[IntoExpr]` in `utils.flatten`

### DIFF
--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -387,11 +387,7 @@ def remove_suffix(text: str, suffix: str) -> str:  # pragma: no cover
 
 
 def flatten(args: Any) -> list[Any]:
-    if not args:
-        return []
-    if len(args) == 1 and _is_iterable(args[0]):
-        return args[0]  # type: ignore[no-any-return]
-    return args  # type: ignore[no-any-return]
+    return list(args[0] if (len(args) == 1 and _is_iterable(args[0])) else args)
 
 
 def tupleify(arg: Any) -> Any:

--- a/tests/expr_and_series/all_horizontal_test.py
+++ b/tests/expr_and_series/all_horizontal_test.py
@@ -70,6 +70,27 @@ def test_allh_nth(
     assert_equal_data(result, expected)
 
 
+def test_allh_iterator(constructor: Constructor) -> None:
+    def iter_eq(items: Any, /) -> Any:
+        for column, value in items:
+            yield nw.col(column) == value
+
+    data = {"a": [1, 2, 3, 3, 3], "b": ["b", "b", "a", "a", "b"]}
+    df = nw.from_native(constructor(data))
+    expr_items = [("a", 3), ("b", "b")]
+    expected = {"a": [3], "b": ["b"]}
+
+    eager = nw.all_horizontal(list(iter_eq(expr_items)))
+    assert_equal_data(df.filter(eager), expected)
+    unpacked = nw.all_horizontal(*iter_eq(expr_items))
+    assert_equal_data(df.filter(unpacked), expected)
+    lazy = nw.all_horizontal(iter_eq(expr_items))
+
+    assert_equal_data(df.filter(lazy), expected)
+    assert_equal_data(df.filter(lazy), expected)
+    assert_equal_data(df.filter(lazy), expected)
+
+
 def test_horizontal_expressions_empty(constructor: Constructor) -> None:
     data = {
         "a": [False, False, True],


### PR DESCRIPTION
Fixes #1897

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues
- Closes #1897

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
- New tests would fail on `main`, but I'm getting a different error than when I raised (#1897)
- Original issue was the expression could only be used once, hence the repeated statements