### PR TITLE
chore(typing): Fix `(Pandas|Arrow)(When|Then)`

### DIFF
--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -27,17 +27,19 @@ from narwhals._expression_parsing import combine_evaluate_output_names
 from narwhals.typing import CompliantNamespace
 from narwhals.utils import Implementation
 from narwhals.utils import import_dtypes_module
-from narwhals.utils import is_compliant_expr
 
 if TYPE_CHECKING:
     from typing import Callable
 
     from typing_extensions import Self
+    from typing_extensions import TypeAlias
 
     from narwhals._arrow.typing import Incomplete
     from narwhals._arrow.typing import IntoArrowExpr
     from narwhals.dtypes import DType
     from narwhals.utils import Version
+
+    _Scalar: TypeAlias = Any
 
 
 class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
@@ -385,15 +387,15 @@ class ArrowWhen:
         self: Self,
         condition: ArrowExpr,
         backend_version: tuple[int, ...],
-        then_value: Any = None,
-        otherwise_value: Any = None,
+        then_value: ArrowExpr | _Scalar = None,
+        otherwise_value: ArrowExpr | _Scalar = None,
         *,
         version: Version,
     ) -> None:
         self._backend_version = backend_version
-        self._condition = condition
-        self._then_value = then_value
-        self._otherwise_value = otherwise_value
+        self._condition: ArrowExpr = condition
+        self._then_value: ArrowExpr | _Scalar = then_value
+        self._otherwise_value: ArrowExpr | _Scalar = otherwise_value
         self._version = version
 
     def __call__(self: Self, df: ArrowDataFrame) -> Sequence[ArrowSeries]:
@@ -401,10 +403,9 @@ class ArrowWhen:
         condition = self._condition(df)[0]
         condition_native = condition._native_series
 
-        if is_compliant_expr(self._then_value):
-            value_series: ArrowSeries = self._then_value(df)[0]
+        if isinstance(self._then_value, ArrowExpr):
+            value_series = self._then_value(df)[0]
         else:
-            # `self._then_value` is a scalar
             value_series = plx._create_series_from_scalar(
                 self._then_value, reference_series=condition.alias("literal")
             )
@@ -420,10 +421,9 @@ class ArrowWhen:
                     pc.if_else(condition_native, value_series_native, otherwise_null)
                 )
             ]
-        if is_compliant_expr(self._otherwise_value):
-            otherwise_series: ArrowSeries = self._otherwise_value(df)[0]
+        if isinstance(self._otherwise_value, ArrowExpr):
+            otherwise_series = self._otherwise_value(df)[0]
         else:
-            # `self._otherwise_value` is a scalar
             otherwise_series = plx._create_series_from_scalar(
                 self._otherwise_value, reference_series=condition.alias("literal")
             )
@@ -438,7 +438,7 @@ class ArrowWhen:
             )
         ]
 
-    def then(self: Self, value: ArrowExpr | ArrowSeries | Any) -> ArrowThen:
+    def then(self: Self, value: ArrowExpr | ArrowSeries | _Scalar) -> ArrowThen:
         self._then_value = value
 
         return ArrowThen(
@@ -469,17 +469,14 @@ class ArrowThen(ArrowExpr):
     ) -> None:
         self._backend_version = backend_version
         self._version = version
-        self._call = call
+        self._call: ArrowWhen = call
         self._depth = depth
         self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names
         self._alias_output_names = alias_output_names
         self._call_kwargs = call_kwargs or {}
 
-    def otherwise(self: Self, value: ArrowExpr | ArrowSeries | Any) -> ArrowExpr:
-        # type ignore because we are setting the `_call` attribute to a
-        # callable object of type `PandasWhen`, base class has the attribute as
-        # only a `Callable`
-        self._call._otherwise_value = value  # type: ignore[attr-defined]
+    def otherwise(self: Self, value: ArrowExpr | ArrowSeries | _Scalar) -> ArrowExpr:
+        self._call._otherwise_value = value
         self._function_name = "whenotherwise"
         return self

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -23,14 +23,16 @@ from narwhals._pandas_like.utils import horizontal_concat
 from narwhals._pandas_like.utils import vertical_concat
 from narwhals.typing import CompliantNamespace
 from narwhals.utils import import_dtypes_module
-from narwhals.utils import is_compliant_expr
 
 if TYPE_CHECKING:
     from typing_extensions import Self
+    from typing_extensions import TypeAlias
 
     from narwhals.dtypes import DType
     from narwhals.utils import Implementation
     from narwhals.utils import Version
+
+    _Scalar: TypeAlias = Any
 
 
 class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeries]):
@@ -405,16 +407,16 @@ class PandasWhen:
         condition: PandasLikeExpr,
         implementation: Implementation,
         backend_version: tuple[int, ...],
-        then_value: Any = None,
-        otherwise_value: Any = None,
+        then_value: PandasLikeExpr | _Scalar = None,
+        otherwise_value: PandasLikeExpr | _Scalar = None,
         *,
         version: Version,
     ) -> None:
         self._implementation = implementation
         self._backend_version = backend_version
-        self._condition = condition
-        self._then_value = then_value
-        self._otherwise_value = otherwise_value
+        self._condition: PandasLikeExpr = condition
+        self._then_value: PandasLikeExpr | _Scalar = then_value
+        self._otherwise_value: PandasLikeExpr | _Scalar = otherwise_value
         self._version = version
 
     def __call__(self: Self, df: PandasLikeDataFrame) -> Sequence[PandasLikeSeries]:
@@ -422,10 +424,9 @@ class PandasWhen:
         condition = self._condition(df)[0]
         condition_native = condition._native_series
 
-        if is_compliant_expr(self._then_value):
-            value_series: PandasLikeSeries = self._then_value(df)[0]
+        if isinstance(self._then_value, PandasLikeExpr):
+            value_series = self._then_value(df)[0]
         else:
-            # `self._then_value` is a scalar
             value_series = plx._create_series_from_scalar(
                 self._then_value, reference_series=condition.alias("literal")
             )
@@ -441,10 +442,9 @@ class PandasWhen:
                 )
             ]
 
-        if is_compliant_expr(self._otherwise_value):
-            otherwise_series: PandasLikeSeries = self._otherwise_value(df)[0]
+        if isinstance(self._otherwise_value, PandasLikeExpr):
+            otherwise_series = self._otherwise_value(df)[0]
         else:
-            # `self._then_value` is a scalar
             otherwise_series = plx._create_series_from_scalar(
                 self._otherwise_value, reference_series=condition.alias("literal")
             )
@@ -458,7 +458,9 @@ class PandasWhen:
             )
         ]
 
-    def then(self: Self, value: PandasLikeExpr | PandasLikeSeries | Any) -> PandasThen:
+    def then(
+        self: Self, value: PandasLikeExpr | PandasLikeSeries | _Scalar
+    ) -> PandasThen:
         self._then_value = value
 
         return PandasThen(
@@ -492,7 +494,7 @@ class PandasThen(PandasLikeExpr):
         self._implementation = implementation
         self._backend_version = backend_version
         self._version = version
-        self._call = call
+        self._call: PandasWhen = call
         self._depth = depth
         self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names
@@ -500,11 +502,8 @@ class PandasThen(PandasLikeExpr):
         self._call_kwargs = call_kwargs or {}
 
     def otherwise(
-        self: Self, value: PandasLikeExpr | PandasLikeSeries | Any
+        self: Self, value: PandasLikeExpr | PandasLikeSeries | _Scalar
     ) -> PandasLikeExpr:
-        # type ignore because we are setting the `_call` attribute to a
-        # callable object of type `PandasWhen`, base class has the attribute as
-        # only a `Callable`
-        self._call._otherwise_value = value  # type: ignore[attr-defined]
+        self._call._otherwise_value = value
         self._function_name = "whenotherwise"
         return self


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- https://github.com/narwhals-dev/narwhals/pull/2087#discussion_r1968034436
- [`ef85eda` (#2064)](https://github.com/narwhals-dev/narwhals/pull/2064/commits/ef85eda6599d0a0fce261c35416983756fa456e5)
- https://github.com/narwhals-dev/narwhals/actions/runs/13483136123/job/37670892891?pr=2064

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below
This change is a pre-emptive fix for an issue that would appear after annotating `CompliantExpr.__call__(df: <...>)`:

https://github.com/narwhals-dev/narwhals/blob/372f1eb17ff05457b7b8fb9caa1f46da1ae3cd7d/narwhals/typing.py#L119

Hoping to merge this and (#2087) to get the changes out of (#2064).
Should make the review for (#2064) a lot simpler 🙂 