### PR TITLE
perf: avoid try/except in _hasattr_static

### DIFF
--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -1277,11 +1277,8 @@ def dtype_matches_time_unit_and_time_zone(
 
 
 def _hasattr_static(obj: Any, attr: str) -> bool:
-    try:
-        getattr_static(obj, attr)
-    except AttributeError:
-        return False
-    return True
+    sentinel = object()
+    return getattr_static(obj, attr, sentinel) is not sentinel
 
 
 def is_compliant_dataframe(obj: Any) -> TypeIs[CompliantDataFrame]:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

In #2011 @dangotbanned pointed out that `try/except` is expensive in Python<3.11 and opted to use a sentinel to avoid those statements.

This codepath is triggered 3 times for every call to `from_native` so it will be regularly hit multiple times by end users so this could be worth doing.