### PR TITLE
fix(typing): Backport `from_native` overload fixes to `v1`

### DIFF
--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -67,7 +67,7 @@ from narwhals.translate import get_native_namespace
 from narwhals.translate import to_py_scalar
 from narwhals.typing import IntoDataFrameT
 from narwhals.typing import IntoFrameT
-from narwhals.typing import IntoSeriesT
+from narwhals.typing import IntoSeriesT as IntoSeriesT  # noqa: PLC0414
 from narwhals.utils import Implementation
 from narwhals.utils import Version
 from narwhals.utils import find_stacklevel
@@ -90,6 +90,7 @@ if TYPE_CHECKING:
     from narwhals.dtypes import DType
     from narwhals.functions import ArrowStreamExportable
     from narwhals.typing import IntoExpr
+    from narwhals.typing import IntoFrame
     from narwhals.typing import IntoSeries
 
 T = TypeVar("T")
@@ -1124,7 +1125,7 @@ def _stableify(
 
 @overload
 def from_native(
-    native_object: IntoDataFrameT | IntoSeriesT,
+    native_object: IntoDataFrameT | IntoSeries,
     *,
     strict: Literal[False],
     eager_only: Literal[False] = ...,
@@ -1136,7 +1137,7 @@ def from_native(
 
 @overload
 def from_native(
-    native_object: IntoDataFrameT | IntoSeriesT,
+    native_object: IntoDataFrameT | IntoSeries,
     *,
     strict: Literal[False],
     eager_only: Literal[True],
@@ -1196,7 +1197,7 @@ def from_native(
 
 @overload
 def from_native(
-    native_object: IntoFrameT | IntoSeriesT,
+    native_object: IntoFrameT | IntoSeries,
     *,
     strict: Literal[False],
     eager_only: Literal[False] = ...,
@@ -1208,7 +1209,7 @@ def from_native(
 
 @overload
 def from_native(
-    native_object: IntoSeriesT,
+    native_object: IntoSeries,
     *,
     strict: Literal[False],
     eager_only: Literal[False] = ...,
@@ -1268,7 +1269,7 @@ def from_native(
 
 @overload
 def from_native(
-    native_object: IntoFrameT | IntoSeriesT,
+    native_object: IntoFrame | IntoSeries,
     *,
     strict: Literal[True] = ...,
     eager_only: Literal[False] = ...,
@@ -1280,7 +1281,7 @@ def from_native(
 
 @overload
 def from_native(
-    native_object: IntoSeriesT | Any,  # remain `Any` for downstream compatibility
+    native_object: IntoSeries | Any,  # remain `Any` for downstream compatibility
     *,
     strict: Literal[True] = ...,
     eager_only: Literal[False] = ...,
@@ -1304,7 +1305,7 @@ def from_native(
 
 @overload
 def from_native(
-    native_object: IntoDataFrameT | IntoSeriesT,
+    native_object: IntoDataFrameT | IntoSeries,
     *,
     pass_through: Literal[True],
     eager_only: Literal[False] = ...,
@@ -1316,7 +1317,7 @@ def from_native(
 
 @overload
 def from_native(
-    native_object: IntoDataFrameT | IntoSeriesT,
+    native_object: IntoDataFrameT | IntoSeries,
     *,
     pass_through: Literal[True],
     eager_only: Literal[True],
@@ -1376,7 +1377,7 @@ def from_native(
 
 @overload
 def from_native(
-    native_object: IntoFrameT | IntoSeriesT,
+    native_object: IntoFrameT | IntoSeries,
     *,
     pass_through: Literal[True],
     eager_only: Literal[False] = ...,
@@ -1388,7 +1389,7 @@ def from_native(
 
 @overload
 def from_native(
-    native_object: IntoSeriesT,
+    native_object: IntoSeries,
     *,
     pass_through: Literal[True],
     eager_only: Literal[False] = ...,
@@ -1448,7 +1449,7 @@ def from_native(
 
 @overload
 def from_native(
-    native_object: IntoFrameT | IntoSeriesT,
+    native_object: IntoFrame | IntoSeries,
     *,
     pass_through: Literal[False] = ...,
     eager_only: Literal[False] = ...,
@@ -1460,7 +1461,7 @@ def from_native(
 
 @overload
 def from_native(
-    native_object: IntoSeriesT,
+    native_object: IntoSeries,
     *,
     pass_through: Literal[False] = ...,
     eager_only: Literal[False] = ...,
@@ -1496,7 +1497,7 @@ def from_native(
 
 
 def from_native(
-    native_object: IntoFrameT | IntoSeries | T,
+    native_object: IntoFrameT | IntoFrame | IntoSeries | T,
     *,
     strict: bool | None = None,
     pass_through: bool | None = None,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix


## Related issues

- Related PR #1935

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Aligns with #1935, without using `IntoSeriesT` as `v1.Series` is not generic
https://narwhals-dev.github.io/narwhals/backcompat/#breaking-changes-carried-out-so-far