### PR TITLE
fix(typing): add missing `Series._level` annotation

### DIFF
--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -72,7 +72,7 @@ class Series(Generic[IntoSeriesT]):
         *,
         level: Literal["full", "lazy", "interchange"],
     ) -> None:
-        self._level = level
+        self._level: Literal["full", "lazy", "interchange"] = level
         if hasattr(series, "__narwhals_series__"):
             self._compliant_series = series.__narwhals_series__()
         else:  # pragma: no cover


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Resolves a few of these messages:
> Argument of type "str" cannot be assigned to parameter "level" of type "Literal['full', 'lazy', 'interchange']" in function "__init__"


![image](https://github.com/user-attachments/assets/f13a2194-0428-44a0-b6ef-37abac6a4290)


The same is already in `BaseFrame`

https://github.com/narwhals-dev/narwhals/blob/c5748be5770a42d0915b124cde272a4d69faf512/narwhals/dataframe.py#L63-L65

aaaand in `DataFrame`:

https://github.com/narwhals-dev/narwhals/blob/c5748be5770a42d0915b124cde272a4d69faf512/narwhals/dataframe.py#L440-L446