### PR TITLE
chore(typing): remove unused ignores

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -109,7 +109,7 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
 
     @property
     def shape(self: Self) -> tuple[int, int]:
-        return self._native_frame.shape  # type: ignore[no-any-return]
+        return self._native_frame.shape
 
     def __len__(self: Self) -> int:
         return len(self._native_frame)
@@ -131,7 +131,7 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
     def rows(self: Self, *, named: bool) -> list[tuple[Any, ...]] | list[dict[str, Any]]:
         if not named:
             return list(self.iter_rows(named=False, buffer_size=512))  # type: ignore[return-value]
-        return self._native_frame.to_pylist()  # type: ignore[no-any-return]
+        return self._native_frame.to_pylist()
 
     def iter_rows(
         self: Self, *, named: bool, buffer_size: int
@@ -302,7 +302,7 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
 
     @property
     def columns(self: Self) -> list[str]:
-        return self._native_frame.schema.names  # type: ignore[no-any-return]
+        return self._native_frame.schema.names
 
     def simple_select(self, *column_names: str) -> Self:
         return self._from_native_frame(
@@ -676,8 +676,9 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
         if file is None:
             csv_buffer = pa.BufferOutputStream()
             pa_csv.write_csv(pa_table, csv_buffer)
-            return csv_buffer.getvalue().to_pybytes().decode()  # type: ignore[no-any-return]
-        return pa_csv.write_csv(pa_table, file)  # type: ignore[no-any-return]
+            return csv_buffer.getvalue().to_pybytes().decode()
+        pa_csv.write_csv(pa_table, file)
+        return None
 
     def is_unique(self: Self) -> ArrowSeries:
         from narwhals._arrow.series import ArrowSeries

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -355,7 +355,7 @@ class ArrowSeries(CompliantSeries):
         return self._from_native_series(result)
 
     def to_list(self: Self) -> list[Any]:
-        return self._native_series.to_pylist()  # type: ignore[no-any-return]
+        return self._native_series.to_pylist()
 
     def __array__(self: Self, dtype: Any = None, copy: bool | None = None) -> np.ndarray:
         return self._native_series.__array__(dtype=dtype, copy=copy)

--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -251,7 +251,7 @@ class DuckDBLazyFrame(CompliantLazyFrame):
 
     @property
     def columns(self: Self) -> list[str]:
-        return self._native_frame.columns  # type: ignore[no-any-return]
+        return self._native_frame.columns
 
     def to_pandas(self: Self) -> pd.DataFrame:
         # only if version is v1, keep around for backcompat

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -189,7 +189,7 @@ class Implementation(Enum):
         if self is Implementation.PYARROW:
             import pyarrow as pa  # ignore-banned-import
 
-            return pa  # type: ignore[no-any-return]
+            return pa
         if self is Implementation.PYSPARK:  # pragma: no cover
             import pyspark.sql
 
@@ -201,12 +201,12 @@ class Implementation(Enum):
         if self is Implementation.DASK:
             import dask.dataframe  # ignore-banned-import
 
-            return dask.dataframe  # type: ignore[no-any-return]
+            return dask.dataframe
 
         if self is Implementation.DUCKDB:
             import duckdb  # ignore-banned-import
 
-            return duckdb  # type: ignore[no-any-return]
+            return duckdb
         msg = "Not supported Implementation"  # pragma: no cover
         raise AssertionError(msg)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
```
shape: (9, 7)
┌───────────────────────────────┬──────┬────────┬───────────────────────────────┬──────┬───────────────┬──────────┐
│ file                          ┆ line ┆ column ┆ message                       ┆ hint ┆ code          ┆ severity │
│ ---                           ┆ ---  ┆ ---    ┆ ---                           ┆ ---  ┆ ---           ┆ ---      │
│ str                           ┆ i64  ┆ i64    ┆ str                           ┆ str  ┆ str           ┆ str      │
╞═══════════════════════════════╪══════╪════════╪═══════════════════════════════╪══════╪═══════════════╪══════════╡
│ narwhals/utils.py             ┆ 192  ┆ -1     ┆ Unused "type: ignore" comment ┆ null ┆ unused-ignore ┆ error    │
│ narwhals/utils.py             ┆ 204  ┆ -1     ┆ Unused "type: ignore" comment ┆ null ┆ unused-ignore ┆ error    │
│ narwhals/utils.py             ┆ 209  ┆ -1     ┆ Unused "type: ignore" comment ┆ null ┆ unused-ignore ┆ error    │
│ narwhals/_duckdb/dataframe.py ┆ 254  ┆ -1     ┆ Unused "type: ignore" comment ┆ null ┆ unused-ignore ┆ error    │
│ narwhals/_arrow/dataframe.py  ┆ 112  ┆ -1     ┆ Unused "type: ignore" comment ┆ null ┆ unused-ignore ┆ error    │
│ narwhals/_arrow/dataframe.py  ┆ 134  ┆ -1     ┆ Unused "type: ignore" comment ┆ null ┆ unused-ignore ┆ error    │
│ narwhals/_arrow/dataframe.py  ┆ 305  ┆ -1     ┆ Unused "type: ignore" comment ┆ null ┆ unused-ignore ┆ error    │
│ narwhals/_arrow/dataframe.py  ┆ 679  ┆ -1     ┆ Unused "type: ignore" comment ┆ null ┆ unused-ignore ┆ error    │
│ narwhals/_arrow/series.py     ┆ 358  ┆ -1     ┆ Unused "type: ignore" comment ┆ null ┆ unused-ignore ┆ error    │
└───────────────────────────────┴──────┴────────┴───────────────────────────────┴──────┴───────────────┴──────────┘
```