### PR TITLE
chore: add colors in CI and run `marimo` only in selected python version

### DIFF
--- a/.github/workflows/check_tpch_queries.yml
+++ b/.github/workflows/check_tpch_queries.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+env:
+  PY_COLORS: 1
+
 jobs:
   validate-queries:
     strategy:

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+env:
+  PY_COLORS: 1
+
 jobs:
   altair:
     strategy:

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -116,7 +116,7 @@ jobs:
           # the local narwhals install is picked up
           sed -i '/^\[tool.hatch.envs.default\]/a path = ".venv"' pyproject.toml
           hatch run python -c "import narwhals; print(narwhals.__file__)"
-          hatch run test-optional:test-narwhals
+          hatch run +py=${{ matrix.python-version }} test-optional:test-narwhals
         timeout-minutes: 15
 
   scikit-lego:

--- a/.github/workflows/downstream_tests_slow.yml
+++ b/.github/workflows/downstream_tests_slow.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+env:
+  PY_COLORS: 1
+
 jobs:
   vegafusion:
      env:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+env:
+  PY_COLORS: 1
+
 jobs:
   pytest-38:
     strategy:

--- a/.github/workflows/random_ci_pytest.yml
+++ b/.github/workflows/random_ci_pytest.yml
@@ -3,6 +3,9 @@ name: Random Versions
 on:
   pull_request:
 
+env:
+  PY_COLORS: 1
+
 jobs:
   tox:
     strategy:

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+env:
+  PY_COLORS: 1
+
 jobs:
   mypy:
     strategy:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

Very minor PR
The `marimo` tests currently run for every python version in the `hatch` matrix. I guess in the same env since we inject `path = ".venv"` right? 🤔
Adding colors that help when reading the logs 😇