### PR TITLE
chore: refactor right-hand-side arithmetic to not use lit

### DIFF
--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -164,6 +164,9 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
     def __add__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__add__", other=other)
 
+    def __radd__(self: Self, other: ArrowExpr | Any) -> Self:
+        return reuse_series_implementation(self.alias("literal"), "__radd__", other=other)
+
     def __sub__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__sub__", other=other)
 

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -164,11 +164,11 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
     def __add__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__add__", other=other)
 
-    def __radd__(self: Self, other: ArrowExpr | Any) -> Self:
-        return reuse_series_implementation(self.alias("literal"), "__radd__", other=other)
-
     def __sub__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__sub__", other=other)
+
+    def __rsub__(self: Self, other: ArrowExpr | Any) -> Self:
+        return reuse_series_implementation(self.alias("literal"), "__rsub__", other=other)
 
     def __mul__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__mul__", other=other)
@@ -176,14 +176,30 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
     def __pow__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__pow__", other=other)
 
+    def __rpow__(self: Self, other: ArrowExpr | Any) -> Self:
+        return reuse_series_implementation(self.alias("literal"), "__rpow__", other=other)
+
     def __floordiv__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__floordiv__", other=other)
+
+    def __rfloordiv__(self: Self, other: ArrowExpr | Any) -> Self:
+        return reuse_series_implementation(
+            self.alias("literal"), "__rfloordiv__", other=other
+        )
 
     def __truediv__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__truediv__", other=other)
 
+    def __rtruediv__(self: Self, other: ArrowExpr | Any) -> Self:
+        return reuse_series_implementation(
+            self.alias("literal"), "__rtruediv__", other=other
+        )
+
     def __mod__(self: Self, other: ArrowExpr | Any) -> Self:
         return reuse_series_implementation(self, "__mod__", other=other)
+
+    def __rmod__(self: Self, other: ArrowExpr | Any) -> Self:
+        return reuse_series_implementation(self.alias("literal"), "__rmod__", other=other)
 
     def __invert__(self: Self) -> Self:
         return reuse_series_implementation(self, "__invert__")

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -193,14 +193,6 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
-    def __radd__(self: Self, other: Any) -> Self:
-        return self._from_call(
-            lambda _input, other: _input.__radd__(other),
-            "__radd__",
-            other=other,
-            returns_scalar=binary_operation_returns_scalar(self, other),
-        ).alias("literal")
-
     def __sub__(self: Self, other: Any) -> Self:
         return self._from_call(
             lambda _input, other: _input.__sub__(other),
@@ -208,6 +200,14 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             other=other,
             returns_scalar=binary_operation_returns_scalar(self, other),
         )
+
+    def __rsub__(self: Self, other: Any) -> Self:
+        return self._from_call(
+            lambda _input, other: _input.__rsub__(other),
+            "__rsub__",
+            other=other,
+            returns_scalar=binary_operation_returns_scalar(self, other),
+        ).alias("literal")
 
     def __mul__(self: Self, other: Any) -> Self:
         return self._from_call(

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -203,7 +203,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
 
     def __rsub__(self: Self, other: Any) -> Self:
         return self._from_call(
-            lambda _input, other: _input.__rsub__(other),
+            lambda _input, other: other - _input,
             "__rsub__",
             other=other,
             returns_scalar=binary_operation_returns_scalar(self, other),
@@ -227,7 +227,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
 
     def __rtruediv__(self: Self, other: Any) -> Self:
         return self._from_call(
-            lambda _input, other: other.__truediv__(_input),
+            lambda _input, other: other / _input,
             "__rtruediv__",
             other=other,
             returns_scalar=binary_operation_returns_scalar(self, other),
@@ -243,7 +243,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
 
     def __rfloordiv__(self: Self, other: Any) -> Self:
         return self._from_call(
-            lambda _input, other: other.__floordiv__(_input),
+            lambda _input, other: other // _input,
             "__rfloordiv__",
             other=other,
             returns_scalar=binary_operation_returns_scalar(self, other),
@@ -259,7 +259,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
 
     def __rpow__(self: Self, other: Any) -> Self:
         return self._from_call(
-            lambda _input, other: other.__pow__(_input),
+            lambda _input, other: other**_input,
             "__rpow__",
             other=other,
             returns_scalar=binary_operation_returns_scalar(self, other),
@@ -275,7 +275,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
 
     def __rmod__(self: Self, other: Any) -> Self:
         return self._from_call(
-            lambda _input, other: other.__mod__(_input),
+            lambda _input, other: other % _input,
             "__rmod__",
             other=other,
             returns_scalar=binary_operation_returns_scalar(self, other),

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -193,6 +193,14 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
+    def __radd__(self: Self, other: Any) -> Self:
+        return self._from_call(
+            lambda _input, other: _input.__radd__(other),
+            "__radd__",
+            other=other,
+            returns_scalar=binary_operation_returns_scalar(self, other),
+        ).alias("literal")
+
     def __sub__(self: Self, other: Any) -> Self:
         return self._from_call(
             lambda _input, other: _input.__sub__(other),

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -225,6 +225,14 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
+    def __rtruediv__(self: Self, other: Any) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__truediv__(_input),
+            "__rtruediv__",
+            other=other,
+            returns_scalar=binary_operation_returns_scalar(self, other),
+        ).alias("literal")
+
     def __floordiv__(self: Self, other: Any) -> Self:
         return self._from_call(
             lambda _input, other: _input.__floordiv__(other),
@@ -232,6 +240,14 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             other=other,
             returns_scalar=binary_operation_returns_scalar(self, other),
         )
+
+    def __rfloordiv__(self: Self, other: Any) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__floordiv__(_input),
+            "__rfloordiv__",
+            other=other,
+            returns_scalar=binary_operation_returns_scalar(self, other),
+        ).alias("literal")
 
     def __pow__(self: Self, other: Any) -> Self:
         return self._from_call(
@@ -241,6 +257,14 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             returns_scalar=binary_operation_returns_scalar(self, other),
         )
 
+    def __rpow__(self: Self, other: Any) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__pow__(_input),
+            "__rpow__",
+            other=other,
+            returns_scalar=binary_operation_returns_scalar(self, other),
+        ).alias("literal")
+
     def __mod__(self: Self, other: Any) -> Self:
         return self._from_call(
             lambda _input, other: _input.__mod__(other),
@@ -248,6 +272,14 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             other=other,
             returns_scalar=binary_operation_returns_scalar(self, other),
         )
+
+    def __rmod__(self: Self, other: Any) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__mod__(_input),
+            "__rmod__",
+            other=other,
+            returns_scalar=binary_operation_returns_scalar(self, other),
+        ).alias("literal")
 
     def __eq__(self: Self, other: DaskExpr) -> Self:  # type: ignore[override]
         return self._from_call(

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -175,14 +175,6 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):  # type: ignore[type-var]
             expr_kind=n_ary_operation_expr_kind(self, other),
         )
 
-    def __radd__(self: Self, other: DuckDBExpr) -> Self:
-        return self._from_call(
-            lambda _input, other: _input.__radd__(other),
-            "__radd__",
-            other=other,
-            expr_kind=n_ary_operation_expr_kind(self, other),
-        ).alias("literal")
-
     def __truediv__(self: Self, other: DuckDBExpr) -> Self:
         return self._from_call(
             lambda _input, other: _input / other,
@@ -190,6 +182,14 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):  # type: ignore[type-var]
             other=other,
             expr_kind=n_ary_operation_expr_kind(self, other),
         )
+
+    def __rtruediv__(self: Self, other: DuckDBExpr) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__truediv__(_input),
+            "__rtruediv__",
+            other=other,
+            expr_kind=n_ary_operation_expr_kind(self, other),
+        ).alias("literal")
 
     def __floordiv__(self: Self, other: DuckDBExpr) -> Self:
         return self._from_call(
@@ -199,6 +199,14 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):  # type: ignore[type-var]
             expr_kind=n_ary_operation_expr_kind(self, other),
         )
 
+    def __rfloordiv__(self: Self, other: DuckDBExpr) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__floordiv__(_input),
+            "__rfloordiv__",
+            other=other,
+            expr_kind=n_ary_operation_expr_kind(self, other),
+        ).alias("literal")
+
     def __mod__(self: Self, other: DuckDBExpr) -> Self:
         return self._from_call(
             lambda _input, other: _input.__mod__(other),
@@ -207,6 +215,14 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):  # type: ignore[type-var]
             expr_kind=n_ary_operation_expr_kind(self, other),
         )
 
+    def __rmod__(self: Self, other: DuckDBExpr) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__mod__(_input),
+            "__rmod__",
+            other=other,
+            expr_kind=n_ary_operation_expr_kind(self, other),
+        ).alias("literal")
+
     def __sub__(self: Self, other: DuckDBExpr) -> Self:
         return self._from_call(
             lambda _input, other: _input - other,
@@ -214,6 +230,14 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):  # type: ignore[type-var]
             other=other,
             expr_kind=n_ary_operation_expr_kind(self, other),
         )
+
+    def __rsub__(self: Self, other: DuckDBExpr) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__sub__(_input),
+            "__rsub__",
+            other=other,
+            expr_kind=n_ary_operation_expr_kind(self, other),
+        ).alias("literal")
 
     def __mul__(self: Self, other: DuckDBExpr) -> Self:
         return self._from_call(
@@ -230,6 +254,14 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):  # type: ignore[type-var]
             other=other,
             expr_kind=n_ary_operation_expr_kind(self, other),
         )
+
+    def __rpow__(self: Self, other: DuckDBExpr) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__pow__(_input),
+            "__rpow__",
+            other=other,
+            expr_kind=n_ary_operation_expr_kind(self, other),
+        ).alias("literal")
 
     def __lt__(self: Self, other: DuckDBExpr) -> Self:
         return self._from_call(

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -175,6 +175,14 @@ class DuckDBExpr(CompliantExpr["duckdb.Expression"]):  # type: ignore[type-var]
             expr_kind=n_ary_operation_expr_kind(self, other),
         )
 
+    def __radd__(self: Self, other: DuckDBExpr) -> Self:
+        return self._from_call(
+            lambda _input, other: _input.__radd__(other),
+            "__radd__",
+            other=other,
+            expr_kind=n_ary_operation_expr_kind(self, other),
+        ).alias("literal")
+
     def __truediv__(self: Self, other: DuckDBExpr) -> Self:
         return self._from_call(
             lambda _input, other: _input / other,

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -185,11 +185,11 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
     def __add__(self: Self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__add__", other=other)
 
-    def __radd__(self: Self, other: PandasLikeExpr | Any) -> Self:
-        return reuse_series_implementation(self.alias("literal"), "__radd__", other=other)
-
     def __sub__(self: Self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__sub__", other=other)
+
+    def __rsub__(self: Self, other: PandasLikeExpr | Any) -> Self:
+        return reuse_series_implementation(self.alias("literal"), "__rsub__", other=other)
 
     def __mul__(self: Self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__mul__", other=other)
@@ -197,14 +197,30 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
     def __truediv__(self: Self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__truediv__", other=other)
 
+    def __rtruediv__(self: Self, other: PandasLikeExpr | Any) -> Self:
+        return reuse_series_implementation(
+            self.alias("literal"), "__rtruediv__", other=other
+        )
+
     def __floordiv__(self: Self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__floordiv__", other=other)
+
+    def __rfloordiv__(self: Self, other: PandasLikeExpr | Any) -> Self:
+        return reuse_series_implementation(
+            self.alias("literal"), "__rfloordiv__", other=other
+        )
 
     def __pow__(self: Self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__pow__", other=other)
 
+    def __rpow__(self: Self, other: PandasLikeExpr | Any) -> Self:
+        return reuse_series_implementation(self.alias("literal"), "__rpow__", other=other)
+
     def __mod__(self: Self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__mod__", other=other)
+
+    def __rmod__(self: Self, other: PandasLikeExpr | Any) -> Self:
+        return reuse_series_implementation(self.alias("literal"), "__rmod__", other=other)
 
     # Unary
     def __invert__(self: Self) -> Self:

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -185,6 +185,9 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
     def __add__(self: Self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__add__", other=other)
 
+    def __radd__(self: Self, other: PandasLikeExpr | Any) -> Self:
+        return reuse_series_implementation(self.alias("literal"), "__radd__", other=other)
+
     def __sub__(self: Self, other: PandasLikeExpr | Any) -> Self:
         return reuse_series_implementation(self, "__sub__", other=other)
 

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -209,7 +209,7 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             "__rsub__",
             other=other,
             expr_kind=n_ary_operation_expr_kind(self, other),
-        )
+        ).alias("literal")
 
     def __mul__(self: Self, other: SparkLikeExpr) -> Self:
         return self._from_call(

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -203,6 +203,14 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             expr_kind=n_ary_operation_expr_kind(self, other),
         )
 
+    def __rsub__(self: Self, other: SparkLikeExpr) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__sub__(_input),
+            "__rsub__",
+            other=other,
+            expr_kind=n_ary_operation_expr_kind(self, other),
+        )
+
     def __mul__(self: Self, other: SparkLikeExpr) -> Self:
         return self._from_call(
             lambda _input, other: _input.__mul__(other),
@@ -219,6 +227,14 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             expr_kind=n_ary_operation_expr_kind(self, other),
         )
 
+    def __rtruediv__(self: Self, other: SparkLikeExpr) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__truediv__(_input),
+            "__rtruediv__",
+            other=other,
+            expr_kind=n_ary_operation_expr_kind(self, other),
+        ).alias("literal")
+
     def __floordiv__(self: Self, other: SparkLikeExpr) -> Self:
         def _floordiv(_input: Column, other: Column) -> Column:
             return self._F.floor(_input / other)
@@ -230,6 +246,17 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             expr_kind=n_ary_operation_expr_kind(self, other),
         )
 
+    def __rfloordiv__(self: Self, other: SparkLikeExpr) -> Self:
+        def _rfloordiv(_input: Column, other: Column) -> Column:
+            return self._F.floor(other / _input)
+
+        return self._from_call(
+            _rfloordiv,
+            "__rfloordiv__",
+            other=other,
+            expr_kind=n_ary_operation_expr_kind(self, other),
+        ).alias("literal")
+
     def __pow__(self: Self, other: SparkLikeExpr) -> Self:
         return self._from_call(
             lambda _input, other: _input.__pow__(other),
@@ -238,6 +265,14 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             expr_kind=n_ary_operation_expr_kind(self, other),
         )
 
+    def __rpow__(self: Self, other: SparkLikeExpr) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__pow__(_input),
+            "__rpow__",
+            other=other,
+            expr_kind=n_ary_operation_expr_kind(self, other),
+        ).alias("literal")
+
     def __mod__(self: Self, other: SparkLikeExpr) -> Self:
         return self._from_call(
             lambda _input, other: _input.__mod__(other),
@@ -245,6 +280,14 @@ class SparkLikeExpr(CompliantExpr["Column"]):
             other=other,
             expr_kind=n_ary_operation_expr_kind(self, other),
         )
+
+    def __rmod__(self: Self, other: SparkLikeExpr) -> Self:
+        return self._from_call(
+            lambda _input, other: other.__mod__(_input),
+            "__rmod__",
+            other=other,
+            expr_kind=n_ary_operation_expr_kind(self, other),
+        ).alias("literal")
 
     def __ge__(self: Self, other: SparkLikeExpr) -> Self:
         return self._from_call(

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -218,12 +218,7 @@ class Expr:
         )
 
     def __radd__(self: Self, other: Any) -> Self:
-        return self.__class__(
-            lambda plx: self._to_compliant_expr(plx).__radd__(
-                extract_compliant(plx, other, strings_are_column_names=False)
-            ),
-            combine_metadata(self, other, strings_are_column_names=False),
-        )
+        return (self + other).alias("literal")
 
     def __sub__(self: Self, other: Any) -> Self:
         return self.__class__(
@@ -234,13 +229,11 @@ class Expr:
         )
 
     def __rsub__(self: Self, other: Any) -> Self:
-        def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
-            return plx.lit(
-                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
-            ).__sub__(extract_compliant(plx, self, strings_are_column_names=False))
-
         return self.__class__(
-            func, combine_metadata(self, other, strings_are_column_names=False)
+            lambda plx: self._to_compliant_expr(plx).__rsub__(
+                extract_compliant(plx, other, strings_are_column_names=False)
+            ),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __truediv__(self: Self, other: Any) -> Self:
@@ -252,13 +245,11 @@ class Expr:
         )
 
     def __rtruediv__(self: Self, other: Any) -> Self:
-        def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
-            return plx.lit(
-                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
-            ).__truediv__(extract_compliant(plx, self, strings_are_column_names=False))
-
         return self.__class__(
-            func, combine_metadata(self, other, strings_are_column_names=False)
+            lambda plx: self._to_compliant_expr(plx).__rtruediv__(
+                extract_compliant(plx, other, strings_are_column_names=False)
+            ),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __mul__(self: Self, other: Any) -> Self:
@@ -270,14 +261,7 @@ class Expr:
         )
 
     def __rmul__(self: Self, other: Any) -> Self:
-        def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
-            return plx.lit(
-                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
-            ).__mul__(extract_compliant(plx, self, strings_are_column_names=False))
-
-        return self.__class__(
-            func, combine_metadata(self, other, strings_are_column_names=False)
-        )
+        return (self * other).alias("literal")
 
     def __le__(self: Self, other: Any) -> Self:
         return self.__class__(
@@ -320,13 +304,11 @@ class Expr:
         )
 
     def __rpow__(self: Self, other: Any) -> Self:
-        def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
-            return plx.lit(
-                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
-            ).__pow__(extract_compliant(plx, self, strings_are_column_names=False))
-
         return self.__class__(
-            func, combine_metadata(self, other, strings_are_column_names=False)
+            lambda plx: self._to_compliant_expr(plx).__rpow__(
+                extract_compliant(plx, other, strings_are_column_names=False)
+            ),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __floordiv__(self: Self, other: Any) -> Self:
@@ -338,13 +320,11 @@ class Expr:
         )
 
     def __rfloordiv__(self: Self, other: Any) -> Self:
-        def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
-            return plx.lit(
-                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
-            ).__floordiv__(extract_compliant(plx, self, strings_are_column_names=False))
-
         return self.__class__(
-            func, combine_metadata(self, other, strings_are_column_names=False)
+            lambda plx: self._to_compliant_expr(plx).__rfloordiv__(
+                extract_compliant(plx, other, strings_are_column_names=False)
+            ),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __mod__(self: Self, other: Any) -> Self:
@@ -356,13 +336,11 @@ class Expr:
         )
 
     def __rmod__(self: Self, other: Any) -> Self:
-        def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
-            return plx.lit(
-                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
-            ).__mod__(extract_compliant(plx, self, strings_are_column_names=False))
-
         return self.__class__(
-            func, combine_metadata(self, other, strings_are_column_names=False)
+            lambda plx: self._to_compliant_expr(plx).__rmod__(
+                extract_compliant(plx, other, strings_are_column_names=False)
+            ),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     # --- unary ---

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -218,13 +218,11 @@ class Expr:
         )
 
     def __radd__(self: Self, other: Any) -> Self:
-        def func(plx: CompliantNamespace[Any]) -> CompliantExpr[Any]:
-            return plx.lit(
-                extract_compliant(plx, other, strings_are_column_names=False), dtype=None
-            ).__add__(extract_compliant(plx, self, strings_are_column_names=False))
-
         return self.__class__(
-            func, combine_metadata(self, other, strings_are_column_names=False)
+            lambda plx: self._to_compliant_expr(plx).__radd__(
+                extract_compliant(plx, other, strings_are_column_names=False)
+            ),
+            combine_metadata(self, other, strings_are_column_names=False),
         )
 
     def __sub__(self: Self, other: Any) -> Self:


### PR DESCRIPTION
Using `nw.lit` for parsing literals does introduce some unneeded complexity, as we need to create a temporary 1-row series and then broadcast it. For such a common operation (e.g. `1 - nw.col('a')`) we can keep it simpler by just keeping the `1` as a Python scalar

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
