### PR TITLE
chore(typing): add `CompliantExpr._version`

### DIFF
--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from narwhals.expr import Expr
     from narwhals.series import Series
     from narwhals.utils import Implementation
+    from narwhals.utils import Version
 
     # All dataframes supported by Narwhals have a
     # `columns` property. Their similarities don't extend
@@ -79,6 +80,7 @@ CompliantSeriesT_co = TypeVar(
 class CompliantExpr(Protocol, Generic[CompliantSeriesT_co]):
     _implementation: Implementation
     _backend_version: tuple[int, ...]
+    _version: Version
     _evaluate_output_names: Callable[
         [CompliantDataFrame | CompliantLazyFrame], Sequence[str]
     ]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- Mentioned in https://discord.com/channels/1235257048170762310/1272835922924273694/1342486928250900570

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
All implementors of the protocol already define this, meaning `CompliantExpr` can now match `_FullContext`

https://github.com/narwhals-dev/narwhals/blob/4dda548fc36ebcef3bb70e8d4581de1774879060/narwhals/utils.py#L77-L100