### PR TITLE
fix: PySpark was raising during `collect` when it contained no rows and a void dtype column

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -481,5 +481,7 @@ jobs:
         run: |
           cd validoopsie
           . .venv/bin/activate
+          touch tests/__init__.py
+          touch tests/utils/__init__.py
           pytest tests
         timeout-minutes: 15

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -462,7 +462,7 @@ jobs:
         run: |
           cd validoopsie
           uv sync --dev
-          uv pip install pytest-env
+          uv pip install pytest-env pytest
           which python
       - name: show-deps
         run: uv pip freeze

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -483,5 +483,5 @@ jobs:
           . .venv/bin/activate
           touch tests/__init__.py
           touch tests/utils/__init__.py
-          pytest tests -W ignore
+          pytest tests
         timeout-minutes: 15

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -461,18 +461,26 @@ jobs:
       - name: install-validoopsie-dev
         run: |
           cd validoopsie
+          uv venv
+          . .venv/bin/activate
           uv sync --dev
-          uv pip install pytest-env pytest
+          uv pip install pytest-env
           which python
       - name: show-deps
-        run: uv pip freeze
+        run: |
+          cd validoopsie
+          . .venv/bin/activate
+          uv pip freeze
       - name: install-narwhals-dev
         run: |
           cd validoopsie
+          uv venv
+          . .venv/bin/activate
           uv pip uninstall narwhals
           uv pip install -e ./..
       - name: Run tests
         run: |
           cd validoopsie
+          . .venv/bin/activate
           pytest tests
         timeout-minutes: 15

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -483,5 +483,5 @@ jobs:
           . .venv/bin/activate
           touch tests/__init__.py
           touch tests/utils/__init__.py
-          pytest tests
+          pytest tests -W ignore
         timeout-minutes: 15

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -474,5 +474,5 @@ jobs:
       - name: Run tests
         run: |
           cd validoopsie
-          uv run --no-sync pytest
+          pytest tests
         timeout-minutes: 15

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -474,5 +474,5 @@ jobs:
       - name: Run tests
         run: |
           cd validoopsie
-          uv run pytest
+          uv run --no-sync pytest
         timeout-minutes: 15

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -474,7 +474,6 @@ jobs:
       - name: install-narwhals-dev
         run: |
           cd validoopsie
-          uv venv
           . .venv/bin/activate
           uv pip uninstall narwhals
           uv pip install -e ./..

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -494,7 +494,7 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):  # type: ignore[type-var]
 
     def is_in(self: Self, other: Sequence[Any]) -> Self:
         return self._from_call(
-            lambda _input: _input.contains([], _input),
+            lambda _input: FunctionExpression("contains", lit(other), _input),
             "is_in",
             expr_kind=self._expr_kind,
         )

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -494,9 +494,7 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):  # type: ignore[type-var]
 
     def is_in(self: Self, other: Sequence[Any]) -> Self:
         return self._from_call(
-            lambda _input: lit(False)  # noqa: FBT003
-            if not other
-            else _input.isin(*[lit(x) for x in other]),
+            lambda _input: _input.contains([], _input),
             "is_in",
             expr_kind=self._expr_kind,
         )

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
@@ -13,6 +14,7 @@ from narwhals.typing import CompliantDataFrame
 from narwhals.typing import CompliantLazyFrame
 from narwhals.utils import Implementation
 from narwhals.utils import check_column_exists
+from narwhals.utils import find_stacklevel
 from narwhals.utils import import_dtypes_module
 from narwhals.utils import parse_columns_to_drop
 from narwhals.utils import parse_version
@@ -124,13 +126,20 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
                     from narwhals._arrow.utils import narwhals_to_native_dtype
 
                     data: dict[str, list[Any]] = {}
-                    schema = []
+                    schema: list[tuple[str, pa.DataType]] = []
                     current_schema = self.collect_schema()
                     for key, value in current_schema.items():
                         data[key] = []
-                        schema.append(
-                            (key, narwhals_to_native_dtype(value, self._version))
-                        )
+                        try:
+                            native_dtype = narwhals_to_native_dtype(value, self._version)
+                        except Exception as exc:  # noqa: BLE001
+                            warnings.warn(
+                                f"Could not convert dtype {self._native_frame.schema[key]} to PyArrow dtype, {exc!r}",
+                                stacklevel=find_stacklevel(),
+                            )
+                            schema.append((key, pa.null()))
+                        else:
+                            schema.append((key, native_dtype))
                     native_pyarrow_frame = pa.Table.from_pydict(
                         data, schema=pa.schema(schema)
                     )

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -134,7 +134,7 @@ class SparkLikeLazyFrame(CompliantLazyFrame):
                             native_dtype = narwhals_to_native_dtype(value, self._version)
                         except Exception as exc:  # noqa: BLE001
                             warnings.warn(
-                                f"Could not convert dtype {self._native_frame.schema[key]} to PyArrow dtype, {exc!r}",
+                                f"Could not convert dtype {self._native_frame.schema[key].dataType} to PyArrow dtype, {exc!r}",
                                 stacklevel=find_stacklevel(),
                             )
                             schema.append((key, pa.null()))

--- a/tests/frame/collect_test.py
+++ b/tests/frame/collect_test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from contextlib import nullcontext
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -111,11 +110,5 @@ def test_collect_with_kwargs(constructor: Constructor) -> None:
 def test_collect_empty_pyspark(constructor: Constructor) -> None:
     df = nw_v1.from_native(constructor({"a": [1, 2, 3]}))
     df = df.filter(nw.col("a").is_null()).with_columns(b=nw.lit(None)).lazy()
-    context = (
-        pytest.warns(UserWarning, match="Could not convert dtype")
-        if "pyspark" in str(constructor)
-        else nullcontext()
-    )
-    with context:
-        result = df.collect()
+    result = df.collect()
     assert_equal_data(result, {"a": [], "b": []})


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
