### PR TITLE
test(typing): fix `DataFrame.sort_values` overload match

### DIFF
--- a/tests/hypothesis/join_test.py
+++ b/tests/hypothesis/join_test.py
@@ -69,12 +69,12 @@ def test_join(  # pragma: no cover
 
     dframe_pd1 = nw.to_native(dframe_pl).to_pandas()
     dframe_pd1 = dframe_pd1.sort_values(
-        by=dframe_pd1.columns.to_list(), ignore_index=True
+        by=dframe_pd1.columns.to_list(), ignore_index=True, inplace=False
     )
 
     dframe_pd2 = nw.to_native(dframe_pd)
     dframe_pd2 = dframe_pd2.sort_values(
-        by=dframe_pd2.columns.to_list(), ignore_index=True
+        by=dframe_pd2.columns.to_list(), ignore_index=True, inplace=False
     )
 
     assert_frame_equal(dframe_pd1, dframe_pd2)
@@ -114,12 +114,12 @@ def test_cross_join(  # pragma: no cover
 
     dframe_pd1 = nw.to_native(dframe_pl).to_pandas()
     dframe_pd1 = dframe_pd1.sort_values(
-        by=dframe_pd1.columns.to_list(), ignore_index=True
+        by=dframe_pd1.columns.to_list(), ignore_index=True, inplace=False
     )
 
     dframe_pd2 = nw.to_native(dframe_pd)
     dframe_pd2 = dframe_pd2.sort_values(
-        by=dframe_pd2.columns.to_list(), ignore_index=True
+        by=dframe_pd2.columns.to_list(), ignore_index=True, inplace=False
     )
 
     assert_frame_equal(dframe_pd1, dframe_pd2)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- https://github.com/narwhals-dev/narwhals/pull/2108#issuecomment-2687797364
- https://github.com/narwhals-dev/narwhals/actions/runs/13564954226/job/37915886536#step:9:29
- https://github.com/narwhals-dev/narwhals/actions/runs/13567019211/job/37922301165?pr=2110

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Gets CI passing again https://github.com/narwhals-dev/narwhals/actions/runs/13566402865/job/37920404861?pr=2109