### PR TITLE
chore: remove unused kwargs in `_pandas_like` and `_arrow`

### DIFF
--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -441,7 +441,6 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={**self._kwargs, "keys": keys},
         )
 
     def mode(self: Self) -> Self:
@@ -483,7 +482,6 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={**self._kwargs, "function": function, "return_dtype": return_dtype},
         )
 
     def is_finite(self: Self) -> Self:

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -43,7 +43,7 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any] | None = None,
+        call_kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._call = call
         self._depth = depth
@@ -53,7 +53,7 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
         self._alias_output_names = alias_output_names
         self._backend_version = backend_version
         self._version = version
-        self._kwargs = kwargs or {}
+        self._call_kwargs = call_kwargs or {}
 
     def __repr__(self: Self) -> str:  # pragma: no cover
         return f"ArrowExpr(depth={self._depth}, function_name={self._function_name}, "
@@ -80,7 +80,7 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs=self._kwargs,
+            call_kwargs=self._call_kwargs,
         )
 
     @classmethod
@@ -317,7 +317,7 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
             alias_output_names=alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs=self._kwargs,
+            call_kwargs=self._call_kwargs,
         )
 
     def null_count(self: Self) -> Self:

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -246,10 +246,14 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
         return reuse_series_implementation(self, "n_unique", returns_scalar=True)
 
     def std(self: Self, ddof: int) -> Self:
-        return reuse_series_implementation(self, "std", ddof=ddof, returns_scalar=True)
+        return reuse_series_implementation(
+            self, "std", call_kwargs={"ddof": ddof}, returns_scalar=True
+        )
 
     def var(self: Self, ddof: int) -> Self:
-        return reuse_series_implementation(self, "var", ddof=ddof, returns_scalar=True)
+        return reuse_series_implementation(
+            self, "var", call_kwargs={"ddof": ddof}, returns_scalar=True
+        )
 
     def skew(self: Self) -> Self:
         return reuse_series_implementation(self, "skew", returns_scalar=True)

--- a/narwhals/_arrow/expr_name.py
+++ b/narwhals/_arrow/expr_name.py
@@ -79,5 +79,5 @@ class ArrowExprNameNamespace:
             alias_output_names=alias_output_names,
             backend_version=self._compliant_expr._backend_version,
             version=self._compliant_expr._version,
-            kwargs=self._compliant_expr._kwargs,
+            call_kwargs=self._compliant_expr._call_kwargs,
         )

--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -93,7 +93,7 @@ class ArrowGroupBy:
 
             function_name = re.sub(r"(\w+->)", "", expr._function_name)
             if function_name in {"std", "var"}:
-                option: Any = pc.VarianceOptions(ddof=expr._kwargs["ddof"])
+                option: Any = pc.VarianceOptions(ddof=expr._call_kwargs["ddof"])
             elif function_name in {"len", "n_unique"}:
                 option = pc.CountOptions(mode="all")
             elif function_name == "count":

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -49,7 +49,7 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
         function_name: str,
         evaluate_output_names: Callable[[ArrowDataFrame], Sequence[str]],
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
-        kwargs: dict[str, Any] | None = None,
+        call_kwargs: dict[str, Any] | None = None,
     ) -> ArrowExpr:
         from narwhals._arrow.expr import ArrowExpr
 
@@ -61,7 +61,7 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
             alias_output_names=alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs=kwargs,
+            call_kwargs=call_kwargs,
         )
 
     def _create_expr_from_series(self: Self, series: ArrowSeries) -> ArrowExpr:

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -211,7 +211,6 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
             function_name="any_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={"exprs": exprs},
         )
 
     def sum_horizontal(self: Self, *exprs: ArrowExpr) -> ArrowExpr:
@@ -229,7 +228,6 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
             function_name="sum_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={"exprs": exprs},
         )
 
     def mean_horizontal(self: Self, *exprs: ArrowExpr) -> IntoArrowExpr:
@@ -251,7 +249,6 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
             function_name="mean_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={"exprs": exprs},
         )
 
     def min_horizontal(self: Self, *exprs: ArrowExpr) -> ArrowExpr:
@@ -280,7 +277,6 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
             function_name="min_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={"exprs": exprs},
         )
 
     def max_horizontal(self: Self, *exprs: ArrowExpr) -> ArrowExpr:
@@ -310,7 +306,6 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
             function_name="max_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={"exprs": exprs},
         )
 
     def concat(

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -465,7 +465,7 @@ class ArrowThen(ArrowExpr):
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any] | None = None,
+        call_kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._backend_version = backend_version
         self._version = version
@@ -474,7 +474,7 @@ class ArrowThen(ArrowExpr):
         self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names  # pyright: ignore[reportAttributeAccessIssue]
         self._alias_output_names = alias_output_names
-        self._kwargs = kwargs or {}
+        self._call_kwargs = call_kwargs or {}
 
     def otherwise(self: Self, value: ArrowExpr | ArrowSeries | Any) -> ArrowExpr:
         # type ignore because we are setting the `_call` attribute to a

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -190,7 +190,7 @@ def reuse_series_implementation(
         function_name=f"{expr._function_name}->{attr}",
         evaluate_output_names=expr._evaluate_output_names,  # type: ignore[arg-type]
         alias_output_names=expr._alias_output_names,
-        kwargs={**expr._kwargs, **expressifiable_args},
+        kwargs=expressifiable_args,
     )
 
 
@@ -230,7 +230,7 @@ def reuse_series_namespace_implementation(
         function_name=f"{expr._function_name}->{series_namespace}.{attr}",
         evaluate_output_names=expr._evaluate_output_names,  # type: ignore[arg-type]
         alias_output_names=expr._alias_output_names,
-        kwargs={**expr._kwargs, **kwargs},
+        kwargs=kwargs,
     )
 
 

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -212,7 +212,7 @@ def reuse_series_namespace_implementation(
     expr: ArrowExprT | PandasLikeExprT,
     series_namespace: str,
     attr: str,
-    **call_kwargs: Any,
+    **kwargs: Any,
 ) -> ArrowExprT | PandasLikeExprT:
     """Reuse Series implementation for expression.
 
@@ -224,19 +224,18 @@ def reuse_series_namespace_implementation(
         series_namespace: The Series namespace (e.g. `dt`, `cat`, `str`, `list`, `name`)
         attr: name of method.
         args: arguments to pass to function.
-        call_kwargs: keyword arguments to pass to function.
+        kwargs: keyword arguments to pass to function.
     """
     plx = expr.__narwhals_namespace__()
     return plx._create_expr_from_callable(  # type: ignore[return-value]
         lambda df: [
-            getattr(getattr(series, series_namespace), attr)(**call_kwargs)
+            getattr(getattr(series, series_namespace), attr)(**kwargs)
             for series in expr(df)  # type: ignore[arg-type]
         ],
         depth=expr._depth + 1,
         function_name=f"{expr._function_name}->{series_namespace}.{attr}",
         evaluate_output_names=expr._evaluate_output_names,  # type: ignore[arg-type]
         alias_output_names=expr._alias_output_names,
-        call_kwargs=call_kwargs,
     )
 
 

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -133,10 +133,7 @@ def reuse_series_implementation(
     attr: str,
     *,
     returns_scalar: bool = False,
-    # non-expressifiable args which we may need to reuse in `agg` or `over`,
-    # such as `ddof` for `std` and `var`
     call_kwargs: dict[str, Any] | None = None,
-    # arguments which may be (but don't have to be) expressifiable
     **expressifiable_args: Any,
 ) -> ArrowExprT | PandasLikeExprT:
     """Reuse Series implementation for expression.

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -196,7 +196,7 @@ def reuse_series_implementation(
         function_name=f"{expr._function_name}->{attr}",
         evaluate_output_names=expr._evaluate_output_names,  # type: ignore[arg-type]
         alias_output_names=expr._alias_output_names,
-        kwargs=call_kwargs,
+        call_kwargs=call_kwargs,
     )
 
 
@@ -212,7 +212,7 @@ def reuse_series_namespace_implementation(
     expr: ArrowExprT | PandasLikeExprT,
     series_namespace: str,
     attr: str,
-    **kwargs: Any,
+    **call_kwargs: Any,
 ) -> ArrowExprT | PandasLikeExprT:
     """Reuse Series implementation for expression.
 
@@ -224,19 +224,19 @@ def reuse_series_namespace_implementation(
         series_namespace: The Series namespace (e.g. `dt`, `cat`, `str`, `list`, `name`)
         attr: name of method.
         args: arguments to pass to function.
-        kwargs: keyword arguments to pass to function.
+        call_kwargs: keyword arguments to pass to function.
     """
     plx = expr.__narwhals_namespace__()
     return plx._create_expr_from_callable(  # type: ignore[return-value]
         lambda df: [
-            getattr(getattr(series, series_namespace), attr)(**kwargs)
+            getattr(getattr(series, series_namespace), attr)(**call_kwargs)
             for series in expr(df)  # type: ignore[arg-type]
         ],
         depth=expr._depth + 1,
         function_name=f"{expr._function_name}->{series_namespace}.{attr}",
         evaluate_output_names=expr._evaluate_output_names,  # type: ignore[arg-type]
         alias_output_names=expr._alias_output_names,
-        kwargs=kwargs,
+        call_kwargs=call_kwargs,
     )
 
 

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -416,7 +416,7 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={**self._kwargs, "name": name},
+            kwargs=self._kwargs,
         )
 
     def over(self: Self, keys: list[str], kind: ExprKind) -> Self:
@@ -504,7 +504,6 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={**self._kwargs, "keys": keys},
         )
 
     def is_unique(self: Self) -> Self:
@@ -578,7 +577,6 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={**self._kwargs, "function": function, "return_dtype": return_dtype},
         )
 
     def is_finite(self: Self) -> Self:

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -268,10 +268,14 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
         return reuse_series_implementation(self, "median", returns_scalar=True)
 
     def std(self: Self, *, ddof: int) -> Self:
-        return reuse_series_implementation(self, "std", ddof=ddof, returns_scalar=True)
+        return reuse_series_implementation(
+            self, "std", returns_scalar=True, call_kwargs={"ddof": ddof}
+        )
 
     def var(self: Self, *, ddof: int) -> Self:
-        return reuse_series_implementation(self, "var", ddof=ddof, returns_scalar=True)
+        return reuse_series_implementation(
+            self, "var", returns_scalar=True, call_kwargs={"ddof": ddof}
+        )
 
     def skew(self: Self) -> Self:
         return reuse_series_implementation(self, "skew", returns_scalar=True)
@@ -370,7 +374,9 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
         return reuse_series_implementation(self, "abs")
 
     def cum_sum(self: Self, *, reverse: bool) -> Self:
-        return reuse_series_implementation(self, "cum_sum", reverse=reverse)
+        return reuse_series_implementation(
+            self, "cum_sum", call_kwargs={"reverse": reverse}
+        )
 
     def unique(self: Self) -> Self:
         return reuse_series_implementation(self, "unique", maintain_order=False)
@@ -379,7 +385,7 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
         return reuse_series_implementation(self, "diff")
 
     def shift(self: Self, n: int) -> Self:
-        return reuse_series_implementation(self, "shift", n=n)
+        return reuse_series_implementation(self, "shift", call_kwargs={"n": n})
 
     def sample(
         self: Self,
@@ -583,16 +589,24 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
         return reuse_series_implementation(self, "is_finite")
 
     def cum_count(self: Self, *, reverse: bool) -> Self:
-        return reuse_series_implementation(self, "cum_count", reverse=reverse)
+        return reuse_series_implementation(
+            self, "cum_count", call_kwargs={"reverse": reverse}
+        )
 
     def cum_min(self: Self, *, reverse: bool) -> Self:
-        return reuse_series_implementation(self, "cum_min", reverse=reverse)
+        return reuse_series_implementation(
+            self, "cum_min", call_kwargs={"reverse": reverse}
+        )
 
     def cum_max(self: Self, *, reverse: bool) -> Self:
-        return reuse_series_implementation(self, "cum_max", reverse=reverse)
+        return reuse_series_implementation(
+            self, "cum_max", call_kwargs={"reverse": reverse}
+        )
 
     def cum_prod(self: Self, *, reverse: bool) -> Self:
-        return reuse_series_implementation(self, "cum_prod", reverse=reverse)
+        return reuse_series_implementation(
+            self, "cum_prod", call_kwargs={"reverse": reverse}
+        )
 
     def rolling_sum(
         self: Self,
@@ -665,7 +679,7 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
         descending: bool,
     ) -> Self:
         return reuse_series_implementation(
-            self, "rank", method=method, descending=descending
+            self, "rank", call_kwargs={"method": method, "descending": descending}
         )
 
     @property

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -58,7 +58,7 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
         implementation: Implementation,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any] | None = None,
+        call_kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._call = call
         self._depth = depth
@@ -68,7 +68,7 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
         self._implementation = implementation
         self._backend_version = backend_version
         self._version = version
-        self._kwargs = kwargs or {}
+        self._call_kwargs = call_kwargs or {}
 
     def __call__(self: Self, df: PandasLikeDataFrame) -> Sequence[PandasLikeSeries]:
         return self._call(df)
@@ -107,7 +107,7 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
             backend_version=self._backend_version,
             version=self._version,
             implementation=self._implementation,
-            kwargs=self._kwargs,
+            call_kwargs=self._call_kwargs,
         )
 
     @classmethod
@@ -422,7 +422,7 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs=self._kwargs,
+            call_kwargs=self._call_kwargs,
         )
 
     def over(self: Self, keys: list[str], kind: ExprKind) -> Self:
@@ -440,23 +440,23 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
                     "over context for pandas-like backend."
                 )
                 if function_name == "cum_count":
-                    if self._kwargs["reverse"]:
+                    if self._call_kwargs["reverse"]:
                         raise NotImplementedError(unsupported_reverse_msg)
                     plx = self.__narwhals_namespace__()
                     df = df.with_columns(~plx.col(*output_names).is_null())
 
                 if function_name == "shift":
-                    kwargs = {"periods": self._kwargs["n"]}
+                    kwargs = {"periods": self._call_kwargs["n"]}
                 elif function_name == "rank":
-                    _method = self._kwargs["method"]
+                    _method = self._call_kwargs["method"]
                     kwargs = {
                         "method": "first" if _method == "ordinal" else _method,
-                        "ascending": not self._kwargs["descending"],
+                        "ascending": not self._call_kwargs["descending"],
                         "na_option": "keep",
                         "pct": False,
                     }
                 else:  # Cumulative operation
-                    if self._kwargs["reverse"]:
+                    if self._call_kwargs["reverse"]:
                         raise NotImplementedError(unsupported_reverse_msg)
                     kwargs = {"skipna": True}
 

--- a/narwhals/_pandas_like/expr_name.py
+++ b/narwhals/_pandas_like/expr_name.py
@@ -80,5 +80,5 @@ class PandasLikeExprNameNamespace:
             backend_version=self._compliant_expr._backend_version,
             implementation=self._compliant_expr._implementation,
             version=self._compliant_expr._version,
-            kwargs=self._compliant_expr._kwargs,
+            call_kwargs=self._compliant_expr._call_kwargs,
         )

--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -138,10 +138,10 @@ class PandasLikeGroupBy:
                 for output_name, alias in zip(output_names, aliases):
                     if is_n_unique:
                         nunique_aggs[alias] = output_name
-                    elif is_std and (ddof := expr._kwargs["ddof"]) != 1:
+                    elif is_std and (ddof := expr._call_kwargs["ddof"]) != 1:
                         std_aggs[ddof][0].append(output_name)
                         std_aggs[ddof][1].append(alias)
-                    elif is_var and (ddof := expr._kwargs["ddof"]) != 1:
+                    elif is_var and (ddof := expr._call_kwargs["ddof"]) != 1:
                         var_aggs[ddof][0].append(output_name)
                         var_aggs[ddof][1].append(alias)
                     else:

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -487,7 +487,7 @@ class PandasThen(PandasLikeExpr):
         implementation: Implementation,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any] | None = None,
+        call_kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._implementation = implementation
         self._backend_version = backend_version
@@ -497,7 +497,7 @@ class PandasThen(PandasLikeExpr):
         self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names  # pyright: ignore[reportAttributeAccessIssue]
         self._alias_output_names = alias_output_names
-        self._kwargs = kwargs or {}
+        self._call_kwargs = call_kwargs or {}
 
     def otherwise(
         self: Self, value: PandasLikeExpr | PandasLikeSeries | Any

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -57,7 +57,7 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
         function_name: str,
         evaluate_output_names: Callable[[PandasLikeDataFrame], Sequence[str]],
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
-        kwargs: dict[str, Any],
+        kwargs: dict[str, Any] | None = None,
     ) -> PandasLikeExpr:
         return PandasLikeExpr(
             func,
@@ -200,7 +200,6 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
             function_name="sum_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={"exprs": exprs},
         )
 
     def all_horizontal(self: Self, *exprs: PandasLikeExpr) -> PandasLikeExpr:
@@ -216,7 +215,6 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
             function_name="all_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={"exprs": exprs},
         )
 
     def any_horizontal(self: Self, *exprs: PandasLikeExpr) -> PandasLikeExpr:
@@ -232,7 +230,6 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
             function_name="any_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={"exprs": exprs},
         )
 
     def mean_horizontal(self: Self, *exprs: PandasLikeExpr) -> PandasLikeExpr:
@@ -250,7 +247,6 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
             function_name="mean_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={"exprs": exprs},
         )
 
     def min_horizontal(self: Self, *exprs: PandasLikeExpr) -> PandasLikeExpr:
@@ -275,7 +271,6 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
             function_name="min_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={"exprs": exprs},
         )
 
     def max_horizontal(self: Self, *exprs: PandasLikeExpr) -> PandasLikeExpr:
@@ -300,7 +295,6 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
             function_name="max_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={"exprs": exprs},
         )
 
     def concat(
@@ -402,11 +396,6 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
             function_name="concat_str",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
-            kwargs={
-                "exprs": exprs,
-                "separator": separator,
-                "ignore_nulls": ignore_nulls,
-            },
         )
 
 
@@ -483,7 +472,6 @@ class PandasWhen:
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs={"value": value},
         )
 
 
@@ -499,7 +487,7 @@ class PandasThen(PandasLikeExpr):
         implementation: Implementation,
         backend_version: tuple[int, ...],
         version: Version,
-        kwargs: dict[str, Any],
+        kwargs: dict[str, Any] | None = None,
     ) -> None:
         self._implementation = implementation
         self._backend_version = backend_version
@@ -509,7 +497,7 @@ class PandasThen(PandasLikeExpr):
         self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names  # pyright: ignore[reportAttributeAccessIssue]
         self._alias_output_names = alias_output_names
-        self._kwargs = kwargs
+        self._kwargs = kwargs or {}
 
     def otherwise(
         self: Self, value: PandasLikeExpr | PandasLikeSeries | Any

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -57,7 +57,7 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
         function_name: str,
         evaluate_output_names: Callable[[PandasLikeDataFrame], Sequence[str]],
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
-        kwargs: dict[str, Any] | None = None,
+        call_kwargs: dict[str, Any] | None = None,
     ) -> PandasLikeExpr:
         return PandasLikeExpr(
             func,
@@ -68,7 +68,7 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs=kwargs,
+            call_kwargs=call_kwargs,
         )
 
     def _create_series_from_scalar(

--- a/narwhals/_pandas_like/selectors.py
+++ b/narwhals/_pandas_like/selectors.py
@@ -138,7 +138,7 @@ class PandasSelector(PandasLikeExpr):
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            kwargs=self._kwargs,
+            call_kwargs=self._call_kwargs,
         )
 
     def __sub__(self: Self, other: PandasSelector | Any) -> PandasSelector | Any:

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -181,6 +181,8 @@ def _std(
     if np_version > (2, 0):
         if ddof == 1:
             return functions.stddev_samp(_input)
+        if ddof == 0:
+            return functions.stddev_pop(_input)
 
         n_rows = functions.count(_input)
         return functions.stddev_samp(_input) * functions.sqrt(

--- a/narwhals/group_by.py
+++ b/narwhals/group_by.py
@@ -151,8 +151,6 @@ class LazyGroupBy(Generic[LazyFrameT]):
     def agg(self: Self, *aggs: Expr | Iterable[Expr], **named_aggs: Expr) -> LazyFrameT:
         """Compute aggregations for each group of a group by operation.
 
-        If a library does not support lazy execution, then this is a no-op.
-
         Arguments:
             aggs: Aggregations to compute for each group of the group by operation,
                 specified as positional arguments.

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -427,3 +427,25 @@ def test_pandas_group_by_index_and_column_overlap() -> None:
     assert key == (1,)
     expected_native = pd.DataFrame({"a": [1, 1], "b": [4, 5]})
     pd.testing.assert_frame_equal(result.to_native(), expected_native)
+
+
+def test_fancy_functions(constructor: Constructor) -> None:
+    df = nw.from_native(constructor({"a": [1, 1, 2], "b": [4, 5, 6]}))
+    result = df.group_by("a").agg(nw.all().std(ddof=0)).sort("a")
+    expected = {"a": [1, 2], "b": [0.5, 0.0]}
+    assert_equal_data(result, expected)
+    result = df.group_by("a").agg(nw.selectors.numeric().std(ddof=0)).sort("a")
+    assert_equal_data(result, expected)
+    result = df.group_by("a").agg(nw.selectors.matches("b").std(ddof=0)).sort("a")
+    assert_equal_data(result, expected)
+    result = (
+        df.group_by("a").agg(nw.selectors.matches("b").std(ddof=0).alias("c")).sort("a")
+    )
+    expected = {"a": [1, 2], "c": [0.5, 0.0]}
+    assert_equal_data(result, expected)
+    result = (
+        df.group_by("a")
+        .agg(nw.selectors.matches("b").std(ddof=0).name.map(lambda _x: "c"))
+        .sort("a")
+    )
+    assert_equal_data(result, expected)


### PR DESCRIPTION
More separation between expressifiable kwargs and call kwargs

This doesn't go all the way (yet) but does reduce passing around kwargs when it's not necessary

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
