### PR TITLE
chore: determine whether to use compliant_frame.aggregate at narwhals level

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -341,6 +341,9 @@ class ArrowDataFrame(CompliantDataFrame, CompliantLazyFrame):
             self._native_frame.select(list(column_names)), validate_column_names=False
         )
 
+    def aggregate(self: Self, *exprs: IntoArrowExpr) -> Self:
+        return self.select(*exprs)
+
     def select(self: Self, *exprs: IntoArrowExpr) -> Self:
         new_series: list[ArrowSeries] = evaluate_into_exprs(self, *exprs)
         if not new_series:

--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -9,7 +9,7 @@ import dask.dataframe as dd
 import pandas as pd
 
 from narwhals._dask.utils import add_row_index
-from narwhals._dask.utils import parse_exprs_and_named_exprs
+from narwhals._dask.utils import parse_exprs
 from narwhals._pandas_like.utils import check_column_names_are_unique
 from narwhals._pandas_like.utils import native_to_narwhals_dtype
 from narwhals._pandas_like.utils import select_columns_by_name
@@ -86,7 +86,7 @@ class DaskLazyFrame(CompliantLazyFrame):
 
     def with_columns(self: Self, *exprs: DaskExpr) -> Self:
         df = self._native_frame
-        new_series = parse_exprs_and_named_exprs(self, *exprs)
+        new_series = parse_exprs(self, *exprs)
         df = df.assign(**new_series)
         return self._from_native_frame(df)
 
@@ -159,8 +159,15 @@ class DaskLazyFrame(CompliantLazyFrame):
             validate_column_names=False,
         )
 
+    def aggregate(self: Self, *exprs: DaskExpr) -> Self:
+        new_series = parse_exprs(self, *exprs)
+        df = dd.concat(
+            [val.to_series().rename(name) for name, val in new_series.items()], axis=1
+        )
+        return self._from_native_frame(df, validate_column_names=False)
+
     def select(self: Self, *exprs: DaskExpr) -> Self:
-        new_series = parse_exprs_and_named_exprs(self, *exprs)
+        new_series = parse_exprs(self, *exprs)
 
         if not new_series:
             # return empty dataframe, like Polars does

--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -178,12 +178,6 @@ class DaskLazyFrame(CompliantLazyFrame):
                 validate_column_names=False,
             )
 
-        if all(getattr(expr, "_returns_scalar", False) for expr in exprs):
-            df = dd.concat(
-                [val.to_series().rename(name) for name, val in new_series.items()], axis=1
-            )
-            return self._from_native_frame(df, validate_column_names=False)
-
         df = select_columns_by_name(
             self._native_frame.assign(**new_series),
             list(new_series.keys()),

--- a/narwhals/_dask/utils.py
+++ b/narwhals/_dask/utils.py
@@ -44,9 +44,7 @@ def maybe_evaluate(df: DaskLazyFrame, obj: Any) -> Any:
     return obj
 
 
-def parse_exprs_and_named_exprs(
-    df: DaskLazyFrame, /, *exprs: DaskExpr
-) -> dict[str, dx.Series]:
+def parse_exprs(df: DaskLazyFrame, /, *exprs: DaskExpr) -> dict[str, dx.Series]:
     native_results: dict[str, dx.Series] = {}
     for expr in exprs:
         native_series_list = expr._call(df)

--- a/narwhals/_duckdb/utils.py
+++ b/narwhals/_duckdb/utils.py
@@ -57,7 +57,7 @@ def maybe_evaluate(df: DuckDBLazyFrame, obj: Any, *, expr_kind: ExprKind) -> Any
     return duckdb.ConstantExpression(obj)
 
 
-def parse_exprs_and_named_exprs(
+def parse_exprs(
     df: DuckDBLazyFrame, /, *exprs: DuckDBExpr
 ) -> dict[str, duckdb.Expression]:
     native_results: dict[str, duckdb.Expression] = {}

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -25,7 +25,6 @@ from narwhals.utils import is_compliant_series
 if TYPE_CHECKING:
     from narwhals._arrow.expr import ArrowExpr
     from narwhals._pandas_like.expr import PandasLikeExpr
-    from narwhals.expr import Expr
     from narwhals.typing import CompliantDataFrame
     from narwhals.typing import CompliantExpr
     from narwhals.typing import CompliantLazyFrame
@@ -443,13 +442,18 @@ def check_expressions_transform(*args: IntoExpr, function_name: str) -> None:
         raise ShapeError(msg)
 
 
-def all_expressions_aggregate(*args: Expr, **kwargs: Expr) -> bool:
+def all_expressions_aggregate(*args: IntoExpr, **kwargs: IntoExpr) -> bool:
     # Raise if any argument in `args` isn't an aggregation or literal.
     # For Series input, we don't raise (yet), we let such checks happen later,
     # as this function works lazily and so can't evaluate lengths.
+    from narwhals import Expr
+
     return all(
-        x._metadata["kind"] in (ExprKind.AGGREGATION, ExprKind.LITERAL) for x in args
+        isinstance(x, Expr)
+        and x._metadata["kind"] in (ExprKind.AGGREGATION, ExprKind.LITERAL)
+        for x in args
     ) and all(
-        x._metadata["kind"] in (ExprKind.AGGREGATION, ExprKind.LITERAL)
+        isinstance(x, Expr)
+        and x._metadata["kind"] in (ExprKind.AGGREGATION, ExprKind.LITERAL)
         for x in kwargs.values()
     )

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -442,7 +442,7 @@ def check_expressions_transform(*args: IntoExpr, function_name: str) -> None:
         raise ShapeError(msg)
 
 
-def all_expressions_aggregate(*args: IntoExpr, **kwargs: IntoExpr) -> bool:
+def all_exprs_are_aggs_or_literals(*args: IntoExpr, **kwargs: IntoExpr) -> bool:
     # Raise if any argument in `args` isn't an aggregation or literal.
     # For Series input, we don't raise (yet), we let such checks happen later,
     # as this function works lazily and so can't evaluate lengths.

--- a/narwhals/_ibis/dataframe.py
+++ b/narwhals/_ibis/dataframe.py
@@ -110,6 +110,9 @@ class IbisLazyFrame:
     def simple_select(self, *column_names: str) -> Self:
         return self._from_native_frame(self._native_frame.select(s.cols(*column_names)))
 
+    def aggregate(self: Self, *exprs: Any) -> Self:
+        raise NotImplementedError
+
     def select(
         self: Self,
         *exprs: Any,

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -387,6 +387,9 @@ class PandasLikeDataFrame(CompliantDataFrame, CompliantLazyFrame):
             validate_column_names=False,
         )
 
+    def aggregate(self: Self, *exprs: IntoPandasLikeExpr) -> Self:
+        return self.select(*exprs)
+
     def select(
         self: Self,
         *exprs: IntoPandasLikeExpr,

--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -220,6 +220,9 @@ class PolarsDataFrame:
     def simple_select(self, *column_names: str) -> Self:
         return self._from_native_frame(self._native_frame.select(*column_names))
 
+    def aggregate(self: Self, *exprs: Any) -> Self:
+        return self.select(*exprs)  # type: ignore[no-any-return]
+
     def get_column(self: Self, name: str) -> PolarsSeries:
         from narwhals._polars.series import PolarsSeries
 
@@ -544,3 +547,6 @@ class PolarsLazyFrame:
 
     def simple_select(self, *column_names: str) -> Self:
         return self._from_native_frame(self._native_frame.select(*column_names))
+
+    def aggregate(self: Self, *exprs: Any) -> Self:
+        return self.select(*exprs)  # type: ignore[no-any-return]

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -141,7 +141,7 @@ def narwhals_to_native_dtype(
     raise AssertionError(msg)
 
 
-def parse_exprs_and_named_exprs(
+def parse_exprs(
     df: SparkLikeLazyFrame, /, *exprs: SparkLikeExpr
 ) -> tuple[dict[str, Column], list[ExprKind]]:
     native_results: dict[str, list[Column]] = {}

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -162,7 +162,7 @@ class BaseFrame(Generic[_FrameT]):
                     missing_columns, available_columns
                 ) from e
         compliant_exprs = self._flatten_and_extract(*flat_exprs, **named_exprs)
-        if flat_exprs and all_expressions_aggregate(*flat_exprs):
+        if flat_exprs and all_expressions_aggregate(*flat_exprs, **named_exprs):
             return self._from_compliant_dataframe(
                 self._compliant_frame.aggregate(*compliant_exprs),
             )

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -162,7 +162,9 @@ class BaseFrame(Generic[_FrameT]):
                     missing_columns, available_columns
                 ) from e
         compliant_exprs = self._flatten_and_extract(*flat_exprs, **named_exprs)
-        if flat_exprs and all_exprs_are_aggs_or_literals(*flat_exprs, **named_exprs):
+        if (flat_exprs or named_exprs) and all_exprs_are_aggs_or_literals(
+            *flat_exprs, **named_exprs
+        ):
             return self._from_compliant_dataframe(
                 self._compliant_frame.aggregate(*compliant_exprs),
             )

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -16,7 +16,7 @@ from typing import overload
 from warnings import warn
 
 from narwhals._expression_parsing import ExprKind
-from narwhals._expression_parsing import all_expressions_aggregate
+from narwhals._expression_parsing import all_exprs_are_aggs_or_literals
 from narwhals._expression_parsing import check_expressions_transform
 from narwhals.dependencies import get_polars
 from narwhals.dependencies import is_numpy_array
@@ -162,7 +162,7 @@ class BaseFrame(Generic[_FrameT]):
                     missing_columns, available_columns
                 ) from e
         compliant_exprs = self._flatten_and_extract(*flat_exprs, **named_exprs)
-        if flat_exprs and all_expressions_aggregate(*flat_exprs, **named_exprs):
+        if flat_exprs and all_exprs_are_aggs_or_literals(*flat_exprs, **named_exprs):
             return self._from_compliant_dataframe(
                 self._compliant_frame.aggregate(*compliant_exprs),
             )

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -57,7 +57,11 @@ class Expr:
         # This is just used to test out the stable api feature in a realistic-ish way.
         # It's not intended to be used.
         return self.__class__(
-            lambda plx: self._to_compliant_expr(plx).abs().sum(), self._metadata
+            lambda plx: self._to_compliant_expr(plx).abs().sum(),
+            ExprMetadata(
+                kind=ExprKind.AGGREGATION,
+                is_order_dependent=self._metadata["is_order_dependent"],
+            ),
         )
 
     # --- convert ---

--- a/narwhals/group_by.py
+++ b/narwhals/group_by.py
@@ -8,7 +8,7 @@ from typing import Iterator
 from typing import TypeVar
 from typing import cast
 
-from narwhals._expression_parsing import all_expressions_aggregate
+from narwhals._expression_parsing import all_exprs_are_aggs_or_literals
 from narwhals.dataframe import DataFrame
 from narwhals.dataframe import LazyFrame
 from narwhals.exceptions import InvalidOperationError
@@ -113,7 +113,7 @@ class GroupBy(Generic[DataFrameT]):
             └─────┴─────┴─────┘
         """
         flat_aggs = tuple(flatten(aggs))
-        if not all_expressions_aggregate(*flat_aggs, **named_aggs):
+        if not all_exprs_are_aggs_or_literals(*flat_aggs, **named_aggs):
             msg = (
                 "Found expression which does not aggregate.\n\n"
                 "All expressions passed to GroupBy.agg must aggregate.\n"
@@ -215,7 +215,7 @@ class LazyGroupBy(Generic[LazyFrameT]):
             └─────┴─────┴─────┘
         """
         flat_aggs = tuple(flatten(aggs))
-        if not all_expressions_aggregate(*flat_aggs, **named_aggs):
+        if not all_exprs_are_aggs_or_literals(*flat_aggs, **named_aggs):
             msg = (
                 "Found expression which does not aggregate.\n\n"
                 "All expressions passed to GroupBy.agg must aggregate.\n"

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -49,19 +49,25 @@ class CompliantSeries(Protocol):
 
 
 class CompliantDataFrame(Protocol):
-    def __narwhals_dataframe__(self) -> CompliantDataFrame: ...
+    def __narwhals_dataframe__(self) -> Self: ...
     def __narwhals_namespace__(self) -> Any: ...
     def simple_select(
         self, *column_names: str
-    ) -> CompliantDataFrame: ...  # `select` where all args are column names
+    ) -> Self: ...  # `select` where all args are column names.
+    def aggregate(self, *exprs: Any) -> Self:
+        ...  # `select` where all args are aggregations or literals
+        # (so, no broadcasting is necessary).
 
 
 class CompliantLazyFrame(Protocol):
-    def __narwhals_lazyframe__(self) -> CompliantLazyFrame: ...
+    def __narwhals_lazyframe__(self) -> Self: ...
     def __narwhals_namespace__(self) -> Any: ...
     def simple_select(
         self, *column_names: str
-    ) -> CompliantLazyFrame: ...  # `select` where all args are column names
+    ) -> Self: ...  # `select` where all args are column names.
+    def aggregate(self, *exprs: Any) -> Self:
+        ...  # `select` where all args are aggregations or literals
+        # (so, no broadcasting is necessary).
 
 
 CompliantSeriesT_co = TypeVar(


### PR DESCRIPTION
I'm hoping to get to the point where we don't even need `ExprKind`, or any logic to do broadcasting, at the compliant level

I think we're not that far off

We may need to introduce something like `CompliantNamespace.broadcast_exprs` and then determine at the Narwhals level when to call it

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
