### PR TITLE
feat: support casting to and from spark-like structs

### DIFF
--- a/tests/expr_and_series/cast_test.py
+++ b/tests/expr_and_series/cast_test.py
@@ -259,7 +259,7 @@ def test_cast_struct(request: pytest.FixtureRequest, constructor: Constructor) -
     assert result.schema == {"a": dtype}
 
 
-def test_cast_struct_pyspark() -> None:
+def test_cast_struct_pyspark() -> None:  # pragma: no cover
     pytest.importorskip("pyspark")
 
     from pyspark.sql import SparkSession

--- a/tests/expr_and_series/cast_test.py
+++ b/tests/expr_and_series/cast_test.py
@@ -251,7 +251,7 @@ def test_cast_struct(request: pytest.FixtureRequest, constructor: Constructor) -
 
     native_df = constructor(data)
 
-    if "spark" in str(constructor):
+    if "spark" in str(constructor):  # pragma: no cover
         # Special handling for pyspark as it natively maps the input to
         # a column of type MAP<STRING, STRING>
         import pyspark.sql.functions as F  # noqa: N812

--- a/tests/expr_and_series/cast_test.py
+++ b/tests/expr_and_series/cast_test.py
@@ -257,7 +257,7 @@ def test_cast_struct(request: pytest.FixtureRequest, constructor: Constructor) -
         import pyspark.sql.functions as F  # noqa: N812
         import pyspark.sql.types as T  # noqa: N812
 
-        native_df = native_df.withColumn(
+        native_df = native_df.withColumn(  # type: ignore[union-attr]
             "a",
             F.struct(
                 F.col("a.movie ").alias("movie ").cast(T.StringType()),


### PR DESCRIPTION
## Reason

There are multiple reason for this PR to happen 😁

- Eventually I would like to support `Schema.to_pyspark`
- For some integration it might be useful to have: 
  - `nw.struct` emulating [`pl.struct`](https://docs.pola.rs/api/python/dev/reference/expressions/api/polars.struct.html)
  - `.struct.unnest()` and/or `Frame.unnest`

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #1743

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

I am having a hard time testing this 🤔
