### PR TITLE
chore(typing): fix remaining `functions`, `series` warnings

### DIFF
--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -222,7 +222,7 @@ class Series(Generic[IntoSeriesT]):
         if parse_version(pa.__version__) < (16, 0):  # pragma: no cover
             msg = f"PyArrow>=16.0.0 is required for `Series.__arrow_c_stream__` for object of type {type(native_series)}"
             raise ModuleNotFoundError(msg)
-        ca = pa.chunked_array([self.to_arrow()])
+        ca = pa.chunked_array([self.to_arrow()])  # type: ignore[call-overload]
         return ca.__arrow_c_stream__(requested_schema=requested_schema)
 
     def to_native(self: Self) -> IntoSeriesT:

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -222,7 +222,7 @@ class Series(Generic[IntoSeriesT]):
         if parse_version(pa.__version__) < (16, 0):  # pragma: no cover
             msg = f"PyArrow>=16.0.0 is required for `Series.__arrow_c_stream__` for object of type {type(native_series)}"
             raise ModuleNotFoundError(msg)
-        ca = pa.chunked_array([self.to_arrow()])  # type: ignore[call-overload]
+        ca = pa.chunked_array([self.to_arrow()])  # type: ignore[call-overload, unused-ignore]
         return ca.__arrow_c_stream__(requested_schema=requested_schema)
 
     def to_native(self: Self) -> IntoSeriesT:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Mentioned https://github.com/narwhals-dev/narwhals/pull/1969#issuecomment-2645867682

- Ignored invalid `pa.chunked_array` stubs
- Avoid reassigning `dtype`
- Add inline annotation to avoid inferrence of `Iterator[str | None]`


![image](https://github.com/user-attachments/assets/7a557b2a-fddc-4d7c-8a62-e8ec9e318935)
