### PR TITLE
refactor(typing): Add `__getitem__` selector aliases

### DIFF
--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -49,6 +49,10 @@ if TYPE_CHECKING:
     from narwhals._pandas_like.group_by import PandasLikeGroupBy
     from narwhals._pandas_like.namespace import PandasLikeNamespace
     from narwhals.dtypes import DType
+    from narwhals.typing import MultiColSelector
+    from narwhals.typing import MultiIndexSelector
+    from narwhals.typing import SingleColSelector
+    from narwhals.typing import SingleIndexSelector
     from narwhals.typing import SizeUnit
     from narwhals.typing import _1DArray
     from narwhals.typing import _2DArray
@@ -161,38 +165,38 @@ class PandasLikeDataFrame(CompliantDataFrame, CompliantLazyFrame):
         return self.to_numpy(dtype=dtype, copy=copy)
 
     @overload
+    def __getitem__(
+        self: Self, item: tuple[SingleIndexSelector, SingleColSelector]
+    ) -> Any: ...
+
+    @overload
     def __getitem__(  # type: ignore[overload-overlap]
         self: Self,
-        item: str | tuple[slice | Sequence[int] | _1DArray, int | str],
+        item: str | tuple[MultiIndexSelector, SingleColSelector],
     ) -> PandasLikeSeries: ...
 
     @overload
     def __getitem__(
         self: Self,
         item: (
-            int
-            | slice
-            | Sequence[int]
-            | Sequence[str]
-            | _1DArray
-            | tuple[
-                slice | Sequence[int] | _1DArray, slice | Sequence[int] | Sequence[str]
-            ]
+            SingleIndexSelector
+            | MultiIndexSelector
+            | MultiColSelector
+            | tuple[SingleIndexSelector, MultiColSelector]
+            | tuple[MultiIndexSelector, MultiColSelector]
         ),
     ) -> Self: ...
     def __getitem__(
         self: Self,
         item: (
-            str
-            | int
-            | slice
-            | Sequence[int]
-            | Sequence[str]
-            | _1DArray
-            | tuple[slice | Sequence[int] | _1DArray, int | str]
-            | tuple[
-                slice | Sequence[int] | _1DArray, slice | Sequence[int] | Sequence[str]
-            ]
+            SingleIndexSelector
+            | SingleColSelector
+            | MultiColSelector
+            | MultiIndexSelector
+            | tuple[SingleIndexSelector, SingleColSelector]
+            | tuple[SingleIndexSelector, MultiColSelector]
+            | tuple[MultiIndexSelector, SingleColSelector]
+            | tuple[MultiIndexSelector, MultiColSelector]
         ),
     ) -> PandasLikeSeries | Self:
         if isinstance(item, tuple):

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -268,9 +268,58 @@ TimeUnit: TypeAlias = Literal["ns", "us", "ms", "s"]
 
 _ShapeT = TypeVar("_ShapeT", bound="tuple[int, ...]")
 _NDArray: TypeAlias = "np.ndarray[_ShapeT, Any]"
-_1DArray: TypeAlias = "_NDArray[tuple[int]]"  # noqa: PYI042, PYI047
+_1DArray: TypeAlias = "_NDArray[tuple[int]]"  # noqa: PYI042
 _2DArray: TypeAlias = "_NDArray[tuple[int, int]]"  # noqa: PYI042, PYI047
 _AnyDArray: TypeAlias = "_NDArray[tuple[int, ...]]"  # noqa: PYI047
+
+
+# Annotations for `__getitem__` methods
+_Slice: TypeAlias = "slice[Any, Any, Any]"
+
+SingleIndexSelector: TypeAlias = int
+SingleNameSelector: TypeAlias = str
+
+MultiIndexSelector: TypeAlias = Union[
+    _Slice,
+    Sequence[int],
+    _1DArray,
+    # IntoSeriesT, Would need support like (#2013)
+]
+MultiNameSelector: TypeAlias = Union[
+    _Slice,
+    Sequence[str],
+    _1DArray,
+    # IntoSeriesT, Would need support like (#2013)
+]
+BooleanMask: TypeAlias = Union[
+    Sequence[bool],
+    _1DArray,
+    # IntoSeriesT, Would need support like (#2013)
+]
+
+
+SingleColSelector: TypeAlias = "SingleIndexSelector | SingleNameSelector"
+MultiColSelector: TypeAlias = "MultiIndexSelector | MultiNameSelector | BooleanMask"
+
+# NOTE: Not keeping, but using as a reference for each backend
+Overload1: TypeAlias = "tuple[SingleIndexSelector, SingleColSelector]"
+Overload2: TypeAlias = "str | tuple[MultiIndexSelector, SingleColSelector]"
+Overload3: TypeAlias = """
+    SingleIndexSelector
+    | MultiIndexSelector
+    | MultiColSelector
+    | tuple[SingleIndexSelector, MultiColSelector]
+    | tuple[MultiIndexSelector, MultiColSelector]"""
+
+OverloadUnion: TypeAlias = """
+    SingleIndexSelector
+    | SingleColSelector
+    | MultiColSelector
+    | MultiIndexSelector
+    | tuple[SingleIndexSelector, SingleColSelector]
+    | tuple[SingleIndexSelector, MultiColSelector]
+    | tuple[MultiIndexSelector, SingleColSelector]
+    | tuple[MultiIndexSelector, MultiColSelector]"""
 
 
 class DTypes:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

Discussed in: 
- https://github.com/narwhals-dev/narwhals/pull/1963#issuecomment-2645456279
- https://github.com/narwhals-dev/narwhals/pull/1963#issuecomment-2645527746

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
- Just demonstrating what it looks like for a single backend (`pandas`)
  - Can do the others if anyone else is on board (*besides myself and @EdAbati*) 
- The goal is to have something that's *easier* to understand, than the current `@overload`(s)
- Stealing pretty directly from (https://github.com/pola-rs/polars/blob/4eb4fb7527d26d3ecf9b80cc4ad92809064f8c35/py-polars/polars/_typing.py#L281)

