### PR TITLE
chore(typing): add `np.ndarray` aliases

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -171,6 +171,10 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
 
     @overload
     def __getitem__(  # type: ignore[overload-overlap, unused-ignore]
+        self: Self, item: str | tuple[slice | Sequence[int] | _1DArray, int | str]
+    ) -> ArrowSeries: ...
+    @overload
+    def __getitem__(
         self: Self,
         item: (
             int
@@ -183,10 +187,6 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
             ]
         ),
     ) -> Self: ...
-    @overload
-    def __getitem__(
-        self: Self, item: str | tuple[slice | Sequence[int] | _1DArray, int | str]
-    ) -> ArrowSeries: ...
     def __getitem__(
         self: Self,
         item: (

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -37,7 +37,9 @@ if TYPE_CHECKING:
 
     import pandas as pd
     import polars as pl
-    from pyarrow._stubs_typing import Indices  # type: ignore  # noqa: PGH003
+    from pyarrow._stubs_typing import (  # pyright: ignore[reportMissingModuleSource]
+        Indices,
+    )
     from typing_extensions import Self
 
     from narwhals._arrow.group_by import ArrowGroupBy
@@ -168,12 +170,7 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         return self._native_frame.__array__(dtype, copy=copy)
 
     @overload
-    def __getitem__(
-        self: Self, item: str | tuple[slice | Sequence[int] | _1DArray, int | str]
-    ) -> ArrowSeries: ...  # type: ignore[overload-overlap]
-
-    @overload
-    def __getitem__(
+    def __getitem__(  # type: ignore[overload-overlap]
         self: Self,
         item: (
             int
@@ -186,6 +183,10 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
             ]
         ),
     ) -> Self: ...
+    @overload
+    def __getitem__(
+        self: Self, item: str | tuple[slice | Sequence[int] | _1DArray, int | str]
+    ) -> ArrowSeries: ...
     def __getitem__(
         self: Self,
         item: (
@@ -202,7 +203,7 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         ),
     ) -> ArrowSeries | Self:
         if isinstance(item, tuple):
-            item = tuple(list(i) if is_sequence_but_not_str(i) else i for i in item)  # type: ignore[assignment]
+            item = tuple(list(i) if is_sequence_but_not_str(i) else i for i in item)  # pyright: ignore[reportAssignmentType]
 
         if isinstance(item, str):
             from narwhals._arrow.series import ArrowSeries

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -170,7 +170,7 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         return self._native_frame.__array__(dtype, copy=copy)
 
     @overload
-    def __getitem__(  # type: ignore[overload-overlap]
+    def __getitem__(  # type: ignore[overload-overlap, unused-ignore]
         self: Self,
         item: (
             int

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import Iterator
 from typing import Literal
 from typing import Sequence
+from typing import cast
 from typing import overload
 
 import pyarrow as pa
@@ -17,7 +18,7 @@ from narwhals._arrow.utils import convert_str_slice_to_int_slice
 from narwhals._arrow.utils import native_to_narwhals_dtype
 from narwhals._arrow.utils import select_rows
 from narwhals._expression_parsing import evaluate_into_exprs
-from narwhals.dependencies import is_numpy_array
+from narwhals.dependencies import is_numpy_array_1d
 from narwhals.utils import Implementation
 from narwhals.utils import Version
 from narwhals.utils import check_column_exists
@@ -34,9 +35,9 @@ if TYPE_CHECKING:
     from pathlib import Path
     from types import ModuleType
 
-    import numpy as np
     import pandas as pd
     import polars as pl
+    from pyarrow._stubs_typing import Indices  # type: ignore  # noqa: PGH003
     from typing_extensions import Self
 
     from narwhals._arrow.group_by import ArrowGroupBy
@@ -45,6 +46,8 @@ if TYPE_CHECKING:
     from narwhals._arrow.typing import IntoArrowExpr
     from narwhals.dtypes import DType
     from narwhals.typing import SizeUnit
+    from narwhals.typing import _1DArray
+    from narwhals.typing import _2DArray
     from narwhals.utils import Version
 
 from narwhals.typing import CompliantDataFrame
@@ -161,36 +164,43 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
             version=self._version,
         )
 
-    def __array__(self: Self, dtype: Any, copy: bool | None) -> np.ndarray:
+    def __array__(self: Self, dtype: Any, copy: bool | None) -> _2DArray:
         return self._native_frame.__array__(dtype, copy=copy)
 
     @overload
-    def __getitem__(self: Self, item: tuple[Sequence[int], str | int]) -> ArrowSeries: ...  # type: ignore[overload-overlap]
+    def __getitem__(
+        self: Self, item: str | tuple[slice | Sequence[int] | _1DArray, int | str]
+    ) -> ArrowSeries: ...  # type: ignore[overload-overlap]
 
     @overload
-    def __getitem__(self: Self, item: Sequence[int]) -> ArrowDataFrame: ...
-
-    @overload
-    def __getitem__(self: Self, item: str) -> ArrowSeries: ...
-
-    @overload
-    def __getitem__(self: Self, item: slice) -> ArrowDataFrame: ...
-
-    @overload
-    def __getitem__(self: Self, item: tuple[slice, slice]) -> ArrowDataFrame: ...
-
+    def __getitem__(
+        self: Self,
+        item: (
+            int
+            | slice
+            | Sequence[int]
+            | Sequence[str]
+            | _1DArray
+            | tuple[
+                slice | Sequence[int] | _1DArray, slice | Sequence[int] | Sequence[str]
+            ]
+        ),
+    ) -> Self: ...
     def __getitem__(
         self: Self,
         item: (
             str
+            | int
             | slice
             | Sequence[int]
             | Sequence[str]
-            | tuple[Sequence[int], str | int]
-            | tuple[slice, str | int]
-            | tuple[slice, slice]
+            | _1DArray
+            | tuple[slice | Sequence[int] | _1DArray, int | str]
+            | tuple[
+                slice | Sequence[int] | _1DArray, slice | Sequence[int] | Sequence[str]
+            ]
         ),
-    ) -> ArrowSeries | ArrowDataFrame:
+    ) -> ArrowSeries | Self:
         if isinstance(item, tuple):
             item = tuple(list(i) if is_sequence_but_not_str(i) else i for i in item)  # type: ignore[assignment]
 
@@ -207,28 +217,30 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
             isinstance(item, tuple)
             and len(item) == 2
             and is_sequence_but_not_str(item[1])
+            and not isinstance(item[0], str)
         ):
             if len(item[1]) == 0:
                 # Return empty dataframe
                 return self._from_native_frame(self._native_frame.slice(0, 0).select([]))
             selected_rows = select_rows(self._native_frame, item[0])
-            return self._from_native_frame(selected_rows.select(item[1]))
+            return self._from_native_frame(selected_rows.select(cast("Indices", item[1])))
 
         elif isinstance(item, tuple) and len(item) == 2:
             if isinstance(item[1], slice):
                 columns = self.columns
+                indices = cast("Indices", item[0])
                 if item[1] == slice(None):
                     if isinstance(item[0], Sequence) and len(item[0]) == 0:
                         return self._from_native_frame(self._native_frame.slice(0, 0))
-                    return self._from_native_frame(self._native_frame.take(item[0]))
+                    return self._from_native_frame(self._native_frame.take(indices))
                 if isinstance(item[1].start, str) or isinstance(item[1].stop, str):
                     start, stop, step = convert_str_slice_to_int_slice(item[1], columns)
                     return self._from_native_frame(
-                        self._native_frame.take(item[0]).select(columns[start:stop:step])
+                        self._native_frame.take(indices).select(columns[start:stop:step])
                     )
                 if isinstance(item[1].start, int) or isinstance(item[1].stop, int):
                     return self._from_native_frame(
-                        self._native_frame.take(item[0]).select(
+                        self._native_frame.take(indices).select(
                             columns[item[1].start : item[1].stop : item[1].step]
                         )
                     )
@@ -237,7 +249,11 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
             from narwhals._arrow.series import ArrowSeries
 
             # PyArrow columns are always strings
-            col_name = item[1] if isinstance(item[1], str) else self.columns[item[1]]
+            col_name = (
+                item[1]
+                if isinstance(item[1], str)
+                else self.columns[cast("int", item[1])]
+            )
             if isinstance(item[0], str):  # pragma: no cover
                 msg = "Can not slice with tuple with the first element as a str"
                 raise TypeError(msg)
@@ -270,16 +286,18 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
             stop = item.stop if item.stop is not None else len(self._native_frame)
             return self._from_native_frame(self._native_frame.slice(start, stop - start))
 
-        elif isinstance(item, Sequence) or (is_numpy_array(item) and item.ndim == 1):
+        elif isinstance(item, Sequence) or is_numpy_array_1d(item):
             if (
                 isinstance(item, Sequence)
                 and all(isinstance(x, str) for x in item)
                 and len(item) > 0
             ):
-                return self._from_native_frame(self._native_frame.select(item))
+                return self._from_native_frame(
+                    self._native_frame.select(cast("Indices", item))
+                )
             if isinstance(item, Sequence) and len(item) == 0:
                 return self._from_native_frame(self._native_frame.slice(0, 0))
-            return self._from_native_frame(self._native_frame.take(item))
+            return self._from_native_frame(self._native_frame.take(cast("Indices", item)))
 
         else:  # pragma: no cover
             msg = f"Expected str or slice, got: {type(item)}"
@@ -457,10 +475,11 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
 
         return pl.from_arrow(self._native_frame)  # type: ignore[return-value]
 
-    def to_numpy(self: Self) -> np.ndarray:
+    def to_numpy(self: Self) -> _2DArray:
         import numpy as np  # ignore-banned-import
 
-        return np.column_stack([col.to_numpy() for col in self._native_frame.columns])
+        arr: Any = np.column_stack([col.to_numpy() for col in self._native_frame.columns])
+        return arr
 
     @overload
     def to_dict(self: Self, *, as_series: Literal[True]) -> dict[str, ArrowSeries]: ...

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -30,7 +30,6 @@ from narwhals.utils import validate_backend_version
 if TYPE_CHECKING:
     from types import ModuleType
 
-    import numpy as np
     import pandas as pd
     import polars as pl
     from typing_extensions import Self
@@ -38,6 +37,7 @@ if TYPE_CHECKING:
     from narwhals._arrow.dataframe import ArrowDataFrame
     from narwhals._arrow.namespace import ArrowNamespace
     from narwhals.dtypes import DType
+    from narwhals.typing import _1DArray
     from narwhals.utils import Version
 
 
@@ -357,10 +357,10 @@ class ArrowSeries(CompliantSeries):
     def to_list(self: Self) -> list[Any]:
         return self._native_series.to_pylist()  # type: ignore[no-any-return]
 
-    def __array__(self: Self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
+    def __array__(self: Self, dtype: Any = None, copy: bool | None = None) -> _1DArray:
         return self._native_series.__array__(dtype=dtype, copy=copy)
 
-    def to_numpy(self: Self) -> np.ndarray:
+    def to_numpy(self: Self) -> _1DArray:
         return self._native_series.to_numpy()
 
     def alias(self: Self, name: str) -> Self:

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import Iterator
 from typing import Literal
 from typing import Sequence
+from typing import cast
 from typing import overload
 
 import numpy as np
@@ -196,7 +197,7 @@ class PandasLikeDataFrame(CompliantDataFrame, CompliantLazyFrame):
         ),
     ) -> PandasLikeSeries | Self:
         if isinstance(item, tuple):
-            item = tuple(list(i) if is_sequence_but_not_str(i) else i for i in item)  # type: ignore[assignment]
+            item = tuple(list(i) if is_sequence_but_not_str(i) else i for i in item)  # pyright: ignore[reportAssignmentType]
 
         if isinstance(item, str):
             return PandasLikeSeries(
@@ -216,11 +217,11 @@ class PandasLikeDataFrame(CompliantDataFrame, CompliantLazyFrame):
                 return self._from_native_frame(
                     self._native_frame.__class__(), validate_column_names=False
                 )
-            if all(isinstance(x, int) for x in item[1]):
+            if all(isinstance(x, int) for x in item[1]):  # type: ignore[var-annotated]
                 return self._from_native_frame(
                     self._native_frame.iloc[item], validate_column_names=False
                 )
-            if all(isinstance(x, str) for x in item[1]):
+            if all(isinstance(x, str) for x in item[1]):  # type: ignore[var-annotated]
                 indexer = (
                     item[0],
                     self._native_frame.columns.get_indexer(item[1]),
@@ -257,7 +258,7 @@ class PandasLikeDataFrame(CompliantDataFrame, CompliantLazyFrame):
 
         elif isinstance(item, tuple) and len(item) == 2:
             if isinstance(item[1], str):
-                item = (item[0], self._native_frame.columns.get_loc(item[1]))  # type: ignore[assignment]
+                item = (item[0], self._native_frame.columns.get_loc(item[1]))  # pyright: ignore[reportAssignmentType]
                 native_series = self._native_frame.iloc[item]
             elif isinstance(item[1], int):
                 native_series = self._native_frame.iloc[item]
@@ -277,7 +278,7 @@ class PandasLikeDataFrame(CompliantDataFrame, CompliantLazyFrame):
                 return self._from_native_frame(
                     select_columns_by_name(
                         self._native_frame,
-                        item,
+                        cast("Sequence[str] | _1DArray", item),
                         self._backend_version,
                         self._implementation,
                     ),

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -31,7 +31,6 @@ from narwhals.utils import validate_backend_version
 if TYPE_CHECKING:
     from types import ModuleType
 
-    import numpy as np
     import pandas as pd
     import polars as pl
     import pyarrow as pa
@@ -39,6 +38,7 @@ if TYPE_CHECKING:
 
     from narwhals._pandas_like.dataframe import PandasLikeDataFrame
     from narwhals.dtypes import DType
+    from narwhals.typing import _1DArray
     from narwhals.utils import Version
 
 PANDAS_TO_NUMPY_DTYPE_NO_MISSING = {
@@ -670,13 +670,13 @@ class PandasLikeSeries(CompliantSeries):
             )
         return self
 
-    def __array__(self: Self, dtype: Any, copy: bool | None) -> np.ndarray:
+    def __array__(self: Self, dtype: Any, copy: bool | None) -> _1DArray:
         # pandas used to always return object dtype for nullable dtypes.
         # So, we intercept __array__ and pass to `to_numpy` ourselves to make
         # sure an appropriate numpy dtype is returned.
         return self.to_numpy(dtype=dtype, copy=copy)
 
-    def to_numpy(self: Self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
+    def to_numpy(self: Self, dtype: Any = None, copy: bool | None = None) -> _1DArray:
         # the default is meant to be None, but pandas doesn't allow it?
         # https://numpy.org/doc/stable/reference/generated/numpy.ndarray.__array__.html
         copy = copy or self._implementation is Implementation.CUDF

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from narwhals._pandas_like.series import PandasLikeSeries
     from narwhals.dtypes import DType
     from narwhals.typing import DTypeBackend
+    from narwhals.typing import _1DArray
 
     ExprT = TypeVar("ExprT", bound=PandasLikeExpr)
 
@@ -819,7 +820,7 @@ def calculate_timestamp_date(s: pd.Series, time_unit: str) -> pd.Series:
 
 def select_columns_by_name(
     df: T,
-    column_names: Sequence[str],
+    column_names: Sequence[str] | _1DArray,
     backend_version: tuple[int, ...],
     implementation: Implementation,
 ) -> T:

--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from types import ModuleType
     from typing import TypeVar
 
-    import numpy as np
     from typing_extensions import Self
 
     from narwhals._polars.group_by import PolarsGroupBy
@@ -32,6 +31,7 @@ if TYPE_CHECKING:
     from narwhals.dtypes import DType
     from narwhals.typing import CompliantDataFrame
     from narwhals.typing import CompliantLazyFrame
+    from narwhals.typing import _2DArray
     from narwhals.utils import Version
 
     T = TypeVar("T")
@@ -119,7 +119,7 @@ class PolarsDataFrame:
 
     def __array__(
         self: Self, dtype: Any | None = None, copy: bool | None = None
-    ) -> np.ndarray:
+    ) -> _2DArray:
         if self._backend_version < (0, 20, 28) and copy is not None:
             msg = "`copy` in `__array__` is only supported for Polars>=0.20.28"
             raise NotImplementedError(msg)

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -18,11 +18,11 @@ if TYPE_CHECKING:
     from types import ModuleType
     from typing import TypeVar
 
-    import numpy as np
     from typing_extensions import Self
 
     from narwhals._polars.dataframe import PolarsDataFrame
     from narwhals.dtypes import DType
+    from narwhals.typing import _1DArray
     from narwhals.utils import Version
 
     T = TypeVar("T")
@@ -147,7 +147,7 @@ class PolarsSeries:
             raise NotImplementedError(msg)
         return self._from_native_series(ser.replace_strict(old, new, return_dtype=dtype))
 
-    def __array__(self: Self, dtype: Any, copy: bool | None) -> np.ndarray:
+    def __array__(self: Self, dtype: Any, copy: bool | None) -> _1DArray:
         if self._backend_version < (0, 20, 29):
             return self._native_series.__array__(dtype=dtype)
         return self._native_series.__array__(dtype=dtype, copy=copy)

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -16,6 +16,7 @@ from warnings import warn
 
 from narwhals.dependencies import get_polars
 from narwhals.dependencies import is_numpy_array
+from narwhals.dependencies import is_numpy_array_1d
 from narwhals.exceptions import ColumnNotFoundError
 from narwhals.exceptions import InvalidIntoExprError
 from narwhals.exceptions import LengthChangingExprError
@@ -35,7 +36,6 @@ if TYPE_CHECKING:
     from pathlib import Path
     from types import ModuleType
 
-    import numpy as np
     import pandas as pd
     import polars as pl
     import pyarrow as pa
@@ -51,6 +51,8 @@ if TYPE_CHECKING:
     from narwhals.typing import IntoExpr
     from narwhals.typing import IntoFrame
     from narwhals.typing import SizeUnit
+    from narwhals.typing import _1DArray
+    from narwhals.typing import _2DArray
 
     PS = ParamSpec("PS")
 
@@ -477,7 +479,7 @@ class DataFrame(BaseFrame[DataFrameT]):
     def __len__(self: Self) -> int:
         return self._compliant_frame.__len__()  # type: ignore[no-any-return]
 
-    def __array__(self: Self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
+    def __array__(self: Self, dtype: Any = None, copy: bool | None = None) -> _2DArray:
         return self._compliant_frame.__array__(dtype, copy=copy)
 
     def __repr__(self: Self) -> str:  # pragma: no cover
@@ -770,7 +772,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         """
         self._compliant_frame.write_parquet(file)
 
-    def to_numpy(self: Self) -> np.ndarray:
+    def to_numpy(self: Self) -> _2DArray:
         """Convert this DataFrame to a NumPy ndarray.
 
         Returns:
@@ -860,7 +862,7 @@ class DataFrame(BaseFrame[DataFrameT]):
     @overload
     def __getitem__(  # type: ignore[overload-overlap]
         self: Self,
-        item: str | tuple[slice | Sequence[int] | np.ndarray, int | str],
+        item: str | tuple[slice | Sequence[int] | _1DArray, int | str],
     ) -> Series[Any]: ...
 
     @overload
@@ -871,9 +873,9 @@ class DataFrame(BaseFrame[DataFrameT]):
             | slice
             | Sequence[int]
             | Sequence[str]
-            | np.ndarray
+            | _1DArray
             | tuple[
-                slice | Sequence[int] | np.ndarray, slice | Sequence[int] | Sequence[str]
+                slice | Sequence[int] | _1DArray, slice | Sequence[int] | Sequence[str]
             ]
         ),
     ) -> Self: ...
@@ -885,10 +887,10 @@ class DataFrame(BaseFrame[DataFrameT]):
             | slice
             | Sequence[int]
             | Sequence[str]
-            | np.ndarray
-            | tuple[slice | Sequence[int] | np.ndarray, int | str]
+            | _1DArray
+            | tuple[slice | Sequence[int] | _1DArray, int | str]
             | tuple[
-                slice | Sequence[int] | np.ndarray, slice | Sequence[int] | Sequence[str]
+                slice | Sequence[int] | _1DArray, slice | Sequence[int] | Sequence[str]
             ]
         ),
     ) -> Series[Any] | Self:
@@ -971,7 +973,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         elif (
             is_sequence_but_not_str(item)
             or isinstance(item, slice)
-            or (is_numpy_array(item) and item.ndim == 1)
+            or (is_numpy_array_1d(item))
         ):
             return self._from_compliant_dataframe(self._compliant_frame[item])
 

--- a/narwhals/dependencies.py
+++ b/narwhals/dependencies.py
@@ -24,11 +24,16 @@ if TYPE_CHECKING:
     import polars as pl
     import pyarrow as pa
     import pyspark.sql as pyspark_sql
+    from typing_extensions import TypeIs
 
     from narwhals.dataframe import DataFrame
     from narwhals.dataframe import LazyFrame
     from narwhals.series import Series
     from narwhals.typing import IntoSeries
+    from narwhals.typing import _1DArray
+    from narwhals.typing import _2DArray
+    from narwhals.typing import _NDArray
+    from narwhals.typing import _ShapeT
 
 # We silently allow these but - given that they claim
 # to be drop-in replacements for pandas - testing is
@@ -232,9 +237,19 @@ def is_sqlframe_dataframe(df: Any) -> TypeGuard[sqlframe.base.dataframe.BaseData
     )
 
 
-def is_numpy_array(arr: Any) -> TypeGuard[np.ndarray]:
+def is_numpy_array(arr: Any | _NDArray[_ShapeT]) -> TypeIs[_NDArray[_ShapeT]]:
     """Check whether `arr` is a NumPy Array without importing NumPy."""
     return (np := get_numpy()) is not None and isinstance(arr, np.ndarray)
+
+
+def is_numpy_array_1d(arr: Any) -> TypeIs[_1DArray]:
+    """Check whether `arr` is a 1D NumPy Array without importing NumPy."""
+    return is_numpy_array(arr) and arr.ndim == 1
+
+
+def is_numpy_array_2d(arr: Any) -> TypeIs[_2DArray]:
+    """Check whether `arr` is a 2D NumPy Array without importing NumPy."""
+    return is_numpy_array(arr) and arr.ndim == 2
 
 
 def is_numpy_scalar(scalar: Any) -> TypeGuard[np.generic]:

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -19,6 +19,7 @@ from narwhals._expression_parsing import operation_is_order_dependent
 from narwhals.dataframe import DataFrame
 from narwhals.dataframe import LazyFrame
 from narwhals.dependencies import is_numpy_array
+from narwhals.dependencies import is_numpy_array_2d
 from narwhals.exceptions import ShapeError
 from narwhals.expr import Expr
 from narwhals.schema import Schema
@@ -486,7 +487,7 @@ def _from_numpy_impl(
 ) -> DataFrame[Any]:
     from narwhals.schema import Schema
 
-    if data.ndim != 2:
+    if not is_numpy_array_2d(data):
         msg = "`from_numpy` only accepts 2D numpy arrays"
         raise ValueError(msg)
     implementation = Implementation.from_native_namespace(native_namespace)

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -40,7 +40,6 @@ FrameT = TypeVar("FrameT", bound=Union[DataFrame, LazyFrame])  # type: ignore[ty
 if TYPE_CHECKING:
     from types import ModuleType
 
-    import numpy as np
     import pyarrow as pa
     from typing_extensions import Self
 
@@ -51,6 +50,7 @@ if TYPE_CHECKING:
     from narwhals.typing import IntoExpr
     from narwhals.typing import IntoFrameT
     from narwhals.typing import IntoSeriesT
+    from narwhals.typing import _2DArray
 
     class ArrowStreamExportable(Protocol):
         def __arrow_c_stream__(
@@ -546,7 +546,7 @@ def _from_dict_impl(
 
 
 def from_numpy(
-    data: np.ndarray,
+    data: _2DArray,
     schema: dict[str, DType] | Schema | list[str] | None = None,
     *,
     native_namespace: ModuleType,
@@ -695,7 +695,7 @@ def from_numpy(
 
 
 def _from_numpy_impl(
-    data: np.ndarray,
+    data: _2DArray,
     schema: dict[str, DType] | Schema | list[str] | None = None,
     *,
     native_namespace: ModuleType,

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -24,7 +24,6 @@ from narwhals.utils import parse_version
 if TYPE_CHECKING:
     from types import ModuleType
 
-    import numpy as np
     import pandas as pd
     import polars as pl
     import pyarrow as pa
@@ -32,6 +31,7 @@ if TYPE_CHECKING:
 
     from narwhals.dataframe import DataFrame
     from narwhals.dtypes import DType
+    from narwhals.typing import _1DArray
     from narwhals.utils import Implementation
 
 
@@ -110,7 +110,7 @@ class Series(Generic[IntoSeriesT]):
         """
         return self._compliant_series._implementation  # type: ignore[no-any-return]
 
-    def __array__(self: Self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
+    def __array__(self: Self, dtype: Any = None, copy: bool | None = None) -> _1DArray:
         return self._compliant_series.__array__(dtype=dtype, copy=copy)
 
     @overload
@@ -2736,7 +2736,7 @@ class Series(Generic[IntoSeriesT]):
         """
         return self._compliant_series.n_unique()  # type: ignore[no-any-return]
 
-    def to_numpy(self: Self) -> np.ndarray:
+    def to_numpy(self: Self) -> _1DArray:
         """Convert to numpy.
 
         Returns:

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -83,7 +83,6 @@ from narwhals.utils import validate_strict_and_pass_though
 if TYPE_CHECKING:
     from types import ModuleType
 
-    import numpy as np
     from typing_extensions import Self
 
     from narwhals.dtypes import DType
@@ -91,6 +90,8 @@ if TYPE_CHECKING:
     from narwhals.typing import IntoExpr
     from narwhals.typing import IntoFrame
     from narwhals.typing import IntoSeries
+    from narwhals.typing import _1DArray
+    from narwhals.typing import _2DArray
 
 T = TypeVar("T")
 
@@ -134,7 +135,7 @@ class DataFrame(NwDataFrame[IntoDataFrameT]):
     @overload
     def __getitem__(  # type: ignore[overload-overlap]
         self: Self,
-        item: str | tuple[slice | Sequence[int] | np.ndarray, int | str],
+        item: str | tuple[slice | Sequence[int] | _1DArray, int | str],
     ) -> Series: ...
     @overload
     def __getitem__(
@@ -142,11 +143,11 @@ class DataFrame(NwDataFrame[IntoDataFrameT]):
         item: (
             int
             | slice
-            | np.ndarray
+            | _1DArray
             | Sequence[int]
             | Sequence[str]
             | tuple[
-                slice | Sequence[int] | np.ndarray, slice | Sequence[int] | Sequence[str]
+                slice | Sequence[int] | _1DArray, slice | Sequence[int] | Sequence[str]
             ]
         ),
     ) -> Self: ...
@@ -2193,7 +2194,7 @@ def from_dict(
 
 
 def from_numpy(
-    data: np.ndarray,
+    data: _2DArray,
     schema: dict[str, DType] | Schema | list[str] | None = None,
     *,
     native_namespace: ModuleType,

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -13,6 +13,7 @@ from typing import Union
 if TYPE_CHECKING:
     from types import ModuleType
 
+    import numpy as np
     from typing_extensions import Self
     from typing_extensions import TypeAlias
 
@@ -256,6 +257,12 @@ SizeUnit: TypeAlias = Literal[
     "gigabytes",
     "terabytes",
 ]
+
+_ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...])
+_NDArray: TypeAlias = "np.ndarray[_ShapeT, Any]"
+_1DArray: TypeAlias = "_NDArray[tuple[int]]"  # noqa: PYI042, PYI047
+_2DArray: TypeAlias = "_NDArray[tuple[int, int]]"  # noqa: PYI042, PYI047
+_AnyDArray: TypeAlias = "_NDArray[tuple[int, ...]]"  # noqa: PYI047
 
 
 class DTypes:

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -258,7 +258,7 @@ SizeUnit: TypeAlias = Literal[
     "terabytes",
 ]
 
-_ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...])
+_ShapeT = TypeVar("_ShapeT", bound="tuple[int, ...]")
 _NDArray: TypeAlias = "np.ndarray[_ShapeT, Any]"
 _1DArray: TypeAlias = "_NDArray[tuple[int]]"  # noqa: PYI042, PYI047
 _2DArray: TypeAlias = "_NDArray[tuple[int, int]]"  # noqa: PYI042, PYI047

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 
     import pandas as pd
     from typing_extensions import Self
-    from typing_extensions import TypeGuard
     from typing_extensions import TypeIs
 
     from narwhals.dataframe import DataFrame
@@ -60,6 +59,7 @@ if TYPE_CHECKING:
     FrameOrSeriesT = TypeVar(
         "FrameOrSeriesT", bound=Union[LazyFrame[Any], DataFrame[Any], Series[Any]]
     )
+    _T = TypeVar("_T")
 
 
 class Version(Enum):
@@ -996,7 +996,7 @@ def parse_columns_to_drop(
     return to_drop
 
 
-def is_sequence_but_not_str(sequence: Any) -> TypeGuard[Sequence[Any]]:
+def is_sequence_but_not_str(sequence: Any | Sequence[_T]) -> TypeIs[Sequence[_T]]:
     return isinstance(sequence, Sequence) and not isinstance(sequence, str)
 
 


### PR DESCRIPTION
Closes #1972

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues
- Closes #1972

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Resolves warnings that look like this:

```py
narwhals/_pandas_like/dataframe.py:858: error: Missing type parameters for generic type "ndarray"  [type-arg]
```

On `main`, this accounts for **25** warnings:

![image](https://github.com/user-attachments/assets/08d55d54-0ea0-4ff7-9a1e-3ba0ae56637f)
