### PR TITLE
perf: avoid full broadcast for otherwise_value in when/then/otherwise

### DIFF
--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -424,13 +424,10 @@ class ArrowWhen:
         if isinstance(self._otherwise_value, ArrowExpr):
             otherwise_series = self._otherwise_value(df)[0]
         else:
-            return [
-                value_series._from_native_series(
-                    pc.if_else(
-                        condition_native, value_series_native, self._otherwise_value
-                    )
-                )
-            ]
+            native_result = pc.if_else(
+                condition_native, value_series_native, self._otherwise_value
+            )
+            return [value_series._from_native_series(native_result)]
 
         otherwise_series_native = extract_dataframe_comparand(
             len(df), otherwise_series, self._backend_version

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -424,10 +424,13 @@ class ArrowWhen:
         if isinstance(self._otherwise_value, ArrowExpr):
             otherwise_series = self._otherwise_value(df)[0]
         else:
-            otherwise_series = plx._create_series_from_scalar(
-                self._otherwise_value, reference_series=condition.alias("literal")
-            )
-            otherwise_series._broadcast = True
+            return [
+                value_series._from_native_series(
+                    pc.if_else(
+                        condition_native, value_series_native, self._otherwise_value
+                    )
+                )
+            ]
 
         otherwise_series_native = extract_dataframe_comparand(
             len(df), otherwise_series, self._backend_version

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -363,7 +363,7 @@ class DaskWhen:
         if isinstance(self._otherwise_value, DaskExpr):
             otherwise_value = self._otherwise_value(df)[0]
         else:
-            otherwise_value = self._otherwise_value
+            return [then_series.where(condition, self._otherwise_value)]
         (otherwise_series,) = align_series_full_broadcast(df, otherwise_value)
         validate_comparand(condition, otherwise_series)
         return [then_series.where(condition, otherwise_series)]  # pyright: ignore[reportArgumentType]

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -445,10 +445,11 @@ class PandasWhen:
         if isinstance(self._otherwise_value, PandasLikeExpr):
             otherwise_series = self._otherwise_value(df)[0]
         else:
-            otherwise_series = plx._create_series_from_scalar(
-                self._otherwise_value, reference_series=condition.alias("literal")
-            )
-            otherwise_series._broadcast = True
+            return [
+                value_series._from_native_series(
+                    value_series_native.where(condition_native, self._otherwise_value)
+                )
+            ]
         otherwise_series_native = extract_dataframe_comparand(
             df._native_frame.index, otherwise_series
         )

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -445,11 +445,10 @@ class PandasWhen:
         if isinstance(self._otherwise_value, PandasLikeExpr):
             otherwise_series = self._otherwise_value(df)[0]
         else:
-            return [
-                value_series._from_native_series(
-                    value_series_native.where(condition_native, self._otherwise_value)
-                )
-            ]
+            native_result = value_series_native.where(
+                condition_native, self._otherwise_value
+            )
+            return [value_series._from_native_series(native_result)]
         otherwise_series_native = extract_dataframe_comparand(
             df._native_frame.index, otherwise_series
         )

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from narwhals.utils import Version
 
 
+# note: don't lru_cache this as `ModuleType` isn't hashable
 def native_to_narwhals_dtype(
     dtype: pyspark_types.DataType,
     version: Version,

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from narwhals.utils import Version
 
 
-# note: don't lru_cache this as `ModuleType` isn't hashable
+# NOTE: don't lru_cache this as `ModuleType` isn't hashable
 def native_to_narwhals_dtype(
     dtype: pyspark_types.DataType,
     version: Version,


### PR DESCRIPTION
A full broadcast is inevitable for the `then` value, but for the `otherwise` value we can avoid it

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
