### PR TITLE
chore(typing): relax `from_dict` to use `Mapping`

### DIFF
--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterable
 from typing import Literal
+from typing import Mapping
 from typing import Protocol
 from typing import Sequence
 from typing import TypeVar
@@ -291,8 +292,8 @@ def _new_series_impl(
 
 
 def from_dict(
-    data: dict[str, Any],
-    schema: dict[str, DType] | Schema | None = None,
+    data: Mapping[str, Any],
+    schema: Mapping[str, DType] | Schema | None = None,
     *,
     backend: ModuleType | Implementation | str | None = None,
     native_namespace: ModuleType | None = None,
@@ -348,8 +349,8 @@ def from_dict(
 
 
 def _from_dict_impl(
-    data: dict[str, Any],
-    schema: dict[str, DType] | Schema | None = None,
+    data: Mapping[str, Any],
+    schema: Mapping[str, DType] | Schema | None = None,
     *,
     backend: ModuleType | Implementation | str | None = None,
 ) -> DataFrame[Any]:

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -84,6 +84,7 @@ from narwhals.utils import validate_strict_and_pass_though
 
 if TYPE_CHECKING:
     from types import ModuleType
+    from typing import Mapping
 
     from typing_extensions import Self
 
@@ -2169,8 +2170,8 @@ def from_arrow(
 
 
 def from_dict(
-    data: dict[str, Any],
-    schema: dict[str, DType] | Schema | None = None,
+    data: Mapping[str, Any],
+    schema: Mapping[str, DType] | Schema | None = None,
     *,
     backend: ModuleType | Implementation | str | None = None,
     native_namespace: ModuleType | None = None,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Current `dict[str, Any]` will reject `Mapping[str, Sequence[Any]]`.
I noticed this in `altair`, where I needed to cast to `dict[str, Any]`:
- https://github.com/vega/altair/blob/ddda22c50f7265728dcec26afec02d6d0dbda189/altair/datasets/_reader.py#L362-L366
- https://github.com/vega/altair/blob/ddda22c50f7265728dcec26afec02d6d0dbda189/altair/datasets/_cache.py#L182

For reference, [`polars.from_dict`](https://docs.pola.rs/api/python/stable/reference/api/polars.from_dict.html) uses `Mapping` but with some constraints on the value type