### PR TITLE
chore(typing): fix `_from_compliant_dataframe` type ignore

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -72,9 +72,7 @@ class BaseFrame(Generic[_FrameT]):
 
     def _from_compliant_dataframe(self: Self, df: Any) -> Self:
         # construct, preserving properties
-        return self.__class__(  # type: ignore[call-arg]
-            df, level=self._level
-        )
+        return self.__class__(df, level=self._level)  # type: ignore[call-arg]
 
     def _flatten_and_extract(
         self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other


## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Comment was missing the target

Removes the last `pyright` warning in `dataframe.py`

![image](https://github.com/user-attachments/assets/82e5b375-7a4a-4852-b86c-14c8687438b9)


![image](https://github.com/user-attachments/assets/51ab5ab5-5525-43bb-9f8c-1e76eb1c06c9)
