### PR TITLE
ci: fix plotly tests location

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -308,7 +308,7 @@ jobs:
       - name: Run pytest on plotly express
         run: |
           cd plotly.py
-          pytest plotly/tests/test_optional/test_px
+          pytest tests/test_optional/test_px
 
   hierarchicalforecast:
     strategy:

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -299,6 +299,7 @@ jobs:
         run: |
           cd plotly.py
           uv pip install -r test_requirements/requirements_312_optional.txt --system
+          uv pip install -e . --system
       - name: install-narwhals-dev
         run: |
           uv pip uninstall narwhals --system

--- a/narwhals/_ibis/dataframe.py
+++ b/narwhals/_ibis/dataframe.py
@@ -130,7 +130,7 @@ class IbisLazyFrame:
                 for column_name, ibis_dtype in self._native_frame.schema().items()
             }
         elif attr == "columns":
-            return self._native_frame.columns
+            return list(self._native_frame.columns)
         msg = (
             f"Attribute {attr} is not supported for metadata-only dataframes.\n\n"
             "If you would like to see this kind of object better supported in "


### PR DESCRIPTION
# Description

Plotly moved the tests outside the library folder.

Noticed the CI failure in #1955 