### PR TITLE
docs: Make DataFrame and LazyFrame docstrings shorter and more concise

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1348,49 +1348,16 @@ class DataFrame(BaseFrame[DataFrameT]):
             The dataframe with the specified columns renamed.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_rename(df_native: IntoFrameT) -> IntoFrameT:
-            ...     return nw.from_native(df_native).rename({"foo": "apple"}).to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_rename`:
-
-            >>> agnostic_rename(df_pd)
-               apple  bar ham
-            0      1    6   a
-            1      2    7   b
-            2      3    8   c
-            >>> agnostic_rename(df_pl)
-            shape: (3, 3)
-            ┌───────┬─────┬─────┐
-            │ apple ┆ bar ┆ ham │
-            │ ---   ┆ --- ┆ --- │
-            │ i64   ┆ i64 ┆ str │
-            ╞═══════╪═════╪═════╡
-            │ 1     ┆ 6   ┆ a   │
-            │ 2     ┆ 7   ┆ b   │
-            │ 3     ┆ 8   ┆ c   │
-            └───────┴─────┴─────┘
-            >>> agnostic_rename(df_pa)
+            >>> df_native = pa.table({"foo": [1, 2], "bar": [6, 7]})
+            >>> nw.from_native(df_native).rename({"foo": "apple"}).to_native()
             pyarrow.Table
             apple: int64
             bar: int64
-            ham: string
             ----
-            apple: [[1,2,3]]
-            bar: [[6,7,8]]
-            ham: [["a","b","c"]]
+            apple: [[1,2]]
+            bar: [[6,7]]
         """
         return super().rename(mapping)
 
@@ -1406,52 +1373,11 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "foo": [1, 2, 3, 4, 5],
-            ...     "bar": [6, 7, 8, 9, 10],
-            ...     "ham": ["a", "b", "c", "d", "e"],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function that gets the first 3 rows.
-
-            >>> def agnostic_head(df_native: IntoFrameT) -> IntoFrameT:
-            ...     return nw.from_native(df_native).head(3).to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_head`:
-
-            >>> agnostic_head(df_pd)
-               foo  bar ham
-            0    1    6   a
-            1    2    7   b
-            2    3    8   c
-            >>> agnostic_head(df_pl)
-            shape: (3, 3)
-            ┌─────┬─────┬─────┐
-            │ foo ┆ bar ┆ ham │
-            │ --- ┆ --- ┆ --- │
-            │ i64 ┆ i64 ┆ str │
-            ╞═════╪═════╪═════╡
-            │ 1   ┆ 6   ┆ a   │
-            │ 2   ┆ 7   ┆ b   │
-            │ 3   ┆ 8   ┆ c   │
-            └─────┴─────┴─────┘
-            >>> agnostic_head(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: int64
-            ham: string
-            ----
-            foo: [[1,2,3]]
-            bar: [[6,7,8]]
-            ham: [["a","b","c"]]
+            >>> df_native = pd.DataFrame({"a": [1, 2], "b": [0.5, 4.0]})
+            >>> nw.from_native(df_native).head(1)
+               a    b
+            0  1  0.5
         """
         return super().head(n)
 
@@ -1467,52 +1393,11 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "foo": [1, 2, 3, 4, 5],
-            ...     "bar": [6, 7, 8, 9, 10],
-            ...     "ham": ["a", "b", "c", "d", "e"],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function that gets the last 3 rows.
-
-            >>> def agnostic_tail(df_native: IntoFrameT) -> IntoFrameT:
-            ...     return nw.from_native(df_native).tail(3).to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_tail`:
-
-            >>> agnostic_tail(df_pd)
-               foo  bar ham
-            2    3    8   c
-            3    4    9   d
-            4    5   10   e
-            >>> agnostic_tail(df_pl)
-            shape: (3, 3)
-            ┌─────┬─────┬─────┐
-            │ foo ┆ bar ┆ ham │
-            │ --- ┆ --- ┆ --- │
-            │ i64 ┆ i64 ┆ str │
-            ╞═════╪═════╪═════╡
-            │ 3   ┆ 8   ┆ c   │
-            │ 4   ┆ 9   ┆ d   │
-            │ 5   ┆ 10  ┆ e   │
-            └─────┴─────┴─────┘
-            >>> agnostic_tail(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: int64
-            ham: string
-            ----
-            foo: [[3,4,5]]
-            bar: [[8,9,10]]
-            ham: [["c","d","e"]]
+            >>> df_native = pd.DataFrame({"a": [1, 2], "b": [0.5, 4.0]})
+            >>> nw.from_native(df_native).tail(1)
+               a    b
+            0  2  4.0
         """
         return super().tail(n)
 
@@ -1529,74 +1414,12 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_drop(df_native: IntoFrameT) -> IntoFrameT:
-            ...     return nw.from_native(df_native).drop("ham").to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_drop`:
-
-            >>> agnostic_drop(df_pd)
+            >>> df_native = pd.DataFrame({"foo": [1, 2], "bar": [6.0, 7.0], "ham": ["a", "b"]})
+            >>> nw.from_native(df_native).drop("ham").to_native()
                foo  bar
             0    1  6.0
             1    2  7.0
-            2    3  8.0
-            >>> agnostic_drop(df_pl)
-            shape: (3, 2)
-            ┌─────┬─────┐
-            │ foo ┆ bar │
-            │ --- ┆ --- │
-            │ i64 ┆ f64 │
-            ╞═════╪═════╡
-            │ 1   ┆ 6.0 │
-            │ 2   ┆ 7.0 │
-            │ 3   ┆ 8.0 │
-            └─────┴─────┘
-            >>> agnostic_drop(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: double
-            ----
-            foo: [[1,2,3]]
-            bar: [[6,7,8]]
-
-            Use positional arguments to drop multiple columns.
-
-            >>> def agnostic_drop_multi(df_native: IntoFrameT) -> IntoFrameT:
-            ...     return nw.from_native(df_native).drop("foo", "ham").to_native()
-
-            >>> agnostic_drop_multi(df_pd)
-               bar
-            0  6.0
-            1  7.0
-            2  8.0
-            >>> agnostic_drop_multi(df_pl)
-            shape: (3, 1)
-            ┌─────┐
-            │ bar │
-            │ --- │
-            │ f64 │
-            ╞═════╡
-            │ 6.0 │
-            │ 7.0 │
-            │ 8.0 │
-            └─────┘
-            >>> agnostic_drop_multi(df_pa)
-            pyarrow.Table
-            bar: double
-            ----
-            bar: [[6,7,8]]
-
         """
         return super().drop(*flatten(columns), strict=strict)
 
@@ -1627,48 +1450,11 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "foo": [1, 2, 3, 1],
-            ...     "bar": ["a", "a", "a", "a"],
-            ...     "ham": ["b", "b", "b", "b"],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_unique(df_native: IntoFrameT) -> IntoFrameT:
-            ...     return nw.from_native(df_native).unique(["bar", "ham"]).to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_unique`:
-
-            >>> agnostic_unique(df_pd)
+            >>> df_native = pd.DataFrame({"foo": [1, 2], "bar": ["a", "a"], "ham": ["b", "b"]})
+            >>> nw.from_native(df_native).unique(["bar", "ham"]).to_native()
                foo bar ham
             0    1   a   b
-            >>> agnostic_unique(df_pl)
-            shape: (1, 3)
-            ┌─────┬─────┬─────┐
-            │ foo ┆ bar ┆ ham │
-            │ --- ┆ --- ┆ --- │
-            │ i64 ┆ str ┆ str │
-            ╞═════╪═════╪═════╡
-            │ 1   ┆ a   ┆ b   │
-            └─────┴─────┴─────┘
-            >>> agnostic_unique(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: string
-            ham: string
-            ----
-            foo: [[1]]
-            bar: [["a"]]
-            ham: [["b"]]
         """
         if keep not in {"any", "none", "first", "last"}:
             msg = f"Expected {'any', 'none', 'first', 'last'}, got: {keep}"
@@ -1702,169 +1488,30 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6, 7, 8],
-            ...     "ham": ["a", "b", "c"],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
+            >>> df_native = pd.DataFrame({"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]})
 
-            Let's define a dataframe-agnostic function in which we filter on
-            one condition.
-
-            >>> def agnostic_filter(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return df.filter(nw.col("foo") > 1).to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_filter`:
-
-            >>> agnostic_filter(df_pd)
+            Filter on one condition
+            >>> nw.from_native(df_native).filter(nw.col("foo") > 1).to_native()
                foo  bar ham
             1    2    7   b
             2    3    8   c
-            >>> agnostic_filter(df_pl)
-            shape: (2, 3)
-            ┌─────┬─────┬─────┐
-            │ foo ┆ bar ┆ ham │
-            │ --- ┆ --- ┆ --- │
-            │ i64 ┆ i64 ┆ str │
-            ╞═════╪═════╪═════╡
-            │ 2   ┆ 7   ┆ b   │
-            │ 3   ┆ 8   ┆ c   │
-            └─────┴─────┴─────┘
-            >>> agnostic_filter(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: int64
-            ham: string
-            ----
-            foo: [[2,3]]
-            bar: [[7,8]]
-            ham: [["b","c"]]
 
-            Filter on multiple conditions, combined with and/or operators:
-
-            >>> def agnostic_filter(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return df.filter(
-            ...         (nw.col("foo") < 3) & (nw.col("ham") == "a")
-            ...     ).to_native()
-            >>> agnostic_filter(df_pd)
+            Filter on multiple conditions with `&`
+            >>> nw.from_native(df_native).filter(nw.col("foo") < 3, nw.col("ham") == "a").to_native()
                foo  bar ham
             0    1    6   a
-            >>> agnostic_filter(df_pl)
-            shape: (1, 3)
-            ┌─────┬─────┬─────┐
-            │ foo ┆ bar ┆ ham │
-            │ --- ┆ --- ┆ --- │
-            │ i64 ┆ i64 ┆ str │
-            ╞═════╪═════╪═════╡
-            │ 1   ┆ 6   ┆ a   │
-            └─────┴─────┴─────┘
-            >>> agnostic_filter(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: int64
-            ham: string
-            ----
-            foo: [[1]]
-            bar: [[6]]
-            ham: [["a"]]
 
-            >>> def agnostic_filter(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     dframe = df.filter(
-            ...         (nw.col("foo") == 1) | (nw.col("ham") == "c")
-            ...     ).to_native()
-            ...     return dframe
-            >>> agnostic_filter(df_pd)
+            # Filter on multiple conditions with `|`
+            >>> nw.from_native(df_native).filter((nw.col("foo") == 1) | (nw.col("ham") == "c")).to_native()
                foo  bar ham
             0    1    6   a
             2    3    8   c
-            >>> agnostic_filter(df_pl)
-            shape: (2, 3)
-            ┌─────┬─────┬─────┐
-            │ foo ┆ bar ┆ ham │
-            │ --- ┆ --- ┆ --- │
-            │ i64 ┆ i64 ┆ str │
-            ╞═════╪═════╪═════╡
-            │ 1   ┆ 6   ┆ a   │
-            │ 3   ┆ 8   ┆ c   │
-            └─────┴─────┴─────┘
-            >>> agnostic_filter(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: int64
-            ham: string
-            ----
-            foo: [[1,3]]
-            bar: [[6,8]]
-            ham: [["a","c"]]
 
-            Provide multiple filters using `*args` syntax:
-
-            >>> def agnostic_filter(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     dframe = df.filter(
-            ...         nw.col("foo") <= 2,
-            ...         ~nw.col("ham").is_in(["b", "c"]),
-            ...     ).to_native()
-            ...     return dframe
-            >>> agnostic_filter(df_pd)
-               foo  bar ham
-            0    1    6   a
-            >>> agnostic_filter(df_pl)
-            shape: (1, 3)
-            ┌─────┬─────┬─────┐
-            │ foo ┆ bar ┆ ham │
-            │ --- ┆ --- ┆ --- │
-            │ i64 ┆ i64 ┆ str │
-            ╞═════╪═════╪═════╡
-            │ 1   ┆ 6   ┆ a   │
-            └─────┴─────┴─────┘
-            >>> agnostic_filter(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: int64
-            ham: string
-            ----
-            foo: [[1]]
-            bar: [[6]]
-            ham: [["a"]]
-
-            Provide multiple filters using `**kwargs` syntax:
-
-            >>> def agnostic_filter(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return df.filter(foo=2, ham="b").to_native()
-            >>> agnostic_filter(df_pd)
+            # Filter using `**kwargs` syntax
+            >>> nw.from_native(df_native).filter(foo=2, ham="b").to_native()
                foo  bar ham
             1    2    7   b
-            >>> agnostic_filter(df_pl)
-            shape: (1, 3)
-            ┌─────┬─────┬─────┐
-            │ foo ┆ bar ┆ ham │
-            │ --- ┆ --- ┆ --- │
-            │ i64 ┆ i64 ┆ str │
-            ╞═════╪═════╪═════╡
-            │ 2   ┆ 7   ┆ b   │
-            └─────┴─────┴─────┘
-            >>> agnostic_filter(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: int64
-            ham: string
-            ----
-            foo: [[2]]
-            bar: [[7]]
-            ham: [["b"]]
         """
         return super().filter(*predicates, **constraints)
 
@@ -1883,91 +1530,29 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrameT
-            >>> data = {
-            ...     "a": ["a", "b", "a", "b", "c"],
-            ...     "b": [1, 2, 1, 3, 3],
-            ...     "c": [5, 4, 3, 2, 1],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
+            >>> df_native = pd.DataFrame({"a": ["a", "b", "a", "b", "c"], "b": [1, 2, 1, 3, 3], "c": [5, 4, 3, 2, 1]})
 
-            Let's define a dataframe-agnostic function in which we group by one column
-            and call `agg` to compute the grouped sum of another column.
-
-            >>> def agnostic_group_by_agg(df_native: IntoDataFrameT) -> IntoDataFrameT:
-            ...     df = nw.from_native(df_native, eager_only=True)
-            ...     return df.group_by("a").agg(nw.col("b").sum()).sort("a").to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_group_by_agg`:
-
-            >>> agnostic_group_by_agg(df_pd)
+            # Group by one column and compute the sum of another column
+            >>> nw.from_native(df_native, eager_only=True).group_by("a").agg(nw.col("b").sum()).sort("a").to_native()
                a  b
             0  a  2
             1  b  5
             2  c  3
-            >>> agnostic_group_by_agg(df_pl)
-            shape: (3, 2)
-            ┌─────┬─────┐
-            │ a   ┆ b   │
-            │ --- ┆ --- │
-            │ str ┆ i64 │
-            ╞═════╪═════╡
-            │ a   ┆ 2   │
-            │ b   ┆ 5   │
-            │ c   ┆ 3   │
-            └─────┴─────┘
-            >>> agnostic_group_by_agg(df_pa)
-            pyarrow.Table
-            a: string
-            b: int64
-            ----
-            a: [["a","b","c"]]
-            b: [[2,5,3]]
 
-            Group by multiple columns by passing a list of column names.
-
-            >>> def agnostic_group_by_agg(df_native: IntoDataFrameT) -> IntoDataFrameT:
-            ...     df = nw.from_native(df_native, eager_only=True)
-            ...     return (
-            ...         df.group_by(["a", "b"])
-            ...         .agg(nw.max("c"))
-            ...         .sort("a", "b")
-            ...         .to_native()
-            ...     )
-
-            >>> agnostic_group_by_agg(df_pd)
+            # Group by multiple columns and compute the max of another column
+            >>> (
+            ...     nw.from_native(df_native, eager_only=True)
+            ...     .group_by(["a", "b"])
+            ...     .agg(nw.max("c"))
+            ...     .sort("a", "b")
+            ...     .to_native()
+            ... )
                a  b  c
             0  a  1  5
             1  b  2  4
             2  b  3  2
             3  c  3  1
-            >>> agnostic_group_by_agg(df_pl)
-            shape: (4, 3)
-            ┌─────┬─────┬─────┐
-            │ a   ┆ b   ┆ c   │
-            │ --- ┆ --- ┆ --- │
-            │ str ┆ i64 ┆ i64 │
-            ╞═════╪═════╪═════╡
-            │ a   ┆ 1   ┆ 5   │
-            │ b   ┆ 2   ┆ 4   │
-            │ b   ┆ 3   ┆ 2   │
-            │ c   ┆ 3   ┆ 1   │
-            └─────┴─────┴─────┘
-            >>> agnostic_group_by_agg(df_pa)
-            pyarrow.Table
-            a: string
-            b: int64
-            c: int64
-            ----
-            a: [["a","b","b","c"]]
-            b: [[1,2,3,3]]
-            c: [[5,4,2,1]]
         """
         from narwhals.expr import Expr
         from narwhals.group_by import GroupBy
@@ -2001,61 +1586,16 @@ class DataFrame(BaseFrame[DataFrameT]):
         Returns:
             The sorted dataframe.
 
-        Warning:
+        Note:
             Unlike Polars, it is not possible to specify a sequence of booleans for
             `nulls_last` in order to control per-column behaviour. Instead a single
             boolean is applied for all `by` columns.
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "a": [1, 2, None],
-            ...     "b": [6.0, 5.0, 4.0],
-            ...     "c": ["a", "c", "b"],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function in which we sort by multiple
-            columns in different orders
-
-            >>> def agnostic_sort(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return df.sort("c", "a", descending=[False, True]).to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_sort`:
-
-            >>> agnostic_sort(df_pd)
-                 a    b  c
-            0  1.0  6.0  a
-            2  NaN  4.0  b
-            1  2.0  5.0  c
-            >>> agnostic_sort(df_pl)
-            shape: (3, 3)
-            ┌──────┬─────┬─────┐
-            │ a    ┆ b   ┆ c   │
-            │ ---  ┆ --- ┆ --- │
-            │ i64  ┆ f64 ┆ str │
-            ╞══════╪═════╪═════╡
-            │ 1    ┆ 6.0 ┆ a   │
-            │ null ┆ 4.0 ┆ b   │
-            │ 2    ┆ 5.0 ┆ c   │
-            └──────┴─────┴─────┘
-            >>> agnostic_sort(df_pa)
-            pyarrow.Table
-            a: int64
-            b: double
-            c: string
-            ----
-            a: [[1,null,2]]
-            b: [[6,4,5]]
-            c: [["a","b","c"]]
+            >>> df_native = pd.DataFrame({"foo": [2, 1], "bar": [6.0, 7.0], "ham": ["a", "b"]})
+            >>> nw.from_native(df_native).sort('foo')
         """
         return super().sort(by, *more_by, descending=descending, nulls_last=nulls_last)
 
@@ -2091,67 +1631,10 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6.0, 7.0, 8.0],
-            ...     "ham": ["a", "b", "c"],
-            ... }
-            >>> data_other = {
-            ...     "apple": ["x", "y", "z"],
-            ...     "ham": ["a", "b", "d"],
-            ... }
-
-            >>> df_pd = pd.DataFrame(data)
-            >>> other_pd = pd.DataFrame(data_other)
-
-            >>> df_pl = pl.DataFrame(data)
-            >>> other_pl = pl.DataFrame(data_other)
-
-            >>> df_pa = pa.table(data)
-            >>> other_pa = pa.table(data_other)
-
-            Let's define a dataframe-agnostic function in which we join over "ham" column:
-
-            >>> def agnostic_join_on_ham(
-            ...     df_native: IntoFrameT, other_native: IntoFrameT
-            ... ) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     other = nw.from_native(other_native)
-            ...     return df.join(other, left_on="ham", right_on="ham").to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_join_on_ham`:
-
-            >>> agnostic_join_on_ham(df_pd, other_pd)
-               foo  bar ham apple
-            0    1  6.0   a     x
-            1    2  7.0   b     y
-
-            >>> agnostic_join_on_ham(df_pl, other_pl)
-            shape: (2, 4)
-            ┌─────┬─────┬─────┬───────┐
-            │ foo ┆ bar ┆ ham ┆ apple │
-            │ --- ┆ --- ┆ --- ┆ ---   │
-            │ i64 ┆ f64 ┆ str ┆ str   │
-            ╞═════╪═════╪═════╪═══════╡
-            │ 1   ┆ 6.0 ┆ a   ┆ x     │
-            │ 2   ┆ 7.0 ┆ b   ┆ y     │
-            └─────┴─────┴─────┴───────┘
-            >>> agnostic_join_on_ham(df_pa, other_pa)
-            pyarrow.Table
-            foo: int64
-            bar: double
-            ham: string
-            apple: string
-            ----
-            foo: [[1,2]]
-            bar: [[6,7]]
-            ham: [["a","b"]]
-            apple: [["x","y"]]
+            >>> df_1_native = pd.DataFrame({"id": ['a', 'b'], "price": [6.0, 7.0]})
+            >>> df_2_native = pd.DataFrame({"id": ['a', 'b', 'c'], "qty": [1,2,3]})
+            >>> nw.from_native(df_1_native).join(nw.from_native(df_2_native), on='id')
         """
         return super().join(
             other, how=how, left_on=left_on, right_on=right_on, on=on, suffix=suffix
@@ -2196,11 +1679,8 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> from datetime import datetime
-            >>> from typing import Literal
             >>> import pandas as pd
-            >>> import polars as pl
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
             >>> data_gdp = {
             ...     "datetime": [
             ...         datetime(2016, 1, 1),
@@ -2219,125 +1699,11 @@ class DataFrame(BaseFrame[DataFrameT]):
             ...     ],
             ...     "population": [82.19, 82.66, 83.12],
             ... }
-            >>> gdp_pd = pd.DataFrame(data_gdp)
-            >>> population_pd = pd.DataFrame(data_population)
-
-            >>> gdp_pl = pl.DataFrame(data_gdp).sort("datetime")
-            >>> population_pl = pl.DataFrame(data_population).sort("datetime")
-
-            Let's define a dataframe-agnostic function in which we join over "datetime" column:
-
-            >>> def agnostic_join_asof_datetime(
-            ...     df_native: IntoFrameT,
-            ...     other_native: IntoFrameT,
-            ...     strategy: Literal["backward", "forward", "nearest"],
-            ... ) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     other = nw.from_native(other_native)
-            ...     return df.join_asof(
-            ...         other, on="datetime", strategy=strategy
-            ...     ).to_native()
-
-            We can then pass any supported library such as Pandas or Polars
-            to `agnostic_join_asof_datetime`:
-
-            >>> agnostic_join_asof_datetime(population_pd, gdp_pd, strategy="backward")
-                datetime  population   gdp
-            0 2016-03-01       82.19  4164
-            1 2018-08-01       82.66  4566
-            2 2019-01-01       83.12  4696
-
-            >>> agnostic_join_asof_datetime(population_pl, gdp_pl, strategy="backward")
-            shape: (3, 3)
-            ┌─────────────────────┬────────────┬──────┐
-            │ datetime            ┆ population ┆ gdp  │
-            │ ---                 ┆ ---        ┆ ---  │
-            │ datetime[μs]        ┆ f64        ┆ i64  │
-            ╞═════════════════════╪════════════╪══════╡
-            │ 2016-03-01 00:00:00 ┆ 82.19      ┆ 4164 │
-            │ 2018-08-01 00:00:00 ┆ 82.66      ┆ 4566 │
-            │ 2019-01-01 00:00:00 ┆ 83.12      ┆ 4696 │
-            └─────────────────────┴────────────┴──────┘
-
-            Here is a real-world times-series example that uses `by` argument.
-
-            >>> from datetime import datetime
-            >>> import narwhals as nw
-            >>> import pandas as pd
-            >>> import polars as pl
-            >>> data_quotes = {
-            ...     "datetime": [
-            ...         datetime(2016, 5, 25, 13, 30, 0, 23),
-            ...         datetime(2016, 5, 25, 13, 30, 0, 23),
-            ...         datetime(2016, 5, 25, 13, 30, 0, 30),
-            ...         datetime(2016, 5, 25, 13, 30, 0, 41),
-            ...         datetime(2016, 5, 25, 13, 30, 0, 48),
-            ...         datetime(2016, 5, 25, 13, 30, 0, 49),
-            ...         datetime(2016, 5, 25, 13, 30, 0, 72),
-            ...         datetime(2016, 5, 25, 13, 30, 0, 75),
-            ...     ],
-            ...     "ticker": [
-            ...         "GOOG",
-            ...         "MSFT",
-            ...         "MSFT",
-            ...         "MSFT",
-            ...         "GOOG",
-            ...         "AAPL",
-            ...         "GOOG",
-            ...         "MSFT",
-            ...     ],
-            ...     "bid": [720.50, 51.95, 51.97, 51.99, 720.50, 97.99, 720.50, 52.01],
-            ...     "ask": [720.93, 51.96, 51.98, 52.00, 720.93, 98.01, 720.88, 52.03],
-            ... }
-            >>> data_trades = {
-            ...     "datetime": [
-            ...         datetime(2016, 5, 25, 13, 30, 0, 23),
-            ...         datetime(2016, 5, 25, 13, 30, 0, 38),
-            ...         datetime(2016, 5, 25, 13, 30, 0, 48),
-            ...         datetime(2016, 5, 25, 13, 30, 0, 48),
-            ...         datetime(2016, 5, 25, 13, 30, 0, 48),
-            ...     ],
-            ...     "ticker": ["MSFT", "MSFT", "GOOG", "GOOG", "AAPL"],
-            ...     "price": [51.95, 51.95, 720.77, 720.92, 98.0],
-            ...     "quantity": [75, 155, 100, 100, 100],
-            ... }
-            >>> quotes_pd = pd.DataFrame(data_quotes)
-            >>> trades_pd = pd.DataFrame(data_trades)
-            >>> quotes_pl = pl.DataFrame(data_quotes).sort("datetime")
-            >>> trades_pl = pl.DataFrame(data_trades).sort("datetime")
-
-            Let's define a dataframe-agnostic function in which we join over "datetime" and by "ticker" columns:
-
-            >>> def agnostic_join_asof_datetime_by_ticker(
-            ...     df_native: IntoFrameT, other_native: IntoFrameT
-            ... ) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     other = nw.from_native(other_native)
-            ...     return df.join_asof(other, on="datetime", by="ticker").to_native()
-
-            We can now pass either pandas or Polars to the function:
-
-            >>> agnostic_join_asof_datetime_by_ticker(trades_pd, quotes_pd)
-                                datetime ticker   price  quantity     bid     ask
-            0 2016-05-25 13:30:00.000023   MSFT   51.95        75   51.95   51.96
-            1 2016-05-25 13:30:00.000038   MSFT   51.95       155   51.97   51.98
-            2 2016-05-25 13:30:00.000048   GOOG  720.77       100  720.50  720.93
-            3 2016-05-25 13:30:00.000048   GOOG  720.92       100  720.50  720.93
-            4 2016-05-25 13:30:00.000048   AAPL   98.00       100     NaN     NaN
-
-            >>> agnostic_join_asof_datetime_by_ticker(trades_pl, quotes_pl)
-            shape: (5, 6)
-            ┌────────────────────────────┬────────┬────────┬──────────┬───────┬────────┐
-            │ datetime                   ┆ ticker ┆ price  ┆ quantity ┆ bid   ┆ ask    │
-            │ ---                        ┆ ---    ┆ ---    ┆ ---      ┆ ---   ┆ ---    │
-            │ datetime[μs]               ┆ str    ┆ f64    ┆ i64      ┆ f64   ┆ f64    │
-            ╞════════════════════════════╪════════╪════════╪══════════╪═══════╪════════╡
-            │ 2016-05-25 13:30:00.000023 ┆ MSFT   ┆ 51.95  ┆ 75       ┆ 51.95 ┆ 51.96  │
-            │ 2016-05-25 13:30:00.000038 ┆ MSFT   ┆ 51.95  ┆ 155      ┆ 51.97 ┆ 51.98  │
-            │ 2016-05-25 13:30:00.000048 ┆ GOOG   ┆ 720.77 ┆ 100      ┆ 720.5 ┆ 720.93 │
-            │ 2016-05-25 13:30:00.000048 ┆ GOOG   ┆ 720.92 ┆ 100      ┆ 720.5 ┆ 720.93 │
-            │ 2016-05-25 13:30:00.000048 ┆ AAPL   ┆ 98.0   ┆ 100      ┆ null  ┆ null   │
-            └────────────────────────────┴────────┴────────┴──────────┴───────┴────────┘
+            >>> gdp_native = pd.DataFrame(data_gdp)
+            >>> population_native = pd.DataFrame(data_population)
+            >>> gdp = nw.from_native(gdp_native)
+            >>> population = nw.from_native(population_native)
+            >>> population.join_asof(gdp, on='datetime', strategy='backward')
         """
         return super().join_asof(
             other,
@@ -2360,54 +1726,9 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> from narwhals.typing import IntoSeries
-            >>> data = {
-            ...     "a": [1, 2, 3, 1],
-            ...     "b": ["x", "y", "z", "x"],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_is_duplicated(df_native: IntoDataFrame) -> IntoSeries:
-            ...     df = nw.from_native(df_native, eager_only=True)
-            ...     return df.is_duplicated().to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_is_duplicated`:
-
-            >>> agnostic_is_duplicated(df_pd)
-            0     True
-            1    False
-            2    False
-            3     True
-            dtype: bool
-
-            >>> agnostic_is_duplicated(df_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: '' [bool]
-            [
-                true
-                false
-                false
-                true
-            ]
-            >>> agnostic_is_duplicated(df_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                true,
-                false,
-                false,
-                true
-              ]
-            ]
+            >>> df_native = pd.DataFrame({"foo": [2, 2,2], "bar": [6.0, 6., 7.0]})
+            >>> nw.from_native(df_native).is_duplicated()
         """
         return self._series(
             self._compliant_frame.is_duplicated(),
@@ -2422,42 +1743,9 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-
-            Let's define a dataframe-agnostic function that filters rows in which "foo"
-            values are greater than 10, and then checks if the result is empty or not:
-
-            >>> def agnostic_is_empty(df_native: IntoDataFrame) -> bool:
-            ...     df = nw.from_native(df_native, eager_only=True)
-            ...     return df.filter(nw.col("foo") > 10).is_empty()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_is_empty`:
-
-            >>> data = {"foo": [1, 2, 3], "bar": [4, 5, 6]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-            >>> (
-            ...     agnostic_is_empty(df_pd),
-            ...     agnostic_is_empty(df_pl),
-            ...     agnostic_is_empty(df_pa),
-            ... )
-            (True, True, True)
-
-            >>> data = {"foo": [100, 2, 3], "bar": [4, 5, 6]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-            >>> (
-            ...     agnostic_is_empty(df_pd),
-            ...     agnostic_is_empty(df_pl),
-            ...     agnostic_is_empty(df_pa),
-            ... )
-            (False, False, False)
+            >>> df_native = pd.DataFrame({"foo": [2, 2,2], "bar": [6.0, 6., 7.0]})
+            >>> nw.from_native(df_native).is_empty()
         """
         return self._compliant_frame.is_empty()  # type: ignore[no-any-return]
 
@@ -2469,54 +1757,9 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> from narwhals.typing import IntoSeries
-            >>> data = {
-            ...     "a": [1, 2, 3, 1],
-            ...     "b": ["x", "y", "z", "x"],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_is_unique(df_native: IntoDataFrame) -> IntoSeries:
-            ...     df = nw.from_native(df_native, eager_only=True)
-            ...     return df.is_unique().to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_is_unique`:
-
-            >>> agnostic_is_unique(df_pd)
-            0    False
-            1     True
-            2     True
-            3    False
-            dtype: bool
-
-            >>> agnostic_is_unique(df_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: '' [bool]
-            [
-                false
-                 true
-                 true
-                false
-            ]
-            >>> agnostic_is_unique(df_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                false,
-                true,
-                true,
-                false
-              ]
-            ]
+            >>> df_native = pd.DataFrame({"foo": [2, 2,2], "bar": [6.0, 6., 7.0]})
+            >>> nw.from_native(df_native).is_unique()
         """
         return self._series(
             self._compliant_frame.is_unique(),
@@ -2535,53 +1778,10 @@ class DataFrame(BaseFrame[DataFrameT]):
             for reference.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "foo": [1, None, 3],
-            ...     "bar": [6, 7, None],
-            ...     "ham": ["a", "b", "c"],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function that returns the null count of
-            each columns:
-
-            >>> def agnostic_null_count(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return df.null_count().to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow to
-            `agnostic_null_count`:
-
-            >>> agnostic_null_count(df_pd)
-               foo  bar  ham
-            0    1    1    0
-
-            >>> agnostic_null_count(df_pl)
-            shape: (1, 3)
-            ┌─────┬─────┬─────┐
-            │ foo ┆ bar ┆ ham │
-            │ --- ┆ --- ┆ --- │
-            │ u32 ┆ u32 ┆ u32 │
-            ╞═════╪═════╪═════╡
-            │ 1   ┆ 1   ┆ 0   │
-            └─────┴─────┴─────┘
-
-            >>> agnostic_null_count(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: int64
-            ham: int64
-            ----
-            foo: [[1]]
-            bar: [[1]]
-            ham: [[0]]
+            >>> df_native = pa.table({"foo": [1, None], "bar": [2, 3]})
+            >>> nw.from_native(df_native).null_count()
         """
         return self._from_compliant_dataframe(self._compliant_frame.null_count())
 
@@ -2600,33 +1800,10 @@ class DataFrame(BaseFrame[DataFrameT]):
             With row/col, this is equivalent to df[row,col].
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> data = {"a": [1, 2, 3], "b": [4, 5, 6]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function that returns item at given row/column
-
-            >>> def agnostic_item(
-            ...     df_native: IntoDataFrame, row: int | None, column: int | str | None
-            ... ):
-            ...     df = nw.from_native(df_native, eager_only=True)
-            ...     return df.item(row, column)
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_item`:
-
-            >>> agnostic_item(df_pd, 1, 1), agnostic_item(df_pd, 2, "b")
-            (np.int64(5), np.int64(6))
-            >>> agnostic_item(df_pl, 1, 1), agnostic_item(df_pl, 2, "b")
-            (5, 6)
-            >>> agnostic_item(df_pa, 1, 1), agnostic_item(df_pa, 2, "b")
-            (5, 6)
+            >>> df_native = pa.table({"foo": [1, None], "bar": [2, 3]})
+            >>> nw.from_native(df_native).item(0, 1)
         """
         return self._compliant_frame.item(row=row, column=column)
 
@@ -2635,41 +1812,6 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Returns:
             An identical copy of the original dataframe.
-
-        Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
-            >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {"a": [1, 2], "b": [3, 4]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-
-            Let's define a dataframe-agnostic function in which we clone the DataFrame:
-
-            >>> def agnostic_clone(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return df.clone().to_native()
-
-            We can then pass any supported library such as Pandas or Polars
-            to `agnostic_clone`:
-
-            >>> agnostic_clone(df_pd)
-               a  b
-            0  1  3
-            1  2  4
-
-            >>> agnostic_clone(df_pl)
-            shape: (2, 2)
-            ┌─────┬─────┐
-            │ a   ┆ b   │
-            │ --- ┆ --- │
-            │ i64 ┆ i64 │
-            ╞═════╪═════╡
-            │ 1   ┆ 3   │
-            │ 2   ┆ 4   │
-            └─────┴─────┘
         """
         return super().clone()
 
@@ -2684,48 +1826,10 @@ class DataFrame(BaseFrame[DataFrameT]):
             The dataframe containing only the selected rows.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function in which gather every 2 rows,
-            starting from a offset of 1:
-
-            >>> def agnostic_gather_every(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return df.gather_every(n=2, offset=1).to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_gather_every`:
-
-            >>> agnostic_gather_every(df_pd)
-               a  b
-            1  2  6
-            3  4  8
-
-            >>> agnostic_gather_every(df_pl)
-            shape: (2, 2)
-            ┌─────┬─────┐
-            │ a   ┆ b   │
-            │ --- ┆ --- │
-            │ i64 ┆ i64 │
-            ╞═════╪═════╡
-            │ 2   ┆ 6   │
-            │ 4   ┆ 8   │
-            └─────┴─────┘
-            >>> agnostic_gather_every(df_pa)
-            pyarrow.Table
-            a: int64
-            b: int64
-            ----
-            a: [[2,4]]
-            b: [[6,8]]
+            >>> df_native = pa.table({"foo": [1, None, 2 3]})
+            >>> nw.from_native(df_native).gather_every(2)
         """
         return super().gather_every(n=n, offset=offset)
 

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1875,45 +1875,15 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrameT
             >>> data = {
             ...     "ix": [1, 1, 2, 2, 1, 2],
             ...     "col": ["a", "a", "a", "a", "b", "b"],
             ...     "foo": [0, 1, 2, 2, 7, 1],
             ...     "bar": [0, 2, 0, 0, 9, 4],
             ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_pivot(df_native: IntoDataFrameT) -> IntoDataFrameT:
-            ...     df = nw.from_native(df_native, eager_only=True)
-            ...     return df.pivot(
-            ...         "col", index="ix", aggregate_function="sum"
-            ...     ).to_native()
-
-            We can then pass any supported library such as Pandas or Polars
-            to `agnostic_pivot`:
-
-            >>> agnostic_pivot(df_pd)
-               ix  foo_a  foo_b  bar_a  bar_b
-            0   1      1      7      2      9
-            1   2      4      1      0      4
-            >>> agnostic_pivot(df_pl)
-            shape: (2, 5)
-            ┌─────┬───────┬───────┬───────┬───────┐
-            │ ix  ┆ foo_a ┆ foo_b ┆ bar_a ┆ bar_b │
-            │ --- ┆ ---   ┆ ---   ┆ ---   ┆ ---   │
-            │ i64 ┆ i64   ┆ i64   ┆ i64   ┆ i64   │
-            ╞═════╪═══════╪═══════╪═══════╪═══════╡
-            │ 1   ┆ 1     ┆ 7     ┆ 2     ┆ 9     │
-            │ 2   ┆ 4     ┆ 1     ┆ 0     ┆ 4     │
-            └─────┴───────┴───────┴───────┴───────┘
+            >>> df_native = pd.DataFrame(data)
+            >>> df.pivot('col', index='ix', aggregate_function='sum')
         """
         if values is None and index is None:
             msg = "At least one of `values` and `index` must be passed"
@@ -1944,47 +1914,9 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> data = {"foo": [1, 2, 3], "bar": ["a", "b", "c"]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function that converts to arrow table:
-
-            >>> def agnostic_to_arrow(df_native: IntoDataFrame) -> pa.Table:
-            ...     df = nw.from_native(df_native, eager_only=True)
-            ...     return df.to_arrow()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_to_arrow`:
-
-            >>> agnostic_to_arrow(df_pd)
-            pyarrow.Table
-            foo: int64
-            bar: string
-            ----
-            foo: [[1,2,3]]
-            bar: [["a","b","c"]]
-
-            >>> agnostic_to_arrow(df_pl)
-            pyarrow.Table
-            foo: int64
-            bar: large_string
-            ----
-            foo: [[1,2,3]]
-            bar: [["a","b","c"]]
-
-            >>> agnostic_to_arrow(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: string
-            ----
-            foo: [[1,2,3]]
-            bar: [["a","b","c"]]
+            >>> df_native = pd.DataFrame({"foo": [1, None], "bar": [2, 3]})
+            >>> nw.from_native(df_native).to_arrow()
         """
         return self._compliant_frame.to_arrow()
 
@@ -2013,48 +1945,9 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrameT
-            >>> data = {"a": [1, 2, 3, 4], "b": ["x", "y", "x", "y"]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_sample(df_native: IntoDataFrameT) -> IntoDataFrameT:
-            ...     df = nw.from_native(df_native, eager_only=True)
-            ...     return df.sample(n=2, seed=123).to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_sample`:
-
-            >>> agnostic_sample(df_pd)
-               a  b
-            3  4  y
-            0  1  x
-            >>> agnostic_sample(df_pl)
-            shape: (2, 2)
-            ┌─────┬─────┐
-            │ a   ┆ b   │
-            │ --- ┆ --- │
-            │ i64 ┆ str │
-            ╞═════╪═════╡
-            │ 2   ┆ y   │
-            │ 3   ┆ x   │
-            └─────┴─────┘
-            >>> agnostic_sample(df_pa)
-            pyarrow.Table
-            a: int64
-            b: string
-            ----
-            a: [[1,3]]
-            b: [["x","x"]]
-
-            As you can see, by using the same seed, the result will be consistent within
-            the same backend, but not necessarely across different backends.
+            >>> df_native = pd.DataFrame({"foo": [1, 2, 3], "bar": [19,32,4]})
+            >>> nw.from_native(df_native).to_sample(n=2)  # doctest:+SKIP
         """
         return self._from_compliant_dataframe(
             self._compliant_frame.sample(
@@ -2096,58 +1989,14 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
             >>> data = {
             ...     "a": ["x", "y", "z"],
             ...     "b": [1, 3, 5],
             ...     "c": [2, 4, 6],
             ... }
-
-            We define a library agnostic function:
-
-            >>> def agnostic_unpivot(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return df.unpivot(on=["b", "c"], index="a").to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_unpivot`:
-
-            >>> agnostic_unpivot(pl.DataFrame(data))
-            shape: (6, 3)
-            ┌─────┬──────────┬───────┐
-            │ a   ┆ variable ┆ value │
-            │ --- ┆ ---      ┆ ---   │
-            │ str ┆ str      ┆ i64   │
-            ╞═════╪══════════╪═══════╡
-            │ x   ┆ b        ┆ 1     │
-            │ y   ┆ b        ┆ 3     │
-            │ z   ┆ b        ┆ 5     │
-            │ x   ┆ c        ┆ 2     │
-            │ y   ┆ c        ┆ 4     │
-            │ z   ┆ c        ┆ 6     │
-            └─────┴──────────┴───────┘
-
-            >>> agnostic_unpivot(pd.DataFrame(data))
-               a variable  value
-            0  x        b      1
-            1  y        b      3
-            2  z        b      5
-            3  x        c      2
-            4  y        c      4
-            5  z        c      6
-
-            >>> agnostic_unpivot(pa.table(data))
-            pyarrow.Table
-            a: string
-            variable: string
-            value: int64
-            ----
-            a: [["x","y","z"],["x","y","z"]]
-            variable: [["b","b","b"],["c","c","c"]]
-            value: [[1,3,5],[2,4,6]]
+            >>> df_native = pd.DataFrame(data)
+            >>> nw.from_native(df_native).unpivot(['b', 'c'], index='a')
         """
         return super().unpivot(
             on=on, index=index, variable_name=variable_name, value_name=value_name
@@ -2169,49 +2018,11 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "a": ["x", "y", "z", "w"],
-            ...     "lst1": [[1, 2], None, [None], []],
-            ...     "lst2": [[3, None], None, [42], []],
-            ... }
-
-            We define a library agnostic function:
-
-            >>> def agnostic_explode(df_native: IntoFrameT) -> IntoFrameT:
-            ...     return (
-            ...         nw.from_native(df_native)
-            ...         .with_columns(nw.col("lst1", "lst2").cast(nw.List(nw.Int32())))
-            ...         .explode("lst1", "lst2")
-            ...         .to_native()
-            ...     )
-
-            We can then pass any supported library such as pandas, Polars (eager),
-            or PyArrow to `agnostic_explode`:
-
-            >>> agnostic_explode(pd.DataFrame(data))
-               a  lst1  lst2
-            0  x     1     3
-            0  x     2  <NA>
-            1  y  <NA>  <NA>
-            2  z  <NA>    42
-            3  w  <NA>  <NA>
-            >>> agnostic_explode(pl.DataFrame(data))
-            shape: (5, 3)
-            ┌─────┬──────┬──────┐
-            │ a   ┆ lst1 ┆ lst2 │
-            │ --- ┆ ---  ┆ ---  │
-            │ str ┆ i32  ┆ i32  │
-            ╞═════╪══════╪══════╡
-            │ x   ┆ 1    ┆ 3    │
-            │ x   ┆ 2    ┆ null │
-            │ y   ┆ null ┆ null │
-            │ z   ┆ null ┆ 42   │
-            │ w   ┆ null ┆ null │
-            └─────┴──────┴──────┘
+            >>> data = {'a': ['x', 'y'], 'b': [[1, 2], [3]]}
+            >>> df_native = pd.DataFrame(data).convert_dtypes(dtype_backend='pyarrow')
+            >>> nw.from_native(df_native).explode('lst1')
         """
         return super().explode(columns, *more_columns)
 

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1016,7 +1016,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             A mapping from column name to values / Series.
 
         Examples:
-        >>> import pyarrow as pa
+            >>> import pyarrow as pa
             >>> import narwhals as nw
             >>> df_native = pa.table({"A": [1, 2], "fruits": ["banana", "apple"]})
             >>> df = nw.from_native(df_native)
@@ -1510,19 +1510,22 @@ class DataFrame(BaseFrame[DataFrameT]):
             ... )
 
             Filter on one condition
+
             >>> nw.from_native(df_native).filter(nw.col("foo") > 1).to_native()
                foo  bar ham
             1    2    7   b
             2    3    8   c
 
             Filter on multiple conditions with `&`
+
             >>> nw.from_native(df_native).filter(
             ...     nw.col("foo") < 3, nw.col("ham") == "a"
             ... ).to_native()
                foo  bar ham
             0    1    6   a
 
-            # Filter on multiple conditions with `|`
+            Filter on multiple conditions with `|`
+
             >>> nw.from_native(df_native).filter(
             ...     (nw.col("foo") == 1) | (nw.col("ham") == "c")
             ... ).to_native()
@@ -1530,7 +1533,8 @@ class DataFrame(BaseFrame[DataFrameT]):
             0    1    6   a
             2    3    8   c
 
-            # Filter using `**kwargs` syntax
+            Filter using `**kwargs` syntax
+
             >>> nw.from_native(df_native).filter(foo=2, ham="b").to_native()
                foo  bar ham
             1    2    7   b
@@ -1561,7 +1565,8 @@ class DataFrame(BaseFrame[DataFrameT]):
             ...     }
             ... )
 
-            # Group by one column and compute the sum of another column
+            Group by one column and compute the sum of another column
+
             >>> nw.from_native(df_native, eager_only=True).group_by("a").agg(
             ...     nw.col("b").sum()
             ... ).sort("a").to_native()
@@ -1570,7 +1575,8 @@ class DataFrame(BaseFrame[DataFrameT]):
             1  b  5
             2  c  3
 
-            # Group by multiple columns and compute the max of another column
+            Group by multiple columns and compute the max of another column
+
             >>> (
             ...     nw.from_native(df_native, eager_only=True)
             ...     .group_by(["a", "b"])
@@ -2052,7 +2058,14 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import pandas as pd
             >>> import narwhals as nw
             >>> df_native = pd.DataFrame({"foo": [1, 2, 3], "bar": [19, 32, 4]})
-            >>> nw.from_native(df_native).to_sample(n=2)  # doctest:+SKIP
+            >>> nw.from_native(df_native).sample(n=2)  # doctest:+SKIP
+            ┌──────────────────┐
+            |Narwhals DataFrame|
+            |------------------|
+            |      foo  bar    |
+            |   2    3    4    |
+            |   1    2   32    |
+            └──────────────────┘
         """
         return self._from_compliant_dataframe(
             self._compliant_frame.sample(
@@ -2289,7 +2302,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql("select * from (values (1, 2), (3, 4)) df(a, b)")
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, 2), (3, 4) df(a, b)")
             >>> lf = nw.from_native(lf_native)
             >>> lf
             ┌──────────────────┐
@@ -2338,7 +2351,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql("select * from (values (1, 2), (3, 4)) df(a, b)")
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, 2), (3, 4) df(a, b)")
             >>> nw.from_native(lf_native).to_native()
             ┌───────┬───────┐
             │   a   │   b   │
@@ -2371,7 +2384,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql("select * from (values (1, 2), (3, 4)) df(a, b)")
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, 2), (3, 4) df(a, b)")
             >>> nw.from_native(lf_native).pipe(lambda x: x.select("a")).to_native()
             ┌───────┐
             │   a   │
@@ -2402,9 +2415,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql(
-            ...     "select * from (values (1, null), (3, 4)) df(a, b)"
-            ... )
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, null), (3, 4) df(a, b)")
             >>> nw.from_native(lf_native).drop_nulls()
             ┌──────────────────┐
             |Narwhals LazyFrame|
@@ -2453,9 +2464,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql(
-            ...     "select * from (values (1, 4.5), (3, 2.)) df(a, b)"
-            ... )
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, 4.5), (3, 2.) df(a, b)")
             >>> nw.from_native(lf_native).schema
             Schema({'a': Int32, 'b': Decimal})
         """
@@ -2470,9 +2479,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql(
-            ...     "select * from (values (1, 4.5), (3, 2.)) df(a, b)"
-            ... )
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, 4.5), (3, 2.) df(a, b)")
             >>> nw.from_native(lf_native).collect_schema()
             Schema({'a': Int32, 'b': Decimal})
         """
@@ -2488,9 +2495,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql(
-            ...     "select * from (values (1, 4.5), (3, 2.)) df(a, b)"
-            ... )
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, 4.5), (3, 2.) df(a, b)")
             >>> nw.from_native(lf_native).columns
             ['a', 'b']
         """
@@ -2521,9 +2526,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql(
-            ...     "select * from (values (1, 4.5), (3, 2.)) df(a, b)"
-            ... )
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, 4.5), (3, 2.) df(a, b)")
             >>> nw.from_native(lf_native).with_columns(c=nw.col("a") + 1)
             ┌────────────────────────────────┐
             |       Narwhals LazyFrame       |
@@ -2564,9 +2567,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql(
-            ...     "select * from (values (1, 4.5), (3, 2.)) df(a, b)"
-            ... )
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, 4.5), (3, 2.) df(a, b)")
             >>> nw.from_native(lf_native).select("a", a_plus_1=nw.col("a") + 1)
             ┌────────────────────┐
             | Narwhals LazyFrame |
@@ -2596,9 +2597,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql(
-            ...     "select * from (values (1, 4.5), (3, 2.)) df(a, b)"
-            ... )
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, 4.5), (3, 2.) df(a, b)")
             >>> nw.from_native(lf_native).rename({"a": "c"})
             ┌────────────────────────┐
             |   Narwhals LazyFrame   |
@@ -2673,7 +2672,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql("select * from (values (1, 2), (3, 4)) df(a, b)")
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, 2), (3, 4) df(a, b)")
             >>> nw.from_native(lf_native).drop("a").to_native()
             ┌───────┐
             │   b   │
@@ -2712,7 +2711,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql("select * from (values (1, 1), (3, 4)) df(a, b)")
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, 1), (3, 4) df(a, b)")
             >>> nw.from_native(lf_native).unique("a").sort("a", descending=True)
             ┌──────────────────┐
             |Narwhals LazyFrame|
@@ -2769,7 +2768,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql("select * from values (1, 1), (3, 4) df(a, b)")
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, 1), (3, 4) df(a, b)")
             >>> nw.from_native(lf_native).filter(nw.col("b") == 4)
             ┌──────────────────┐
             |Narwhals LazyFrame|
@@ -2812,7 +2811,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import duckdb
             >>> import narwhals as nw
             >>> df_native = duckdb.sql(
-            ...     "select * from values (1, 'a'), (2, 'b'), (3, 'a') df(a, b)"
+            ...     "SELECT * FROM VALUES (1, 'a'), (2, 'b'), (3, 'a') df(a, b)"
             ... )
             >>> df = nw.from_native(df_native)
             >>> df.group_by("b").agg(nw.col("a").sum()).sort("b").to_native()
@@ -2867,7 +2866,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import duckdb
             >>> import narwhals as nw
             >>> df_native = duckdb.sql(
-            ...     "select * from (values (1, 6.0, 'a'), (2, 5.0, 'c'), (null, 4.0, 'b')) df(a, b, c)"
+            ...     "SELECT * FROM VALUES (1, 6.0, 'a'), (2, 5.0, 'c'), (null, 4.0, 'b') df(a, b, c)"
             ... )
             >>> df = nw.from_native(df_native)
             >>> df.sort(by="a")
@@ -2920,10 +2919,10 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import duckdb
             >>> import narwhals as nw
             >>> df_native1 = duckdb.sql(
-            ...     "select * from (values (1, 'a'), (2, 'b')) df(a, b)"
+            ...     "SELECT * FROM VALUES (1, 'a'), (2, 'b') df(a, b)"
             ... )
             >>> df_native2 = duckdb.sql(
-            ...     "select * from (values (1, 'x'), (3, 'y')) df(a, c)"
+            ...     "SELECT * FROM VALUES (1, 'x'), (3, 'y') df(a, c)"
             ... )
             >>> df1 = nw.from_native(df_native1)
             >>> df2 = nw.from_native(df_native2)
@@ -3097,7 +3096,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import duckdb
             >>> import narwhals as nw
             >>> df_native = duckdb.sql(
-            ...     "select * from (values ('x', 1, 2), ('y', 3, 4), ('z', 5, 6)) df(a, b, c)"
+            ...     "SELECT * FROM VALUES ('x', 1, 2), ('y', 3, 4), ('z', 5, 6) df(a, b, c)"
             ... )
             >>> df = nw.from_native(df_native)
             >>> df.unpivot(on=["b", "c"], index="a").sort("a", "variable").to_native()
@@ -3136,7 +3135,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import duckdb
             >>> import narwhals as nw
             >>> df_native = duckdb.sql(
-            ...     "select * from values ('x', [1, 2]), ('y', [3, 4]), ('z', [5, 6]) df(a, b)"
+            ...     "SELECT * FROM VALUES ('x', [1, 2]), ('y', [3, 4]), ('z', [5, 6]) df(a, b)"
             ... )
             >>> df = nw.from_native(df_native)
             >>> df.explode("b").to_native()

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -686,7 +686,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> df_native = pa.table({'foo': [1, 2], 'bar': [6.0, 7.0]})
+            >>> df_native = pa.table({"foo": [1, 2], "bar": [6.0, 7.0]})
             >>> df = nw.from_native(df_native)
             >>> df.to_polars()
             shape: (2, 2)
@@ -763,10 +763,9 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> df_native = pa.table({'foo': [1, 2], 'bar': [6.0, 7.0]})
+            >>> df_native = pa.table({"foo": [1, 2], "bar": [6.0, 7.0]})
             >>> df = nw.from_native(df_native)
-            >>> df.write_csv()
-            'foo,bar\n1,6.0\n2,7.0\n'
+            >>> df.write_parquet("out.parquet")  # doctest:+SKIP
         """
         self._compliant_frame.write_parquet(file)
 
@@ -779,11 +778,11 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pd.DataFrame{'foo': [1, 2], 'bar': [6.5, 7.0]})
+            >>> df_native = pd.DataFrame({"foo": [1, 2], "bar": [6.5, 7.0]})
             >>> df = nw.from_native(df_native)
             >>> df.to_numpy()
             array([[1. , 6.5],
-                   [2. , 7.0]])
+                   [2. , 7. ]])
         """
         return self._compliant_frame.to_numpy()
 
@@ -797,7 +796,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pd.DataFrame{'foo': [1, 2]})
+            >>> df_native = pd.DataFrame({"foo": [1, 2]})
             >>> df = nw.from_native(df_native)
             >>> df.shape
             (2, 1)
@@ -821,17 +820,14 @@ class DataFrame(BaseFrame[DataFrameT]):
             there is no risk of ambiguity.
 
         Examples:
-            >>> import pyarrow as pa
+            >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pa.table({'a': [1, 2]})
+            >>> df_native = pd.DataFrame({"a": [1, 2]})
             >>> df = nw.from_native(df_native)
-            >>> df.get_column('a').to_native()
-            [
-              [
-                1,
-                2
-              ]
-            ]
+            >>> df.get_column("a").to_native()
+            0    1
+            1    2
+            Name: a, dtype: int64
         """
         return self._series(
             self._compliant_frame.get_column(name),
@@ -853,10 +849,10 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> df_native = pa.table({'foo': [1, 2], 'bar': [6.0, 7.0]})
+            >>> df_native = pa.table({"foo": [1, 2], "bar": [6.0, 7.0]})
             >>> df = nw.from_native(df_native)
             >>> df.estimated_size()
-            63
+            32
         """
         return self._compliant_frame.estimated_size(unit=unit)  # type: ignore[no-any-return]
 
@@ -947,17 +943,14 @@ class DataFrame(BaseFrame[DataFrameT]):
             use `DataFrame.get_column` instead.
 
         Examples:
-            >>> import pyarrow as pa
+            >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pa.table({'a': [1, 2]})
+            >>> df_native = pd.DataFrame({"a": [1, 2]})
             >>> df = nw.from_native(df_native)
-            >>> df['a'].to_native()
-            [
-            [
-                1,
-                2
-            ]
-            ]
+            >>> df["a"].to_native()
+            0    1
+            1    2
+            Name: a, dtype: int64
         """
         if isinstance(item, int):
             item = [item]
@@ -1025,7 +1018,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
         >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> df_native = pa.table({'A': [1, 2], 'fruits': ['banana', 'apple']})
+            >>> df_native = pa.table({"A": [1, 2], "fruits": ["banana", "apple"]})
             >>> df = nw.from_native(df_native)
             >>> df.to_dict(as_series=False)
             {'A': [1, 2], 'fruits': ['banana', 'apple']}
@@ -1062,7 +1055,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> df_native = pa.table({'a': [1, 2], 'b': [4, 5]})
+            >>> df_native = pa.table({"a": [1, 2], "b": [4, 5]})
             >>> nw.from_native(df_native).row(1)
             (<pyarrow.Int64Scalar: 2>, <pyarrow.Int64Scalar: 5>)
         """
@@ -1090,9 +1083,11 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import narwhals as nw
             >>> df_native = pd.DataFrame({"a": [1, 2], "ba": [4, 5]})
             >>> nw.from_native(df_native).pipe(
-            ...     lambda _df: _df.select([x for x in _df.columns if len(x) == 1]).to_native()
+            ...     lambda _df: _df.select(
+            ...         [x for x in _df.columns if len(x) == 1]
+            ...     ).to_native()
             ... )
-            a
+               a
             0  1
             1  2
         """
@@ -1164,7 +1159,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import narwhals as nw
             >>> df_native = pa.table({"foo": [1, 2], "bar": [6.0, 7.0]})
             >>> nw.from_native(df_native).schema
-            Schema({'foo': Int64, 'bar': Float64}) 
+            Schema({'foo': Int64, 'bar': Float64})
         """
         return super().schema
 
@@ -1227,7 +1222,8 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import pyarrow as pa
             >>> import narwhals as nw
             >>> df_native = pa.table({"foo": [1, 2], "bar": [6.0, 7.0]})
-            >>> nw.from_native(df_native).rows
+            >>> nw.from_native(df_native).rows()
+            [(1, 6.0), (2, 7.0)]
         """
         return self._compliant_frame.rows(named=named)  # type: ignore[no-any-return]
 
@@ -1271,7 +1267,9 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> df_native = pa.table({"foo": [1, 2], "bar": [6.0, 7.0]})
             >>> iter_rows = nw.from_native(df_native).iter_rows()
             >>> next(iter_rows)
+            (1, 6.0)
             >>> next(iter_rows)
+            (2, 7.0)
         """
         return self._compliant_frame.iter_rows(named=named, buffer_size=buffer_size)  # type: ignore[no-any-return]
 
@@ -1333,8 +1331,18 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> df_native = pa.table({'a': [1, 2], 'b': [3, 4]})
-            >>> nw.from_native(df_native).select('a', a_plus_1=nw.col('a')+1)
+            >>> df_native = pa.table({"a": [1, 2], "b": [3, 4]})
+            >>> nw.from_native(df_native).select("a", a_plus_1=nw.col("a") + 1)
+            ┌──────────────────┐
+            |Narwhals DataFrame|
+            |------------------|
+            |pyarrow.Table     |
+            |a: int64          |
+            |a_plus_1: int64   |
+            |----              |
+            |a: [[1,2]]        |
+            |a_plus_1: [[2,3]] |
+            └──────────────────┘
         """
         return super().select(*exprs, **named_exprs)
 
@@ -1375,7 +1383,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import pandas as pd
             >>> import narwhals as nw
             >>> df_native = pd.DataFrame({"a": [1, 2], "b": [0.5, 4.0]})
-            >>> nw.from_native(df_native).head(1)
+            >>> nw.from_native(df_native).head(1).to_native()
                a    b
             0  1  0.5
         """
@@ -1396,8 +1404,12 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import narwhals as nw
             >>> df_native = pd.DataFrame({"a": [1, 2], "b": [0.5, 4.0]})
             >>> nw.from_native(df_native).tail(1)
-               a    b
-            0  2  4.0
+            ┌──────────────────┐
+            |Narwhals DataFrame|
+            |------------------|
+            |       a    b     |
+            |    1  2  4.0     |
+            └──────────────────┘
         """
         return super().tail(n)
 
@@ -1415,7 +1427,9 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pd.DataFrame({"foo": [1, 2], "bar": [6.0, 7.0], "ham": ["a", "b"]})
+            >>> df_native = pd.DataFrame(
+            ...     {"foo": [1, 2], "bar": [6.0, 7.0], "ham": ["a", "b"]}
+            ... )
             >>> nw.from_native(df_native).drop("ham").to_native()
                foo  bar
             0    1  6.0
@@ -1451,7 +1465,9 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pd.DataFrame({"foo": [1, 2], "bar": ["a", "a"], "ham": ["b", "b"]})
+            >>> df_native = pd.DataFrame(
+            ...     {"foo": [1, 2], "bar": ["a", "a"], "ham": ["b", "b"]}
+            ... )
             >>> nw.from_native(df_native).unique(["bar", "ham"]).to_native()
                foo bar ham
             0    1   a   b
@@ -1489,7 +1505,9 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pd.DataFrame({"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]})
+            >>> df_native = pd.DataFrame(
+            ...     {"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]}
+            ... )
 
             Filter on one condition
             >>> nw.from_native(df_native).filter(nw.col("foo") > 1).to_native()
@@ -1498,12 +1516,16 @@ class DataFrame(BaseFrame[DataFrameT]):
             2    3    8   c
 
             Filter on multiple conditions with `&`
-            >>> nw.from_native(df_native).filter(nw.col("foo") < 3, nw.col("ham") == "a").to_native()
+            >>> nw.from_native(df_native).filter(
+            ...     nw.col("foo") < 3, nw.col("ham") == "a"
+            ... ).to_native()
                foo  bar ham
             0    1    6   a
 
             # Filter on multiple conditions with `|`
-            >>> nw.from_native(df_native).filter((nw.col("foo") == 1) | (nw.col("ham") == "c")).to_native()
+            >>> nw.from_native(df_native).filter(
+            ...     (nw.col("foo") == 1) | (nw.col("ham") == "c")
+            ... ).to_native()
                foo  bar ham
             0    1    6   a
             2    3    8   c
@@ -1531,10 +1553,18 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pd.DataFrame({"a": ["a", "b", "a", "b", "c"], "b": [1, 2, 1, 3, 3], "c": [5, 4, 3, 2, 1]})
+            >>> df_native = pd.DataFrame(
+            ...     {
+            ...         "a": ["a", "b", "a", "b", "c"],
+            ...         "b": [1, 2, 1, 3, 3],
+            ...         "c": [5, 4, 3, 2, 1],
+            ...     }
+            ... )
 
             # Group by one column and compute the sum of another column
-            >>> nw.from_native(df_native, eager_only=True).group_by("a").agg(nw.col("b").sum()).sort("a").to_native()
+            >>> nw.from_native(df_native, eager_only=True).group_by("a").agg(
+            ...     nw.col("b").sum()
+            ... ).sort("a").to_native()
                a  b
             0  a  2
             1  b  5
@@ -1594,8 +1624,17 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pd.DataFrame({"foo": [2, 1], "bar": [6.0, 7.0], "ham": ["a", "b"]})
-            >>> nw.from_native(df_native).sort('foo')
+            >>> df_native = pd.DataFrame(
+            ...     {"foo": [2, 1], "bar": [6.0, 7.0], "ham": ["a", "b"]}
+            ... )
+            >>> nw.from_native(df_native).sort("foo")
+            ┌──────────────────┐
+            |Narwhals DataFrame|
+            |------------------|
+            |    foo  bar ham  |
+            | 1    1  7.0   b  |
+            | 0    2  6.0   a  |
+            └──────────────────┘
         """
         return super().sort(by, *more_by, descending=descending, nulls_last=nulls_last)
 
@@ -1632,9 +1671,16 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_1_native = pd.DataFrame({"id": ['a', 'b'], "price": [6.0, 7.0]})
-            >>> df_2_native = pd.DataFrame({"id": ['a', 'b', 'c'], "qty": [1,2,3]})
-            >>> nw.from_native(df_1_native).join(nw.from_native(df_2_native), on='id')
+            >>> df_1_native = pd.DataFrame({"id": ["a", "b"], "price": [6.0, 7.0]})
+            >>> df_2_native = pd.DataFrame({"id": ["a", "b", "c"], "qty": [1, 2, 3]})
+            >>> nw.from_native(df_1_native).join(nw.from_native(df_2_native), on="id")
+            ┌──────────────────┐
+            |Narwhals DataFrame|
+            |------------------|
+            |   id  price  qty |
+            | 0  a    6.0    1 |
+            | 1  b    7.0    2 |
+            └──────────────────┘
         """
         return super().join(
             other, how=how, left_on=left_on, right_on=right_on, on=on, suffix=suffix
@@ -1703,7 +1749,15 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> population_native = pd.DataFrame(data_population)
             >>> gdp = nw.from_native(gdp_native)
             >>> population = nw.from_native(population_native)
-            >>> population.join_asof(gdp, on='datetime', strategy='backward')
+            >>> population.join_asof(gdp, on="datetime", strategy="backward")
+            ┌──────────────────────────────┐
+            |      Narwhals DataFrame      |
+            |------------------------------|
+            |    datetime  population   gdp|
+            |0 2016-03-01       82.19  4164|
+            |1 2018-08-01       82.66  4566|
+            |2 2019-01-01       83.12  4696|
+            └──────────────────────────────┘
         """
         return super().join_asof(
             other,
@@ -1727,8 +1781,16 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pd.DataFrame({"foo": [2, 2,2], "bar": [6.0, 6., 7.0]})
+            >>> df_native = pd.DataFrame({"foo": [2, 2, 2], "bar": [6.0, 6.0, 7.0]})
             >>> nw.from_native(df_native).is_duplicated()
+            ┌───────────────┐
+            |Narwhals Series|
+            |---------------|
+            |  0     True   |
+            |  1     True   |
+            |  2    False   |
+            |  dtype: bool  |
+            └───────────────┘
         """
         return self._series(
             self._compliant_frame.is_duplicated(),
@@ -1744,8 +1806,9 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pd.DataFrame({"foo": [2, 2,2], "bar": [6.0, 6., 7.0]})
+            >>> df_native = pd.DataFrame({"foo": [2, 2, 2], "bar": [6.0, 6.0, 7.0]})
             >>> nw.from_native(df_native).is_empty()
+            False
         """
         return self._compliant_frame.is_empty()  # type: ignore[no-any-return]
 
@@ -1758,8 +1821,16 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pd.DataFrame({"foo": [2, 2,2], "bar": [6.0, 6., 7.0]})
+            >>> df_native = pd.DataFrame({"foo": [2, 2, 2], "bar": [6.0, 6.0, 7.0]})
             >>> nw.from_native(df_native).is_unique()
+            ┌───────────────┐
+            |Narwhals Series|
+            |---------------|
+            |  0    False   |
+            |  1    False   |
+            |  2     True   |
+            |  dtype: bool  |
+            └───────────────┘
         """
         return self._series(
             self._compliant_frame.is_unique(),
@@ -1782,6 +1853,16 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import narwhals as nw
             >>> df_native = pa.table({"foo": [1, None], "bar": [2, 3]})
             >>> nw.from_native(df_native).null_count()
+            ┌──────────────────┐
+            |Narwhals DataFrame|
+            |------------------|
+            |  pyarrow.Table   |
+            |  foo: int64      |
+            |  bar: int64      |
+            |  ----            |
+            |  foo: [[1]]      |
+            |  bar: [[0]]      |
+            └──────────────────┘
         """
         return self._from_compliant_dataframe(self._compliant_frame.null_count())
 
@@ -1804,6 +1885,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import narwhals as nw
             >>> df_native = pa.table({"foo": [1, None], "bar": [2, 3]})
             >>> nw.from_native(df_native).item(0, 1)
+            2
         """
         return self._compliant_frame.item(row=row, column=column)
 
@@ -1828,8 +1910,16 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> df_native = pa.table({"foo": [1, None, 2 3]})
+            >>> df_native = pa.table({"foo": [1, None, 2, 3]})
             >>> nw.from_native(df_native).gather_every(2)
+            ┌──────────────────┐
+            |Narwhals DataFrame|
+            |------------------|
+            |  pyarrow.Table   |
+            |  foo: int64      |
+            |  ----            |
+            |  foo: [[1,2]]    |
+            └──────────────────┘
         """
         return super().gather_every(n=n, offset=offset)
 
@@ -1883,7 +1973,16 @@ class DataFrame(BaseFrame[DataFrameT]):
             ...     "bar": [0, 2, 0, 0, 9, 4],
             ... }
             >>> df_native = pd.DataFrame(data)
-            >>> df.pivot('col', index='ix', aggregate_function='sum')
+            >>> nw.from_native(df_native).pivot(
+            ...     "col", index="ix", aggregate_function="sum"
+            ... )
+            ┌─────────────────────────────────┐
+            |       Narwhals DataFrame        |
+            |---------------------------------|
+            |   ix  foo_a  foo_b  bar_a  bar_b|
+            |0   1      1      7      2      9|
+            |1   2      4      1      0      4|
+            └─────────────────────────────────┘
         """
         if values is None and index is None:
             msg = "At least one of `values` and `index` must be passed"
@@ -1917,6 +2016,12 @@ class DataFrame(BaseFrame[DataFrameT]):
             >>> import narwhals as nw
             >>> df_native = pd.DataFrame({"foo": [1, None], "bar": [2, 3]})
             >>> nw.from_native(df_native).to_arrow()
+            pyarrow.Table
+            foo: double
+            bar: int64
+            ----
+            foo: [[1,null]]
+            bar: [[2,3]]
         """
         return self._compliant_frame.to_arrow()
 
@@ -1946,7 +2051,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pd.DataFrame({"foo": [1, 2, 3], "bar": [19,32,4]})
+            >>> df_native = pd.DataFrame({"foo": [1, 2, 3], "bar": [19, 32, 4]})
             >>> nw.from_native(df_native).to_sample(n=2)  # doctest:+SKIP
         """
         return self._from_compliant_dataframe(
@@ -1996,7 +2101,18 @@ class DataFrame(BaseFrame[DataFrameT]):
             ...     "c": [2, 4, 6],
             ... }
             >>> df_native = pd.DataFrame(data)
-            >>> nw.from_native(df_native).unpivot(['b', 'c'], index='a')
+            >>> nw.from_native(df_native).unpivot(["b", "c"], index="a")
+            ┌────────────────────┐
+            | Narwhals DataFrame |
+            |--------------------|
+            |   a variable  value|
+            |0  x        b      1|
+            |1  y        b      3|
+            |2  z        b      5|
+            |3  x        c      2|
+            |4  y        c      4|
+            |5  z        c      6|
+            └────────────────────┘
         """
         return super().unpivot(
             on=on, index=index, variable_name=variable_name, value_name=value_name
@@ -2017,12 +2133,21 @@ class DataFrame(BaseFrame[DataFrameT]):
             New DataFrame
 
         Examples:
-            >>> import pandas as pd
-            >>> import pyarrow as pa
+            >>> import polars as pl
             >>> import narwhals as nw
-            >>> data = {'a': ['x', 'y'], 'b': [[1, 2], [3]]}
-            >>> df_native = pd.DataFrame(data).convert_dtypes(dtype_backend='pyarrow')
-            >>> nw.from_native(df_native).explode('lst1')
+            >>> data = {"a": ["x", "y"], "b": [[1, 2], [3]]}
+            >>> df_native = pl.DataFrame(data)
+            >>> nw.from_native(df_native).explode("b").to_native()
+            shape: (3, 2)
+            ┌─────┬─────┐
+            │ a   ┆ b   │
+            │ --- ┆ --- │
+            │ str ┆ i64 │
+            ╞═════╪═════╡
+            │ x   ┆ 1   │
+            │ x   ┆ 2   │
+            │ y   ┆ 3   │
+            └─────┴─────┘
         """
         return super().explode(columns, *more_columns)
 

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -2415,7 +2415,7 @@ class LazyFrame(BaseFrame[FrameT]):
         Examples:
             >>> import duckdb
             >>> import narwhals as nw
-            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, null), (3, 4) df(a, b)")
+            >>> lf_native = duckdb.sql("SELECT * FROM VALUES (1, NULL), (3, 4) df(a, b)")
             >>> nw.from_native(lf_native).drop_nulls()
             ┌──────────────────┐
             |Narwhals LazyFrame|
@@ -2866,7 +2866,7 @@ class LazyFrame(BaseFrame[FrameT]):
             >>> import duckdb
             >>> import narwhals as nw
             >>> df_native = duckdb.sql(
-            ...     "SELECT * FROM VALUES (1, 6.0, 'a'), (2, 5.0, 'c'), (null, 4.0, 'b') df(a, b, c)"
+            ...     "SELECT * FROM VALUES (1, 6.0, 'a'), (2, 5.0, 'c'), (NULL, 4.0, 'b') df(a, b, c)"
             ... )
             >>> df = nw.from_native(df_native)
             >>> df.sort(by="a")

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -684,62 +684,20 @@ class DataFrame(BaseFrame[DataFrameT]):
             A polars DataFrame.
 
         Examples:
-            Construct pandas, Polars (eager) and PyArrow DataFrames:
-
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_to_polars(df_native: IntoDataFrame) -> pl.DataFrame:
-            ...     df = nw.from_native(df_native)
-            ...     return df.to_polars()
-
-            We can then pass any supported library such as pandas, Polars (eager), or
-            PyArrow to `agnostic_to_polars`:
-
-            >>> agnostic_to_polars(df_pd)
-            shape: (3, 3)
-            ┌─────┬─────┬─────┐
-            │ foo ┆ bar ┆ ham │
-            │ --- ┆ --- ┆ --- │
-            │ i64 ┆ f64 ┆ str │
-            ╞═════╪═════╪═════╡
-            │ 1   ┆ 6.0 ┆ a   │
-            │ 2   ┆ 7.0 ┆ b   │
-            │ 3   ┆ 8.0 ┆ c   │
-            └─────┴─────┴─────┘
-
-            >>> agnostic_to_polars(df_pl)
-            shape: (3, 3)
-            ┌─────┬─────┬─────┐
-            │ foo ┆ bar ┆ ham │
-            │ --- ┆ --- ┆ --- │
-            │ i64 ┆ f64 ┆ str │
-            ╞═════╪═════╪═════╡
-            │ 1   ┆ 6.0 ┆ a   │
-            │ 2   ┆ 7.0 ┆ b   │
-            │ 3   ┆ 8.0 ┆ c   │
-            └─────┴─────┴─────┘
-
-            >>> agnostic_to_polars(df_pa)
-            shape: (3, 3)
-            ┌─────┬─────┬─────┐
-            │ foo ┆ bar ┆ ham │
-            │ --- ┆ --- ┆ --- │
-            │ i64 ┆ f64 ┆ str │
-            ╞═════╪═════╪═════╡
-            │ 1   ┆ 6.0 ┆ a   │
-            │ 2   ┆ 7.0 ┆ b   │
-            │ 3   ┆ 8.0 ┆ c   │
-            └─────┴─────┴─────┘
+            >>> df_native = pa.table({'foo': [1, 2], 'bar': [6.0, 7.0]})
+            >>> df = nw.from_native(df_native)
+            >>> df.to_polars()
+            shape: (2, 2)
+            ┌─────┬─────┐
+            │ foo ┆ bar │
+            │ --- ┆ --- │
+            │ i64 ┆ f64 │
+            ╞═════╪═════╡
+            │ 1   ┆ 6.0 │
+            │ 2   ┆ 7.0 │
+            └─────┴─────┘
         """
         return self._compliant_frame.to_polars()  # type: ignore[no-any-return]
 
@@ -803,29 +761,12 @@ class DataFrame(BaseFrame[DataFrameT]):
             None.
 
         Examples:
-            Construct pandas, Polars and PyArrow DataFrames:
-
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_write_parquet(df_native: IntoDataFrame):
-            ...     df = nw.from_native(df_native)
-            ...     df.write_parquet("foo.parquet")
-
-            We can then pass either pandas, Polars or PyArrow to `agnostic_write_parquet`:
-
-            >>> agnostic_write_parquet(df_pd)  # doctest:+SKIP
-            >>> agnostic_write_parquet(df_pl)  # doctest:+SKIP
-            >>> agnostic_write_parquet(df_pa)  # doctest:+SKIP
+            >>> df_native = pa.table({'foo': [1, 2], 'bar': [6.0, 7.0]})
+            >>> df = nw.from_native(df_native)
+            >>> df.write_csv()
+            'foo,bar\n1,6.0\n2,7.0\n'
         """
         self._compliant_frame.write_parquet(file)
 
@@ -836,39 +777,13 @@ class DataFrame(BaseFrame[DataFrameT]):
             A NumPy ndarray array.
 
         Examples:
-            Construct pandas and polars DataFrames:
-
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> import numpy as np
-            >>> from narwhals.typing import IntoDataFrame
-            >>> data = {"foo": [1, 2, 3], "bar": [6.5, 7.0, 8.5], "ham": ["a", "b", "c"]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_to_numpy(df_native: IntoDataFrame) -> np.ndarray:
-            ...     df = nw.from_native(df_native)
-            ...     return df.to_numpy()
-
-            We can then pass either pandas, Polars or PyArrow to `agnostic_to_numpy`:
-
-            >>> agnostic_to_numpy(df_pd)
-            array([[1, 6.5, 'a'],
-                   [2, 7.0, 'b'],
-                   [3, 8.5, 'c']], dtype=object)
-            >>> agnostic_to_numpy(df_pl)
-            array([[1, 6.5, 'a'],
-                   [2, 7.0, 'b'],
-                   [3, 8.5, 'c']], dtype=object)
-            >>> agnostic_to_numpy(df_pa)
-            array([[1, 6.5, 'a'],
-                   [2, 7.0, 'b'],
-                   [3, 8.5, 'c']], dtype=object)
+            >>> df_native = pd.DataFrame{'foo': [1, 2], 'bar': [6.5, 7.0]})
+            >>> df = nw.from_native(df_native)
+            >>> df.to_numpy()
+            array([[1. , 6.5],
+                   [2. , 7.0]])
         """
         return self._compliant_frame.to_numpy()
 
@@ -880,32 +795,12 @@ class DataFrame(BaseFrame[DataFrameT]):
             The shape of the dataframe as a tuple.
 
         Examples:
-            Construct pandas and polars DataFrames:
-
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> data = {"foo": [1, 2, 3, 4, 5]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_shape(df_native: IntoDataFrame) -> tuple[int, int]:
-            ...     df = nw.from_native(df_native)
-            ...     return df.shape
-
-            We can then pass either pandas, Polars or PyArrow to `agnostic_shape`:
-
-            >>> agnostic_shape(df_pd)
-            (5, 1)
-            >>> agnostic_shape(df_pl)
-            (5, 1)
-            >>> agnostic_shape(df_pa)
-            (5, 1)
+            >>> df_native = pd.DataFrame{'foo': [1, 2]})
+            >>> df = nw.from_native(df_native)
+            >>> df.shape
+            (2, 1)
         """
         return self._compliant_frame.shape  # type: ignore[no-any-return]
 
@@ -926,39 +821,11 @@ class DataFrame(BaseFrame[DataFrameT]):
             there is no risk of ambiguity.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> from narwhals.typing import IntoSeries
-            >>> data = {"a": [1, 2], "b": [3, 4]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_get_column(df_native: IntoDataFrame) -> IntoSeries:
-            ...     df = nw.from_native(df_native)
-            ...     name = df.columns[0]
-            ...     return df.get_column(name).to_native()
-
-            We can then pass either pandas, Polars or PyArrow to `agnostic_get_column`:
-
-            >>> agnostic_get_column(df_pd)
-            0    1
-            1    2
-            Name: a, dtype: int64
-            >>> agnostic_get_column(df_pl)  # doctest:+NORMALIZE_WHITESPACE
-            shape: (2,)
-            Series: 'a' [i64]
-            [
-                1
-                2
-            ]
-            >>> agnostic_get_column(df_pa)  # doctest:+ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
+            >>> df_native = pa.table({'a': [1, 2]})
+            >>> df = nw.from_native(df_native)
+            >>> df.get_column('a').to_native()
             [
               [
                 1,
@@ -984,33 +851,11 @@ class DataFrame(BaseFrame[DataFrameT]):
             Integer or Float.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrameT
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6.0, 7.0, 8.0],
-            ...     "ham": ["a", "b", "c"],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_estimated_size(df_native: IntoDataFrameT) -> int | float:
-            ...     df = nw.from_native(df_native)
-            ...     return df.estimated_size()
-
-            We can then pass either pandas, Polars or PyArrow to `agnostic_estimated_size`:
-
-            >>> agnostic_estimated_size(df_pd)
-            np.int64(330)
-            >>> agnostic_estimated_size(df_pl)
-            51
-            >>> agnostic_estimated_size(df_pa)
+            >>> df_native = pa.table({'foo': [1, 2], 'bar': [6.0, 7.0]})
+            >>> df = nw.from_native(df_native)
+            >>> df.estimated_size()
             63
         """
         return self._compliant_frame.estimated_size(unit=unit)  # type: ignore[no-any-return]
@@ -1102,45 +947,17 @@ class DataFrame(BaseFrame[DataFrameT]):
             use `DataFrame.get_column` instead.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> from narwhals.typing import IntoSeries
-            >>> data = {"a": [1, 2], "b": [3, 4]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_slice(df_native: IntoDataFrame) -> IntoSeries:
-            ...     df = nw.from_native(df_native)
-            ...     return df["a"].to_native()
-
-            We can then pass either pandas, Polars or PyArrow to `agnostic_slice`:
-
-            >>> agnostic_slice(df_pd)
-            0    1
-            1    2
-            Name: a, dtype: int64
-            >>> agnostic_slice(df_pl)  # doctest:+NORMALIZE_WHITESPACE
-            shape: (2,)
-            Series: 'a' [i64]
+            >>> df_native = pa.table({'a': [1, 2]})
+            >>> df = nw.from_native(df_native)
+            >>> df['a'].to_native()
             [
-                1
-                2
-            ]
-            >>> agnostic_slice(df_pa)  # doctest:+ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
             [
-              [
                 1,
                 2
-              ]
             ]
-
+            ]
         """
         if isinstance(item, int):
             item = [item]
@@ -1206,38 +1023,12 @@ class DataFrame(BaseFrame[DataFrameT]):
             A mapping from column name to values / Series.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
+        >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> data = {
-            ...     "A": [1, 2, 3, 4, 5],
-            ...     "fruits": ["banana", "banana", "apple", "apple", "banana"],
-            ...     "B": [5, 4, 3, 2, 1],
-            ...     "animals": ["beetle", "fly", "beetle", "beetle", "beetle"],
-            ...     "optional": [28, 300, None, 2, -30],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_to_dict(
-            ...     df_native: IntoDataFrame,
-            ... ) -> dict[str, list[int | str | float | None]]:
-            ...     df = nw.from_native(df_native)
-            ...     return df.to_dict(as_series=False)
-
-            We can then pass either pandas, Polars or PyArrow to `agnostic_to_dict`:
-
-            >>> agnostic_to_dict(df_pd)
-            {'A': [1, 2, 3, 4, 5], 'fruits': ['banana', 'banana', 'apple', 'apple', 'banana'], 'B': [5, 4, 3, 2, 1], 'animals': ['beetle', 'fly', 'beetle', 'beetle', 'beetle'], 'optional': [28.0, 300.0, nan, 2.0, -30.0]}
-            >>> agnostic_to_dict(df_pl)
-            {'A': [1, 2, 3, 4, 5], 'fruits': ['banana', 'banana', 'apple', 'apple', 'banana'], 'B': [5, 4, 3, 2, 1], 'animals': ['beetle', 'fly', 'beetle', 'beetle', 'beetle'], 'optional': [28, 300, None, 2, -30]}
-            >>> agnostic_to_dict(df_pa)
-            {'A': [1, 2, 3, 4, 5], 'fruits': ['banana', 'banana', 'apple', 'apple', 'banana'], 'B': [5, 4, 3, 2, 1], 'animals': ['beetle', 'fly', 'beetle', 'beetle', 'beetle'], 'optional': [28, 300, None, 2, -30]}
+            >>> df_native = pa.table({'A': [1, 2], 'fruits': ['banana', 'apple']})
+            >>> df = nw.from_native(df_native)
+            >>> df.to_dict(as_series=False)
+            {'A': [1, 2], 'fruits': ['banana', 'apple']}
         """
         if as_series:
             return {
@@ -1269,29 +1060,10 @@ class DataFrame(BaseFrame[DataFrameT]):
             cuDF doesn't support this method.
 
         Examples:
-            >>> import narwhals as nw
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
-            >>> from narwhals.typing import IntoDataFrame
-            >>> from typing import Any
-            >>> data = {"a": [1, 2, 3], "b": [4, 5, 6]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a library-agnostic function to get the second row.
-
-            >>> def agnostic_row(df_native: IntoDataFrame) -> tuple[Any, ...]:
-            ...     return nw.from_native(df_native).row(1)
-
-            We can then pass either pandas, Polars or PyArrow to `agnostic_row`:
-
-            >>> agnostic_row(df_pd)
-            (2, 5)
-            >>> agnostic_row(df_pl)
-            (2, 5)
-            >>> agnostic_row(df_pa)
+            >>> import narwhals as nw
+            >>> df_native = pa.table({'a': [1, 2], 'b': [4, 5]})
+            >>> nw.from_native(df_native).row(1)
             (<pyarrow.Int64Scalar: 2>, <pyarrow.Int64Scalar: 5>)
         """
         return self._compliant_frame.row(index)  # type: ignore[no-any-return]
@@ -1315,48 +1087,14 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {"a": [1, 2, 3], "ba": [4, 5, 6]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_pipe(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return df.pipe(
-            ...         lambda _df: _df.select(
-            ...             [x for x in _df.columns if len(x) == 1]
-            ...         ).to_native()
-            ...     )
-
-            We can then pass either pandas, Polars or PyArrow to `agnostic_pipe`:
-
-            >>> agnostic_pipe(df_pd)
-               a
+            >>> df_native = pd.DataFrame({"a": [1, 2], "ba": [4, 5]})
+            >>> nw.from_native(df_native).pipe(
+            ...     lambda _df: _df.select([x for x in _df.columns if len(x) == 1]).to_native()
+            ... )
+            a
             0  1
             1  2
-            2  3
-            >>> agnostic_pipe(df_pl)
-            shape: (3, 1)
-            ┌─────┐
-            │ a   │
-            │ --- │
-            │ i64 │
-            ╞═════╡
-            │ 1   │
-            │ 2   │
-            │ 3   │
-            └─────┘
-            >>> agnostic_pipe(df_pa)
-            pyarrow.Table
-            a: int64
-            ----
-            a: [[1,2,3]]
         """
         return super().pipe(function, *args, **kwargs)
 
@@ -1376,38 +1114,10 @@ class DataFrame(BaseFrame[DataFrameT]):
             for reference.
 
         Examples:
-            >>> import polars as pl
-            >>> import pandas as pd
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {"a": [1.0, 2.0, None], "ba": [1.0, None, 2.0]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_drop_nulls(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return df.drop_nulls().to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_drop_nulls`:
-
-            >>> agnostic_drop_nulls(df_pd)
-                 a   ba
-            0  1.0  1.0
-            >>> agnostic_drop_nulls(df_pl)
-            shape: (1, 2)
-            ┌─────┬─────┐
-            │ a   ┆ ba  │
-            │ --- ┆ --- │
-            │ f64 ┆ f64 │
-            ╞═════╪═════╡
-            │ 1.0 ┆ 1.0 │
-            └─────┴─────┘
-            >>> agnostic_drop_nulls(df_pa)
+            >>> df_native = pa.table({"a": [1.0, None], "ba": [1.0, 2.0]})
+            >>> nw.from_native(df_native).drop_nulls().to_native()
             pyarrow.Table
             a: double
             ba: double
@@ -1427,52 +1137,18 @@ class DataFrame(BaseFrame[DataFrameT]):
             The original object with the column added.
 
         Examples:
-            Construct pandas as polars DataFrames:
-
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {"a": [1, 2, 3], "b": [4, 5, 6]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_with_row_index(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return df.with_row_index().to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_with_row_index`:
-
-            >>> agnostic_with_row_index(df_pd)
-               index  a  b
-            0      0  1  4
-            1      1  2  5
-            2      2  3  6
-            >>> agnostic_with_row_index(df_pl)
-            shape: (3, 3)
-            ┌───────┬─────┬─────┐
-            │ index ┆ a   ┆ b   │
-            │ ---   ┆ --- ┆ --- │
-            │ u32   ┆ i64 ┆ i64 │
-            ╞═══════╪═════╪═════╡
-            │ 0     ┆ 1   ┆ 4   │
-            │ 1     ┆ 2   ┆ 5   │
-            │ 2     ┆ 3   ┆ 6   │
-            └───────┴─────┴─────┘
-            >>> agnostic_with_row_index(df_pa)
+            >>> df_native = pa.table({"a": [1, 2], "b": [4, 5]})
+            >>> nw.from_native(df_native).with_row_index().to_native()
             pyarrow.Table
             index: int64
             a: int64
             b: int64
             ----
-            index: [[0,1,2]]
-            a: [[1,2,3]]
-            b: [[4,5,6]]
+            index: [[0,1]]
+            a: [[1,2]]
+            b: [[4,5]]
         """
         return super().with_row_index(name)
 
@@ -1484,36 +1160,11 @@ class DataFrame(BaseFrame[DataFrameT]):
             A Narwhals Schema object that displays the mapping of column names.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.schema import Schema
-            >>> from narwhals.typing import IntoFrame
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6.0, 7.0, 8.0],
-            ...     "ham": ["a", "b", "c"],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_schema(df_native: IntoFrame) -> Schema:
-            ...     df = nw.from_native(df_native)
-            ...     return df.schema
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_schema`:
-
-            >>> agnostic_schema(df_pd)
-            Schema({'foo': Int64, 'bar': Float64, 'ham': String})
-            >>> agnostic_schema(df_pl)
-            Schema({'foo': Int64, 'bar': Float64, 'ham': String})
-            >>> agnostic_schema(df_pa)
-            Schema({'foo': Int64, 'bar': Float64, 'ham': String})
+            >>> df_native = pa.table({"foo": [1, 2], "bar": [6.0, 7.0]})
+            >>> nw.from_native(df_native).schema
+            Schema({'foo': Int64, 'bar': Float64}) 
         """
         return super().schema
 
@@ -1524,36 +1175,11 @@ class DataFrame(BaseFrame[DataFrameT]):
             A Narwhals Schema object that displays the mapping of column names.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.schema import Schema
-            >>> from narwhals.typing import IntoFrame
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6.0, 7.0, 8.0],
-            ...     "ham": ["a", "b", "c"],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_collect_schema(df_native: IntoFrame) -> Schema:
-            ...     df = nw.from_native(df_native)
-            ...     return df.collect_schema()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_collect_schema`:
-
-            >>> agnostic_collect_schema(df_pd)
-            Schema({'foo': Int64, 'bar': Float64, 'ham': String})
-            >>> agnostic_collect_schema(df_pl)
-            Schema({'foo': Int64, 'bar': Float64, 'ham': String})
-            >>> agnostic_collect_schema(df_pa)
-            Schema({'foo': Int64, 'bar': Float64, 'ham': String})
+            >>> df_native = pa.table({"foo": [1, 2], "bar": [6.0, 7.0]})
+            >>> nw.from_native(df_native).collect_schema()
+            Schema({'foo': Int64, 'bar': Float64})
         """
         return super().collect_schema()
 
@@ -1565,31 +1191,11 @@ class DataFrame(BaseFrame[DataFrameT]):
             The column names stored in a list.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrame
-            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_columns(df_native: IntoFrame) -> list[str]:
-            ...     df = nw.from_native(df_native)
-            ...     return df.columns
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_columns`:
-
-            >>> agnostic_columns(df_pd)
-            ['foo', 'bar', 'ham']
-            >>> agnostic_columns(df_pl)
-            ['foo', 'bar', 'ham']
-            >>> agnostic_columns(df_pa)
-            ['foo', 'bar', 'ham']
+            >>> df_native = pa.table({"foo": [1, 2], "bar": [6.0, 7.0]})
+            >>> nw.from_native(df_native).columns
+            ['foo', 'bar']
         """
         return super().columns
 
@@ -1618,36 +1224,10 @@ class DataFrame(BaseFrame[DataFrameT]):
             The data as a list of rows.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_rows(df_native: IntoDataFrame, *, named: bool):
-            ...     return nw.from_native(df_native, eager_only=True).rows(named=named)
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_rows`:
-
-            >>> agnostic_rows(df_pd, named=False)
-            [(1, 6.0, 'a'), (2, 7.0, 'b'), (3, 8.0, 'c')]
-            >>> agnostic_rows(df_pd, named=True)
-            [{'foo': 1, 'bar': 6.0, 'ham': 'a'}, {'foo': 2, 'bar': 7.0, 'ham': 'b'}, {'foo': 3, 'bar': 8.0, 'ham': 'c'}]
-            >>> agnostic_rows(df_pl, named=False)
-            [(1, 6.0, 'a'), (2, 7.0, 'b'), (3, 8.0, 'c')]
-            >>> agnostic_rows(df_pl, named=True)
-            [{'foo': 1, 'bar': 6.0, 'ham': 'a'}, {'foo': 2, 'bar': 7.0, 'ham': 'b'}, {'foo': 3, 'bar': 8.0, 'ham': 'c'}]
-            >>> agnostic_rows(df_pa, named=False)
-            [(1, 6.0, 'a'), (2, 7.0, 'b'), (3, 8.0, 'c')]
-            >>> agnostic_rows(df_pa, named=True)
-            [{'foo': 1, 'bar': 6.0, 'ham': 'a'}, {'foo': 2, 'bar': 7.0, 'ham': 'b'}, {'foo': 3, 'bar': 8.0, 'ham': 'c'}]
+            >>> df_native = pa.table({"foo": [1, 2], "bar": [6.0, 7.0]})
+            >>> nw.from_native(df_native).rows
         """
         return self._compliant_frame.rows(named=named)  # type: ignore[no-any-return]
 
@@ -1686,38 +1266,12 @@ class DataFrame(BaseFrame[DataFrameT]):
             cuDF doesn't support this method.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> data = {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_iter_rows(df_native: IntoDataFrame, *, named: bool):
-            ...     return nw.from_native(df_native, eager_only=True).iter_rows(
-            ...         named=named
-            ...     )
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_iter_rows`:
-
-            >>> [row for row in agnostic_iter_rows(df_pd, named=False)]
-            [(1, 6.0, 'a'), (2, 7.0, 'b'), (3, 8.0, 'c')]
-            >>> [row for row in agnostic_iter_rows(df_pd, named=True)]
-            [{'foo': 1, 'bar': 6.0, 'ham': 'a'}, {'foo': 2, 'bar': 7.0, 'ham': 'b'}, {'foo': 3, 'bar': 8.0, 'ham': 'c'}]
-            >>> [row for row in agnostic_iter_rows(df_pl, named=False)]
-            [(1, 6.0, 'a'), (2, 7.0, 'b'), (3, 8.0, 'c')]
-            >>> [row for row in agnostic_iter_rows(df_pl, named=True)]
-            [{'foo': 1, 'bar': 6.0, 'ham': 'a'}, {'foo': 2, 'bar': 7.0, 'ham': 'b'}, {'foo': 3, 'bar': 8.0, 'ham': 'c'}]
-            >>> [row for row in agnostic_iter_rows(df_pa, named=False)]
-            [(1, 6.0, 'a'), (2, 7.0, 'b'), (3, 8.0, 'c')]
-            >>> [row for row in agnostic_iter_rows(df_pa, named=True)]
-            [{'foo': 1, 'bar': 6.0, 'ham': 'a'}, {'foo': 2, 'bar': 7.0, 'ham': 'b'}, {'foo': 3, 'bar': 8.0, 'ham': 'c'}]
+            >>> df_native = pa.table({"foo": [1, 2], "bar": [6.0, 7.0]})
+            >>> iter_rows = nw.from_native(df_native).iter_rows()
+            >>> next(iter_rows)
+            >>> next(iter_rows)
         """
         return self._compliant_frame.iter_rows(named=named, buffer_size=buffer_size)  # type: ignore[no-any-return]
 
@@ -1745,61 +1299,16 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "a": [1, 2, 3, 4],
-            ...     "b": [0.5, 4, 10, 13],
-            ...     "c": [True, True, False, True],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function in which we pass an expression
-            to add it as a new column:
-
-            >>> def agnostic_with_columns(df_native: IntoFrameT) -> IntoFrameT:
-            ...     return (
-            ...         nw.from_native(df_native)
-            ...         .with_columns((nw.col("a") * 2).alias("a*2"))
-            ...         .to_native()
-            ...     )
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_with_columns`:
-
-            >>> agnostic_with_columns(df_pd)
-               a     b      c  a*2
-            0  1   0.5   True    2
-            1  2   4.0   True    4
-            2  3  10.0  False    6
-            3  4  13.0   True    8
-            >>> agnostic_with_columns(df_pl)
-            shape: (4, 4)
-            ┌─────┬──────┬───────┬─────┐
-            │ a   ┆ b    ┆ c     ┆ a*2 │
-            │ --- ┆ ---  ┆ ---   ┆ --- │
-            │ i64 ┆ f64  ┆ bool  ┆ i64 │
-            ╞═════╪══════╪═══════╪═════╡
-            │ 1   ┆ 0.5  ┆ true  ┆ 2   │
-            │ 2   ┆ 4.0  ┆ true  ┆ 4   │
-            │ 3   ┆ 10.0 ┆ false ┆ 6   │
-            │ 4   ┆ 13.0 ┆ true  ┆ 8   │
-            └─────┴──────┴───────┴─────┘
-            >>> agnostic_with_columns(df_pa)
-            pyarrow.Table
-            a: int64
-            b: double
-            c: bool
-            a*2: int64
-            ----
-            a: [[1,2,3,4]]
-            b: [[0.5,4,10,13]]
-            c: [[true,true,false,true]]
-            a*2: [[2,4,6,8]]
+            >>> df_native = pd.DataFrame({"a": [1, 2], "b": [0.5, 4.0]})
+            >>> (
+            ...     nw.from_native(df_native)
+            ...     .with_columns((nw.col("a") * 2).alias("a*2"))
+            ...     .to_native()
+            ... )
+               a    b  a*2
+            0  1  0.5    2
+            1  2  4.0    4
         """
         return super().with_columns(*exprs, **named_exprs)
 
@@ -1822,144 +1331,10 @@ class DataFrame(BaseFrame[DataFrameT]):
             The dataframe containing only the selected columns.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>> data = {
-            ...     "foo": [1, 2, 3],
-            ...     "bar": [6, 7, 8],
-            ...     "ham": ["a", "b", "c"],
-            ... }
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define a dataframe-agnostic function in which we pass the name of a
-            column to select that column.
-
-            >>> def agnostic_single_select(df_native: IntoFrameT) -> IntoFrameT:
-            ...     return nw.from_native(df_native).select("foo").to_native()
-
-            We can then pass any supported library such as Pandas, Polars, or PyArrow
-            to `agnostic_single_select`:
-
-            >>> agnostic_single_select(df_pd)
-               foo
-            0    1
-            1    2
-            2    3
-            >>> agnostic_single_select(df_pl)
-            shape: (3, 1)
-            ┌─────┐
-            │ foo │
-            │ --- │
-            │ i64 │
-            ╞═════╡
-            │ 1   │
-            │ 2   │
-            │ 3   │
-            └─────┘
-            >>> agnostic_single_select(df_pa)
-            pyarrow.Table
-            foo: int64
-            ----
-            foo: [[1,2,3]]
-
-            Multiple columns can be selected by passing a list of column names.
-
-            >>> def agnostic_multi_select(df_native: IntoFrameT) -> IntoFrameT:
-            ...     return nw.from_native(df_native).select(["foo", "bar"]).to_native()
-
-            >>> agnostic_multi_select(df_pd)
-               foo  bar
-            0    1    6
-            1    2    7
-            2    3    8
-            >>> agnostic_multi_select(df_pl)
-            shape: (3, 2)
-            ┌─────┬─────┐
-            │ foo ┆ bar │
-            │ --- ┆ --- │
-            │ i64 ┆ i64 │
-            ╞═════╪═════╡
-            │ 1   ┆ 6   │
-            │ 2   ┆ 7   │
-            │ 3   ┆ 8   │
-            └─────┴─────┘
-            >>> agnostic_multi_select(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: int64
-            ----
-            foo: [[1,2,3]]
-            bar: [[6,7,8]]
-
-            Multiple columns can also be selected using positional arguments instead of a
-            list. Expressions are also accepted.
-
-            >>> def agnostic_select(df_native: IntoFrameT) -> IntoFrameT:
-            ...     return (
-            ...         nw.from_native(df_native)
-            ...         .select(nw.col("foo"), nw.col("bar") + 1)
-            ...         .to_native()
-            ...     )
-
-            >>> agnostic_select(df_pd)
-               foo  bar
-            0    1    7
-            1    2    8
-            2    3    9
-            >>> agnostic_select(df_pl)
-            shape: (3, 2)
-            ┌─────┬─────┐
-            │ foo ┆ bar │
-            │ --- ┆ --- │
-            │ i64 ┆ i64 │
-            ╞═════╪═════╡
-            │ 1   ┆ 7   │
-            │ 2   ┆ 8   │
-            │ 3   ┆ 9   │
-            └─────┴─────┘
-            >>> agnostic_select(df_pa)
-            pyarrow.Table
-            foo: int64
-            bar: int64
-            ----
-            foo: [[1,2,3]]
-            bar: [[7,8,9]]
-
-            Use keyword arguments to easily name your expression inputs.
-
-            >>> def agnostic_select_w_kwargs(df_native: IntoFrameT) -> IntoFrameT:
-            ...     return (
-            ...         nw.from_native(df_native)
-            ...         .select(threshold=nw.col("foo") * 2)
-            ...         .to_native()
-            ...     )
-
-            >>> agnostic_select_w_kwargs(df_pd)
-               threshold
-            0          2
-            1          4
-            2          6
-            >>> agnostic_select_w_kwargs(df_pl)
-            shape: (3, 1)
-            ┌───────────┐
-            │ threshold │
-            │ ---       │
-            │ i64       │
-            ╞═══════════╡
-            │ 2         │
-            │ 4         │
-            │ 6         │
-            └───────────┘
-            >>> agnostic_select_w_kwargs(df_pa)
-            pyarrow.Table
-            threshold: int64
-            ----
-            threshold: [[2,4,6]]
+            >>> df_native = pa.table({'a': [1, 2], 'b': [3, 4]})
+            >>> nw.from_native(df_native).select('a', a_plus_1=nw.col('a')+1)
         """
         return super().select(*exprs, **named_exprs)
 
@@ -4308,50 +3683,17 @@ class LazyFrame(BaseFrame[FrameT]):
             existing data.
 
         Examples:
-            >>> import polars as pl
-            >>> import dask.dataframe as dd
+            >>> import pandas as pd
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-            >>>
-            >>> data = {
-            ...     "a": [1, 2, 3, 4],
-            ...     "b": [0.5, 4, 10, 13],
-            ...     "c": [True, True, False, True],
-            ... }
-            >>> lf_pl = pl.LazyFrame(data)
-            >>> lf_dask = dd.from_dict(data, npartitions=2)
-
-            Let's define a dataframe-agnostic function in which we pass an expression
-            to add it as a new column:
-
-            >>> def agnostic_with_columns(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return (
-            ...         df.with_columns((nw.col("a") * 2).alias("2a"))
-            ...         .collect()
-            ...         .to_native()
-            ...     )
-
-            We can then pass any supported library such as Polars or Dask to `agnostic_with_columns`:
-
-            >>> agnostic_with_columns(lf_pl)
-            shape: (4, 4)
-            ┌─────┬──────┬───────┬─────┐
-            │ a   ┆ b    ┆ c     ┆ 2a  │
-            │ --- ┆ ---  ┆ ---   ┆ --- │
-            │ i64 ┆ f64  ┆ bool  ┆ i64 │
-            ╞═════╪══════╪═══════╪═════╡
-            │ 1   ┆ 0.5  ┆ true  ┆ 2   │
-            │ 2   ┆ 4.0  ┆ true  ┆ 4   │
-            │ 3   ┆ 10.0 ┆ false ┆ 6   │
-            │ 4   ┆ 13.0 ┆ true  ┆ 8   │
-            └─────┴──────┴───────┴─────┘
-            >>> agnostic_with_columns(lf_dask)
-               a     b      c  2a
-            0  1   0.5   True   2
-            1  2   4.0   True   4
-            2  3  10.0  False   6
-            3  4  13.0   True   8
+            >>> df_native = pd.DataFrame({"a": [1, 2], "b": [0.5, 4.0]})
+            >>> (
+            ...     nw.from_native(df_native)
+            ...     .with_columns((nw.col("a") * 2).alias("a*2"))
+            ...     .to_native()
+            ... )
+               a    b  a*2
+            0  1  0.5    2
+            1  2  4.0    4
         """
         return super().with_columns(*exprs, **named_exprs)
 


### PR DESCRIPTION
As discussed in the last call

This took some effort, but I think it's worth keeping package size under control. Seeing the docstrings like this, i also think they generally look better, my fault for having suggested such long docstrings in the first place

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
