### PR TITLE
fix(typing): Use `IntoDataFrameT` in `to_native`

### DIFF
--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -83,11 +83,13 @@ def to_native(narwhals_object: Any, *, pass_through: bool) -> Any: ...
 
 
 def to_native(
-    narwhals_object: DataFrame[IntoFrameT] | LazyFrame[IntoFrameT] | Series[IntoSeriesT],
+    narwhals_object: DataFrame[IntoDataFrameT]
+    | LazyFrame[IntoFrameT]
+    | Series[IntoSeriesT],
     *,
     strict: bool | None = None,
     pass_through: bool | None = None,
-) -> IntoFrameT | Any:
+) -> IntoDataFrameT | IntoFrameT | IntoSeriesT | Any:
     """Convert Narwhals object to native one.
 
     Arguments:


### PR DESCRIPTION


<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

Mentioned in https://github.com/narwhals-dev/narwhals/pull/1935#issuecomment-2634298106

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Resolves a similar issue as (#1935)

<details><summary>Warning (very long message)</summary>
<p>

> Overloaded implementation is not consistent with signature of overload 1
>   Type "(narwhals_object: DataFrame[IntoFrameT@to_native] | LazyFrame[IntoFrameT@to_native] | Series[IntoSeriesT@to_native], *, strict: bool | None = None, pass_through: bool | None = None) -> (IntoFrameT@to_native | Any)" is not assignable to type "(narwhals_object: DataFrame[IntoDataFrameT@to_native], *, pass_through: Literal[False] = ...) -> IntoDataFrameT@to_native"
>     Parameter 1: type "DataFrame[IntoDataFrameT@to_native]" is incompatible with type "DataFrame[IntoFrameT@to_native] | LazyFrame[IntoFrameT@to_native] | Series[IntoSeriesT@to_native]"
>       Type "DataFrame[IntoDataFrameT@to_native]" is not assignable to type "DataFrame[IntoFrameT@to_native] | LazyFrame[IntoFrameT@to_native] | Series[IntoSeriesT@to_native]"
>         "DataFrame[IntoDataFrameT@to_native]" is not assignable to "DataFrame[IntoFrameT@to_native]"
>           Type parameter "DataFrameT@DataFrame" is invariant, but "IntoDataFrameT@to_native" is not the same as "IntoFrameT@to_native"
>         "DataFrame[IntoDataFrameT@to_native]" is not assignable to "LazyFrame[IntoFrameT@to_native]"
>         "DataFrame[IntoDataFrameT@to_native]" is not assignable to "Series[IntoSeriesT@to_native]"PylancereportInconsistentOverload
> translate.py(70, 5): Overload signature is defined here

![image](https://github.com/user-attachments/assets/710ea3af-254c-40b0-a963-85a5e47fca50)


</p>
</details> 