### PR TITLE
fix(RFC): Use metaclass for safe `DType` attr access

### DIFF
--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
     from narwhals._arrow.typing import Incomplete
     from narwhals._arrow.typing import StringArray
     from narwhals.dtypes import DType
-    from narwhals.typing import TimeUnit
     from narwhals.typing import _AnyDArray
     from narwhals.utils import Version
 
@@ -182,12 +181,9 @@ def narwhals_to_native_dtype(dtype: DType | type[DType], version: Version) -> pa
     if isinstance_or_issubclass(dtype, dtypes.Categorical):
         return pa.dictionary(pa.uint32(), pa.string())
     if isinstance_or_issubclass(dtype, dtypes.Datetime):
-        time_unit: TimeUnit = getattr(dtype, "time_unit", "us")
-        time_zone = getattr(dtype, "time_zone", None)
-        return pa.timestamp(time_unit, tz=time_zone)
+        return pa.timestamp(dtype.time_unit, tz=dtype.time_zone)  # type: ignore[arg-type]
     if isinstance_or_issubclass(dtype, dtypes.Duration):
-        time_unit = getattr(dtype, "time_unit", "us")
-        return pa.duration(time_unit)
+        return pa.duration(dtype.time_unit)
     if isinstance_or_issubclass(dtype, dtypes.Date):
         return pa.date32()
     if isinstance_or_issubclass(dtype, dtypes.List):

--- a/narwhals/_duckdb/utils.py
+++ b/narwhals/_duckdb/utils.py
@@ -176,12 +176,12 @@ def narwhals_to_native_dtype(dtype: DType | type[DType], version: Version) -> st
         msg = "Categorical not supported by DuckDB"
         raise NotImplementedError(msg)
     if isinstance_or_issubclass(dtype, dtypes.Datetime):
-        _time_unit = getattr(dtype, "time_unit", "us")
-        _time_zone = getattr(dtype, "time_zone", None)
+        _time_unit = dtype.time_unit
+        _time_zone = dtype.time_zone
         msg = "todo"
         raise NotImplementedError(msg)
     if isinstance_or_issubclass(dtype, dtypes.Duration):  # pragma: no cover
-        _time_unit = getattr(dtype, "time_unit", "us")
+        _time_unit = dtype.time_unit
         msg = "todo"
         raise NotImplementedError(msg)
     if isinstance_or_issubclass(dtype, dtypes.Date):  # pragma: no cover

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -613,27 +613,26 @@ def narwhals_to_native_dtype(  # noqa: PLR0915
         # convert to it?
         return "category"
     if isinstance_or_issubclass(dtype, dtypes.Datetime):
-        dt_time_unit = getattr(dtype, "time_unit", "us")
-        dt_time_zone = getattr(dtype, "time_zone", None)
-
         # Pandas does not support "ms" or "us" time units before version 2.0
-        # Let's overwrite with "ns"
         if implementation is Implementation.PANDAS and backend_version < (
             2,
         ):  # pragma: no cover
             dt_time_unit = "ns"
+        else:
+            dt_time_unit = dtype.time_unit
 
         if dtype_backend == "pyarrow":
-            tz_part = f", tz={dt_time_zone}" if dt_time_zone else ""
+            tz_part = f", tz={tz}" if (tz := dtype.time_zone) else ""
             return f"timestamp[{dt_time_unit}{tz_part}][pyarrow]"
         else:
-            tz_part = f", {dt_time_zone}" if dt_time_zone else ""
+            tz_part = f", {tz}" if (tz := dtype.time_zone) else ""
             return f"datetime64[{dt_time_unit}{tz_part}]"
     if isinstance_or_issubclass(dtype, dtypes.Duration):
-        du_time_unit = getattr(dtype, "time_unit", "us")
+        du_time_unit = dtype.time_unit
         if implementation is Implementation.PANDAS and backend_version < (
             2,
         ):  # pragma: no cover
+            # NOTE: I think this assignment was a typo, it never gets used (should be du_)
             dt_time_unit = "ns"
         return (
             f"duration[{du_time_unit}][pyarrow]"

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -628,12 +628,12 @@ def narwhals_to_native_dtype(  # noqa: PLR0915
             tz_part = f", {tz}" if (tz := dtype.time_zone) else ""
             return f"datetime64[{dt_time_unit}{tz_part}]"
     if isinstance_or_issubclass(dtype, dtypes.Duration):
-        du_time_unit = dtype.time_unit
         if implementation is Implementation.PANDAS and backend_version < (
             2,
         ):  # pragma: no cover
-            # NOTE: I think this assignment was a typo, it never gets used (should be du_)
-            dt_time_unit = "ns"
+            du_time_unit = "ns"
+        else:
+            du_time_unit = dtype.time_unit
         return (
             f"duration[{du_time_unit}][pyarrow]"
             if dtype_backend == "pyarrow"

--- a/narwhals/_polars/utils.py
+++ b/narwhals/_polars/utils.py
@@ -192,7 +192,6 @@ def narwhals_to_native_dtype(
         msg = "Casting to Decimal is not supported yet."
         raise NotImplementedError(msg)
     if isinstance_or_issubclass(dtype, dtypes.Datetime):
-        # [s] is not allowed for polars
         return pl.Datetime(dtype.time_unit, dtype.time_zone)  # type: ignore[arg-type]
     if isinstance_or_issubclass(dtype, dtypes.Duration):
         return pl.Duration(dtype.time_unit)  # type: ignore[arg-type]

--- a/narwhals/_polars/utils.py
+++ b/narwhals/_polars/utils.py
@@ -14,6 +14,7 @@ from narwhals.exceptions import InvalidOperationError
 from narwhals.exceptions import NarwhalsError
 from narwhals.exceptions import ShapeError
 from narwhals.utils import import_dtypes_module
+from narwhals.utils import isinstance_or_issubclass
 
 if TYPE_CHECKING:
     from narwhals._polars.dataframe import PolarsDataFrame
@@ -190,10 +191,9 @@ def narwhals_to_native_dtype(
     if dtype == dtypes.Decimal:
         msg = "Casting to Decimal is not supported yet."
         raise NotImplementedError(msg)
-    if dtype == dtypes.Datetime or isinstance(dtype, dtypes.Datetime):
-        dt_time_unit: TimeUnit = getattr(dtype, "time_unit", "us")
-        dt_time_zone = getattr(dtype, "time_zone", None)
-        return pl.Datetime(dt_time_unit, dt_time_zone)  # type: ignore[arg-type]
+    if isinstance_or_issubclass(dtype, dtypes.Datetime):
+        # [s] is not allowed for polars
+        return pl.Datetime(dtype.time_unit, dtype.time_zone)  # type: ignore[arg-type]
     if dtype == dtypes.Duration or isinstance(dtype, dtypes.Duration):
         du_time_unit: TimeUnit = getattr(dtype, "time_unit", "us")
         return pl.Duration(time_unit=du_time_unit)  # type: ignore[arg-type]

--- a/narwhals/_polars/utils.py
+++ b/narwhals/_polars/utils.py
@@ -194,9 +194,8 @@ def narwhals_to_native_dtype(
     if isinstance_or_issubclass(dtype, dtypes.Datetime):
         # [s] is not allowed for polars
         return pl.Datetime(dtype.time_unit, dtype.time_zone)  # type: ignore[arg-type]
-    if dtype == dtypes.Duration or isinstance(dtype, dtypes.Duration):
-        du_time_unit: TimeUnit = getattr(dtype, "time_unit", "us")
-        return pl.Duration(time_unit=du_time_unit)  # type: ignore[arg-type]
+    if isinstance_or_issubclass(dtype, dtypes.Duration):
+        return pl.Duration(dtype.time_unit)  # type: ignore[arg-type]
     if dtype == dtypes.List:
         return pl.List(narwhals_to_native_dtype(dtype.inner, version, backend_version))  # type: ignore[union-attr]
     if dtype == dtypes.Struct:

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -116,7 +116,7 @@ def narwhals_to_native_dtype(
     if isinstance_or_issubclass(dtype, dtypes.Date):
         return spark_types.DateType()
     if isinstance_or_issubclass(dtype, dtypes.Datetime):
-        dt_time_zone = getattr(dtype, "time_zone", None)
+        dt_time_zone = dtype.time_zone
         if dt_time_zone is None:
             return spark_types.TimestampNTZType()
         if dt_time_zone != "UTC":  # pragma: no cover

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -534,7 +534,13 @@ class Datetime(TemporalType, metaclass=_DatetimeMeta):
         return f"{class_name}(time_unit={self.time_unit!r}, time_zone={self.time_zone!r})"
 
 
-class Duration(TemporalType):
+class _DurationMeta(type):
+    @property
+    def time_unit(cls) -> TimeUnit:
+        return "us"
+
+
+class Duration(TemporalType, metaclass=_DurationMeta):
     """Data type representing a time duration.
 
     Arguments:
@@ -562,10 +568,7 @@ class Duration(TemporalType):
         Duration(time_unit='ms')
     """
 
-    def __init__(
-        self: Self,
-        time_unit: TimeUnit = "us",
-    ) -> None:
+    def __init__(self: Self, time_unit: TimeUnit = "us") -> None:
         if time_unit not in ("s", "ms", "us", "ns"):
             msg = (
                 "invalid `time_unit`"
@@ -573,11 +576,11 @@ class Duration(TemporalType):
             )
             raise ValueError(msg)
 
-        self.time_unit = time_unit
+        self.time_unit: TimeUnit = time_unit
 
     def __eq__(self: Self, other: object) -> bool:
         # allow comparing object instances to class
-        if type(other) is type and issubclass(other, self.__class__):
+        if type(other) is _DurationMeta and issubclass(other, self.__class__):
             return True
         elif isinstance(other, self.__class__):
             return self.time_unit == other.time_unit

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -519,7 +519,7 @@ class Datetime(TemporalType, metaclass=_DatetimeMeta):
 
     def __eq__(self: Self, other: object) -> bool:
         # allow comparing object instances to class
-        if type(other) is _DatetimeMeta and issubclass(other, self.__class__):
+        if type(other) is _DatetimeMeta:
             return True
         elif isinstance(other, self.__class__):
             return self.time_unit == other.time_unit and self.time_zone == other.time_zone
@@ -580,7 +580,7 @@ class Duration(TemporalType, metaclass=_DurationMeta):
 
     def __eq__(self: Self, other: object) -> bool:
         # allow comparing object instances to class
-        if type(other) is _DurationMeta and issubclass(other, self.__class__):
+        if type(other) is _DurationMeta:
             return True
         elif isinstance(other, self.__class__):
             return self.time_unit == other.time_unit

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -448,7 +448,17 @@ class Unknown(DType):
     """
 
 
-class Datetime(TemporalType):
+class _DatetimeMeta(type):
+    @property
+    def time_unit(cls) -> TimeUnit:
+        return "us"
+
+    @property
+    def time_zone(cls) -> str | None:
+        return None
+
+
+class Datetime(TemporalType, metaclass=_DatetimeMeta):
     """Data type representing a calendar date and time of day.
 
     Arguments:
@@ -504,12 +514,12 @@ class Datetime(TemporalType):
         if isinstance(time_zone, timezone):
             time_zone = str(time_zone)
 
-        self.time_unit = time_unit
-        self.time_zone = time_zone
+        self.time_unit: TimeUnit = time_unit
+        self.time_zone: str | None = time_zone
 
     def __eq__(self: Self, other: object) -> bool:
         # allow comparing object instances to class
-        if type(other) is type and issubclass(other, self.__class__):
+        if type(other) is _DatetimeMeta and issubclass(other, self.__class__):
             return True
         elif isinstance(other, self.__class__):
             return self.time_unit == other.time_unit and self.time_zone == other.time_zone


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

Mentioned in
- https://github.com/narwhals-dev/narwhals/pull/1991#discussion_r1957328569
- https://github.com/narwhals-dev/narwhals/pull/1807#discussion_r1956331625

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
- I started with an implementation for `Datetime`, when used in `_polars` only
- Was expecting this to be a more complex task, but realised I could use the same idea as https://github.com/vega/altair/blob/f61a22e4fb0fb0822e7e3fb440b716d93a261474/altair/expr/__init__.py#L23

This gives you a read-only default for:

```py
Datetime.time_unit
```

Which is unaffected by the instance-level version:

```py
dtype = Datetime("ms")
dtype.time_unit
```

I imagined this would also be useful `Duration`:

https://github.com/narwhals-dev/narwhals/blob/43d072b41b8d4098c89b6798da46199e31368513/narwhals/dtypes.py#L527

Originally thought this would be beneficial for the `NestedType` classes, but I'm seeing that they *don't* have defaults