### PR TITLE
fix: raise NotImplementedError for DataFramte.is_duplicated for PyArrow when there is more than one column

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -694,6 +694,16 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         from narwhals._arrow.series import ArrowSeries
 
         columns = self.columns
+        if (
+            len(columns) > 1
+            and pc.any(
+                [pc.any(pc.is_null(self._native_frame[col])).as_py() for col in columns]
+            ).as_py()
+        ):
+            # blocked on https://github.com/apache/arrow/issues/32204
+            msg = "DataFrame.is_duplicated with more than one column when nulls are present is not yet supported for PyArrow."
+            raise NotImplementedError(msg)
+
         index_token = generate_temporary_column_name(n_bytes=8, columns=columns)
         col_token = generate_temporary_column_name(
             n_bytes=8, columns=[*columns, index_token]


### PR DESCRIPTION
closes #1947 


<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
