### PR TITLE
RFC, chore: shrink `series` module docstrings

### DIFF
--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -196,9 +196,8 @@ class Series(Generic[IntoSeriesT]):
             >>> import narwhals as nw
             >>>
             >>> s_native = pl.Series([1, 2])
-            >>> nw.from_native(
-            ...     s_native, series_only=True
-            ... ).to_native()  # doctest: +NORMALIZE_WHITESPACE
+            >>> s = nw.from_native(s_native, series_only=True)
+            >>> s.to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (2,)
             Series: '' [i64]
             [
@@ -299,9 +298,8 @@ class Series(Generic[IntoSeriesT]):
             >>> import polars as pl
             >>> import narwhals as nw
             >>> s_native = pl.Series([1, 2, 3])
-            >>> nw.from_native(s_native, series_only=True).pipe(
-            ...     lambda x: x + 2
-            ... ).to_native()  # doctest: +NORMALIZE_WHITESPACE
+            >>> s = nw.from_native(s_native, series_only=True)
+            >>> s.pipe(lambda x: x + 2).to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (3,)
             Series: '' [i64]
             [
@@ -789,9 +787,8 @@ class Series(Generic[IntoSeriesT]):
             >>> import narwhals as nw
             >>>
             >>> s_native = pa.chunked_array([[1, 2, 3]])
-            >>> nw.from_native(s_native, series_only=True).is_in(
-            ...     [3, 2, 8]
-            ... ).to_native()  # doctest: +ELLIPSIS
+            >>> s = nw.from_native(s_native, series_only=True)
+            >>> s.is_in([3, 2, 8]).to_native()  # doctest: +ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -918,7 +915,8 @@ class Series(Generic[IntoSeriesT]):
             >>> import narwhals as nw
             >>>
             >>> s_native = pl.Series([2, 4, 4, 6])
-            >>> nw.from_native(s_native, series_only=True).unique(
+            >>> s = nw.from_native(s_native, series_only=True)
+            >>> s.unique(
             ...     maintain_order=True
             ... ).to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (3,)
@@ -1029,7 +1027,8 @@ class Series(Generic[IntoSeriesT]):
             >>> import narwhals as nw
             >>>
             >>> s_native = pl.Series([1, 2, 3, 4])
-            >>> nw.from_native(s_native, series_only=True).sample(
+            >>> s = nw.from_native(s_native, series_only=True)
+            >>> s.sample(
             ...     fraction=1.0, with_replacement=True
             ... ).to_native()  # doctest: +SKIP
             shape: (4,)
@@ -1123,9 +1122,8 @@ class Series(Generic[IntoSeriesT]):
             >>> import narwhals as nw
             >>>
             >>> s_native = pl.Series("foo", [1, 2, 3])
-            >>> nw.from_native(s_native, series_only=True).rename(
-            ...     "bar"
-            ... ).to_native()  # doctest: +NORMALIZE_WHITESPACE
+            >>> s = nw.from_native(s_native, series_only=True)
+            >>> s.rename("bar").to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (3,)
             Series: 'bar' [i64]
             [
@@ -1202,9 +1200,8 @@ class Series(Generic[IntoSeriesT]):
             >>> import narwhals as nw
             >>>
             >>> s_native = pl.Series([5, None, 1, 2])
-            >>> nw.from_native(s_native, series_only=True).sort(
-            ...     descending=True
-            ... ).to_native()  # doctest: +NORMALIZE_WHITESPACE
+            >>> s = nw.from_native(s_native, series_only=True)
+            >>> s.sort(descending=True).to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (4,)
             Series: '' [i64]
             [
@@ -1353,9 +1350,8 @@ class Series(Generic[IntoSeriesT]):
             >>> import narwhals as nw
             >>>
             >>> s_native = pa.chunked_array([[1, 2, 3, 4, 5]])
-            >>> nw.from_native(s_native, series_only=True).is_between(
-            ...     2, 4, "right"
-            ... ).to_native()  # doctest: +ELLIPSIS
+            >>> s = nw.from_native(s_native, series_only=True)
+            >>> s.is_between(2, 4, "right").to_native()  # doctest: +ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -1930,9 +1926,8 @@ class Series(Generic[IntoSeriesT]):
             >>> import narwhals as nw
             >>>
             >>> s_native = pa.chunked_array([list(range(10))])
-            >>> nw.from_native(s_native, series_only=True).tail(
-            ...     3
-            ... ).to_native()  # doctest: +ELLIPSIS
+            >>> s = nw.from_native(s_native, series_only=True)
+            >>> s.tail(3).to_native()  # doctest: +ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -1966,9 +1961,8 @@ class Series(Generic[IntoSeriesT]):
             >>> import narwhals as nw
             >>>
             >>> s_native = pl.Series([1.12345, 2.56789, 3.901234])
-            >>> nw.from_native(s_native, series_only=True).round(
-            ...     1
-            ... ).to_native()  # doctest: +NORMALIZE_WHITESPACE
+            >>> s = nw.from_native(s_native, series_only=True)
+            >>> s.round(1).to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (3,)
             Series: '' [f64]
             [

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -133,56 +133,16 @@ class Series(Generic[IntoSeriesT]):
             A single element if `idx` is an integer, else a subset of the Series.
 
         Examples:
-            >>> from typing import Any
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_get_first_item(s_native: IntoSeriesT) -> Any:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s[0]
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_get_first_item`:
-
-            >>> agnostic_get_first_item(s_pd)
-            np.int64(1)
-
-            >>> agnostic_get_first_item(s_pl)
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, 3]])
+            >>> nw.from_native(s_native, series_only=True)[0]
             1
 
-            >>> agnostic_get_first_item(s_pa)
-            1
-
-            We can also make a function to slice the Series:
-
-            >>> def agnostic_slice(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s[:2].to_native()
-
-            >>> agnostic_slice(s_pd)
-            0    1
-            1    2
-            dtype: int64
-
-            >>> agnostic_slice(s_pl)  # doctest:+NORMALIZE_WHITESPACE
-            shape: (2,)
-            Series: '' [i64]
-            [
-                1
-                2
-            ]
-
-            >>> agnostic_slice(s_pa)  # doctest:+ELLIPSIS
+            >>> nw.from_native(s_native, series_only=True)[
+            ...     :2
+            ... ].to_native()  # doctest:+ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -232,49 +192,18 @@ class Series(Generic[IntoSeriesT]):
             Series of class that user started with.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_to_native(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_to_native`:
-
-            >>> agnostic_to_native(s_pd)
-            0    1
-            1    2
-            2    3
-            dtype: int64
-
-            >>> agnostic_to_native(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
+            >>>
+            >>> s_native = pl.Series([1, 2])
+            >>> nw.from_native(
+            ...     s_native, series_only=True
+            ... ).to_native()  # doctest: +NORMALIZE_WHITESPACE
+            shape: (2,)
             Series: '' [i64]
             [
-                1
-                2
-                3
-            ]
-
-            >>> agnostic_to_native(s_pa)  # doctest:+ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                1,
-                2,
-                3
-              ]
+              1
+              2
             ]
         """
         return self._compliant_series._native_series  # type: ignore[no-any-return]
@@ -311,47 +240,12 @@ class Series(Generic[IntoSeriesT]):
             ```
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoFrameT
-
-            >>> data = {"a": [1, 2, 3], "b": [4, 5, 6]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_scatter(df_native: IntoFrameT) -> IntoFrameT:
-            ...     df = nw.from_native(df_native)
-            ...     return df.with_columns(
-            ...         df["a"].scatter([0, 1], [999, 888])
-            ...     ).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_scatter`:
-
-            >>> agnostic_scatter(df_pd)
-                 a  b
-            0  999  4
-            1  888  5
-            2    3  6
-
-            >>> agnostic_scatter(df_pl)
-            shape: (3, 2)
-            ┌─────┬─────┐
-            │ a   ┆ b   │
-            │ --- ┆ --- │
-            │ i64 ┆ i64 │
-            ╞═════╪═════╡
-            │ 999 ┆ 4   │
-            │ 888 ┆ 5   │
-            │ 3   ┆ 6   │
-            └─────┴─────┘
-
-            >>> agnostic_scatter(df_pa)
+            >>>
+            >>> df_native = pa.table({"a": [1, 2, 3], "b": [4, 5, 6]})
+            >>> df_nw = nw.from_native(df_native)
+            >>> df_nw.with_columns(df_nw["a"].scatter([0, 1], [999, 888])).to_native()
             pyarrow.Table
             a: int64
             b: int64
@@ -372,32 +266,10 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_shape(s_native: IntoSeries) -> tuple[int]:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.shape
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_shape`:
-
-            >>> agnostic_shape(s_pd)
-            (3,)
-
-            >>> agnostic_shape(s_pl)
-            (3,)
-
-            >>> agnostic_shape(s_pa)
+            >>>
+            >>> s_native = pd.Series([1, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).shape
             (3,)
         """
         return self._compliant_series.shape  # type: ignore[no-any-return]
@@ -425,48 +297,17 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import polars as pl
-            >>> import pandas as pd
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a function to pipe into:
-
-            >>> def agnostic_pipe(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.pipe(lambda x: x + 2).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_pipe`:
-
-            >>> agnostic_pipe(s_pd)
-            0    3
-            1    4
-            2    5
-            dtype: int64
-
-            >>> agnostic_pipe(s_pl)  # doctest: +NORMALIZE_WHITESPACE
+            >>> s_native = pl.Series([1, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).pipe(
+            ...     lambda x: x + 2
+            ... ).to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (3,)
             Series: '' [i64]
             [
-               3
-               4
-               5
-            ]
-
-            >>> agnostic_pipe(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                3,
-                4,
+                3
+                4
                 5
-              ]
             ]
         """
         return function(self, *args, **kwargs)
@@ -486,33 +327,11 @@ class Series(Generic[IntoSeriesT]):
             The number of elements in the Series.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, None]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function that computes the len of the series:
-
-            >>> def agnostic_len(s_native: IntoSeries) -> int:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.len()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_len`:
-
-            >>> agnostic_len(s_pd)
-            3
-
-            >>> agnostic_len(s_pl)
-            3
-
-            >>> agnostic_len(s_pa)
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, None]])
+            >>> nw.from_native(s_native, series_only=True).len()
             3
         """
         return len(self._compliant_series)
@@ -526,32 +345,10 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_dtype(s_native: IntoSeriesT) -> nw.dtypes.DType:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.dtype
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_dtype`:
-
-            >>> agnostic_dtype(s_pd)
-            Int64
-
-            >>> agnostic_dtype(s_pl)
-            Int64
-
-            >>> agnostic_dtype(s_pa)
+            >>>
+            >>> s_native = pd.Series([1, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).dtype
             Int64
         """
         return self._compliant_series.dtype  # type: ignore[no-any-return]
@@ -564,29 +361,11 @@ class Series(Generic[IntoSeriesT]):
             The name of the Series.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data, name="foo")
-            >>> s_pl = pl.Series("foo", data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_name(s_native: IntoSeries) -> str:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.name
-
-            We can then pass any supported library such as pandas or Polars
-            to `agnostic_name`:
-
-            >>> agnostic_name(s_pd)
-            'foo'
-
-            >>> agnostic_name(s_pl)
+            >>>
+            >>> s_native = pl.Series("foo", [1, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).name
             'foo'
         """
         return self._compliant_series.name  # type: ignore[no-any-return]
@@ -645,37 +424,16 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(name="a", data=data)
-            >>> s_pl = pl.Series(name="a", values=data)
-
-            We define a library agnostic function:
-
-            >>> def agnostic_ewm_mean(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.ewm_mean(com=1, ignore_nulls=False).to_native()
-
-            We can then pass any supported library such as pandas or Polars
-            to `agnostic_ewm_mean`:
-
-            >>> agnostic_ewm_mean(s_pd)
+            >>>
+            >>> s_native = pd.Series(name="a", data=[1, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).ewm_mean(
+            ...     com=1, ignore_nulls=False
+            ... ).to_native()
             0    1.000000
             1    1.666667
             2    2.428571
             Name: a, dtype: float64
-
-            >>> agnostic_ewm_mean(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: 'a' [f64]
-            [
-               1.0
-               1.666667
-               2.428571
-            ]
         """
         return self._from_compliant_series(
             self._compliant_series.ewm_mean(
@@ -699,42 +457,11 @@ class Series(Generic[IntoSeriesT]):
             A new Series with the specified data type.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [True, False, True]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a dataframe-agnostic function:
-
-            >>> def agnostic_cast(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.cast(nw.Int64).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_cast`:
-
-            >>> agnostic_cast(s_pd)
-            0    1
-            1    0
-            2    1
-            dtype: int64
-
-            >>> agnostic_cast(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [i64]
-            [
-               1
-               0
-               1
-            ]
-
-            >>> agnostic_cast(s_pa)  # doctest: +ELLIPSIS
+            >>>
+            >>> s_native = pa.chunked_array([[True, False, True]])
+            >>> nw.from_native(s_native, series_only=True).cast(nw.Int64).to_native()
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -754,33 +481,11 @@ class Series(Generic[IntoSeriesT]):
             A DataFrame containing this Series as a single column.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2]
-            >>> s_pd = pd.Series(data, name="a")
-            >>> s_pl = pl.Series("a", data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_to_frame(s_native: IntoSeries) -> IntoDataFrame:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.to_frame().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_to_frame`:
-
-            >>> agnostic_to_frame(s_pd)
-               a
-            0  1
-            1  2
-
-            >>> agnostic_to_frame(s_pl)
+            >>>
+            >>> s_native = pl.Series("a", [1, 2])
+            >>> nw.from_native(s_native, series_only=True).to_frame().to_native()
             shape: (2, 1)
             ┌─────┐
             │ a   │
@@ -790,12 +495,6 @@ class Series(Generic[IntoSeriesT]):
             │ 1   │
             │ 2   │
             └─────┘
-
-            >>> agnostic_to_frame(s_pa)
-            pyarrow.Table
-            : int64
-            ----
-            : [[1,2]]
         """
         return self._dataframe(
             self._compliant_series.to_frame(),
@@ -815,33 +514,11 @@ class Series(Generic[IntoSeriesT]):
             A list of Python objects.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_to_list(s_native: IntoSeries):
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.to_list()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_to_list`:
-
-            >>> agnostic_to_list(s_pd)
-            [1, 2, 3]
-
-            >>> agnostic_to_list(s_pl)
-            [1, 2, 3]
-
-            >>> agnostic_to_list(s_pa)
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, 3]])
+            >>> nw.from_native(s_native, series_only=True).to_list()
             [1, 2, 3]
         """
         return self._compliant_series.to_list()  # type: ignore[no-any-return]
@@ -854,33 +531,11 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_mean(s_native: IntoSeries) -> float:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.mean()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_mean`:
-
-            >>> agnostic_mean(s_pd)
-            np.float64(2.0)
-
-            >>> agnostic_mean(s_pl)
-            2.0
-
-            >>> agnostic_mean(s_pa)
-            2.0
+            >>>
+            >>> s_native = pd.Series([1.2, 4.2])
+            >>> nw.from_native(s_native, series_only=True).mean()
+            np.float64(2.7)
         """
         return self._compliant_series.mean()  # type: ignore[no-any-return]
 
@@ -894,33 +549,11 @@ class Series(Generic[IntoSeriesT]):
             The median value of all elements in the Series.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [5, 3, 8]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a library agnostic function:
-
-            >>> def agnostic_median(s_native: IntoSeries) -> float:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.median()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_median`:
-
-            >>> agnostic_median(s_pd)
-            np.float64(5.0)
-
-            >>> agnostic_median(s_pl)
-            5.0
-
-            >>> agnostic_median(s_pa)
+            >>>
+            >>> s_native = pa.chunked_array([[5, 3, 8]])
+            >>> nw.from_native(s_native, series_only=True).median()
             5.0
         """
         return self._compliant_series.median()  # type: ignore[no-any-return]
@@ -932,33 +565,11 @@ class Series(Generic[IntoSeriesT]):
             The sample skewness of the Series.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 1, 2, 10, 100]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_skew(s_native: IntoSeries) -> float:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.skew()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_skew`:
-
-            >>> agnostic_skew(s_pd)
-            np.float64(1.4724267269058975)
-
-            >>> agnostic_skew(s_pl)
-            1.4724267269058975
-
-            >>> agnostic_skew(s_pa)
+            >>>
+            >>> s_native = pl.Series([1, 1, 2, 10, 100])
+            >>> nw.from_native(s_native, series_only=True).skew()
             1.4724267269058975
 
         Notes:
@@ -974,34 +585,12 @@ class Series(Generic[IntoSeriesT]):
             The number of non-null elements in the Series.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_count(s_native: IntoSeries) -> int:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.count()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_count`:
-
-            >>> agnostic_count(s_pd)
-            np.int64(3)
-
-            >>> agnostic_count(s_pl)
-            3
-
-            >>> agnostic_count(s_pa)
-            3
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, None]])
+            >>> nw.from_native(s_native, series_only=True).count()
+            2
         """
         return self._compliant_series.count()  # type: ignore[no-any-return]
 
@@ -1016,33 +605,11 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [False, True, False]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_any(s_native: IntoSeries) -> bool:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.any()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_any`:
-
-            >>> agnostic_any(s_pd)
+            >>>
+            >>> s_native = pd.Series([False, True, False])
+            >>> nw.from_native(s_native, series_only=True).any()
             np.True_
-
-            >>> agnostic_any(s_pl)
-            True
-
-            >>> agnostic_any(s_pa)
-            True
         """
         return self._compliant_series.any()  # type: ignore[no-any-return]
 
@@ -1053,33 +620,11 @@ class Series(Generic[IntoSeriesT]):
             A boolean indicating if all values in the Series are True.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [False, True, False]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_all(s_native: IntoSeries) -> bool:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.all()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_all`:
-
-            >>> agnostic_all(s_pd)
-            np.False_
-
-            >>> agnostic_all(s_pl)
-            False
-
-            >>> agnostic_all(s_pa)
+            >>>
+            >>> s_native = pa.chunked_array([[False, True, False]])
+            >>> nw.from_native(s_native, series_only=True).all()
             False
         """
         return self._compliant_series.all()  # type: ignore[no-any-return]
@@ -1091,33 +636,11 @@ class Series(Generic[IntoSeriesT]):
             The minimum value in the Series.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_min(s_native: IntoSeries):
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.min()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_min`:
-
-            >>> agnostic_min(s_pd)
-            np.int64(1)
-
-            >>> agnostic_min(s_pl)
-            1
-
-            >>> agnostic_min(s_pa)
+            >>>
+            >>> s_native = pl.Series([1, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).min()
             1
         """
         return self._compliant_series.min()
@@ -1130,33 +653,11 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_max(s_native: IntoSeries):
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.max()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_max`:
-
-            >>> agnostic_max(s_pd)
+            >>>
+            >>> s_native = pd.Series([1, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).max()
             np.int64(3)
-
-            >>> agnostic_max(s_pl)
-            3
-
-            >>> agnostic_max(s_pa)
-            3
         """
         return self._compliant_series.max()
 
@@ -1164,33 +665,11 @@ class Series(Generic[IntoSeriesT]):
         """Returns the index of the minimum value.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_arg_min(s_native: IntoSeries):
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.arg_min()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_arg_min`:
-
-            >>> agnostic_arg_min(s_pd)
-            np.int64(0)
-
-            >>> agnostic_arg_min(s_pl)
-            0
-
-            >>> agnostic_arg_min(s_pa)
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, 3]])
+            >>> nw.from_native(s_native, series_only=True).arg_min()
             0
         """
         return self._compliant_series.arg_min()  # type: ignore[no-any-return]
@@ -1199,33 +678,11 @@ class Series(Generic[IntoSeriesT]):
         """Returns the index of the maximum value.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_arg_max(s_native: IntoSeries):
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.arg_max()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_arg_max`:
-
-            >>> agnostic_arg_max(s_pd)
-            np.int64(2)
-
-            >>> agnostic_arg_max(s_pl)
-            2
-
-            >>> agnostic_arg_max(s_pa)
+            >>>
+            >>> s_native = pl.Series([1, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).arg_max()
             2
         """
         return self._compliant_series.arg_max()  # type: ignore[no-any-return]
@@ -1237,33 +694,11 @@ class Series(Generic[IntoSeriesT]):
             The sum of all elements in the Series.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_sum(s_native: IntoSeries):
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.sum()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_sum`:
-
-            >>> agnostic_sum(s_pd)
-            np.int64(6)
-
-            >>> agnostic_sum(s_pl)
-            6
-
-            >>> agnostic_sum(s_pa)
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, 3]])
+            >>> nw.from_native(s_native, series_only=True).sum()
             6
         """
         return self._compliant_series.sum()  # type: ignore[no-any-return]
@@ -1279,33 +714,11 @@ class Series(Generic[IntoSeriesT]):
             The standard deviation of all elements in the Series.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_std(s_native: IntoSeries) -> float:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.std()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_std`:
-
-            >>> agnostic_std(s_pd)
-            np.float64(1.0)
-
-            >>> agnostic_std(s_pl)
-            1.0
-
-            >>> agnostic_std(s_pa)
+            >>>
+            >>> s_native = pl.Series([1, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).std()
             1.0
         """
         return self._compliant_series.std(ddof=ddof)  # type: ignore[no-any-return]
@@ -1318,33 +731,11 @@ class Series(Generic[IntoSeriesT]):
                      where N represents the number of elements.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_var(s_native: IntoSeries) -> float:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.var()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_var`:
-
-            >>> agnostic_var(s_pd)
-            np.float64(1.0)
-
-            >>> agnostic_var(s_pl)
-            1.0
-
-            >>> agnostic_var(s_pa)
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, 3]])
+            >>> nw.from_native(s_native, series_only=True).var()
             1.0
         """
         return self._compliant_series.var(ddof=ddof)  # type: ignore[no-any-return]
@@ -1365,101 +756,10 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_clip_lower(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.clip(2).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_clip_lower`:
-
-            >>> agnostic_clip_lower(s_pd)
-            0    2
-            1    2
-            2    3
-            dtype: int64
-
-            >>> agnostic_clip_lower(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [i64]
-            [
-               2
-               2
-               3
-            ]
-
-            >>> agnostic_clip_lower(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                2,
-                2,
-                3
-              ]
-            ]
-
-            We define another library agnostic function:
-
-            >>> def agnostic_clip_upper(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.clip(upper_bound=2).to_native()
-
-           We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_clip_upper`:
-
-            >>> agnostic_clip_upper(s_pd)
-            0    1
-            1    2
-            2    2
-            dtype: int64
-
-            >>> agnostic_clip_upper(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [i64]
-            [
-               1
-               2
-               2
-            ]
-
-            >>> agnostic_clip_upper(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                1,
-                2,
-                2
-              ]
-            ]
-
-            We can have both at the same time
-
-            >>> data = [-1, 1, -3, 3, -5, 5]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_clip(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.clip(-1, 3).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_clip`:
-
-            >>> agnostic_clip(s_pd)
+            >>>
+            >>> s_native = pd.Series([-1, 1, -3, 3, -5, 5])
+            >>> nw.from_native(s_native, series_only=True).clip(-1, 3).to_native()
             0   -1
             1    1
             2   -1
@@ -1467,31 +767,6 @@ class Series(Generic[IntoSeriesT]):
             4   -1
             5    3
             dtype: int64
-
-            >>> agnostic_clip(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (6,)
-            Series: '' [i64]
-            [
-               -1
-                1
-               -1
-                3
-               -1
-                3
-            ]
-
-            >>> agnostic_clip_upper(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                -1,
-                1,
-                -3,
-                2,
-                -5,
-                2
-              ]
-            ]
         """
         return self._from_compliant_series(
             self._compliant_series.clip(
@@ -1510,42 +785,13 @@ class Series(Generic[IntoSeriesT]):
             A new Series with boolean values indicating if the elements are in the other sequence.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_is_in(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.is_in([3, 2, 8]).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_is_in`:
-
-            >>> agnostic_is_in(s_pd)
-            0    False
-            1     True
-            2     True
-            dtype: bool
-
-            >>> agnostic_is_in(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [bool]
-            [
-               false
-               true
-               true
-            ]
-
-            >>> agnostic_is_in(s_pa)  # doctest: +ELLIPSIS
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, 3]])
+            >>> nw.from_native(s_native, series_only=True).is_in(
+            ...     [3, 2, 8]
+            ... ).to_native()  # doctest: +ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -1566,46 +812,18 @@ class Series(Generic[IntoSeriesT]):
             A new Series with the indices of elements that are True.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, None, None, 2]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_arg_true(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.is_null().arg_true().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_arg_true`:
-
-            >>> agnostic_arg_true(s_pd)
-            1    1
-            2    2
-            dtype: int64
-
-            >>> agnostic_arg_true(s_pl)  # doctest: +NORMALIZE_WHITESPACE
+            >>>
+            >>> s_native = pl.Series([1, None, None, 2])
+            >>> nw.from_native(
+            ...     s_native, series_only=True
+            ... ).is_null().arg_true().to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (2,)
             Series: '' [u32]
             [
                1
                2
-            ]
-
-            >>> agnostic_arg_true(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                1,
-                2
-              ]
             ]
         """
         return self._from_compliant_series(self._compliant_series.arg_true())
@@ -1623,52 +841,15 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [2, 4, None, 3, 5]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_drop_nulls(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.drop_nulls().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_drop_nulls`:
-
-            >>> agnostic_drop_nulls(s_pd)
+            >>>
+            >>> s_native = pd.Series([2, 4, None, 3, 5])
+            >>> nw.from_native(s_native, series_only=True).drop_nulls().to_native()
             0    2.0
             1    4.0
             3    3.0
             4    5.0
             dtype: float64
-
-            >>> agnostic_drop_nulls(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: '' [i64]
-            [
-                2
-                4
-                3
-                5
-            ]
-
-            >>> agnostic_drop_nulls(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                2,
-                4,
-                3,
-                5
-              ]
-            ]
         """
         return self._from_compliant_series(self._compliant_series.drop_nulls())
 
@@ -1679,42 +860,13 @@ class Series(Generic[IntoSeriesT]):
             A new Series with the absolute values of the original elements.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [2, -4, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a dataframe-agnostic function:
-
-            >>> def agnostic_abs(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.abs().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_abs`:
-
-            >>> agnostic_abs(s_pd)
-            0    2
-            1    4
-            2    3
-            dtype: int64
-
-            >>> agnostic_abs(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [i64]
-            [
-               2
-               4
-               3
-            ]
-
-            >>> agnostic_abs(s_pa)  # doctest: +ELLIPSIS
+            >>>
+            >>> s_native = pa.chunked_array([[2, -4, 3]])
+            >>> nw.from_native(
+            ...     s_native, series_only=True
+            ... ).abs().to_native()  # doctest: +ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -1737,49 +889,14 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [2, 4, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a dataframe-agnostic function:
-
-            >>> def agnostic_cum_sum(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.cum_sum().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_cum_sum`:
-
-            >>> agnostic_cum_sum(s_pd)
+            >>>
+            >>> s_native = pd.Series([2, 4, 3])
+            >>> nw.from_native(s_native, series_only=True).cum_sum().to_native()
             0    2
             1    6
             2    9
             dtype: int64
-
-            >>> agnostic_cum_sum(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [i64]
-            [
-               2
-               6
-               9
-            ]
-
-            >>> agnostic_cum_sum(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                2,
-                6,
-                9
-              ]
-            ]
         """
         return self._from_compliant_series(
             self._compliant_series.cum_sum(reverse=reverse)
@@ -1797,49 +914,19 @@ class Series(Generic[IntoSeriesT]):
             A new Series with duplicate values removed.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [2, 4, 4, 6]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_unique(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.unique(maintain_order=True).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_unique`:
-
-            >>> agnostic_unique(s_pd)
-            0    2
-            1    4
-            2    6
-            dtype: int64
-
-            >>> agnostic_unique(s_pl)  # doctest: +NORMALIZE_WHITESPACE
+            >>>
+            >>> s_native = pl.Series([2, 4, 4, 6])
+            >>> nw.from_native(s_native, series_only=True).unique(
+            ...     maintain_order=True
+            ... ).to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (3,)
             Series: '' [i64]
             [
                2
                4
                6
-            ]
-
-            >>> agnostic_unique(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                2,
-                4,
-                6
-              ]
             ]
         """
         return self._from_compliant_series(
@@ -1862,42 +949,13 @@ class Series(Generic[IntoSeriesT]):
             A new Series with the difference between each element and its predecessor.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [2, 4, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a dataframe-agnostic function:
-
-            >>> def agnostic_diff(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.diff().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_diff`:
-
-            >>> agnostic_diff(s_pd)
-            0    NaN
-            1    2.0
-            2   -1.0
-            dtype: float64
-
-            >>> agnostic_diff(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [i64]
-            [
-               null
-               2
-               -1
-            ]
-
-            >>> agnostic_diff(s_pa)  # doctest: +ELLIPSIS
+            >>>
+            >>> s_native = pa.chunked_array([[2, 4, 3]])
+            >>> nw.from_native(
+            ...     s_native, series_only=True
+            ... ).diff().to_native()  # doctest: +ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -1930,49 +988,14 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [2, 4, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a dataframe-agnostic function:
-
-            >>> def agnostic_shift(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.shift(1).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_shift`:
-
-            >>> agnostic_shift(s_pd)
+            >>>
+            >>> s_native = pd.Series([2, 4, 3])
+            >>> nw.from_native(s_native, series_only=True).shift(1).to_native()
             0    NaN
             1    2.0
             2    4.0
             dtype: float64
-
-            >>> agnostic_shift(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [i64]
-            [
-               null
-               2
-               4
-            ]
-
-            >>> agnostic_shift(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                null,
-                2,
-                4
-              ]
-            ]
         """
         return self._from_compliant_series(self._compliant_series.shift(n))
 
@@ -2002,34 +1025,13 @@ class Series(Generic[IntoSeriesT]):
             The results are not consistent across libraries.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3, 4]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_sample(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.sample(fraction=1.0, with_replacement=True).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_sample`:
-
-            >>> agnostic_sample(s_pd)  # doctest: +SKIP
-               a
-            2  3
-            1  2
-            3  4
-            3  4
-
-            >>> agnostic_sample(s_pl)  # doctest: +SKIP
+            >>>
+            >>> s_native = pl.Series([1, 2, 3, 4])
+            >>> nw.from_native(s_native, series_only=True).sample(
+            ...     fraction=1.0, with_replacement=True
+            ... ).to_native()  # doctest: +SKIP
             shape: (4,)
             Series: '' [i64]
             [
@@ -2037,17 +1039,6 @@ class Series(Generic[IntoSeriesT]):
                4
                3
                4
-            ]
-
-            >>> agnostic_sample(s_pa)  # doctest: +SKIP
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                1,
-                4,
-                3,
-                4
-              ]
             ]
         """
         return self._from_compliant_series(
@@ -2086,49 +1077,14 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data, name="foo")
-            >>> s_pl = pl.Series("foo", data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_alias(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.alias("bar").to_native()
-
-            We can then pass any supported library such as pandas or Polars, or
-            PyArrow to `agnostic_alias`:
-
-            >>> agnostic_alias(s_pd)
+            >>>
+            >>> s_native = pd.Series([1, 2, 3], name="foo")
+            >>> nw.from_native(s_native, series_only=True).alias("bar").to_native()
             0    1
             1    2
             2    3
             Name: bar, dtype: int64
-
-            >>> agnostic_alias(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: 'bar' [i64]
-            [
-               1
-               2
-               3
-            ]
-
-            >>> agnostic_alias(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at 0x...>
-            [
-              [
-                1,
-                2,
-                3
-              ]
-            ]
         """
         return self._from_compliant_series(self._compliant_series.alias(name=name))
 
@@ -2163,49 +1119,19 @@ class Series(Generic[IntoSeriesT]):
             A new Series with the updated name.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data, name="foo")
-            >>> s_pl = pl.Series("foo", data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_rename(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.rename("bar").to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_rename`:
-
-            >>> agnostic_rename(s_pd)
-            0    1
-            1    2
-            2    3
-            Name: bar, dtype: int64
-
-            >>> agnostic_rename(s_pl)  # doctest: +NORMALIZE_WHITESPACE
+            >>>
+            >>> s_native = pl.Series("foo", [1, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).rename(
+            ...     "bar"
+            ... ).to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (3,)
             Series: 'bar' [i64]
             [
                1
                2
                3
-            ]
-
-            >>> agnostic_rename(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at 0x...>
-            [
-              [
-                1,
-                2,
-                3
-              ]
             ]
         """
         return self.alias(name=name)
@@ -2235,56 +1161,19 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = {"a": [3, 0, 1, 2]}
-            >>> df_pd = pd.DataFrame(data)
-            >>> df_pl = pl.DataFrame(data)
-            >>> df_pa = pa.table(data)
-
-            Let's define dataframe-agnostic functions:
-
-            >>> def agnostic_replace_strict(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.replace_strict(
-            ...         [0, 1, 2, 3],
-            ...         ["zero", "one", "two", "three"],
-            ...         return_dtype=nw.String,
-            ...     ).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_replace_strict`:
-
-            >>> agnostic_replace_strict(df_pd["a"])
+            >>>
+            >>> s_native = pd.Series([3, 0, 1, 2], name="a")
+            >>> nw.from_native(s_native, series_only=True).replace_strict(
+            ...     [0, 1, 2, 3],
+            ...     ["zero", "one", "two", "three"],
+            ...     return_dtype=nw.String,
+            ... ).to_native()
             0    three
             1     zero
             2      one
             3      two
             Name: a, dtype: object
-
-            >>> agnostic_replace_strict(df_pl["a"])  # doctest: +NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: 'a' [str]
-            [
-                "three"
-                "zero"
-                "one"
-                "two"
-            ]
-
-            >>> agnostic_replace_strict(df_pa["a"])
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                "three",
-                "zero",
-                "one",
-                "two"
-              ]
-            ]
         """
         if new is None:
             if not isinstance(old, Mapping):
@@ -2309,66 +1198,13 @@ class Series(Generic[IntoSeriesT]):
             A new sorted Series.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [5, None, 1, 2]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define library agnostic functions:
-
-            >>> def agnostic_sort(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.sort().to_native()
-
-            >>> def agnostic_sort_descending(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.sort(descending=True).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_sort` and `agnostic_sort_descending`:
-
-            >>> agnostic_sort(s_pd)
-            1    NaN
-            2    1.0
-            3    2.0
-            0    5.0
-            dtype: float64
-
-            >>> agnostic_sort(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: '' [i64]
-            [
-               null
-               1
-               2
-               5
-            ]
-
-            >>> agnostic_sort(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                null,
-                1,
-                2,
-                5
-              ]
-            ]
-
-            >>> agnostic_sort_descending(s_pd)
-            1    NaN
-            0    5.0
-            3    2.0
-            2    1.0
-            dtype: float64
-
-            >>> agnostic_sort_descending(s_pl)  # doctest: +NORMALIZE_WHITESPACE
+            >>>
+            >>> s_native = pl.Series([5, None, 1, 2])
+            >>> nw.from_native(s_native, series_only=True).sort(
+            ...     descending=True
+            ... ).to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (4,)
             Series: '' [i64]
             [
@@ -2376,17 +1212,6 @@ class Series(Generic[IntoSeriesT]):
                5
                2
                1
-            ]
-
-            >>> agnostic_sort_descending(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                null,
-                5,
-                2,
-                1
-              ]
             ]
         """
         return self._from_compliant_series(
@@ -2405,42 +1230,13 @@ class Series(Generic[IntoSeriesT]):
             A boolean Series indicating which values are null.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, None]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_is_null(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.is_null().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_is_null`:
-
-            >>> agnostic_is_null(s_pd)
-            0    False
-            1    False
-            2     True
-            dtype: bool
-
-            >>> agnostic_is_null(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [bool]
-            [
-               false
-               false
-               true
-            ]
-
-            >>> agnostic_is_null(s_pa)  # doctest:+ELLIPSIS
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, None]])
+            >>> nw.from_native(
+            ...     s_native, series_only=True
+            ... ).is_null().to_native()  # doctest:+ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -2465,43 +1261,14 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [0.0, None, 2.0]
-            >>> s_pd = pd.Series(data, dtype="Float64")
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data], type=pa.float64())
-
-            >>> def agnostic_self_div_is_nan(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.is_nan().to_native()
-
-            >>> print(agnostic_self_div_is_nan(s_pd))
+            >>>
+            >>> s_native = pd.Series([0.0, None, 2.0], dtype="Float64")
+            >>> nw.from_native(s_native, series_only=True).is_nan().to_native()
             0    False
             1     <NA>
             2    False
             dtype: boolean
-
-            >>> print(agnostic_self_div_is_nan(s_pl))  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [bool]
-            [
-                    false
-                    null
-                    false
-            ]
-
-            >>> print(agnostic_self_div_is_nan(s_pa))  # doctest: +NORMALIZE_WHITESPACE
-            [
-              [
-                false,
-                null,
-                false
-              ]
-            ]
         """
         return self._from_compliant_series(self._compliant_series.is_nan())
 
@@ -2528,82 +1295,25 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, None]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_fill_null(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.fill_null(5).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_fill_null`:
-
-            >>> agnostic_fill_null(s_pd)
+            >>>
+            >>> s_native = pd.Series([1, 2, None])
+            >>>
+            >>> nw.from_native(s_native, series_only=True).fill_null(5).to_native()
             0    1.0
             1    2.0
             2    5.0
             dtype: float64
 
-            >>> agnostic_fill_null(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [i64]
-            [
-               1
-               2
-               5
-            ]
+            Or using a strategy:
 
-            >>> agnostic_fill_null(s_pa)  # doctest:+ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                1,
-                2,
-                5
-              ]
-            ]
-
-            Using a strategy:
-
-            >>> def agnostic_fill_null_with_strategy(
-            ...     s_native: IntoSeriesT,
-            ... ) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.fill_null(strategy="forward", limit=1).to_native()
-
-            >>> agnostic_fill_null_with_strategy(s_pd)
+            >>> nw.from_native(s_native, series_only=True).fill_null(
+            ...     strategy="forward", limit=1
+            ... ).to_native()
             0    1.0
             1    2.0
             2    2.0
             dtype: float64
-
-            >>> agnostic_fill_null_with_strategy(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [i64]
-            [
-               1
-               2
-               2
-            ]
-
-            >>> agnostic_fill_null_with_strategy(s_pa)  # doctest:+ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                1,
-                2,
-                2
-              ]
-            ]
         """
         if value is not None and strategy is not None:
             msg = "cannot specify both `value` and `strategy`"
@@ -2639,46 +1349,13 @@ class Series(Generic[IntoSeriesT]):
             A boolean Series indicating which values are between the given bounds.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3, 4, 5]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_is_between(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.is_between(2, 4, "right").to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_is_between`:
-
-            >>> agnostic_is_between(s_pd)
-            0    False
-            1    False
-            2     True
-            3     True
-            4    False
-            dtype: bool
-
-            >>> agnostic_is_between(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (5,)
-            Series: '' [bool]
-            [
-               false
-               false
-               true
-               true
-               false
-            ]
-
-            >>> agnostic_is_between(s_pa)  # doctest: +ELLIPSIS
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, 3, 4, 5]])
+            >>> nw.from_native(s_native, series_only=True).is_between(
+            ...     2, 4, "right"
+            ... ).to_native()  # doctest: +ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -2705,33 +1382,11 @@ class Series(Generic[IntoSeriesT]):
             Number of unique values in the Series.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_n_unique(s_native: IntoSeries) -> int:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.n_unique()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_n_unique`:
-
-            >>> agnostic_n_unique(s_pd)
-            3
-
-            >>> agnostic_n_unique(s_pl)
-            3
-
-            >>> agnostic_n_unique(s_pa)
+            >>>
+            >>> s_native = pl.Series([1, 2, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).n_unique()
             3
         """
         return self._compliant_series.n_unique()  # type: ignore[no-any-return]
@@ -2743,34 +1398,11 @@ class Series(Generic[IntoSeriesT]):
             NumPy ndarray representation of the Series.
 
         Examples:
-            >>> import numpy as np
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data, name="a")
-            >>> s_pl = pl.Series("a", data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_to_numpy(s_native: IntoSeries) -> np.ndarray:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.to_numpy()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_to_numpy`:
-
-            >>> agnostic_to_numpy(s_pd)
-            array([1, 2, 3]...)
-
-            >>> agnostic_to_numpy(s_pl)
-            array([1, 2, 3]...)
-
-            >>> agnostic_to_numpy(s_pa)
+            >>>
+            >>> s_native = pd.Series([1, 2, 3], name="a")
+            >>> nw.from_native(s_native, series_only=True).to_numpy()
             array([1, 2, 3]...)
         """
         return self._compliant_series.to_numpy()
@@ -2782,43 +1414,15 @@ class Series(Generic[IntoSeriesT]):
             A pandas Series containing the data from this Series.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data, name="a")
-            >>> s_pl = pl.Series("a", data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_to_pandas(s_native: IntoSeries) -> pd.Series:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.to_pandas()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_to_pandas`:
-
-            >>> agnostic_to_pandas(s_pd)
+            >>>
+            >>> s_native = pl.Series("a", [1, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).to_pandas()
             0    1
             1    2
             2    3
             Name: a, dtype: int64
-
-            >>> agnostic_to_pandas(s_pl)
-            0    1
-            1    2
-            2    3
-            Name: a, dtype: int64
-
-            >>> agnostic_to_pandas(s_pa)
-            0    1
-            1    2
-            2    3
-            Name: , dtype: int64
         """
         return self._compliant_series.to_pandas()
 
@@ -2829,45 +1433,13 @@ class Series(Generic[IntoSeriesT]):
             A polars Series containing the data from this Series.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data, name="a")
-            >>> s_pl = pl.Series("a", data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_to_polars(s_native: IntoSeries) -> pd.Series:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.to_polars()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_to_polars`:
-
-            >>> agnostic_to_polars(s_pd)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: 'a' [i64]
-            [
-                1
-                2
-                3
-            ]
-
-            >>> agnostic_to_polars(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: 'a' [i64]
-            [
-                1
-                2
-                3
-            ]
-
-            >>> agnostic_to_polars(s_pa)  # doctest: +NORMALIZE_WHITESPACE
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, 3]])
+            >>> nw.from_native(
+            ...     s_native, series_only=True
+            ... ).to_polars()  # doctest: +NORMALIZE_WHITESPACE
             shape: (3,)
             Series: '' [i64]
             [
@@ -3010,49 +1582,15 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [4, 10, 15, 34, 50]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_filter(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.filter(s > 10).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_filter`:
-
-            >>> agnostic_filter(s_pd)
+            >>>
+            >>> s_native = pd.Series([4, 10, 15, 34, 50])
+            >>> s_nw = nw.from_native(s_native, series_only=True)
+            >>> s_nw.filter(s_nw > 10).to_native()
             2    15
             3    34
             4    50
             dtype: int64
-
-            >>> agnostic_filter(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [i64]
-            [
-               15
-               34
-               50
-            ]
-
-            >>> agnostic_filter(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                15,
-                34,
-                50
-              ]
-            ]
         """
         return self._from_compliant_series(
             self._compliant_series.filter(self._extract_native(other))
@@ -3066,44 +1604,13 @@ class Series(Generic[IntoSeriesT]):
             A new Series with boolean values indicating duplicated rows.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3, 1]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_is_duplicated(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.is_duplicated().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_is_duplicated`:
-
-            >>> agnostic_is_duplicated(s_pd)
-            0     True
-            1    False
-            2    False
-            3     True
-            dtype: bool
-
-            >>> agnostic_is_duplicated(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: '' [bool]
-            [
-                true
-                false
-                false
-                true
-            ]
-
-            >>> agnostic_is_duplicated(s_pa)  # doctest: +ELLIPSIS
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, 3, 1]])
+            >>> nw.from_native(
+            ...     s_native, series_only=True
+            ... ).is_duplicated().to_native()  # doctest: +ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -3123,35 +1630,16 @@ class Series(Generic[IntoSeriesT]):
             A boolean indicating if the series is empty.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
+            >>>
+            >>> s_native = pl.Series([1, 2, 3])
+            >>> s_nw = nw.from_native(s_native, series_only=True)
 
-            Let's define a dataframe-agnostic function that filters rows in which "foo"
-            values are greater than 10, and then checks if the result is empty or not:
-
-            >>> def agnostic_is_empty(s_native: IntoSeries) -> bool:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.filter(s > 10).is_empty()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_is_empty`:
-
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-            >>> agnostic_is_empty(s_pd), agnostic_is_empty(s_pl), agnostic_is_empty(s_pa)
-            (True, True, True)
-
-            >>> data = [100, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-            >>> agnostic_is_empty(s_pd), agnostic_is_empty(s_pl), agnostic_is_empty(s_pa)
-            (False, False, False)
+            >>> s_nw.is_empty()
+            False
+            >>> s_nw.filter(s_nw > 10).is_empty()
+            True
         """
         return self._compliant_series.is_empty()  # type: ignore[no-any-return]
 
@@ -3163,51 +1651,15 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3, 1]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_is_unique(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.is_unique().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_is_unique`:
-
-            >>> agnostic_is_unique(s_pd)
+            >>>
+            >>> s_native = pd.Series([1, 2, 3, 1])
+            >>> nw.from_native(s_native, series_only=True).is_unique().to_native()
             0    False
             1     True
             2     True
             3    False
             dtype: bool
-
-            >>> agnostic_is_unique(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: '' [bool]
-            [
-                false
-                 true
-                 true
-                false
-            ]
-            >>> agnostic_is_unique(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                false,
-                true,
-                true,
-                false
-              ]
-            ]
         """
         return self._from_compliant_series(self._compliant_series.is_unique())
 
@@ -3223,34 +1675,11 @@ class Series(Generic[IntoSeriesT]):
             The number of null values in the Series.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, None, None]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function that returns the null count of
-            the series:
-
-            >>> def agnostic_null_count(s_native: IntoSeries) -> int:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.null_count()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_null_count`:
-
-            >>> agnostic_null_count(s_pd)
-            np.int64(2)
-
-            >>> agnostic_null_count(s_pl)
-            2
-
-            >>> agnostic_null_count(s_pa)
+            >>>
+            >>> s_native = pa.chunked_array([[1, None, None]])
+            >>> nw.from_native(s_native, series_only=True).null_count()
             2
         """
         return self._compliant_series.null_count()  # type: ignore[no-any-return]
@@ -3262,35 +1691,13 @@ class Series(Generic[IntoSeriesT]):
             A new Series with boolean values indicating the first occurrence of each distinct value.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 1, 2, 3, 2]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_is_first_distinct(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.is_first_distinct().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_is_first_distinct`:
-
-            >>> agnostic_is_first_distinct(s_pd)
-            0     True
-            1    False
-            2     True
-            3     True
-            4    False
-            dtype: bool
-
-            >>> agnostic_is_first_distinct(s_pl)  # doctest: +NORMALIZE_WHITESPACE
+            >>>
+            >>> s_native = pl.Series([1, 1, 2, 3, 2])
+            >>> nw.from_native(
+            ...     s_native, series_only=True
+            ... ).is_first_distinct().to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (5,)
             Series: '' [bool]
             [
@@ -3299,18 +1706,6 @@ class Series(Generic[IntoSeriesT]):
                 true
                 true
                 false
-            ]
-
-            >>> agnostic_is_first_distinct(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                true,
-                false,
-                true,
-                true,
-                false
-              ]
             ]
         """
         return self._from_compliant_series(self._compliant_series.is_first_distinct())
@@ -3323,55 +1718,16 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 1, 2, 3, 2]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_is_last_distinct(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.is_last_distinct().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_is_last_distinct`:
-
-            >>> agnostic_is_last_distinct(s_pd)
+            >>>
+            >>> s_native = pd.Series([1, 1, 2, 3, 2])
+            >>> nw.from_native(s_native, series_only=True).is_last_distinct().to_native()
             0    False
             1     True
             2    False
             3     True
             4     True
             dtype: bool
-
-            >>> agnostic_is_last_distinct(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (5,)
-            Series: '' [bool]
-            [
-                false
-                true
-                false
-                true
-                true
-            ]
-
-            >>> agnostic_is_last_distinct(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                false,
-                true,
-                false,
-                true,
-                true
-              ]
-            ]
         """
         return self._from_compliant_series(self._compliant_series.is_last_distinct())
 
@@ -3385,40 +1741,16 @@ class Series(Generic[IntoSeriesT]):
             A boolean indicating if the Series is sorted.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
+            >>>
+            >>> s_native = pa.chunked_array([[3, 2, 1]])
+            >>> s_nw = nw.from_native(s_native, series_only=True)
 
-            >>> unsorted_data = [1, 3, 2]
-            >>> sorted_data = [3, 2, 1]
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_is_sorted(s_native: IntoSeries, descending: bool = False):
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.is_sorted(descending=descending)
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_is_sorted`:
-
-            >>> agnostic_is_sorted(pd.Series(unsorted_data))
+            >>> s_nw.is_sorted(descending=False)
             False
 
-            >>> agnostic_is_sorted(pd.Series(sorted_data), descending=True)
-            True
-
-            >>> agnostic_is_sorted(pl.Series(unsorted_data))
-            False
-
-            >>> agnostic_is_sorted(pl.Series(sorted_data), descending=True)
-            True
-
-            >>> agnostic_is_sorted(pa.chunked_array([unsorted_data]))
-            False
-
-            >>> agnostic_is_sorted(pa.chunked_array([sorted_data]), descending=True)
+            >>> s_nw.is_sorted(descending=True)
             True
         """
         return self._compliant_series.is_sorted(descending=descending)  # type: ignore[no-any-return]
@@ -3448,51 +1780,16 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 1, 2, 3, 2]
-            >>> s_pd = pd.Series(data, name="s")
-            >>> s_pl = pl.Series(values=data, name="s")
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_value_counts(s_native: IntoSeries) -> IntoDataFrame:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.value_counts(sort=True).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_value_counts`:
-
-            >>> agnostic_value_counts(s_pd)
+            >>>
+            >>> s_native = pd.Series([1, 1, 2, 3, 2], name="s")
+            >>> nw.from_native(s_native, series_only=True).value_counts(
+            ...     sort=True
+            ... ).to_native()
                s  count
             0  1      2
             1  2      2
             2  3      1
-
-            >>> agnostic_value_counts(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3, 2)
-            ┌─────┬───────┐
-            │ s   ┆ count │
-            │ --- ┆ ---   │
-            │ i64 ┆ u32   │
-            ╞═════╪═══════╡
-            │ 1   ┆ 2     │
-            │ 2   ┆ 2     │
-            │ 3   ┆ 1     │
-            └─────┴───────┘
-
-            >>> agnostic_value_counts(s_pa)
-            pyarrow.Table
-            : int64
-            count: int64
-            ----
-            : [[1,2,3]]
-            count: [[2,2,1]]
         """
         return self._dataframe(
             self._compliant_series.value_counts(
@@ -3519,37 +1816,16 @@ class Series(Generic[IntoSeriesT]):
             The quantile value.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = list(range(50))
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_quantile(s_native: IntoSeries) -> list[float]:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return [
-            ...         s.quantile(quantile=q, interpolation="nearest")
-            ...         for q in (0.1, 0.25, 0.5, 0.75, 0.9)
-            ...     ]
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_quantile`:
-
-            >>> agnostic_quantile(s_pd)
-            [np.int64(5), np.int64(12), np.int64(24), np.int64(37), np.int64(44)]
-
-            >>> agnostic_quantile(s_pl)
+            >>>
+            >>> s_native = pl.Series(list(range(50)))
+            >>> s_nw = nw.from_native(s_native, series_only=True)
+            >>> [
+            ...     s_nw.quantile(quantile=q, interpolation="nearest")
+            ...     for q in (0.1, 0.25, 0.5, 0.75, 0.9)
+            ... ]
             [5.0, 12.0, 25.0, 37.0, 44.0]
-
-            >>> agnostic_quantile(s_pa)
-            [5, 12, 24, 37, 44]
         """
         return self._compliant_series.quantile(  # type: ignore[no-any-return]
             quantile=quantile, interpolation=interpolation
@@ -3569,63 +1845,17 @@ class Series(Generic[IntoSeriesT]):
             A new Series with values selected from self or other based on the mask.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3, 4, 5]
-            >>> other = [5, 4, 3, 2, 1]
-            >>> mask = [True, False, True, False, True]
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_zip_with(
-            ...     s1_native: IntoSeriesT,
-            ...     mask_native: IntoSeriesT,
-            ...     s2_native: IntoSeriesT,
-            ... ) -> IntoSeriesT:
-            ...     s1 = nw.from_native(s1_native, series_only=True)
-            ...     mask = nw.from_native(mask_native, series_only=True)
-            ...     s2 = nw.from_native(s2_native, series_only=True)
-            ...     return s1.zip_with(mask, s2).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_zip_with`:
-
-            >>> agnostic_zip_with(
-            ...     s1_native=pl.Series(data),
-            ...     mask_native=pl.Series(mask),
-            ...     s2_native=pl.Series(other),
-            ... )  # doctest: +NORMALIZE_WHITESPACE
-            shape: (5,)
-            Series: '' [i64]
-            [
-               1
-               4
-               3
-               2
-               5
-            ]
-
-            >>> agnostic_zip_with(
-            ...     s1_native=pd.Series(data),
-            ...     mask_native=pd.Series(mask),
-            ...     s2_native=pd.Series(other),
-            ... )
-            0    1
-            1    4
-            2    3
-            3    2
-            4    5
-            dtype: int64
-
-            >>> agnostic_zip_with(
-            ...     s1_native=pa.chunked_array([data]),
-            ...     mask_native=pa.chunked_array([mask]),
-            ...     s2_native=pa.chunked_array([other]),
-            ... )  # doctest: +ELLIPSIS
+            >>> data_native = pa.chunked_array([[1, 2, 3, 4, 5]])
+            >>> other_native = pa.chunked_array([[5, 4, 3, 2, 1]])
+            >>> mask_native = pa.chunked_array([[True, False, True, False, True]])
+            >>>
+            >>> data_nw = nw.from_native(data_native, series_only=True)
+            >>> other_nw = nw.from_native(other_native, series_only=True)
+            >>> mask_nw = nw.from_native(mask_native, series_only=True)
+            >>>
+            >>> data_nw.zip_with(mask_nw, other_nw).to_native()  # doctest: +ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -3653,34 +1883,14 @@ class Series(Generic[IntoSeriesT]):
             The scalar value of the Series or the element at the given index.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
+            >>>
+            >>> nw.from_native(pl.Series("a", [1]), series_only=True).item()
+            1
 
-            Let's define a dataframe-agnostic function that returns item at given index
-
-            >>> def agnostic_item(s_native: IntoSeries, index=None):
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.item(index)
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_item`:
-
-            >>> (
-            ...     agnostic_item(pl.Series("a", [1]), None),
-            ...     agnostic_item(pd.Series([1]), None),
-            ...     agnostic_item(pa.chunked_array([[1]]), None),
-            ... )
-            (1, np.int64(1), 1)
-
-            >>> (
-            ...     agnostic_item(pl.Series("a", [9, 8, 7]), -1),
-            ...     agnostic_item(pl.Series([9, 8, 7]), -2),
-            ...     agnostic_item(pa.chunked_array([[9, 8, 7]]), -3),
-            ... )
-            (7, 8, 9)
+            >>> nw.from_native(pl.Series("a", [9, 8, 7]), series_only=True).item(-1)
+            7
         """
         return self._compliant_series.item(index=index)
 
@@ -3695,49 +1905,14 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = list(range(10))
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function that returns the first 3 rows:
-
-            >>> def agnostic_head(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.head(3).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_head`:
-
-            >>> agnostic_head(s_pd)
+            >>>
+            >>> s_native = pd.Series(list(range(10)))
+            >>> nw.from_native(s_native, series_only=True).head(3).to_native()
             0    0
             1    1
             2    2
             dtype: int64
-
-            >>> agnostic_head(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [i64]
-            [
-               0
-               1
-               2
-            ]
-
-            >>> agnostic_head(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                0,
-                1,
-                2
-              ]
-            ]
         """
         return self._from_compliant_series(self._compliant_series.head(n))
 
@@ -3751,42 +1926,13 @@ class Series(Generic[IntoSeriesT]):
             A new Series with the last n rows.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = list(range(10))
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function that returns the last 3 rows:
-
-            >>> def agnostic_tail(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.tail(3).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_tail`:
-
-            >>> agnostic_tail(s_pd)
-            7    7
-            8    8
-            9    9
-            dtype: int64
-
-            >>> agnostic_tail(s_pl)  # doctest: +NORMALIZE_WHITESPACE
-            shape: (3,)
-            Series: '' [i64]
-            [
-               7
-               8
-               9
-            ]
-
-            >>> agnostic_tail(s_pa)  # doctest: +ELLIPSIS
+            >>>
+            >>> s_native = pa.chunked_array([list(range(10))])
+            >>> nw.from_native(s_native, series_only=True).tail(
+            ...     3
+            ... ).to_native()  # doctest: +ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -3816,49 +1962,19 @@ class Series(Generic[IntoSeriesT]):
             Polars and Arrow round away from 0 (e.g. -0.5 to -1.0, 0.5 to 1.0, 1.5 to 2.0, 2.5 to 3.0, etc..).
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1.12345, 2.56789, 3.901234]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function that rounds to the first decimal:
-
-            >>> def agnostic_round(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.round(1).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_round`:
-
-            >>> agnostic_round(s_pd)
-            0    1.1
-            1    2.6
-            2    3.9
-            dtype: float64
-
-            >>> agnostic_round(s_pl)  # doctest: +NORMALIZE_WHITESPACE
+            >>>
+            >>> s_native = pl.Series([1.12345, 2.56789, 3.901234])
+            >>> nw.from_native(s_native, series_only=True).round(
+            ...     1
+            ... ).to_native()  # doctest: +NORMALIZE_WHITESPACE
             shape: (3,)
             Series: '' [f64]
             [
                1.1
                2.6
                3.9
-            ]
-
-            >>> agnostic_round(s_pa)  # doctest: +ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                1.1,
-                2.6,
-                3.9
-              ]
             ]
         """
         return self._from_compliant_series(self._compliant_series.round(decimals))
@@ -3881,80 +1997,22 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoDataFrame
-            >>> from narwhals.typing import IntoSeries
+            >>>
+            >>> s_native = pd.Series([1, 2, 3], name="a")
+            >>> s_nw = nw.from_native(s_native, series_only=True)
 
-            >>> data = [1, 2, 3]
-            >>> s_pd = pd.Series(data, name="a")
-            >>> s_pl = pl.Series("a", data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function:
-
-            >>> def agnostic_to_dummies(
-            ...     s_native: IntoSeries, drop_first: bool = False
-            ... ) -> IntoDataFrame:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.to_dummies(drop_first=drop_first).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_to_dummies`:
-
-            >>> agnostic_to_dummies(s_pd)
+            >>> s_nw.to_dummies(drop_first=False).to_native()
                a_1  a_2  a_3
             0    1    0    0
             1    0    1    0
             2    0    0    1
 
-            >>> agnostic_to_dummies(s_pd, drop_first=True)
+            >>> s_nw.to_dummies(drop_first=True).to_native()
                a_2  a_3
             0    0    0
             1    1    0
             2    0    1
-
-            >>> agnostic_to_dummies(s_pl)
-            shape: (3, 3)
-            ┌─────┬─────┬─────┐
-            │ a_1 ┆ a_2 ┆ a_3 │
-            │ --- ┆ --- ┆ --- │
-            │ i8  ┆ i8  ┆ i8  │
-            ╞═════╪═════╪═════╡
-            │ 1   ┆ 0   ┆ 0   │
-            │ 0   ┆ 1   ┆ 0   │
-            │ 0   ┆ 0   ┆ 1   │
-            └─────┴─────┴─────┘
-
-            >>> agnostic_to_dummies(s_pl, drop_first=True)
-            shape: (3, 2)
-            ┌─────┬─────┐
-            │ a_2 ┆ a_3 │
-            │ --- ┆ --- │
-            │ i8  ┆ i8  │
-            ╞═════╪═════╡
-            │ 0   ┆ 0   │
-            │ 1   ┆ 0   │
-            │ 0   ┆ 1   │
-            └─────┴─────┘
-
-            >>> agnostic_to_dummies(s_pa)
-            pyarrow.Table
-            _1: int8
-            _2: int8
-            _3: int8
-            ----
-            _1: [[1,0,0]]
-            _2: [[0,1,0]]
-            _3: [[0,0,1]]
-            >>> agnostic_to_dummies(s_pa, drop_first=True)
-            pyarrow.Table
-            _2: int8
-            _3: int8
-            ----
-            _2: [[0,1,0]]
-            _3: [[0,0,1]]
         """
         return self._dataframe(
             self._compliant_series.to_dummies(separator=separator, drop_first=drop_first),
@@ -3972,41 +2030,13 @@ class Series(Generic[IntoSeriesT]):
             A new Series with every nth value starting from the offset.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 2, 3, 4]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function in which gather every 2 rows,
-            starting from a offset of 1:
-
-            >>> def agnostic_gather_every(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.gather_every(n=2, offset=1).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_gather_every`:
-
-            >>> agnostic_gather_every(s_pd)
-            1    2
-            3    4
-            dtype: int64
-
-            >>> agnostic_gather_every(s_pl)  # doctest:+NORMALIZE_WHITESPACE
-            shape: (2,)
-            Series: '' [i64]
-            [
-               2
-               4
-            ]
-
-            >>> agnostic_gather_every(s_pa)  # doctest:+ELLIPSIS
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, 3, 4]])
+            >>> nw.from_native(s_native, series_only=True).gather_every(
+            ...     n=2, offset=1
+            ... ).to_native()  # doctest:+ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -4026,45 +2056,13 @@ class Series(Generic[IntoSeriesT]):
             A PyArrow Array containing the data from the Series.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeries
-
-            >>> data = [1, 2, 3, 4]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            Let's define a dataframe-agnostic function that converts to arrow:
-
-            >>> def agnostic_to_arrow(s_native: IntoSeries) -> pa.Array:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.to_arrow()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_to_arrow`:
-
-            >>> agnostic_to_arrow(s_pd)  # doctest:+NORMALIZE_WHITESPACE
-            <pyarrow.lib.Int64Array object at ...>
-            [
-                1,
-                2,
-                3,
-                4
-            ]
-
-            >>> agnostic_to_arrow(s_pl)  # doctest:+NORMALIZE_WHITESPACE
-            <pyarrow.lib.Int64Array object at ...>
-            [
-                1,
-                2,
-                3,
-                4
-            ]
-
-            >>> agnostic_to_arrow(s_pa)  # doctest:+NORMALIZE_WHITESPACE
+            >>>
+            >>> s_native = pl.Series([1, 2, 3, 4])
+            >>> nw.from_native(
+            ...     s_native, series_only=True
+            ... ).to_arrow()  # doctest:+NORMALIZE_WHITESPACE
             <pyarrow.lib.Int64Array object at ...>
             [
                 1,
@@ -4085,46 +2083,12 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 1, 2, 2, 3]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_mode(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.mode().sort().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_mode`:
-
-            >>> agnostic_mode(s_pd)
+            >>> s_native = pd.Series([1, 1, 2, 2, 3])
+            >>> nw.from_native(s_native, series_only=True).mode().sort().to_native()
             0    1
             1    2
             dtype: int64
-
-            >>> agnostic_mode(s_pl)  # doctest:+NORMALIZE_WHITESPACE
-            shape: (2,)
-            Series: '' [i64]
-            [
-               1
-               2
-            ]
-
-            >>> agnostic_mode(s_pa)  # doctest:+ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                1,
-                2
-              ]
-            ]
         """
         return self._from_compliant_series(self._compliant_series.mode())
 
@@ -4140,41 +2104,13 @@ class Series(Generic[IntoSeriesT]):
             Expression of `Boolean` data type.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [float("nan"), float("inf"), 2.0, None]
-
-            We define a library agnostic function:
-
-            >>> def agnostic_is_finite(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.is_finite().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_is_finite`:
-
-            >>> agnostic_is_finite(pd.Series(data))
-            0    False
-            1    False
-            2     True
-            3    False
-            dtype: bool
-
-            >>> agnostic_is_finite(pl.Series(data))  # doctest: +NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: '' [bool]
-            [
-               false
-               false
-               true
-               null
-            ]
-
-            >>> agnostic_is_finite(pa.chunked_array([data]))  # doctest: +ELLIPSIS
+            >>>
+            >>> s_native = pa.chunked_array([[float("nan"), float("inf"), 2.0, None]])
+            >>> nw.from_native(
+            ...     s_native, series_only=True
+            ... ).is_finite().to_native()  # doctest: +ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -4197,31 +2133,13 @@ class Series(Generic[IntoSeriesT]):
             A new Series with the cumulative count of non-null values.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = ["x", "k", None, "d"]
-
-            We define a library agnostic function:
-
-            >>> def agnostic_cum_count(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.cum_count(reverse=True).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_cum_count`:
-
-            >>> agnostic_cum_count(pd.Series(data))
-            0    3
-            1    2
-            2    1
-            3    1
-            dtype: int64
-
-            >>> agnostic_cum_count(pl.Series(data))  # doctest:+NORMALIZE_WHITESPACE
+            >>>
+            >>> s_native = pl.Series(["x", "k", None, "d"])
+            >>> nw.from_native(s_native, series_only=True).cum_count(
+            ...     reverse=True
+            ... ).to_native()  # doctest:+NORMALIZE_WHITESPACE
             shape: (4,)
             Series: '' [u32]
             [
@@ -4230,18 +2148,6 @@ class Series(Generic[IntoSeriesT]):
                 1
                 1
             ]
-
-            >>> agnostic_cum_count(pa.chunked_array([data]))  # doctest:+ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                3,
-                2,
-                1,
-                1
-              ]
-            ]
-
         """
         return self._from_compliant_series(
             self._compliant_series.cum_count(reverse=reverse)
@@ -4258,50 +2164,15 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [3, 1, None, 2]
-
-            We define a library agnostic function:
-
-            >>> def agnostic_cum_min(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.cum_min().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_cum_min`:
-
-            >>> agnostic_cum_min(pd.Series(data))
+            >>>
+            >>> s_native = pd.Series([3, 1, None, 2])
+            >>> nw.from_native(s_native, series_only=True).cum_min().to_native()
             0    3.0
             1    1.0
             2    NaN
             3    1.0
             dtype: float64
-
-            >>> agnostic_cum_min(pl.Series(data))  # doctest:+NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: '' [i64]
-            [
-               3
-               1
-               null
-               1
-            ]
-
-            >>> agnostic_cum_min(pa.chunked_array([data]))  # doctest:+ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                3,
-                1,
-                null,
-                1
-              ]
-            ]
-
         """
         return self._from_compliant_series(
             self._compliant_series.cum_min(reverse=reverse)
@@ -4317,41 +2188,13 @@ class Series(Generic[IntoSeriesT]):
             A new Series with the cumulative max of non-null values.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 3, None, 2]
-
-            We define a library agnostic function:
-
-            >>> def agnostic_cum_max(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.cum_max().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_cum_max`:
-
-            >>> agnostic_cum_max(pd.Series(data))
-            0    1.0
-            1    3.0
-            2    NaN
-            3    3.0
-            dtype: float64
-
-            >>> agnostic_cum_max(pl.Series(data))  # doctest:+NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: '' [i64]
-            [
-               1
-               3
-               null
-               3
-            ]
-
-            >>> agnostic_cum_max(pa.chunked_array([data]))  # doctest:+ELLIPSIS
+            >>>
+            >>> s_native = pa.chunked_array([[1, 3, None, 2]])
+            >>> nw.from_native(
+            ...     s_native, series_only=True
+            ... ).cum_max().to_native()  # doctest:+ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -4377,31 +2220,13 @@ class Series(Generic[IntoSeriesT]):
             A new Series with the cumulative product of non-null values.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1, 3, None, 2]
-
-            We define a library agnostic function:
-
-            >>> def agnostic_cum_prod(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.cum_prod().to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_cum_prod`:
-
-            >>> agnostic_cum_prod(pd.Series(data))
-            0    1.0
-            1    3.0
-            2    NaN
-            3    6.0
-            dtype: float64
-
-            >>> agnostic_cum_prod(pl.Series(data))  # doctest:+NORMALIZE_WHITESPACE
+            >>>
+            >>> s_native = pl.Series([1, 3, None, 2])
+            >>> nw.from_native(
+            ...     s_native, series_only=True
+            ... ).cum_prod().to_native()  # doctest:+NORMALIZE_WHITESPACE
             shape: (4,)
             Series: '' [i64]
             [
@@ -4410,18 +2235,6 @@ class Series(Generic[IntoSeriesT]):
                null
                6
             ]
-
-            >>> agnostic_cum_prod(pa.chunked_array([data]))  # doctest:+ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                1,
-                3,
-                null,
-                6
-              ]
-            ]
-
         """
         return self._from_compliant_series(
             self._compliant_series.cum_prod(reverse=reverse)
@@ -4460,52 +2273,17 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1.0, 2.0, 3.0, 4.0]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_rolling_sum(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.rolling_sum(window_size=2).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_rolling_sum`:
-
-            >>> agnostic_rolling_sum(s_pd)
+            >>>
+            >>> s_native = pd.Series([1.0, 2.0, 3.0, 4.0])
+            >>> nw.from_native(s_native, series_only=True).rolling_sum(
+            ...     window_size=2
+            ... ).to_native()
             0    NaN
             1    3.0
             2    5.0
             3    7.0
             dtype: float64
-
-            >>> agnostic_rolling_sum(s_pl)  # doctest:+NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: '' [f64]
-            [
-               null
-               3.0
-               5.0
-               7.0
-            ]
-
-            >>> agnostic_rolling_sum(s_pa)  # doctest:+ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                null,
-                3,
-                5,
-                7
-              ]
-            ]
         """
         window_size, min_samples = _validate_rolling_arguments(
             window_size=window_size, min_samples=min_samples
@@ -4554,44 +2332,13 @@ class Series(Generic[IntoSeriesT]):
             A new series.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1.0, 2.0, 3.0, 4.0]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_rolling_mean(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.rolling_mean(window_size=2).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_rolling_mean`:
-
-            >>> agnostic_rolling_mean(s_pd)
-            0    NaN
-            1    1.5
-            2    2.5
-            3    3.5
-            dtype: float64
-
-            >>> agnostic_rolling_mean(s_pl)  # doctest:+NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: '' [f64]
-            [
-               null
-               1.5
-               2.5
-               3.5
-            ]
-
-            >>> agnostic_rolling_mean(s_pa)  # doctest:+ELLIPSIS
+            >>>
+            >>> s_native = pa.chunked_array([[1.0, 2.0, 3.0, 4.0]])
+            >>> nw.from_native(s_native, series_only=True).rolling_mean(
+            ...     window_size=2
+            ... ).to_native()  # doctest:+ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [
@@ -4651,34 +2398,13 @@ class Series(Generic[IntoSeriesT]):
             A new series.
 
         Examples:
-            >>> import pandas as pd
             >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1.0, 3.0, 1.0, 4.0]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_rolling_var(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.rolling_var(window_size=2, min_samples=1).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_rolling_var`:
-
-            >>> agnostic_rolling_var(s_pd)
-            0    NaN
-            1    2.0
-            2    2.0
-            3    4.5
-            dtype: float64
-
-            >>> agnostic_rolling_var(s_pl)  # doctest:+NORMALIZE_WHITESPACE
+            >>>
+            >>> s_native = pl.Series([1.0, 3.0, 1.0, 4.0])
+            >>> nw.from_native(s_native, series_only=True).rolling_var(
+            ...     window_size=2, min_samples=1
+            ... ).to_native()  # doctest:+NORMALIZE_WHITESPACE
             shape: (4,)
             Series: '' [f64]
             [
@@ -4686,17 +2412,6 @@ class Series(Generic[IntoSeriesT]):
                2.0
                2.0
                4.5
-            ]
-
-            >>> agnostic_rolling_var(s_pa)  # doctest:+ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                nan,
-                2,
-                2,
-                4.5
-              ]
             ]
         """
         window_size, min_samples = _validate_rolling_arguments(
@@ -4747,52 +2462,17 @@ class Series(Generic[IntoSeriesT]):
 
         Examples:
             >>> import pandas as pd
-            >>> import polars as pl
-            >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
-
-            >>> data = [1.0, 3.0, 1.0, 4.0]
-            >>> s_pd = pd.Series(data)
-            >>> s_pl = pl.Series(data)
-            >>> s_pa = pa.chunked_array([data])
-
-            We define a library agnostic function:
-
-            >>> def agnostic_rolling_std(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.rolling_std(window_size=2, min_samples=1).to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_rolling_std`:
-
-            >>> agnostic_rolling_std(s_pd)
+            >>>
+            >>> s_native = pd.Series([1.0, 3.0, 1.0, 4.0])
+            >>> nw.from_native(s_native, series_only=True).rolling_std(
+            ...     window_size=2, min_samples=1
+            ... ).to_native()
             0         NaN
             1    1.414214
             2    1.414214
             3    2.121320
             dtype: float64
-
-            >>> agnostic_rolling_std(s_pl)  # doctest:+NORMALIZE_WHITESPACE
-            shape: (4,)
-            Series: '' [f64]
-            [
-               null
-               1.414214
-               1.414214
-               2.12132
-            ]
-
-            >>> agnostic_rolling_std(s_pa)  # doctest:+ELLIPSIS
-            <pyarrow.lib.ChunkedArray object at ...>
-            [
-              [
-                nan,
-                1.4142135623730951,
-                1.4142135623730951,
-                2.1213203435596424
-              ]
-            ]
         """
         window_size, min_samples = _validate_rolling_arguments(
             window_size=window_size, min_samples=min_samples
@@ -4847,44 +2527,13 @@ class Series(Generic[IntoSeriesT]):
             A new series with rank data as values.
 
         Examples:
-            >>> import pandas as pd
-            >>> import polars as pl
             >>> import pyarrow as pa
             >>> import narwhals as nw
-            >>> from narwhals.typing import IntoSeriesT
             >>>
-            >>> data = [3, 6, 1, 1, 6]
-
-            We define a dataframe-agnostic function that computes the dense rank for
-            the data:
-
-            >>> def agnostic_dense_rank(s_native: IntoSeriesT) -> IntoSeriesT:
-            ...     s = nw.from_native(s_native, series_only=True)
-            ...     return s.rank(method="dense").to_native()
-
-            We can then pass any supported library such as pandas, Polars, or
-            PyArrow to `agnostic_dense_rank`:
-
-            >>> agnostic_dense_rank(pd.Series(data))
-            0    2.0
-            1    3.0
-            2    1.0
-            3    1.0
-            4    3.0
-            dtype: float64
-
-            >>> agnostic_dense_rank(pl.Series(data))  # doctest:+NORMALIZE_WHITESPACE
-            shape: (5,)
-            Series: '' [u32]
-            [
-               2
-               3
-               1
-               1
-               3
-            ]
-
-            >>> agnostic_dense_rank(pa.chunked_array([data]))  # doctest:+ELLIPSIS
+            >>> s_native = pa.chunked_array([[3, 6, 1, 1, 6]])
+            >>> nw.from_native(s_native, series_only=True).rank(
+            ...     method="dense"
+            ... ).to_native()  # doctest:+ELLIPSIS
             <pyarrow.lib.ChunkedArray object at ...>
             [
               [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- Towards #1942 

## If you have comments or can explain your changes, please do so below

- Is this an overkill? It almost cuts in half the file lines
- Reason to always go to `to_native()` is mainly ArrowSeries repr not being great when ELLIPSIS are required to pass the doctest
