### PR TITLE
refactor: remove `Array` shape default

### DIFF
--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -790,16 +790,9 @@ class Array(NestedType):
     shape: tuple[int, ...]
 
     def __init__(
-        self: Self,
-        inner: DType | type[DType],
-        shape: int | tuple[int, ...] | None = None,
+        self: Self, inner: DType | type[DType], shape: int | tuple[int, ...]
     ) -> None:
         inner_shape: tuple[int, ...] = inner.shape if isinstance(inner, Array) else ()
-
-        if shape is None:  # pragma: no cover
-            msg = "Array constructor is missing the required argument `shape`"
-            raise TypeError(msg)
-
         if isinstance(shape, int):
             self.inner = inner
             self.size = shape

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -87,10 +87,8 @@ def test_array_valid() -> None:
     assert dtype != nw.Array(nw.Array(nw.Float32, 2), 2)
     assert dtype in {nw.Array(nw.Array(nw.Int64, 2), 2)}
 
-    with pytest.raises(
-        TypeError, match="Array constructor is missing the required argument `shape`"
-    ):
-        nw.Array(nw.Int64)
+    with pytest.raises(TypeError, match="invalid input for shape"):
+        nw.Array(nw.Int64(), shape=None)  # type: ignore[arg-type]
 
     with pytest.raises(TypeError, match="invalid input for shape"):
         nw.Array(nw.Int64(), shape="invalid_type")  # type: ignore[arg-type]


### PR DESCRIPTION


<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
We get the `TypeError` for free:
```py
import narwhals as nw
>>> nw.Array(nw.Int64)
TypeError: Array.__init__() missing 1 required positional argument: 'shape'
```

And your IDE can let you know statically:

![image](https://github.com/user-attachments/assets/b17e5867-1474-432e-947c-ca55960d04e5)