### PR TITLE
perf: Avoid redefining `lambda` in `*Namespace.all`

### DIFF
--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -26,6 +26,7 @@ from narwhals._expression_parsing import combine_alias_output_names
 from narwhals._expression_parsing import combine_evaluate_output_names
 from narwhals.typing import CompliantNamespace
 from narwhals.utils import Implementation
+from narwhals.utils import get_column_names
 from narwhals.utils import import_dtypes_module
 
 if TYPE_CHECKING:
@@ -161,7 +162,7 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
             ],
             depth=0,
             function_name="all",
-            evaluate_output_names=lambda df: df.columns,
+            evaluate_output_names=get_column_names,
             alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -23,6 +23,7 @@ from narwhals._dask.utils import validate_comparand
 from narwhals._expression_parsing import combine_alias_output_names
 from narwhals._expression_parsing import combine_evaluate_output_names
 from narwhals.typing import CompliantNamespace
+from narwhals.utils import get_column_names
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -55,7 +56,7 @@ class DaskNamespace(CompliantNamespace[DaskLazyFrame, "dx.Series"]):  # pyright:
             func,
             depth=0,
             function_name="all",
-            evaluate_output_names=lambda df: df.columns,
+            evaluate_output_names=get_column_names,
             alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -24,6 +24,7 @@ from narwhals._duckdb.utils import narwhals_to_native_dtype
 from narwhals._expression_parsing import combine_alias_output_names
 from narwhals._expression_parsing import combine_evaluate_output_names
 from narwhals.typing import CompliantNamespace
+from narwhals.utils import get_column_names
 
 if TYPE_CHECKING:
     import duckdb
@@ -52,7 +53,7 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "duckdb.Expression"]
         return DuckDBExpr(
             call=_all,
             function_name="all",
-            evaluate_output_names=lambda df: df.columns,
+            evaluate_output_names=get_column_names,
             alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -22,6 +22,7 @@ from narwhals._pandas_like.utils import extract_dataframe_comparand
 from narwhals._pandas_like.utils import horizontal_concat
 from narwhals._pandas_like.utils import vertical_concat
 from narwhals.typing import CompliantNamespace
+from narwhals.utils import get_column_names
 from narwhals.utils import import_dtypes_module
 
 if TYPE_CHECKING:
@@ -135,7 +136,7 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
             ],
             depth=0,
             function_name="all",
-            evaluate_output_names=lambda df: df.columns,
+            evaluate_output_names=get_column_names,
             alias_output_names=None,
             implementation=self._implementation,
             backend_version=self._backend_version,

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -17,6 +17,7 @@ from narwhals._spark_like.selectors import SparkLikeSelectorNamespace
 from narwhals._spark_like.utils import maybe_evaluate_expr
 from narwhals._spark_like.utils import narwhals_to_native_dtype
 from narwhals.typing import CompliantNamespace
+from narwhals.utils import get_column_names
 
 if TYPE_CHECKING:
     from pyspark.sql import Column
@@ -51,7 +52,7 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "Column"]):
         return SparkLikeExpr(
             call=_all,
             function_name="all",
-            evaluate_output_names=lambda df: df.columns,
+            evaluate_output_names=get_column_names,
             alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -62,6 +62,9 @@ class CompliantDataFrame(Protocol):
         ...  # `select` where all args are aggregations or literals
         # (so, no broadcasting is necessary).
 
+    @property
+    def columns(self) -> Sequence[str]: ...
+
 
 class CompliantLazyFrame(Protocol):
     def __narwhals_lazyframe__(self) -> Self: ...
@@ -72,6 +75,9 @@ class CompliantLazyFrame(Protocol):
     def aggregate(self, *exprs: Any) -> Self:
         ...  # `select` where all args are aggregations or literals
         # (so, no broadcasting is necessary).
+
+    @property
+    def columns(self) -> Sequence[str]: ...
 
 
 CompliantFrameT_contra = TypeVar(

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -103,6 +103,10 @@ if TYPE_CHECKING:
         - `_version`
         """
 
+    class _StoresColumns(Protocol):
+        @property
+        def columns(self) -> Sequence[str]: ...
+
 
 class Version(Enum):
     V1 = auto()
@@ -1342,6 +1346,10 @@ def dtype_matches_time_unit_and_time_zone(
             or ("*" in time_zones and dtype.time_zone is not None)
         )
     )
+
+
+def get_column_names(frame: _StoresColumns, /) -> Sequence[str]:
+    return frame.columns
 
 
 def _hasattr_static(obj: Any, attr: str) -> bool:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Mentioned in (https://github.com/narwhals-dev/narwhals/pull/2058#discussion_r1964137667)
- Originally (https://github.com/narwhals-dev/narwhals/pull/2064/commits/028098e4b5091f73fca2f812830d54f109875777) and (https://github.com/narwhals-dev/narwhals/pull/2064/commits/c597ba7c2b06b1d1db29e9b7f254aa3be47b5d86)

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below
Previously, a new function was created in each of these locations - but it didn't bind any arguments - so there was no benefit to using a `lambda`