### PR TITLE
tests: Allow to run pytest narwhals --doctest-modules without ibis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ required-imports = ["from __future__ import annotations"]
 docstring-code-format = true
 
 [tool.pytest.ini_options]
-norecursedirs =  ['*.egg', '.*', '_darcs', 'build', 'CVS', 'dist', 'node_modules', 'venv', '{arch}', "_ibis"]
+norecursedirs =  ['*.egg', '.*', '_darcs', 'build', 'CVS', 'dist', 'node_modules', 'venv', '{arch}', 'narwhals/_*']
 testpaths = ["tests"]
 filterwarnings = [
   "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ required-imports = ["from __future__ import annotations"]
 docstring-code-format = true
 
 [tool.pytest.ini_options]
+norecursedirs =  ['*.egg', '.*', '_darcs', 'build', 'CVS', 'dist', 'node_modules', 'venv', '{arch}', "_ibis"]
 testpaths = ["tests"]
 filterwarnings = [
   "error",


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #2017
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

@FBruzzesi : I'm not sure if you meant (in the issue) that we should detect automatically the dependencies that we want to skip...? In case we only need to skip ibis, this does it. 

Per the link you shared about `norecursedirs` : "Default patterns are '*.egg', '.*', '_darcs', 'build', 'CVS', 'dist', 'node_modules', 'venv', '{arch}'. Setting a `norecursedirs` replaces the default."