### PR TITLE
chore: remove more `kwargs` from dask, dont treat `ddof` as expressifiable arg

### DIFF
--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -48,6 +48,8 @@ class DaskExpr(CompliantExpr["dx.Series"]):
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
         backend_version: tuple[int, ...],
         version: Version,
+        # Kwargs with metadata which we may need in group-by agg
+        # (e.g. `ddof` for `std` and `var`).
         kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._call = call
@@ -139,8 +141,6 @@ class DaskExpr(CompliantExpr["dx.Series"]):
         # First argument to `call` should be `dx.Series`
         call: Callable[..., dx.Series],
         expr_name: str,
-        # Kwargs with metadata which we may need in group-by agg
-        # (e.g. `ddof` for `std` and `var`).
         kwargs: dict[str, Any] | None = None,
         **expressifiable_args: Self | Any,
     ) -> Self:
@@ -152,9 +152,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
                 for key, value in expressifiable_args.items()
             }
             for native_series in native_series_list:
-                result_native = call(
-                    native_series, **(kwargs or {}), **other_native_series
-                )
+                result_native = call(native_series, **other_native_series)
                 native_results.append(result_native)
             return native_results
 

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -48,7 +48,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any],
+        kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._call = call
         self._depth = depth
@@ -57,7 +57,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
         self._alias_output_names = alias_output_names
         self._backend_version = backend_version
         self._version = version
-        self._kwargs = kwargs
+        self._kwargs = kwargs or {}
 
     def __call__(self: Self, df: DaskLazyFrame) -> Sequence[dx.Series]:
         return self._call(df)
@@ -110,7 +110,6 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             alias_output_names=None,
             backend_version=backend_version,
             version=version,
-            kwargs={},
         )
 
     @classmethod
@@ -133,7 +132,6 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             alias_output_names=None,
             backend_version=backend_version,
             version=version,
-            kwargs={},
         )
 
     def _from_call(
@@ -141,6 +139,9 @@ class DaskExpr(CompliantExpr["dx.Series"]):
         # First argument to `call` should be `dx.Series`
         call: Callable[..., dx.Series],
         expr_name: str,
+        # Kwargs with metadata which we may need in group-by agg
+        # (e.g. `ddof` for `std` and `var`).
+        kwargs: dict[str, Any] | None = None,
         **expressifiable_args: Self | Any,
     ) -> Self:
         def func(df: DaskLazyFrame) -> list[dx.Series]:
@@ -151,7 +152,9 @@ class DaskExpr(CompliantExpr["dx.Series"]):
                 for key, value in expressifiable_args.items()
             }
             for native_series in native_series_list:
-                result_native = call(native_series, **other_native_series)
+                result_native = call(
+                    native_series, **(kwargs or {}), **other_native_series
+                )
                 native_results.append(result_native)
             return native_results
 
@@ -163,7 +166,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={**self._kwargs, **expressifiable_args},
+            kwargs=kwargs,
         )
 
     def alias(self: Self, name: str) -> Self:
@@ -310,12 +313,16 @@ class DaskExpr(CompliantExpr["dx.Series"]):
 
     def std(self: Self, ddof: int) -> Self:
         return self._from_call(
-            lambda _input, ddof: _input.std(ddof=ddof).to_series(), "std", ddof=ddof
+            lambda _input: _input.std(ddof=ddof).to_series(),
+            "std",
+            kwargs={"ddof": ddof},
         )
 
     def var(self: Self, ddof: int) -> Self:
         return self._from_call(
-            lambda _input, ddof: _input.var(ddof=ddof).to_series(), "var", ddof=ddof
+            lambda _input: _input.var(ddof=ddof).to_series(),
+            "var",
+            kwargs={"ddof": ddof},
         )
 
     def skew(self: Self) -> Self:

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -50,7 +50,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
         version: Version,
         # Kwargs with metadata which we may need in group-by agg
         # (e.g. `ddof` for `std` and `var`).
-        kwargs: dict[str, Any] | None = None,
+        call_kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._call = call
         self._depth = depth
@@ -59,7 +59,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
         self._alias_output_names = alias_output_names
         self._backend_version = backend_version
         self._version = version
-        self._kwargs = kwargs or {}
+        self._call_kwargs = call_kwargs or {}
 
     def __call__(self: Self, df: DaskLazyFrame) -> Sequence[dx.Series]:
         return self._call(df)
@@ -84,7 +84,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs=self._kwargs,
+            call_kwargs=self._call_kwargs,
         )
 
     @classmethod
@@ -164,7 +164,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs=kwargs,
+            call_kwargs=kwargs,
         )
 
     def alias(self: Self, name: str) -> Self:
@@ -182,7 +182,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             alias_output_names=alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={**self._kwargs, "name": name},
+            call_kwargs=self._call_kwargs,
         )
 
     def __add__(self: Self, other: Any) -> Self:
@@ -313,14 +313,14 @@ class DaskExpr(CompliantExpr["dx.Series"]):
         return self._from_call(
             lambda _input: _input.std(ddof=ddof).to_series(),
             "std",
-            kwargs={"ddof": ddof},
+            call_kwargs={"ddof": ddof},
         )
 
     def var(self: Self, ddof: int) -> Self:
         return self._from_call(
             lambda _input: _input.var(ddof=ddof).to_series(),
             "var",
-            kwargs={"ddof": ddof},
+            call_kwargs={"ddof": ddof},
         )
 
     def skew(self: Self) -> Self:
@@ -568,7 +568,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={**self._kwargs, "keys": keys},
+            call_kwargs=self._call_kwargs,
         )
 
     def cast(self: Self, dtype: DType | type[DType]) -> Self:

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -141,7 +141,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
         # First argument to `call` should be `dx.Series`
         call: Callable[..., dx.Series],
         expr_name: str,
-        kwargs: dict[str, Any] | None = None,
+        call_kwargs: dict[str, Any] | None = None,
         **expressifiable_args: Self | Any,
     ) -> Self:
         def func(df: DaskLazyFrame) -> list[dx.Series]:
@@ -164,7 +164,7 @@ class DaskExpr(CompliantExpr["dx.Series"]):
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            call_kwargs=kwargs,
+            call_kwargs=call_kwargs,
         )
 
     def alias(self: Self, name: str) -> Self:

--- a/narwhals/_dask/expr_name.py
+++ b/narwhals/_dask/expr_name.py
@@ -64,5 +64,5 @@ class DaskExprNameNamespace:
             alias_output_names=alias_output_names,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs=self._compliant_expr._kwargs,
+            call_kwargs=self._compliant_expr._call_kwargs,
         )

--- a/narwhals/_dask/group_by.py
+++ b/narwhals/_dask/group_by.py
@@ -145,14 +145,12 @@ def agg_dask(
 
             # e.g. agg(nw.mean('a')) # noqa: ERA001
             function_name = re.sub(r"(\w+->)", "", expr._function_name)
-            kwargs: dict[str, Any] = (
-                {"ddof": expr._kwargs["ddof"]} if function_name in {"std", "var"} else {}  # type: ignore[attr-defined]
-            )
-
             agg_function = POLARS_TO_DASK_AGGREGATIONS.get(function_name, function_name)
             # deal with n_unique case in a "lazy" mode to not depend on dask globally
             agg_function = (
-                agg_function(**kwargs) if callable(agg_function) else agg_function
+                agg_function(**expr._call_kwargs)  # type: ignore[attr-defined]
+                if callable(agg_function)
+                else agg_function
             )
 
             simple_aggregations.update(

--- a/narwhals/_dask/group_by.py
+++ b/narwhals/_dask/group_by.py
@@ -47,11 +47,11 @@ def n_unique() -> dd.Aggregation:
     return dd.Aggregation(name="nunique", chunk=chunk, agg=agg)
 
 
-def var(ddof: int = 1) -> _AggFn:
+def var(ddof: int) -> _AggFn:
     return partial(_DaskGroupBy.var, ddof=ddof)
 
 
-def std(ddof: int = 1) -> _AggFn:
+def std(ddof: int) -> _AggFn:
     return partial(_DaskGroupBy.std, ddof=ddof)
 
 

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -401,7 +401,7 @@ class DaskThen(DaskExpr):
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any] | None = None,
+        call_kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._backend_version = backend_version
         self._version = version
@@ -410,7 +410,7 @@ class DaskThen(DaskExpr):
         self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names  # pyright: ignore[reportAttributeAccessIssue]
         self._alias_output_names = alias_output_names
-        self._kwargs = kwargs or {}
+        self._call_kwargs = call_kwargs or {}
 
     def otherwise(self: Self, value: DaskExpr | Any) -> DaskExpr:
         # type ignore because we are setting the `_call` attribute to a

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -61,7 +61,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
             alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def col(self: Self, *column_names: str) -> DaskExpr:
@@ -93,7 +92,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
             alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def len(self: Self) -> DaskExpr:
@@ -116,7 +114,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
             alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def all_horizontal(self: Self, *exprs: DaskExpr) -> DaskExpr:
@@ -134,7 +131,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def any_horizontal(self: Self, *exprs: DaskExpr) -> DaskExpr:
@@ -152,7 +148,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def sum_horizontal(self: Self, *exprs: DaskExpr) -> DaskExpr:
@@ -170,7 +165,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def concat(
@@ -253,7 +247,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def min_horizontal(self: Self, *exprs: DaskExpr) -> DaskExpr:
@@ -272,7 +265,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def max_horizontal(self: Self, *exprs: DaskExpr) -> DaskExpr:
@@ -291,7 +283,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"exprs": exprs},
         )
 
     def when(self: Self, predicate: DaskExpr) -> DaskWhen:
@@ -342,11 +333,6 @@ class DaskNamespace(CompliantNamespace["dx.Series"]):
             alias_output_names=getattr(exprs[0], "_alias_output_names", None),
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={
-                "exprs": exprs,
-                "separator": separator,
-                "ignore_nulls": ignore_nulls,
-            },
         )
 
 
@@ -401,7 +387,6 @@ class DaskWhen:
             alias_output_names=getattr(value, "_alias_output_names", None),
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"value": value},
         )
 
 
@@ -416,7 +401,7 @@ class DaskThen(DaskExpr):
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any],
+        kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._backend_version = backend_version
         self._version = version
@@ -425,7 +410,7 @@ class DaskThen(DaskExpr):
         self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names  # pyright: ignore[reportAttributeAccessIssue]
         self._alias_output_names = alias_output_names
-        self._kwargs = kwargs
+        self._kwargs = kwargs or {}
 
     def otherwise(self: Self, value: DaskExpr | Any) -> DaskExpr:
         # type ignore because we are setting the `_call` attribute to a

--- a/narwhals/_dask/selectors.py
+++ b/narwhals/_dask/selectors.py
@@ -147,7 +147,6 @@ class DaskSelector(DaskExpr):
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def __sub__(self: Self, other: DaskSelector | Any) -> DaskSelector | Any:
@@ -226,5 +225,4 @@ def selector(
         alias_output_names=None,
         backend_version=context._backend_version,
         version=context._version,
-        kwargs={},
     )

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -58,7 +58,7 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
         implementation: Implementation,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any],
+        kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._call = call
         self._depth = depth
@@ -68,7 +68,7 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
         self._implementation = implementation
         self._backend_version = backend_version
         self._version = version
-        self._kwargs = kwargs
+        self._kwargs = kwargs or {}
 
     def __call__(self: Self, df: PandasLikeDataFrame) -> Sequence[PandasLikeSeries]:
         return self._call(df)
@@ -145,7 +145,6 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
             implementation=implementation,
             backend_version=backend_version,
             version=version,
-            kwargs={},
         )
 
     @classmethod
@@ -176,7 +175,6 @@ class PandasLikeExpr(CompliantExpr[PandasLikeSeries]):
             implementation=implementation,
             backend_version=backend_version,
             version=version,
-            kwargs={},
         )
 
     def cast(self: Self, dtype: DType | type[DType]) -> Self:

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -93,7 +93,6 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeSeries]):
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def _create_compliant_series(self: Self, value: Any) -> PandasLikeSeries:
@@ -139,7 +138,6 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeSeries]):
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def lit(self: Self, value: Any, dtype: DType | None) -> PandasLikeExpr:
@@ -165,7 +163,6 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeSeries]):
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     def len(self: Self) -> PandasLikeExpr:
@@ -187,7 +184,6 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeSeries]):
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={},
         )
 
     # --- horizontal ---

--- a/narwhals/_pandas_like/selectors.py
+++ b/narwhals/_pandas_like/selectors.py
@@ -218,5 +218,4 @@ def selector(
         implementation=context._implementation,
         backend_version=context._backend_version,
         version=context._version,
-        kwargs={},
     )


### PR DESCRIPTION
I don't like how currently we're muddying the waters between "expressifiable arguments" and "kwargs", which leads us to having to pass `ddof` as an expressifiable argument in `std` and `var`

I'd like to start by separating the concepts, and not passing `ddof` as an expressifiable argument

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
