### PR TITLE
chore: Expr metadata refactor

### DIFF
--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -322,14 +322,14 @@ def extract_compliant(
     plx: CompliantNamespace[CompliantSeriesT_co],
     other: Any,
     *,
-    parse_column_name_as_expr: bool,
+    strings_are_column_names: bool,
 ) -> CompliantExpr[CompliantSeriesT_co] | CompliantSeriesT_co | Any:
     from narwhals.expr import Expr
     from narwhals.series import Series
 
     if isinstance(other, Expr):
         return other._to_compliant_expr(plx)
-    if parse_column_name_as_expr and isinstance(other, str):
+    if strings_are_column_names and isinstance(other, str):
         return plx.col(other)
     if isinstance(other, Series):
         return other._compliant_series

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -14,6 +14,7 @@ from typing import overload
 from narwhals.dependencies import is_numpy_array
 from narwhals.exceptions import InvalidIntoExprError
 from narwhals.exceptions import LengthChangingExprError
+from narwhals.utils import ExprKind
 from narwhals.utils import Implementation
 from narwhals.utils import is_compliant_expr
 from narwhals.utils import is_compliant_series
@@ -359,7 +360,10 @@ def operation_changes_length(*args: IntoExpr | Any) -> bool:
     from narwhals.expr import Expr
 
     n_exprs = len([x for x in args if isinstance(x, Expr)])
-    changes_length = any(isinstance(x, Expr) and x._changes_length for x in args)
+    changes_length = any(
+        isinstance(x, Expr) and x._metadata["kind"] is ExprKind.CHANGES_LENGTH
+        for x in args
+    )
     if n_exprs > 1 and changes_length:
         msg = (
             "Found multiple expressions at least one of which changes length.\n"

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -395,14 +395,14 @@ def combine_metadata(*args: IntoExpr, strings_are_column_names: bool) -> ExprMet
     n_transforms = 0
     n_aggregations = 0
     n_literals = 0
-    is_order_dependent = False
+    result_is_order_dependent = False
 
     for arg in args:
         if isinstance(arg, str) and strings_are_column_names:
             n_transforms += 1
         elif isinstance(arg, Expr):
             if arg._metadata["is_order_dependent"]:
-                is_order_dependent = True
+                result_is_order_dependent = True
             kind = arg._metadata["kind"]
             if kind is ExprKind.AGGREGATION:
                 n_aggregations += 1
@@ -416,7 +416,7 @@ def combine_metadata(*args: IntoExpr, strings_are_column_names: bool) -> ExprMet
                 msg = "unreachable code"
                 raise AssertionError(msg)
     if n_literals and not n_aggregations and not n_transforms and not n_changes_length:
-        out_kind = ExprKind.LITERAL
+        result_kind = ExprKind.LITERAL
     elif n_changes_length > 1:
         msg = "Length-changing expressions can only be used in isolation, or followed by an aggregation"
         raise LengthChangingExprError(msg)
@@ -424,13 +424,13 @@ def combine_metadata(*args: IntoExpr, strings_are_column_names: bool) -> ExprMet
         msg = "Cannot combine length-changing expressions with length-preserving ones"
         raise ShapeError(msg)
     elif n_changes_length:
-        out_kind = ExprKind.CHANGES_LENGTH
+        result_kind = ExprKind.CHANGES_LENGTH
     elif n_transforms:
-        out_kind = ExprKind.TRANSFORM
+        result_kind = ExprKind.TRANSFORM
     else:
-        out_kind = ExprKind.AGGREGATION
+        result_kind = ExprKind.AGGREGATION
 
-    return ExprMetadata(kind=out_kind, is_order_dependent=is_order_dependent)
+    return ExprMetadata(kind=result_kind, is_order_dependent=result_is_order_dependent)
 
 
 def check_expressions_transform(*args: IntoExpr, function_name: str) -> None:

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -399,7 +399,7 @@ def combine_metadata(*args: IntoExpr, strings_are_column_names: bool) -> ExprMet
 
     for arg in args:
         if isinstance(arg, str) and strings_are_column_names:
-            has_transforms |= True
+            has_transforms = True
         elif isinstance(arg, Expr):
             if arg._metadata["is_order_dependent"]:
                 result_is_order_dependent = True

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -24,6 +24,7 @@ from narwhals.exceptions import OrderDependentExprError
 from narwhals.exceptions import ShapeError
 from narwhals.schema import Schema
 from narwhals.translate import to_native
+from narwhals.utils import ExprKind
 from narwhals.utils import Implementation
 from narwhals.utils import find_stacklevel
 from narwhals.utils import flatten
@@ -2181,7 +2182,7 @@ class LazyFrame(BaseFrame[FrameT]):
             msg = "Binary operations between Series and LazyFrame are not supported."
             raise TypeError(msg)
         if isinstance(arg, Expr):
-            if arg._is_order_dependent:
+            if arg._metadata["is_order_dependent"]:
                 msg = (
                     "Order-dependent expressions are not supported for use in LazyFrame.\n\n"
                     "Hints:\n"
@@ -2192,7 +2193,7 @@ class LazyFrame(BaseFrame[FrameT]):
                     "  they will be supported."
                 )
                 raise OrderDependentExprError(msg)
-            if arg._changes_length:
+            if arg._metadata["kind"] is ExprKind.CHANGES_LENGTH:
                 msg = (
                     "Length-changing expressions are not supported for use in LazyFrame, unless\n"
                     "followed by an aggregation.\n\n"

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -187,12 +187,12 @@ class BaseFrame(Generic[_FrameT]):
         **constraints: Any,
     ) -> Self:
         flat_predicates = flatten(predicates)
-        check_expression_transforms(*flat_predicates, function_name="filter")
         if not (
             len(predicates) == 1
             and isinstance(predicates[0], list)
             and all(isinstance(x, bool) for x in predicates[0])
         ):
+            check_expression_transforms(*flat_predicates, function_name="filter")
             predicates = [self._extract_compliant(v) for v in flat_predicates]  # type: ignore[assignment]
         return self._from_compliant_dataframe(
             self._compliant_frame.filter(*predicates, **constraints),

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -14,6 +14,8 @@ from typing import TypeVar
 from typing import overload
 from warnings import warn
 
+from narwhals._expression_parsing import ExprKind
+from narwhals._expression_parsing import check_expression_transforms
 from narwhals.dependencies import get_polars
 from narwhals.dependencies import is_numpy_array
 from narwhals.dependencies import is_numpy_array_1d
@@ -23,9 +25,7 @@ from narwhals.exceptions import LengthChangingExprError
 from narwhals.exceptions import OrderDependentExprError
 from narwhals.schema import Schema
 from narwhals.translate import to_native
-from narwhals.utils import ExprKind
 from narwhals.utils import Implementation
-from narwhals.utils import check_expression_transforms
 from narwhals.utils import find_stacklevel
 from narwhals.utils import flatten
 from narwhals.utils import generate_repr

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -15,7 +15,7 @@ from typing import overload
 from warnings import warn
 
 from narwhals._expression_parsing import ExprKind
-from narwhals._expression_parsing import check_expression_transforms
+from narwhals._expression_parsing import check_expressions_transform
 from narwhals.dependencies import get_polars
 from narwhals.dependencies import is_numpy_array
 from narwhals.dependencies import is_numpy_array_1d
@@ -192,7 +192,7 @@ class BaseFrame(Generic[_FrameT]):
             and isinstance(predicates[0], list)
             and all(isinstance(x, bool) for x in predicates[0])
         ):
-            check_expression_transforms(*flat_predicates, function_name="filter")
+            check_expressions_transform(*flat_predicates, function_name="filter")
             predicates = [self._extract_compliant(v) for v in flat_predicates]  # type: ignore[assignment]
         return self._from_compliant_dataframe(
             self._compliant_frame.filter(*predicates, **constraints),

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -21,11 +21,11 @@ from narwhals.exceptions import ColumnNotFoundError
 from narwhals.exceptions import InvalidIntoExprError
 from narwhals.exceptions import LengthChangingExprError
 from narwhals.exceptions import OrderDependentExprError
-from narwhals.exceptions import ShapeError
 from narwhals.schema import Schema
 from narwhals.translate import to_native
 from narwhals.utils import ExprKind
 from narwhals.utils import Implementation
+from narwhals.utils import check_expression_transforms
 from narwhals.utils import find_stacklevel
 from narwhals.utils import flatten
 from narwhals.utils import generate_repr
@@ -187,12 +187,7 @@ class BaseFrame(Generic[_FrameT]):
         **constraints: Any,
     ) -> Self:
         flat_predicates = flatten(predicates)
-        if any(
-            getattr(x, "_aggregates", False) or getattr(x, "_changes_length", False)
-            for x in flat_predicates
-        ):
-            msg = "Expressions which aggregate or change length cannot be passed to `filter`."
-            raise ShapeError(msg)
+        check_expression_transforms(*flat_predicates, function_name="filter")
         if not (
             len(predicates) == 1
             and isinstance(predicates[0], list)

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -8,6 +8,9 @@ from typing import Literal
 from typing import Mapping
 from typing import Sequence
 
+from narwhals._expression_parsing import ExprKind
+from narwhals._expression_parsing import ExprMetadata
+from narwhals._expression_parsing import combine_metadata
 from narwhals._expression_parsing import extract_compliant
 from narwhals._expression_parsing import operation_is_order_dependent
 from narwhals.dtypes import _validate_dtype
@@ -17,10 +20,7 @@ from narwhals.expr_dt import ExprDateTimeNamespace
 from narwhals.expr_list import ExprListNamespace
 from narwhals.expr_name import ExprNameNamespace
 from narwhals.expr_str import ExprStringNamespace
-from narwhals.utils import ExprKind
-from narwhals.utils import ExprMetadata
 from narwhals.utils import _validate_rolling_arguments
-from narwhals.utils import combine_metadata
 from narwhals.utils import flatten
 from narwhals.utils import issue_deprecation_warning
 

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -157,7 +157,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).__eq__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __ne__(self: Self, other: Self | Any) -> Self:  # type: ignore[override]
@@ -165,7 +165,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).__ne__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __and__(self: Self, other: Any) -> Self:
@@ -173,7 +173,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).__and__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __rand__(self: Self, other: Any) -> Self:
@@ -182,14 +182,16 @@ class Expr:
                 extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
             ).__and__(extract_compliant(plx, self, parse_column_name_as_expr=False))
 
-        return self.__class__(func, combine_metadata(self, other))
+        return self.__class__(
+            func, combine_metadata(self, other, strings_are_column_names=False)
+        )
 
     def __or__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__or__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __ror__(self: Self, other: Any) -> Self:
@@ -198,14 +200,16 @@ class Expr:
                 extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
             ).__or__(extract_compliant(plx, self, parse_column_name_as_expr=False))
 
-        return self.__class__(func, combine_metadata(self, other))
+        return self.__class__(
+            func, combine_metadata(self, other, strings_are_column_names=False)
+        )
 
     def __add__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__add__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __radd__(self: Self, other: Any) -> Self:
@@ -214,14 +218,16 @@ class Expr:
                 extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
             ).__add__(extract_compliant(plx, self, parse_column_name_as_expr=False))
 
-        return self.__class__(func, combine_metadata(self, other))
+        return self.__class__(
+            func, combine_metadata(self, other, strings_are_column_names=False)
+        )
 
     def __sub__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__sub__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __rsub__(self: Self, other: Any) -> Self:
@@ -230,14 +236,16 @@ class Expr:
                 extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
             ).__sub__(extract_compliant(plx, self, parse_column_name_as_expr=False))
 
-        return self.__class__(func, combine_metadata(self, other))
+        return self.__class__(
+            func, combine_metadata(self, other, strings_are_column_names=False)
+        )
 
     def __truediv__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__truediv__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __rtruediv__(self: Self, other: Any) -> Self:
@@ -246,14 +254,16 @@ class Expr:
                 extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
             ).__truediv__(extract_compliant(plx, self, parse_column_name_as_expr=False))
 
-        return self.__class__(func, combine_metadata(self, other))
+        return self.__class__(
+            func, combine_metadata(self, other, strings_are_column_names=False)
+        )
 
     def __mul__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__mul__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __rmul__(self: Self, other: Any) -> Self:
@@ -262,14 +272,16 @@ class Expr:
                 extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
             ).__mul__(extract_compliant(plx, self, parse_column_name_as_expr=False))
 
-        return self.__class__(func, combine_metadata(self, other))
+        return self.__class__(
+            func, combine_metadata(self, other, strings_are_column_names=False)
+        )
 
     def __le__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__le__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __lt__(self: Self, other: Any) -> Self:
@@ -277,7 +289,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).__lt__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __gt__(self: Self, other: Any) -> Self:
@@ -285,7 +297,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).__gt__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __ge__(self: Self, other: Any) -> Self:
@@ -293,7 +305,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).__ge__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __pow__(self: Self, other: Any) -> Self:
@@ -301,7 +313,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).__pow__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __rpow__(self: Self, other: Any) -> Self:
@@ -310,14 +322,16 @@ class Expr:
                 extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
             ).__pow__(extract_compliant(plx, self, parse_column_name_as_expr=False))
 
-        return self.__class__(func, combine_metadata(self, other))
+        return self.__class__(
+            func, combine_metadata(self, other, strings_are_column_names=False)
+        )
 
     def __floordiv__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__floordiv__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __rfloordiv__(self: Self, other: Any) -> Self:
@@ -326,14 +340,16 @@ class Expr:
                 extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
             ).__floordiv__(extract_compliant(plx, self, parse_column_name_as_expr=False))
 
-        return self.__class__(func, combine_metadata(self, other))
+        return self.__class__(
+            func, combine_metadata(self, other, strings_are_column_names=False)
+        )
 
     def __mod__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__mod__(
                 extract_compliant(plx, other, parse_column_name_as_expr=False)
             ),
-            combine_metadata(self, other),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __rmod__(self: Self, other: Any) -> Self:
@@ -342,7 +358,9 @@ class Expr:
                 extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
             ).__mod__(extract_compliant(plx, self, parse_column_name_as_expr=False))
 
-        return self.__class__(func, combine_metadata(self, other))
+        return self.__class__(
+            func, combine_metadata(self, other, strings_are_column_names=False)
+        )
 
     # --- unary ---
     def __invert__(self: Self) -> Self:

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -373,7 +373,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).any(),
             ExprMetadata(
                 kind=ExprKind.AGGREGATION,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -400,7 +400,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).all(),
             ExprMetadata(
                 kind=ExprKind.AGGREGATION,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -530,7 +530,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).mean(),
             ExprMetadata(
                 kind=ExprKind.AGGREGATION,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -560,7 +560,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).median(),
             ExprMetadata(
                 kind=ExprKind.AGGREGATION,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -591,7 +591,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).std(ddof=ddof),
             ExprMetadata(
                 kind=ExprKind.AGGREGATION,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -622,7 +622,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).var(ddof=ddof),
             ExprMetadata(
                 kind=ExprKind.AGGREGATION,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -698,7 +698,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).skew(),
             ExprMetadata(
                 kind=ExprKind.AGGREGATION,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -729,7 +729,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).sum(),
             ExprMetadata(
                 kind=ExprKind.AGGREGATION,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -756,7 +756,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).min(),
             ExprMetadata(
                 kind=ExprKind.AGGREGATION,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -783,7 +783,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).max(),
             ExprMetadata(
                 kind=ExprKind.AGGREGATION,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -914,7 +914,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).unique(),
             ExprMetadata(
                 kind=ExprKind.CHANGES_LENGTH,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -970,7 +970,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).cum_sum(reverse=reverse),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def diff(self: Self) -> Self:
@@ -1013,7 +1013,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).diff(),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def shift(self: Self, n: int) -> Self:
@@ -1059,7 +1059,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).shift(n),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def replace_strict(
@@ -1150,7 +1150,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).sort(
                 descending=descending, nulls_last=nulls_last
             ),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     # --- transform ---
@@ -1202,7 +1202,8 @@ class Expr:
 
         is_order_dependent = operation_is_order_dependent(self, lower_bound, upper_bound)
         return self.__class__(
-            func, ExprMetadata(self._metadata.kind, is_order_dependent=is_order_dependent)
+            func,
+            ExprMetadata(self._metadata["kind"], is_order_dependent=is_order_dependent),
         )
 
     def is_in(self: Self, other: Any) -> Self:
@@ -1503,7 +1504,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).drop_nulls(),
             ExprMetadata(
                 kind=ExprKind.CHANGES_LENGTH,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -1547,7 +1548,7 @@ class Expr:
             ),
             ExprMetadata(
                 kind=ExprKind.CHANGES_LENGTH,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -1703,7 +1704,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).is_first_distinct(),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def is_last_distinct(self: Self) -> Self:
@@ -1732,7 +1733,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).is_last_distinct(),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def quantile(
@@ -1962,15 +1963,15 @@ class Expr:
             | 2  3          3  |
             └──────────────────┘
         """
-        is_order_dependent = is_order_dependent = operation_is_order_dependent(
-            self, lower_bound, upper_bound
-        )
+        is_order_dependent = operation_is_order_dependent(self, lower_bound, upper_bound)
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).clip(
                 extract_compliant(plx, lower_bound, parse_column_name_as_expr=True),
                 extract_compliant(plx, upper_bound, parse_column_name_as_expr=True),
             ),
-            ExprMetadata(kind=self._metadata.kind, is_order_dependent=is_order_dependent),
+            ExprMetadata(
+                kind=self._metadata["kind"], is_order_dependent=is_order_dependent
+            ),
         )
 
     def mode(self: Self) -> Self:
@@ -1998,7 +1999,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).mode(),
             ExprMetadata(
                 kind=ExprKind.CHANGES_LENGTH,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -2072,7 +2073,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).cum_count(reverse=reverse),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def cum_min(self: Self, *, reverse: bool = False) -> Self:
@@ -2105,7 +2106,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).cum_min(reverse=reverse),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def cum_max(self: Self, *, reverse: bool = False) -> Self:
@@ -2138,7 +2139,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).cum_max(reverse=reverse),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def cum_prod(self: Self, *, reverse: bool = False) -> Self:
@@ -2171,7 +2172,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).cum_prod(reverse=reverse),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def rolling_sum(
@@ -2233,7 +2234,7 @@ class Expr:
                 min_samples=min_samples,
                 center=center,
             ),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def rolling_mean(
@@ -2295,7 +2296,7 @@ class Expr:
                 min_samples=min_samples,
                 center=center,
             ),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def rolling_var(
@@ -2357,7 +2358,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).rolling_var(
                 window_size=window_size, min_samples=min_samples, center=center, ddof=ddof
             ),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def rolling_std(
@@ -2422,7 +2423,7 @@ class Expr:
                 center=center,
                 ddof=ddof,
             ),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     def rank(
@@ -2488,7 +2489,7 @@ class Expr:
             lambda plx: self._to_compliant_expr(plx).rank(
                 method=method, descending=descending
             ),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(self._metadata["kind"], is_order_dependent=True),
         )
 
     @property

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -1691,7 +1691,11 @@ class Expr:
             └──────────────────┘
         """
         return self.__class__(
-            lambda plx: self._to_compliant_expr(plx).null_count(), self._metadata
+            lambda plx: self._to_compliant_expr(plx).null_count(),
+            ExprMetadata(
+                kind=ExprKind.AGGREGATION,
+                is_order_dependent=self._metadata["is_order_dependent"],
+            ),
         )
 
     def is_first_distinct(self: Self) -> Self:

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -404,9 +404,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).any(),
-            is_order_dependent=self._is_order_dependent,
-            changes_length=False,
-            aggregates=True,
+            ExprMetadata(ExprKind.AGGREGATION, self._metadata._is_order_dependent)
         )
 
     def all(self: Self) -> Self:
@@ -430,9 +428,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).all(),
-            is_order_dependent=self._is_order_dependent,
-            changes_length=False,
-            aggregates=True,
+            ExprMetadata(ExprKind.AGGREGATION, self._metadata._is_order_dependent)
         )
 
     def ewm_mean(
@@ -559,9 +555,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).mean(),
-            is_order_dependent=self._is_order_dependent,
-            changes_length=False,
-            aggregates=True,
+            ExprMetadata(ExprKind.AGGREGATION, self._metadata._is_order_dependent)
         )
 
     def median(self: Self) -> Self:
@@ -588,9 +582,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).median(),
-            is_order_dependent=self._is_order_dependent,
-            changes_length=False,
-            aggregates=True,
+            ExprMetadata(ExprKind.AGGREGATION, self._metadata._is_order_dependent)
         )
 
     def std(self: Self, *, ddof: int = 1) -> Self:
@@ -618,9 +610,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).std(ddof=ddof),
-            is_order_dependent=self._is_order_dependent,
-            changes_length=False,
-            aggregates=True,
+            ExprMetadata(ExprKind.AGGREGATION, self._metadata._is_order_dependent)
         )
 
     def var(self: Self, *, ddof: int = 1) -> Self:
@@ -648,9 +638,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).var(ddof=ddof),
-            is_order_dependent=self._is_order_dependent,
-            changes_length=False,
-            aggregates=True,
+            ExprMetadata(ExprKind.AGGREGATION, self._metadata._is_order_dependent)
         )
 
     def map_batches(
@@ -723,9 +711,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).skew(),
-            is_order_dependent=self._is_order_dependent,
-            changes_length=False,
-            aggregates=True,
+            ExprMetadata(ExprKind.AGGREGATION, self._metadata._is_order_dependent)
         )
 
     def sum(self: Self) -> Expr:
@@ -753,9 +739,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).sum(),
-            is_order_dependent=self._is_order_dependent,
-            changes_length=False,
-            aggregates=True,
+            ExprMetadata(ExprKind.AGGREGATION, self._metadata._is_order_dependent)
         )
 
     def min(self: Self) -> Self:
@@ -779,9 +763,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).min(),
-            is_order_dependent=self._is_order_dependent,
-            changes_length=False,
-            aggregates=True,
+            ExprMetadata(ExprKind.AGGREGATION, self._metadata._is_order_dependent)
         )
 
     def max(self: Self) -> Self:
@@ -805,9 +787,7 @@ class Expr:
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).max(),
-            is_order_dependent=self._is_order_dependent,
-            changes_length=False,
-            aggregates=True,
+            ExprMetadata(ExprKind.AGGREGATION, self._metadata._is_order_dependent)
         )
 
     def arg_min(self: Self) -> Self:

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -155,7 +155,7 @@ class Expr:
     def __eq__(self: Self, other: Self | Any) -> Self:  # type: ignore[override]
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__eq__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -163,7 +163,7 @@ class Expr:
     def __ne__(self: Self, other: Self | Any) -> Self:  # type: ignore[override]
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__ne__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -171,7 +171,7 @@ class Expr:
     def __and__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__and__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -179,8 +179,8 @@ class Expr:
     def __rand__(self: Self, other: Any) -> Self:
         def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
             return plx.lit(
-                extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
-            ).__and__(extract_compliant(plx, self, parse_column_name_as_expr=False))
+                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
+            ).__and__(extract_compliant(plx, self, strings_are_column_names=False))
 
         return self.__class__(
             func, combine_metadata(self, other, strings_are_column_names=False)
@@ -189,7 +189,7 @@ class Expr:
     def __or__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__or__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -197,8 +197,8 @@ class Expr:
     def __ror__(self: Self, other: Any) -> Self:
         def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
             return plx.lit(
-                extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
-            ).__or__(extract_compliant(plx, self, parse_column_name_as_expr=False))
+                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
+            ).__or__(extract_compliant(plx, self, strings_are_column_names=False))
 
         return self.__class__(
             func, combine_metadata(self, other, strings_are_column_names=False)
@@ -207,7 +207,7 @@ class Expr:
     def __add__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__add__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -215,8 +215,8 @@ class Expr:
     def __radd__(self: Self, other: Any) -> Self:
         def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
             return plx.lit(
-                extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
-            ).__add__(extract_compliant(plx, self, parse_column_name_as_expr=False))
+                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
+            ).__add__(extract_compliant(plx, self, strings_are_column_names=False))
 
         return self.__class__(
             func, combine_metadata(self, other, strings_are_column_names=False)
@@ -225,7 +225,7 @@ class Expr:
     def __sub__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__sub__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -233,8 +233,8 @@ class Expr:
     def __rsub__(self: Self, other: Any) -> Self:
         def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
             return plx.lit(
-                extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
-            ).__sub__(extract_compliant(plx, self, parse_column_name_as_expr=False))
+                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
+            ).__sub__(extract_compliant(plx, self, strings_are_column_names=False))
 
         return self.__class__(
             func, combine_metadata(self, other, strings_are_column_names=False)
@@ -243,7 +243,7 @@ class Expr:
     def __truediv__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__truediv__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -251,8 +251,8 @@ class Expr:
     def __rtruediv__(self: Self, other: Any) -> Self:
         def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
             return plx.lit(
-                extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
-            ).__truediv__(extract_compliant(plx, self, parse_column_name_as_expr=False))
+                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
+            ).__truediv__(extract_compliant(plx, self, strings_are_column_names=False))
 
         return self.__class__(
             func, combine_metadata(self, other, strings_are_column_names=False)
@@ -261,7 +261,7 @@ class Expr:
     def __mul__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__mul__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -269,8 +269,8 @@ class Expr:
     def __rmul__(self: Self, other: Any) -> Self:
         def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
             return plx.lit(
-                extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
-            ).__mul__(extract_compliant(plx, self, parse_column_name_as_expr=False))
+                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
+            ).__mul__(extract_compliant(plx, self, strings_are_column_names=False))
 
         return self.__class__(
             func, combine_metadata(self, other, strings_are_column_names=False)
@@ -279,7 +279,7 @@ class Expr:
     def __le__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__le__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -287,7 +287,7 @@ class Expr:
     def __lt__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__lt__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -295,7 +295,7 @@ class Expr:
     def __gt__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__gt__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -303,7 +303,7 @@ class Expr:
     def __ge__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__ge__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -311,7 +311,7 @@ class Expr:
     def __pow__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__pow__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -319,8 +319,8 @@ class Expr:
     def __rpow__(self: Self, other: Any) -> Self:
         def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
             return plx.lit(
-                extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
-            ).__pow__(extract_compliant(plx, self, parse_column_name_as_expr=False))
+                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
+            ).__pow__(extract_compliant(plx, self, strings_are_column_names=False))
 
         return self.__class__(
             func, combine_metadata(self, other, strings_are_column_names=False)
@@ -329,7 +329,7 @@ class Expr:
     def __floordiv__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__floordiv__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -337,8 +337,8 @@ class Expr:
     def __rfloordiv__(self: Self, other: Any) -> Self:
         def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
             return plx.lit(
-                extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
-            ).__floordiv__(extract_compliant(plx, self, parse_column_name_as_expr=False))
+                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
+            ).__floordiv__(extract_compliant(plx, self, strings_are_column_names=False))
 
         return self.__class__(
             func, combine_metadata(self, other, strings_are_column_names=False)
@@ -347,7 +347,7 @@ class Expr:
     def __mod__(self: Self, other: Any) -> Self:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).__mod__(
-                extract_compliant(plx, other, parse_column_name_as_expr=False)
+                extract_compliant(plx, other, strings_are_column_names=False)
             ),
             combine_metadata(self, other, strings_are_column_names=False),
         )
@@ -355,8 +355,8 @@ class Expr:
     def __rmod__(self: Self, other: Any) -> Self:
         def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
             return plx.lit(
-                extract_compliant(plx, other, parse_column_name_as_expr=False), dtype=None
-            ).__mod__(extract_compliant(plx, self, parse_column_name_as_expr=False))
+                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
+            ).__mod__(extract_compliant(plx, self, strings_are_column_names=False))
 
         return self.__class__(
             func, combine_metadata(self, other, strings_are_column_names=False)
@@ -1203,8 +1203,8 @@ class Expr:
         """
 
         def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
-            lb = extract_compliant(plx, lower_bound, parse_column_name_as_expr=True)
-            ub = extract_compliant(plx, upper_bound, parse_column_name_as_expr=True)
+            lb = extract_compliant(plx, lower_bound, strings_are_column_names=True)
+            ub = extract_compliant(plx, upper_bound, strings_are_column_names=True)
             expr = self._to_compliant_expr(plx)
             if closed == "left":
                 return (expr >= lb) & (expr < ub)  # type: ignore[no-any-return]
@@ -1250,7 +1250,7 @@ class Expr:
         if isinstance(other, Iterable) and not isinstance(other, (str, bytes)):
             return self.__class__(
                 lambda plx: self._to_compliant_expr(plx).is_in(
-                    extract_compliant(plx, other, parse_column_name_as_expr=False)
+                    extract_compliant(plx, other, strings_are_column_names=False)
                 ),
                 self._metadata,
             )
@@ -1292,7 +1292,7 @@ class Expr:
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).filter(
                 *[
-                    extract_compliant(plx, pred, parse_column_name_as_expr=True)
+                    extract_compliant(plx, pred, strings_are_column_names=True)
                     for pred in flat_predicates
                 ],
             ),
@@ -1984,8 +1984,8 @@ class Expr:
         is_order_dependent = operation_is_order_dependent(self, lower_bound, upper_bound)
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).clip(
-                extract_compliant(plx, lower_bound, parse_column_name_as_expr=True),
-                extract_compliant(plx, upper_bound, parse_column_name_as_expr=True),
+                extract_compliant(plx, lower_bound, strings_are_column_names=True),
+                extract_compliant(plx, upper_bound, strings_are_column_names=True),
             ),
             ExprMetadata(
                 kind=self._metadata["kind"], is_order_dependent=is_order_dependent

--- a/narwhals/expr_cat.py
+++ b/narwhals/expr_cat.py
@@ -4,6 +4,9 @@ from typing import TYPE_CHECKING
 from typing import Generic
 from typing import TypeVar
 
+from narwhals.utils import ExprKind
+from narwhals.utils import ExprMetadata
+
 if TYPE_CHECKING:
     from typing_extensions import Self
 
@@ -63,7 +66,8 @@ class ExprCatNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).cat.get_categories(),
-            self._expr._is_order_dependent,
-            changes_length=True,
-            aggregates=self._expr._aggregates,
+            ExprMetadata(
+                kind=ExprKind.CHANGES_LENGTH,
+                is_order_dependent=self._expr._metadata["is_order_dependent"],
+            ),
         )

--- a/narwhals/expr_cat.py
+++ b/narwhals/expr_cat.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING
 from typing import Generic
 from typing import TypeVar
 
-from narwhals.utils import ExprKind
-from narwhals.utils import ExprMetadata
+from narwhals._expression_parsing import ExprKind
+from narwhals._expression_parsing import ExprMetadata
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/narwhals/expr_dt.py
+++ b/narwhals/expr_dt.py
@@ -73,10 +73,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             a: [[2012-01-07,2023-03-10]]
         """
         return self._expr.__class__(
-            lambda plx: self._expr._to_compliant_expr(plx).dt.date(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            lambda plx: self._expr._to_compliant_expr(plx).dt.date(), self._expr._metadata
         )
 
     def year(self: Self) -> ExprT:
@@ -144,10 +141,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             year: [[1978,2024,2065]]
         """
         return self._expr.__class__(
-            lambda plx: self._expr._to_compliant_expr(plx).dt.year(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            lambda plx: self._expr._to_compliant_expr(plx).dt.year(), self._expr._metadata
         )
 
     def month(self: Self) -> ExprT:
@@ -216,9 +210,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.month(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def day(self: Self) -> ExprT:
@@ -286,10 +278,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             day: [[1,13,1]]
         """
         return self._expr.__class__(
-            lambda plx: self._expr._to_compliant_expr(plx).dt.day(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            lambda plx: self._expr._to_compliant_expr(plx).dt.day(), self._expr._metadata
         )
 
     def hour(self: Self) -> ExprT:
@@ -357,10 +346,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             hour: [[1,5,10]]
         """
         return self._expr.__class__(
-            lambda plx: self._expr._to_compliant_expr(plx).dt.hour(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            lambda plx: self._expr._to_compliant_expr(plx).dt.hour(), self._expr._metadata
         )
 
     def minute(self: Self) -> ExprT:
@@ -429,9 +415,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.minute(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def second(self: Self) -> ExprT:
@@ -498,9 +482,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.second(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def millisecond(self: Self) -> ExprT:
@@ -567,9 +549,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.millisecond(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def microsecond(self: Self) -> ExprT:
@@ -636,9 +616,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.microsecond(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def nanosecond(self: Self) -> ExprT:
@@ -705,9 +683,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.nanosecond(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def ordinal_day(self: Self) -> ExprT:
@@ -766,9 +742,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.ordinal_day(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def weekday(self: Self) -> ExprT:
@@ -825,9 +799,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.weekday(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def total_minutes(self: Self) -> ExprT:
@@ -891,9 +863,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.total_minutes(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def total_seconds(self: Self) -> ExprT:
@@ -959,9 +929,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.total_seconds(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def total_milliseconds(self: Self) -> ExprT:
@@ -1030,9 +998,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.total_milliseconds(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def total_microseconds(self: Self) -> ExprT:
@@ -1101,9 +1067,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.total_microseconds(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def total_nanoseconds(self: Self) -> ExprT:
@@ -1159,9 +1123,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.total_nanoseconds(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def to_string(self: Self, format: str) -> ExprT:  # noqa: A002
@@ -1260,9 +1222,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.to_string(format),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def replace_time_zone(self: Self, time_zone: str | None) -> ExprT:
@@ -1329,9 +1289,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).dt.replace_time_zone(
                 time_zone
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def convert_time_zone(self: Self, time_zone: str) -> ExprT:
@@ -1404,9 +1362,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).dt.convert_time_zone(
                 time_zone
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def timestamp(self: Self, time_unit: TimeUnit = "us") -> ExprT:
@@ -1480,7 +1436,5 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             raise ValueError(msg)
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).dt.timestamp(time_unit),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )

--- a/narwhals/expr_list.py
+++ b/narwhals/expr_list.py
@@ -74,7 +74,5 @@ class ExprListNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).list.len(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )

--- a/narwhals/expr_name.py
+++ b/narwhals/expr_name.py
@@ -62,9 +62,7 @@ class ExprNameNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).name.keep(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def map(self: Self, function: Callable[[str], str]) -> ExprT:
@@ -114,9 +112,7 @@ class ExprNameNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).name.map(function),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def prefix(self: Self, prefix: str) -> ExprT:
@@ -165,9 +161,7 @@ class ExprNameNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).name.prefix(prefix),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def suffix(self: Self, suffix: str) -> ExprT:
@@ -216,9 +210,7 @@ class ExprNameNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).name.suffix(suffix),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def to_lowercase(self: Self) -> ExprT:
@@ -264,9 +256,7 @@ class ExprNameNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).name.to_lowercase(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def to_uppercase(self: Self) -> ExprT:
@@ -312,7 +302,5 @@ class ExprNameNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).name.to_uppercase(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )

--- a/narwhals/expr_str.py
+++ b/narwhals/expr_str.py
@@ -77,9 +77,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.len_chars(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def replace(
@@ -146,9 +144,7 @@ class ExprStringNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).str.replace(
                 pattern, value, literal=literal, n=n
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def replace_all(
@@ -216,9 +212,7 @@ class ExprStringNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).str.replace_all(
                 pattern, value, literal=literal
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def strip_chars(self: Self, characters: str | None = None) -> ExprT:
@@ -267,9 +261,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.strip_chars(characters),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def starts_with(self: Self, prefix: str) -> ExprT:
@@ -332,9 +324,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.starts_with(prefix),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def ends_with(self: Self, suffix: str) -> ExprT:
@@ -397,9 +387,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.ends_with(suffix),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def contains(self: Self, pattern: str, *, literal: bool = False) -> ExprT:
@@ -480,9 +468,7 @@ class ExprStringNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).str.contains(
                 pattern, literal=literal
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def slice(self: Self, offset: int, length: int | None = None) -> ExprT:
@@ -585,9 +571,7 @@ class ExprStringNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).str.slice(
                 offset=offset, length=length
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def head(self: Self, n: int = 5) -> ExprT:
@@ -655,9 +639,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.slice(0, n),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def tail(self: Self, n: int = 5) -> ExprT:
@@ -727,9 +709,7 @@ class ExprStringNamespace(Generic[ExprT]):
             lambda plx: self._expr._to_compliant_expr(plx).str.slice(
                 offset=-n, length=None
             ),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def to_datetime(self: Self, format: str | None = None) -> ExprT:  # noqa: A002
@@ -799,9 +779,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.to_datetime(format=format),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def to_uppercase(self: Self) -> ExprT:
@@ -866,9 +844,7 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.to_uppercase(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )
 
     def to_lowercase(self: Self) -> ExprT:
@@ -928,7 +904,5 @@ class ExprStringNamespace(Generic[ExprT]):
         """
         return self._expr.__class__(
             lambda plx: self._expr._to_compliant_expr(plx).str.to_lowercase(),
-            self._expr._is_order_dependent,
-            changes_length=self._expr._changes_length,
-            aggregates=self._expr._aggregates,
+            self._expr._metadata,
         )

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -17,15 +17,16 @@ from narwhals.dataframe import DataFrame
 from narwhals.dataframe import LazyFrame
 from narwhals.dependencies import is_numpy_array
 from narwhals.dependencies import is_numpy_array_2d
-from narwhals.exceptions import ShapeError
 from narwhals.expr import Expr
 from narwhals.schema import Schema
+from narwhals.series import Series
 from narwhals.translate import from_native
 from narwhals.translate import to_native
 from narwhals.utils import ExprKind
 from narwhals.utils import ExprMetadata
 from narwhals.utils import Implementation
 from narwhals.utils import Version
+from narwhals.utils import check_expression_transforms
 from narwhals.utils import combine_metadata
 from narwhals.utils import flatten
 from narwhals.utils import parse_version
@@ -1474,12 +1475,7 @@ class When:
         if not self._predicates:
             msg = "At least one predicate needs to be provided to `narwhals.when`."
             raise TypeError(msg)
-        if any(
-            getattr(x, "_aggregates", False) or getattr(x, "_changes_length", False)
-            for x in self._predicates
-        ):
-            msg = "Expressions which aggregate or change length cannot be passed to `filter`."
-            raise ShapeError(msg)
+        check_expression_transforms(*self._predicates, function_name="when")
 
     def _extract_predicates(self: Self, plx: Any) -> Any:
         return [

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -14,7 +14,7 @@ from typing import overload
 
 from narwhals._expression_parsing import ExprKind
 from narwhals._expression_parsing import ExprMetadata
-from narwhals._expression_parsing import check_expression_transforms
+from narwhals._expression_parsing import check_expressions_transform
 from narwhals._expression_parsing import combine_metadata
 from narwhals._expression_parsing import extract_compliant
 from narwhals.dataframe import DataFrame
@@ -1475,7 +1475,7 @@ class When:
         if not self._predicates:
             msg = "At least one predicate needs to be provided to `narwhals.when`."
             raise TypeError(msg)
-        check_expression_transforms(*self._predicates, function_name="when")
+        check_expressions_transform(*self._predicates, function_name="when")
 
     def _extract_predicates(self: Self, plx: Any) -> Any:
         return [

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -1115,7 +1115,7 @@ def all_() -> Expr:
     """
     return Expr(
         lambda plx: plx.all(),
-        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -1149,7 +1149,7 @@ def len_() -> Expr:
     def func(plx: Any) -> Any:
         return plx.len()
 
-    return Expr(func, ExprMetadata(ExprKind.AGGREGATION, is_order_dependent=False))
+    return Expr(func, ExprMetadata(kind=ExprKind.AGGREGATION, is_order_dependent=False))
 
 
 def sum(*columns: str) -> Expr:

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -1178,10 +1178,7 @@ def sum(*columns: str) -> Expr:
         |    0  3  4.8     |
         └──────────────────┘
     """
-    return Expr(
-        lambda plx: plx.col(*columns).sum(),
-        ExprMetadata(kind=ExprKind.AGGREGATION, is_order_dependent=False),
-    )
+    return col(*columns).sum()
 
 
 def mean(*columns: str) -> Expr:
@@ -1213,10 +1210,7 @@ def mean(*columns: str) -> Expr:
         |b: [[17.173333333333336]]|
         └─────────────────────────┘
     """
-    return Expr(
-        lambda plx: plx.col(*columns).mean(),
-        ExprMetadata(kind=ExprKind.AGGREGATION, is_order_dependent=False),
-    )
+    return col(*columns).mean()
 
 
 def median(*columns: str) -> Expr:
@@ -1252,10 +1246,7 @@ def median(*columns: str) -> Expr:
         |  └─────┘         |
         └──────────────────┘
     """
-    return Expr(
-        lambda plx: plx.col(*columns).median(),
-        ExprMetadata(kind=ExprKind.AGGREGATION, is_order_dependent=False),
-    )
+    return col(*columns).median()
 
 
 def min(*columns: str) -> Expr:
@@ -1287,10 +1278,7 @@ def min(*columns: str) -> Expr:
         |  b: [[5]]        |
         └──────────────────┘
     """
-    return Expr(
-        lambda plx: plx.col(*columns).min(),
-        ExprMetadata(kind=ExprKind.AGGREGATION, is_order_dependent=False),
-    )
+    return col(*columns).min()
 
 
 def max(*columns: str) -> Expr:
@@ -1318,10 +1306,7 @@ def max(*columns: str) -> Expr:
         |     0  2  10     |
         └──────────────────┘
     """
-    return Expr(
-        lambda plx: plx.col(*columns).max(),
-        ExprMetadata(kind=ExprKind.AGGREGATION, is_order_dependent=False),
-    )
+    return col(*columns).max()
 
 
 def sum_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -1369,7 +1369,7 @@ def sum_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
                 for v in flat_exprs
             )
         ),
-        combine_metadata(*flat_exprs),
+        combine_metadata(*flat_exprs, strings_are_column_names=True),
     )
 
 
@@ -1416,7 +1416,7 @@ def min_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
                 for v in flat_exprs
             )
         ),
-        combine_metadata(*flat_exprs),
+        combine_metadata(*flat_exprs, strings_are_column_names=True),
     )
 
 
@@ -1465,7 +1465,7 @@ def max_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
                 for v in flat_exprs
             )
         ),
-        combine_metadata(*flat_exprs),
+        combine_metadata(*flat_exprs, strings_are_column_names=True),
     )
 
 
@@ -1488,7 +1488,7 @@ class When:
             lambda plx: plx.when(*self._extract_predicates(plx)).then(
                 extract_compliant(plx, value, parse_column_name_as_expr=True)
             ),
-            combine_metadata(*self._predicates, value),
+            combine_metadata(*self._predicates, value, strings_are_column_names=True),
         )
 
 
@@ -1498,7 +1498,7 @@ class Then(Expr):
             lambda plx: self._to_compliant_expr(plx).otherwise(
                 extract_compliant(plx, value, parse_column_name_as_expr=True)
             ),
-            combine_metadata(self, value),
+            combine_metadata(self, value, strings_are_column_names=True),
         )
 
 
@@ -1589,7 +1589,7 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
                 for v in flat_exprs
             )
         ),
-        combine_metadata(*flat_exprs),
+        combine_metadata(*flat_exprs, strings_are_column_names=True),
     )
 
 
@@ -1684,7 +1684,7 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
                 for v in flat_exprs
             )
         ),
-        combine_metadata(*flat_exprs),
+        combine_metadata(*flat_exprs, strings_are_column_names=True),
     )
 
 
@@ -1733,7 +1733,7 @@ def mean_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
                 for v in flat_exprs
             )
         ),
-        combine_metadata(*flat_exprs),
+        combine_metadata(*flat_exprs, strings_are_column_names=True),
     )
 
 
@@ -1797,5 +1797,5 @@ def concat_str(
             separator=separator,
             ignore_nulls=ignore_nulls,
         ),
-        combine_metadata(*exprs),
+        combine_metadata(*exprs, strings_are_column_names=True),
     )

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -1365,7 +1365,7 @@ def sum_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     return Expr(
         lambda plx: plx.sum_horizontal(
             *(
-                extract_compliant(plx, v, parse_column_name_as_expr=True)
+                extract_compliant(plx, v, strings_are_column_names=True)
                 for v in flat_exprs
             )
         ),
@@ -1412,7 +1412,7 @@ def min_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     return Expr(
         lambda plx: plx.min_horizontal(
             *(
-                extract_compliant(plx, v, parse_column_name_as_expr=True)
+                extract_compliant(plx, v, strings_are_column_names=True)
                 for v in flat_exprs
             )
         ),
@@ -1461,7 +1461,7 @@ def max_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     return Expr(
         lambda plx: plx.max_horizontal(
             *(
-                extract_compliant(plx, v, parse_column_name_as_expr=True)
+                extract_compliant(plx, v, strings_are_column_names=True)
                 for v in flat_exprs
             )
         ),
@@ -1479,14 +1479,14 @@ class When:
 
     def _extract_predicates(self: Self, plx: Any) -> Any:
         return [
-            extract_compliant(plx, v, parse_column_name_as_expr=True)
+            extract_compliant(plx, v, strings_are_column_names=True)
             for v in self._predicates
         ]
 
     def then(self: Self, value: IntoExpr | Any) -> Then:
         return Then(
             lambda plx: plx.when(*self._extract_predicates(plx)).then(
-                extract_compliant(plx, value, parse_column_name_as_expr=True)
+                extract_compliant(plx, value, strings_are_column_names=True)
             ),
             combine_metadata(*self._predicates, value, strings_are_column_names=True),
         )
@@ -1496,7 +1496,7 @@ class Then(Expr):
     def otherwise(self: Self, value: IntoExpr | Any) -> Expr:
         return Expr(
             lambda plx: self._to_compliant_expr(plx).otherwise(
-                extract_compliant(plx, value, parse_column_name_as_expr=True)
+                extract_compliant(plx, value, strings_are_column_names=True)
             ),
             combine_metadata(self, value, strings_are_column_names=True),
         )
@@ -1585,7 +1585,7 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     return Expr(
         lambda plx: plx.all_horizontal(
             *(
-                extract_compliant(plx, v, parse_column_name_as_expr=True)
+                extract_compliant(plx, v, strings_are_column_names=True)
                 for v in flat_exprs
             )
         ),
@@ -1680,7 +1680,7 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     return Expr(
         lambda plx: plx.any_horizontal(
             *(
-                extract_compliant(plx, v, parse_column_name_as_expr=True)
+                extract_compliant(plx, v, strings_are_column_names=True)
                 for v in flat_exprs
             )
         ),
@@ -1729,7 +1729,7 @@ def mean_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     return Expr(
         lambda plx: plx.mean_horizontal(
             *(
-                extract_compliant(plx, v, parse_column_name_as_expr=True)
+                extract_compliant(plx, v, strings_are_column_names=True)
                 for v in flat_exprs
             )
         ),
@@ -1793,7 +1793,7 @@ def concat_str(
     exprs = flatten([*flatten([exprs]), *more_exprs])
     return Expr(
         lambda plx: plx.concat_str(
-            *(extract_compliant(plx, v, parse_column_name_as_expr=True) for v in exprs),
+            *(extract_compliant(plx, v, strings_are_column_names=True) for v in exprs),
             separator=separator,
             ignore_nulls=ignore_nulls,
         ),

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -1052,7 +1052,7 @@ def col(*names: str | Iterable[str]) -> Expr:
     def func(plx: Any) -> Any:
         return plx.col(*flatten(names))
 
-    return Expr(func, is_order_dependent=False, changes_length=False, aggregates=False)
+    return Expr(func, ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False))
 
 
 def nth(*indices: int | Sequence[int]) -> Expr:
@@ -1089,7 +1089,7 @@ def nth(*indices: int | Sequence[int]) -> Expr:
     def func(plx: Any) -> Any:
         return plx.nth(*flatten(indices))
 
-    return Expr(func, is_order_dependent=False, changes_length=False, aggregates=False)
+    return Expr(func, ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False))
 
 
 # Add underscore so it doesn't conflict with builtin `all`
@@ -1115,7 +1115,7 @@ def all_() -> Expr:
     """
     return Expr(
         lambda plx: plx.all(),
-        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False),
     )
 
 

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -12,6 +12,10 @@ from typing import TypeVar
 from typing import Union
 from typing import overload
 
+from narwhals._expression_parsing import ExprKind
+from narwhals._expression_parsing import ExprMetadata
+from narwhals._expression_parsing import check_expression_transforms
+from narwhals._expression_parsing import combine_metadata
 from narwhals._expression_parsing import extract_compliant
 from narwhals.dataframe import DataFrame
 from narwhals.dataframe import LazyFrame
@@ -22,12 +26,8 @@ from narwhals.schema import Schema
 from narwhals.series import Series
 from narwhals.translate import from_native
 from narwhals.translate import to_native
-from narwhals.utils import ExprKind
-from narwhals.utils import ExprMetadata
 from narwhals.utils import Implementation
 from narwhals.utils import Version
-from narwhals.utils import check_expression_transforms
-from narwhals.utils import combine_metadata
 from narwhals.utils import flatten
 from narwhals.utils import parse_version
 from narwhals.utils import validate_laziness

--- a/narwhals/group_by.py
+++ b/narwhals/group_by.py
@@ -8,10 +8,10 @@ from typing import Iterator
 from typing import TypeVar
 from typing import cast
 
+from narwhals._expression_parsing import ExprKind
 from narwhals.dataframe import DataFrame
 from narwhals.dataframe import LazyFrame
 from narwhals.exceptions import InvalidOperationError
-from narwhals.utils import ExprKind
 from narwhals.utils import flatten
 from narwhals.utils import tupleify
 

--- a/narwhals/group_by.py
+++ b/narwhals/group_by.py
@@ -8,7 +8,7 @@ from typing import Iterator
 from typing import TypeVar
 from typing import cast
 
-from narwhals._expression_parsing import ExprKind
+from narwhals._expression_parsing import all_expressions_aggregate
 from narwhals.dataframe import DataFrame
 from narwhals.dataframe import LazyFrame
 from narwhals.exceptions import InvalidOperationError
@@ -113,13 +113,7 @@ class GroupBy(Generic[DataFrameT]):
             └─────┴─────┴─────┘
         """
         flat_aggs = tuple(flatten(aggs))
-        if not all(
-            x._metadata["kind"] in (ExprKind.AGGREGATION, ExprKind.LITERAL)
-            for x in flat_aggs
-        ) and all(
-            x._metadata["kind"] in (ExprKind.AGGREGATION, ExprKind.LITERAL)
-            for x in named_aggs.values()
-        ):
+        if not all_expressions_aggregate(*flat_aggs, **named_aggs):
             msg = (
                 "Found expression which does not aggregate.\n\n"
                 "All expressions passed to GroupBy.agg must aggregate.\n"
@@ -221,13 +215,7 @@ class LazyGroupBy(Generic[LazyFrameT]):
             └─────┴─────┴─────┘
         """
         flat_aggs = tuple(flatten(aggs))
-        if not all(
-            x._metadata["kind"] in (ExprKind.AGGREGATION, ExprKind.LITERAL)
-            for x in flat_aggs
-        ) and all(
-            x._metadata["kind"] in (ExprKind.AGGREGATION, ExprKind.LITERAL)
-            for x in named_aggs.values()
-        ):
+        if not all_expressions_aggregate(*flat_aggs, **named_aggs):
             msg = (
                 "Found expression which does not aggregate.\n\n"
                 "All expressions passed to GroupBy.agg must aggregate.\n"

--- a/narwhals/group_by.py
+++ b/narwhals/group_by.py
@@ -11,6 +11,7 @@ from typing import cast
 from narwhals.dataframe import DataFrame
 from narwhals.dataframe import LazyFrame
 from narwhals.exceptions import InvalidOperationError
+from narwhals.utils import ExprKind
 from narwhals.utils import flatten
 from narwhals.utils import tupleify
 
@@ -112,8 +113,12 @@ class GroupBy(Generic[DataFrameT]):
             └─────┴─────┴─────┘
         """
         flat_aggs = tuple(flatten(aggs))
-        if not all(getattr(x, "_aggregates", True) for x in flat_aggs) and all(
-            getattr(x, "_aggregates", True) for x in named_aggs.values()
+        if not all(
+            x._metadata["kind"] in (ExprKind.AGGREGATION, ExprKind.LITERAL)
+            for x in flat_aggs
+        ) and all(
+            x._metadata["kind"] in (ExprKind.AGGREGATION, ExprKind.LITERAL)
+            for x in named_aggs.values()
         ):
             msg = (
                 "Found expression which does not aggregate.\n\n"
@@ -216,8 +221,12 @@ class LazyGroupBy(Generic[LazyFrameT]):
             └─────┴─────┴─────┘
         """
         flat_aggs = tuple(flatten(aggs))
-        if not all(getattr(x, "_aggregates", True) for x in flat_aggs) and all(
-            getattr(x, "_aggregates", True) for x in named_aggs.values()
+        if not all(
+            x._metadata["kind"] in (ExprKind.AGGREGATION, ExprKind.LITERAL)
+            for x in flat_aggs
+        ) and all(
+            x._metadata["kind"] in (ExprKind.AGGREGATION, ExprKind.LITERAL)
+            for x in named_aggs.values()
         ):
             msg = (
                 "Found expression which does not aggregate.\n\n"

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -5,9 +5,9 @@ from typing import Any
 from typing import Iterable
 from typing import NoReturn
 
+from narwhals._expression_parsing import ExprKind
+from narwhals._expression_parsing import ExprMetadata
 from narwhals.expr import Expr
-from narwhals.utils import ExprKind
-from narwhals.utils import ExprMetadata
 from narwhals.utils import flatten
 
 if TYPE_CHECKING:

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -6,6 +6,8 @@ from typing import Iterable
 from typing import NoReturn
 
 from narwhals.expr import Expr
+from narwhals.utils import ExprKind
+from narwhals.utils import ExprMetadata
 from narwhals.utils import flatten
 
 if TYPE_CHECKING:
@@ -95,7 +97,7 @@ def by_dtype(*dtypes: DType | type[DType] | Iterable[DType | type[DType]]) -> Se
     """
     return Selector(
         lambda plx: plx.selectors.by_dtype(flatten(dtypes)),
-        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False),
     )
 
 
@@ -162,7 +164,7 @@ def matches(pattern: str) -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.matches(pattern),
-        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False),
     )
 
 
@@ -221,7 +223,7 @@ def numeric() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.numeric(),
-        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False),
     )
 
 
@@ -277,7 +279,7 @@ def boolean() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.boolean(),
-        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False),
     )
 
 
@@ -333,7 +335,7 @@ def string() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.string(),
-        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False),
     )
 
 
@@ -394,7 +396,7 @@ def categorical() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.categorical(),
-        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False),
     )
 
 
@@ -454,7 +456,7 @@ def all() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.all(),
-        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False),
     )
 
 
@@ -515,7 +517,7 @@ def datetime(
     """
     return Selector(
         lambda plx: plx.selectors.datetime(time_unit=time_unit, time_zone=time_zone),
-        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False),
     )
 
 

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -19,10 +19,7 @@ if TYPE_CHECKING:
 
 class Selector(Expr):
     def _to_expr(self: Self) -> Expr:
-        return Expr(
-            to_compliant_expr=self._to_compliant_expr,
-            self._metadata
-        )
+        return Expr(self._to_compliant_expr, self._metadata)
 
     def __add__(self: Self, other: Any) -> Expr:  # type: ignore[override]
         if isinstance(other, Selector):

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -95,9 +95,7 @@ def by_dtype(*dtypes: DType | type[DType] | Iterable[DType | type[DType]]) -> Se
     """
     return Selector(
         lambda plx: plx.selectors.by_dtype(flatten(dtypes)),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -164,9 +162,7 @@ def matches(pattern: str) -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.matches(pattern),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -225,9 +221,7 @@ def numeric() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.numeric(),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -283,9 +277,7 @@ def boolean() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.boolean(),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -341,9 +333,7 @@ def string() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.string(),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -404,9 +394,7 @@ def categorical() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.categorical(),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -466,9 +454,7 @@ def all() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.all(),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -529,9 +515,7 @@ def datetime(
     """
     return Selector(
         lambda plx: plx.selectors.datetime(time_unit=time_unit, time_zone=time_zone),
-        is_order_dependent=False,
-        changes_length=False,
-        aggregates=False,
+        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -21,9 +21,7 @@ class Selector(Expr):
     def _to_expr(self: Self) -> Expr:
         return Expr(
             to_compliant_expr=self._to_compliant_expr,
-            is_order_dependent=self._is_order_dependent,
-            changes_length=self._changes_length,
-            aggregates=self._aggregates,
+            self._metadata
         )
 
     def __add__(self: Self, other: Any) -> Expr:  # type: ignore[override]

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -95,7 +95,7 @@ def by_dtype(*dtypes: DType | type[DType] | Iterable[DType | type[DType]]) -> Se
     """
     return Selector(
         lambda plx: plx.selectors.by_dtype(flatten(dtypes)),
-        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -162,7 +162,7 @@ def matches(pattern: str) -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.matches(pattern),
-        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -221,7 +221,7 @@ def numeric() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.numeric(),
-        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -277,7 +277,7 @@ def boolean() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.boolean(),
-        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -333,7 +333,7 @@ def string() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.string(),
-        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -394,7 +394,7 @@ def categorical() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.categorical(),
-        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -454,7 +454,7 @@ def all() -> Selector:
     """
     return Selector(
         lambda plx: plx.selectors.all(),
-        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 
@@ -515,7 +515,7 @@ def datetime(
     """
     return Selector(
         lambda plx: plx.selectors.datetime(time_unit=time_unit, time_zone=time_zone),
-        ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+        ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
     )
 
 

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -15,6 +15,8 @@ import narwhals as nw
 from narwhals import dependencies
 from narwhals import exceptions
 from narwhals import selectors
+from narwhals._expression_parsing import ExprKind
+from narwhals._expression_parsing import ExprMetadata
 from narwhals.dataframe import DataFrame as NwDataFrame
 from narwhals.dataframe import LazyFrame as NwLazyFrame
 from narwhals.dependencies import get_polars
@@ -67,8 +69,6 @@ from narwhals.translate import get_native_namespace
 from narwhals.translate import to_py_scalar
 from narwhals.typing import IntoDataFrameT
 from narwhals.typing import IntoFrameT
-from narwhals.utils import ExprKind
-from narwhals.utils import ExprMetadata
 from narwhals.utils import Implementation
 from narwhals.utils import Version
 from narwhals.utils import find_stacklevel

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -67,6 +67,8 @@ from narwhals.translate import get_native_namespace
 from narwhals.translate import to_py_scalar
 from narwhals.typing import IntoDataFrameT
 from narwhals.typing import IntoFrameT
+from narwhals.utils import ExprKind
+from narwhals.utils import ExprMetadata
 from narwhals.utils import Implementation
 from narwhals.utils import Version
 from narwhals.utils import find_stacklevel
@@ -1016,7 +1018,7 @@ class Expr(NwExpr):
             lambda plx: self._to_compliant_expr(plx).unique(),
             ExprMetadata(
                 kind=ExprKind.CHANGES_LENGTH,
-                is_order_dependent=self._metadata._is_order_dependent,
+                is_order_dependent=self._metadata["is_order_dependent"],
             ),
         )
 
@@ -1034,7 +1036,7 @@ class Expr(NwExpr):
             lambda plx: self._to_compliant_expr(plx).sort(
                 descending=descending, nulls_last=nulls_last
             ),
-            ExprMetadata(self._metadata.kind, is_order_dependent=True),
+            ExprMetadata(kind=self._metadata["kind"], is_order_dependent=True),
         )
 
     def arg_true(self: Self) -> Self:
@@ -1126,12 +1128,7 @@ def _stableify(
             level=obj._level,
         )
     if isinstance(obj, NwExpr):
-        return Expr(
-            obj._to_compliant_expr,
-            is_order_dependent=obj._is_order_dependent,
-            changes_length=obj._changes_length,
-            aggregates=obj._aggregates,
-        )
+        return Expr(obj._to_compliant_expr, obj._metadata)
     return obj
 
 
@@ -2090,10 +2087,7 @@ class Then(NwThen, Expr):
     @classmethod
     def from_then(cls: type, then: NwThen) -> Then:
         return cls(  # type: ignore[no-any-return]
-            then._to_compliant_expr,
-            is_order_dependent=then._is_order_dependent,
-            changes_length=then._changes_length,
-            aggregates=then._aggregates,
+            then._to_compliant_expr, then._metadata
         )
 
     def otherwise(self: Self, value: Any) -> Expr:

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -963,9 +963,7 @@ class Expr(NwExpr):
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).head(n),
-            is_order_dependent=True,
-            changes_length=True,
-            aggregates=self._aggregates,
+            ExprMetadata(kind=ExprKind.CHANGES_LENGTH, is_order_dependent=True),
         )
 
     def tail(self: Self, n: int = 10) -> Self:
@@ -979,9 +977,7 @@ class Expr(NwExpr):
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).tail(n),
-            is_order_dependent=True,
-            changes_length=True,
-            aggregates=self._aggregates,
+            ExprMetadata(kind=ExprKind.CHANGES_LENGTH, is_order_dependent=True),
         )
 
     def gather_every(self: Self, n: int, offset: int = 0) -> Self:
@@ -996,9 +992,7 @@ class Expr(NwExpr):
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).gather_every(n=n, offset=offset),
-            is_order_dependent=True,
-            changes_length=True,
-            aggregates=self._aggregates,
+            ExprMetadata(kind=ExprKind.CHANGES_LENGTH, is_order_dependent=True),
         )
 
     def unique(self: Self, *, maintain_order: bool | None = None) -> Self:
@@ -1020,9 +1014,10 @@ class Expr(NwExpr):
             warn(message=msg, category=UserWarning, stacklevel=find_stacklevel())
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).unique(),
-            self._is_order_dependent,
-            changes_length=True,
-            aggregates=self._aggregates,
+            ExprMetadata(
+                kind=ExprKind.CHANGES_LENGTH,
+                is_order_dependent=self._metadata._is_order_dependent,
+            ),
         )
 
     def sort(self: Self, *, descending: bool = False, nulls_last: bool = False) -> Self:
@@ -1039,9 +1034,7 @@ class Expr(NwExpr):
             lambda plx: self._to_compliant_expr(plx).sort(
                 descending=descending, nulls_last=nulls_last
             ),
-            is_order_dependent=True,
-            changes_length=self._changes_length,
-            aggregates=self._aggregates,
+            ExprMetadata(self._metadata.kind, is_order_dependent=True),
         )
 
     def arg_true(self: Self) -> Self:
@@ -1052,9 +1045,7 @@ class Expr(NwExpr):
         """
         return self.__class__(
             lambda plx: self._to_compliant_expr(plx).arg_true(),
-            is_order_dependent=True,
-            changes_length=True,
-            aggregates=self._aggregates,
+            ExprMetadata(kind=ExprKind.CHANGES_LENGTH, is_order_dependent=True),
         )
 
     def sample(
@@ -1088,9 +1079,7 @@ class Expr(NwExpr):
             lambda plx: self._to_compliant_expr(plx).sample(
                 n, fraction=fraction, with_replacement=with_replacement, seed=seed
             ),
-            is_order_dependent=True,
-            changes_length=True,
-            aggregates=self._aggregates,
+            ExprMetadata(kind=ExprKind.CHANGES_LENGTH, is_order_dependent=True),
         )
 
 

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -1283,4 +1283,4 @@ def combine_metadata(*args: IntoExpr) -> ExprMetadata:
 
     if isinstance(args[0], Expr):
         return args[0]._metadata
-    return ExprMetadata(ExprKind.LITERAL, is_order_dependent=False)
+    return ExprMetadata(kind=ExprKind.LITERAL, is_order_dependent=False)

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -6,7 +6,7 @@ from datetime import timezone
 from enum import Enum
 from enum import auto
 from secrets import token_hex
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 from typing import Any
 from typing import Iterable
 from typing import Sequence
@@ -1253,3 +1253,22 @@ def has_native_namespace(obj: Any) -> TypeIs[SupportsNativeNamespace]:
 
 def _supports_dataframe_interchange(obj: Any) -> TypeIs[DataFrameLike]:
     return hasattr(obj, "__dataframe__")
+
+class ExprKind(Enum):
+    """Describe which kind of expression we are dealing with.
+
+    Composition rule is:
+    - LITERAL vs LITERAL -> LITERAL
+    - TRANSFORM vs anything -> TRANSFORM
+    - anything vs TRANSFORM -> TRANSFORM
+    - all remaining cases -> AGGREGATION
+    """
+
+    LITERAL = auto()  # e.g. nw.lit(1)
+    AGGREGATION = auto()  # e.g. nw.col('a').mean()
+    TRANSFORM = auto()  # e.g. nw.col('a').round()
+    CHANGES_LENGTH = auto()  # e.g. nw.col('a').drop_nulls()
+
+class ExprMetadata(TypedDict):
+    kind: ExprKind
+    is_order_dependent: bool

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -6,10 +6,11 @@ from datetime import timezone
 from enum import Enum
 from enum import auto
 from secrets import token_hex
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterable
 from typing import Sequence
+from typing import TypedDict
 from typing import TypeVar
 from typing import Union
 from typing import cast
@@ -1254,6 +1255,7 @@ def has_native_namespace(obj: Any) -> TypeIs[SupportsNativeNamespace]:
 def _supports_dataframe_interchange(obj: Any) -> TypeIs[DataFrameLike]:
     return hasattr(obj, "__dataframe__")
 
+
 class ExprKind(Enum):
     """Describe which kind of expression we are dealing with.
 
@@ -1269,6 +1271,11 @@ class ExprKind(Enum):
     TRANSFORM = auto()  # e.g. nw.col('a').round()
     CHANGES_LENGTH = auto()  # e.g. nw.col('a').drop_nulls()
 
+
 class ExprMetadata(TypedDict):
     kind: ExprKind
     is_order_dependent: bool
+
+
+def combine_metadata(*args):
+    return args[0]._metadata

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -1279,7 +1279,7 @@ class ExprMetadata(TypedDict):
 
 
 def combine_metadata(*args: IntoExpr) -> ExprMetadata:
-    # do we need a column_names_as_string argument?
+    # Strings are interpreted as column names.
     from narwhals.expr import Expr
 
     kind = ExprKind.AGGREGATION

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -36,6 +36,7 @@ from narwhals.dependencies import is_pyarrow_chunked_array
 from narwhals.exceptions import ColumnNotFoundError
 from narwhals.exceptions import DuplicateError
 from narwhals.exceptions import InvalidOperationError
+from narwhals.exceptions import LengthChangingExprError
 from narwhals.exceptions import ShapeError
 
 if TYPE_CHECKING:
@@ -1312,7 +1313,7 @@ def combine_metadata(*args: IntoExpr) -> ExprMetadata:
         kind = ExprKind.LITERAL
     elif n_changes_length > 1:
         msg = "Length-changing expressions can only be used in isolation, or followed by an aggregation"
-        raise ValueError(msg)
+        raise LengthChangingExprError(msg)
     elif n_changes_length and n_transforms:
         msg = "Cannot combine length-changing expressions with length-preserving ones"
         raise ShapeError(msg)

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from narwhals.typing import CompliantSeriesT_co
     from narwhals.typing import DataFrameLike
     from narwhals.typing import DTypes
+    from narwhals.typing import IntoExpr
     from narwhals.typing import IntoSeriesT
     from narwhals.typing import SizeUnit
     from narwhals.typing import SupportsNativeNamespace
@@ -1277,5 +1278,9 @@ class ExprMetadata(TypedDict):
     is_order_dependent: bool
 
 
-def combine_metadata(*args):
-    return args[0]._metadata
+def combine_metadata(*args: IntoExpr) -> ExprMetadata:
+    from narwhals.expr import Expr
+
+    if isinstance(args[0], Expr):
+        return args[0]._metadata
+    return ExprMetadata(ExprKind.LITERAL, is_order_dependent=False)

--- a/tests/expr_and_series/order_dependent_lazy_test.py
+++ b/tests/expr_and_series/order_dependent_lazy_test.py
@@ -23,6 +23,13 @@ def test_order_dependent_raises_in_lazy(constructor: Constructor) -> None:
     with pytest.raises(OrderDependentExprError, match="Order-dependent expressions"):
         lf.select(nw.sum_horizontal(nw.col("a").diff(), nw.col("a")))
 
+    for agg in ["max", "min", "mean", "sum", "median", "std", "var"]:
+        with pytest.raises(OrderDependentExprError, match="Order-dependent expressions"):
+            lf.select(getattr(nw.col("a").diff(), agg)())
+    for agg in ["any", "all"]:
+        with pytest.raises(OrderDependentExprError, match="Order-dependent expressions"):
+            lf.select(getattr((nw.col("a").diff() > 0), agg)())
+
 
 def test_dask_order_dependent_ops() -> None:
     # Preserve these for narwhals.stable.v1, even though they

--- a/tests/expr_and_series/order_dependent_lazy_test.py
+++ b/tests/expr_and_series/order_dependent_lazy_test.py
@@ -20,6 +20,8 @@ def test_order_dependent_raises_in_lazy(constructor: Constructor) -> None:
         lf.select(nw.col("a").diff())
     with pytest.raises(OrderDependentExprError, match="Order-dependent expressions"):
         lf.select(nw.sum_horizontal(nw.col("a").diff()))
+    with pytest.raises(OrderDependentExprError, match="Order-dependent expressions"):
+        lf.select(nw.sum_horizontal(nw.col("a").diff(), nw.col("a")))
 
 
 def test_dask_order_dependent_ops() -> None:

--- a/tests/expr_and_series/order_dependent_lazy_test.py
+++ b/tests/expr_and_series/order_dependent_lazy_test.py
@@ -18,6 +18,8 @@ def test_order_dependent_raises_in_lazy(constructor: Constructor) -> None:
     lf = nw.from_native(constructor({"a": [1, 2, 3]})).lazy()
     with pytest.raises(OrderDependentExprError, match="Order-dependent expressions"):
         lf.select(nw.col("a").diff())
+    with pytest.raises(OrderDependentExprError, match="Order-dependent expressions"):
+        lf.select(nw.sum_horizontal(nw.col("a").diff()))
 
 
 def test_dask_order_dependent_ops() -> None:

--- a/tests/expr_and_series/unique_test.py
+++ b/tests/expr_and_series/unique_test.py
@@ -7,6 +7,7 @@ import pytest
 import narwhals as nw
 import narwhals.stable.v1 as nw_v1
 from narwhals.exceptions import LengthChangingExprError
+from narwhals.exceptions import ShapeError
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -43,6 +44,8 @@ def test_unique_illegal_combination(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     with pytest.raises(LengthChangingExprError):
         df.select((nw.col("a").unique() + nw.col("b").unique()).sum())
+    with pytest.raises(ShapeError):
+        df.select(nw.col("a").unique() + nw.col("b"))
 
 
 def test_unique_series(constructor_eager: ConstructorEager) -> None:

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -6,8 +6,8 @@ import sys
 import polars as pl
 
 import narwhals as nw
-from narwhals.utils import ExprKind
-from narwhals.utils import ExprMetadata
+from narwhals._expression_parsing import ExprKind
+from narwhals._expression_parsing import ExprMetadata
 from narwhals.utils import remove_prefix
 from narwhals.utils import remove_suffix
 

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -6,7 +6,9 @@ import sys
 import polars as pl
 
 import narwhals as nw
-from narwhals.utils import remove_prefix, ExprMetadata, ExprKind
+from narwhals.utils import ExprKind
+from narwhals.utils import ExprMetadata
+from narwhals.utils import remove_prefix
 from narwhals.utils import remove_suffix
 
 ret = 0
@@ -163,7 +165,7 @@ for namespace in NAMESPACES.difference({"name"}):
 expr_methods = [
     i
     for i in nw.Expr(
-        lambda: 0, ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+        lambda: 0, ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
     ).__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
@@ -189,8 +191,7 @@ for namespace in NAMESPACES:
         i
         for i in getattr(
             nw.Expr(
-                lambda: 0,
-                ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+                lambda: 0, ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
             ),
             namespace,
         ).__dir__()
@@ -236,9 +237,7 @@ if extra := set(documented).difference(dtypes):
 expr = [
     i
     for i in nw.Expr(
-        lambda: 0,
-                ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
-
+        lambda: 0, ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
     ).__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
@@ -262,9 +261,7 @@ for namespace in NAMESPACES.difference({"name"}):
         i
         for i in getattr(
             nw.Expr(
-                lambda: 0,
-
-                ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+                lambda: 0, ExprMetadata(kind=ExprKind.TRANSFORM, is_order_dependent=False)
             ),
             namespace,
         ).__dir__()

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -6,7 +6,7 @@ import sys
 import polars as pl
 
 import narwhals as nw
-from narwhals.utils import remove_prefix
+from narwhals.utils import remove_prefix, ExprMetadata, ExprKind
 from narwhals.utils import remove_suffix
 
 ret = 0
@@ -163,7 +163,7 @@ for namespace in NAMESPACES.difference({"name"}):
 expr_methods = [
     i
     for i in nw.Expr(
-        lambda: 0, is_order_dependent=False, changes_length=False, aggregates=False
+        lambda: 0, ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
     ).__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
@@ -190,9 +190,7 @@ for namespace in NAMESPACES:
         for i in getattr(
             nw.Expr(
                 lambda: 0,
-                is_order_dependent=False,
-                changes_length=False,
-                aggregates=False,
+                ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
             ),
             namespace,
         ).__dir__()
@@ -238,7 +236,9 @@ if extra := set(documented).difference(dtypes):
 expr = [
     i
     for i in nw.Expr(
-        lambda: 0, is_order_dependent=False, changes_length=False, aggregates=False
+        lambda: 0,
+                ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
+
     ).__dir__()
     if not i[0].isupper() and i[0] != "_"
 ]
@@ -263,9 +263,8 @@ for namespace in NAMESPACES.difference({"name"}):
         for i in getattr(
             nw.Expr(
                 lambda: 0,
-                is_order_dependent=False,
-                changes_length=False,
-                aggregates=False,
+
+                ExprMetadata(ExprKind.TRANSFORM, is_order_dependent=False)
             ),
             namespace,
         ).__dir__()


### PR DESCRIPTION
First step towards #1848 

No noticeable difference in perf when running this locally

Theoretically, I'd expect it to make things not-worse, as we're not only looping through `args` once to construct `ExprMetadata`, as opposed to 4 times

But the main reason to do this is to aim towards #1848 , after which, implementations at the compliant level should become much simpler and easier to reason about

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
