### PR TITLE
chore: remove `kwargs` from `selector` function

### DIFF
--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -53,7 +53,7 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
         self._alias_output_names = alias_output_names
         self._backend_version = backend_version
         self._version = version
-        self._kwargs = {} if kwargs is None else kwargs
+        self._kwargs = kwargs or {}
 
     def __repr__(self: Self) -> str:  # pragma: no cover
         return f"ArrowExpr(depth={self._depth}, function_name={self._function_name}, "

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -43,7 +43,7 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any],
+        kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._call = call
         self._depth = depth
@@ -53,7 +53,7 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
         self._alias_output_names = alias_output_names
         self._backend_version = backend_version
         self._version = version
-        self._kwargs = kwargs
+        self._kwargs = {} if kwargs is None else kwargs
 
     def __repr__(self: Self) -> str:  # pragma: no cover
         return f"ArrowExpr(depth={self._depth}, function_name={self._function_name}, "
@@ -117,7 +117,6 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
             alias_output_names=None,
             backend_version=backend_version,
             version=version,
-            kwargs={},
         )
 
     @classmethod
@@ -148,7 +147,6 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
             alias_output_names=None,
             backend_version=backend_version,
             version=version,
-            kwargs={},
         )
 
     def __narwhals_namespace__(self: Self) -> ArrowNamespace:
@@ -315,7 +313,7 @@ class ArrowExpr(CompliantExpr[ArrowSeries]):
             alias_output_names=alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={**self._kwargs, "name": name},
+            kwargs=self._kwargs,
         )
 
     def null_count(self: Self) -> Self:

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -49,7 +49,7 @@ class ArrowNamespace(CompliantNamespace[ArrowSeries]):
         function_name: str,
         evaluate_output_names: Callable[[ArrowDataFrame], Sequence[str]],
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
-        kwargs: dict[str, Any],
+        kwargs: dict[str, Any] | None = None,
     ) -> ArrowExpr:
         from narwhals._arrow.expr import ArrowExpr
 
@@ -75,7 +75,6 @@ class ArrowNamespace(CompliantNamespace[ArrowSeries]):
             alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def _create_series_from_scalar(
@@ -142,7 +141,6 @@ class ArrowNamespace(CompliantNamespace[ArrowSeries]):
             alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def all(self: Self) -> ArrowExpr:
@@ -165,7 +163,6 @@ class ArrowNamespace(CompliantNamespace[ArrowSeries]):
             alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def lit(self: Self, value: Any, dtype: DType | None) -> ArrowExpr:
@@ -188,7 +185,6 @@ class ArrowNamespace(CompliantNamespace[ArrowSeries]):
             alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def all_horizontal(self: Self, *exprs: ArrowExpr) -> ArrowExpr:
@@ -202,7 +198,6 @@ class ArrowNamespace(CompliantNamespace[ArrowSeries]):
             function_name="all_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={"exprs": exprs},
         )
 
     def any_horizontal(self: Self, *exprs: ArrowExpr) -> ArrowExpr:
@@ -387,11 +382,6 @@ class ArrowNamespace(CompliantNamespace[ArrowSeries]):
             function_name="concat_str",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={
-                "exprs": exprs,
-                "separator": separator,
-                "ignore_nulls": ignore_nulls,
-            },
         )
 
 
@@ -466,7 +456,6 @@ class ArrowWhen:
             alias_output_names=getattr(value, "_alias_output_names", None),
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"value": value},
         )
 
 
@@ -481,7 +470,7 @@ class ArrowThen(ArrowExpr):
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any],
+        kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._backend_version = backend_version
         self._version = version
@@ -490,7 +479,7 @@ class ArrowThen(ArrowExpr):
         self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names  # pyright: ignore[reportAttributeAccessIssue]
         self._alias_output_names = alias_output_names
-        self._kwargs = kwargs
+        self._kwargs = {} if kwargs is None else kwargs
 
     def otherwise(self: Self, value: ArrowExpr | ArrowSeries | Any) -> ArrowExpr:
         # type ignore because we are setting the `_call` attribute to a

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -479,7 +479,7 @@ class ArrowThen(ArrowExpr):
         self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names  # pyright: ignore[reportAttributeAccessIssue]
         self._alias_output_names = alias_output_names
-        self._kwargs = {} if kwargs is None else kwargs
+        self._kwargs = kwargs or {}
 
     def otherwise(self: Self, value: ArrowExpr | ArrowSeries | Any) -> ArrowExpr:
         # type ignore because we are setting the `_call` attribute to a

--- a/narwhals/_pandas_like/selectors.py
+++ b/narwhals/_pandas_like/selectors.py
@@ -37,7 +37,7 @@ class PandasSelectorNamespace:
         def evaluate_output_names(df: PandasLikeDataFrame) -> Sequence[str]:
             return [col for col in df.columns if df.schema[col] in dtypes]
 
-        return selector(self, func, evaluate_output_names, {"dtypes": dtypes})
+        return selector(self, func, evaluate_output_names)
 
     def matches(self: Self, pattern: str) -> PandasSelector:
         def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
@@ -46,7 +46,7 @@ class PandasSelectorNamespace:
         def evaluate_output_names(df: PandasLikeDataFrame) -> Sequence[str]:
             return [col for col in df.columns if re.search(pattern, col)]
 
-        return selector(self, func, evaluate_output_names, {"pattern": pattern})
+        return selector(self, func, evaluate_output_names)
 
     def numeric(self: Self) -> PandasSelector:
         dtypes = import_dtypes_module(self._version)
@@ -83,7 +83,7 @@ class PandasSelectorNamespace:
         def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
             return [df[col] for col in df.columns]
 
-        return selector(self, func, lambda df: df.columns, {})
+        return selector(self, func, lambda df: df.columns)
 
     def datetime(
         self: Self,
@@ -119,7 +119,7 @@ class PandasSelectorNamespace:
                 )
             ]
 
-        return selector(self, func, evaluate_output_names, {})
+        return selector(self, func, evaluate_output_names)
 
 
 class PandasSelector(PandasLikeExpr):
@@ -155,9 +155,7 @@ class PandasSelector(PandasLikeExpr):
                 rhs_names = other._evaluate_output_names(df)
                 return [x for x in lhs_names if x not in rhs_names]
 
-            return selector(
-                self, call, evaluate_output_names, {**self._kwargs, "other": other}
-            )
+            return selector(self, call, evaluate_output_names)
         else:
             return self._to_expr() - other
 
@@ -179,9 +177,7 @@ class PandasSelector(PandasLikeExpr):
                 rhs_names = other._evaluate_output_names(df)
                 return [*(x for x in lhs_names if x not in rhs_names), *rhs_names]
 
-            return selector(
-                self, call, evaluate_output_names, {**self._kwargs, "other": other}
-            )
+            return selector(self, call, evaluate_output_names)
         else:
             return self._to_expr() | other
 
@@ -199,9 +195,7 @@ class PandasSelector(PandasLikeExpr):
                 rhs_names = other._evaluate_output_names(df)
                 return [x for x in lhs_names if x in rhs_names]
 
-            return selector(
-                self, call, evaluate_output_names, {**self._kwargs, "other": other}
-            )
+            return selector(self, call, evaluate_output_names)
         else:
             return self._to_expr() & other
 
@@ -213,7 +207,6 @@ def selector(
     context: _FullContext,
     call: Callable[[PandasLikeDataFrame], Sequence[PandasLikeSeries]],
     evaluate_output_names: Callable[[PandasLikeDataFrame], Sequence[str]],
-    kwargs: dict[str, Any],
     /,
 ) -> PandasSelector:
     return PandasSelector(
@@ -225,5 +218,5 @@ def selector(
         implementation=context._implementation,
         backend_version=context._backend_version,
         version=context._version,
-        kwargs=kwargs,
+        kwargs={},
     )


### PR DESCRIPTION
follow-up to #2057 - there's a lot of `kwargs` we're passing around that we don't need

i'd generally like to refactor that whole mechanism (we'll need it for when we want to support `rolling_mean(n).over(group, order_by=id)`), but for a start we can remove them when they're not needed

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
