### PR TITLE
chore(perf): move `combine_evaluate_output_names` check

### DIFF
--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -237,12 +237,13 @@ def combine_evaluate_output_names(
 ) -> Callable[[CompliantDataFrame | CompliantLazyFrame], Sequence[str]]:
     # Follow left-hand-rule for naming. E.g. `nw.sum_horizontal(expr1, expr2)` takes the
     # first name of `expr1`.
+    if not is_compliant_expr(exprs[0]):  # pragma: no cover
+        msg = f"Safety assertion failed, expected expression, got: {type(exprs[0])}. Please report a bug."
+        raise AssertionError(msg)
+
     def evaluate_output_names(
         df: CompliantDataFrame | CompliantLazyFrame,
     ) -> Sequence[str]:
-        if not is_compliant_expr(exprs[0]):  # pragma: no cover
-            msg = f"Safety assertion failed, expected expression, got: {type(exprs[0])}. Please report a bug."
-            raise AssertionError(msg)
         return exprs[0]._evaluate_output_names(df)[:1]
 
     return evaluate_output_names


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
- Will always be the same result on every call to the inner `evaluate_output_names`
- Unsure how frequent it would be called, but noticed in (https://github.com/narwhals-dev/narwhals/pull/2035#discussion_r1959770117)

Unrelated polars nightly failure (https://github.com/narwhals-dev/narwhals/actions/runs/13392572259/job/37403539233?pr=2040)