### PR TITLE
feat(typing): Backport generic `Series` to `v1`

### DIFF
--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -7,7 +7,6 @@ from typing import Callable
 from typing import Iterable
 from typing import Literal
 from typing import Sequence
-from typing import TypeVar
 from typing import overload
 from warnings import warn
 
@@ -86,6 +85,7 @@ if TYPE_CHECKING:
     from typing import Mapping
 
     from typing_extensions import Self
+    from typing_extensions import TypeVar
 
     from narwhals.dtypes import DType
     from narwhals.functions import ArrowStreamExportable
@@ -95,8 +95,13 @@ if TYPE_CHECKING:
     from narwhals.typing import _1DArray
     from narwhals.typing import _2DArray
 
-T = TypeVar("T")
-IntoSeriesT = TypeVar("IntoSeriesT", bound="IntoSeries")
+    IntoSeriesT = TypeVar("IntoSeriesT", bound="IntoSeries", default=Any)
+    T = TypeVar("T", default=Any)
+else:
+    from typing import TypeVar
+
+    IntoSeriesT = TypeVar("IntoSeriesT", bound="IntoSeries")
+    T = TypeVar("T")
 
 
 class DataFrame(NwDataFrame[IntoDataFrameT]):

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -1297,7 +1297,7 @@ def from_native(
 
 @overload
 def from_native(
-    native_object: IntoSeriesT | Any,  # remain `Any` for downstream compatibility
+    native_object: IntoSeriesT,
     *,
     strict: Literal[True] = ...,
     eager_only: Literal[False] = ...,

--- a/narwhals/stable/v1/typing.py
+++ b/narwhals/stable/v1/typing.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
         def __dataframe__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
-IntoExpr: TypeAlias = Union["Expr", str, "Series"]
+IntoExpr: TypeAlias = Union["Expr", str, "Series[Any]"]
 """Anything which can be converted to an expression.
 
 Use this to mean "either a Narwhals expression, or something
@@ -89,7 +89,7 @@ Examples:
     ...     return df.columns
 """
 
-IntoSeries: TypeAlias = Union["Series", "NativeSeries"]
+IntoSeries: TypeAlias = Union["Series[Any]", "NativeSeries"]
 """Anything which can be converted to a Narwhals Series.
 
 Use this if your function can accept an object which can be converted to `nw.Series`

--- a/tests/expr_and_series/dt/timestamp_test.py
+++ b/tests/expr_and_series/dt/timestamp_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 from typing import Literal
 
 import hypothesis.strategies as st
@@ -17,6 +18,9 @@ from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 from tests.utils import is_windows
+
+if TYPE_CHECKING:
+    from narwhals.typing import IntoSeriesT
 
 data = {
     "a": [
@@ -221,7 +225,7 @@ def test_timestamp_hypothesis(
     import polars as pl
 
     @nw.narwhalify
-    def func(s: nw.Series) -> nw.Series:
+    def func(s: nw.Series[IntoSeriesT]) -> nw.Series[IntoSeriesT]:
         return s.dt.timestamp(time_unit)
 
     result_pl = func(pl.Series([inputs], dtype=pl.Datetime(starting_time_unit)))

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -241,7 +241,7 @@ def test_series_only_sqlframe() -> None:  # pragma: no cover
     df = session.createDataFrame([*zip(*data.values())], schema=[*data.keys()])
 
     with pytest.raises(TypeError, match="Cannot only use `series_only`"):
-        nw.from_native(df, series_only=True)
+        nw.from_native(df, series_only=True)  # pyright: ignore[reportArgumentType, reportCallIssue]
 
 
 @pytest.mark.parametrize(

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from contextlib import nullcontext as does_not_raise
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Iterable
+from typing import Literal
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -287,3 +290,18 @@ def test_from_mock_interchange_protocol_non_strict() -> None:
     mockdf = MockDf()
     result = nw.from_native(mockdf, eager_only=True, strict=False)
     assert result is mockdf
+
+
+def test_from_native_altair_array_like() -> None:
+    obj: list[int] = [1, 2, 3, 4]
+    array_like = cast("Iterable[Any]", obj)
+    not_array_like: Literal[1] = 1
+
+    with pytest.raises(TypeError, match="got.+list"):
+        false_positive_native_series = nw.from_native(obj, series_only=True)  # noqa: F841
+
+    with pytest.raises(TypeError, match="got.+list"):
+        true_negative_iterable = nw.from_native(array_like, series_only=True)  # type: ignore[call-overload] # noqa: F841
+
+    with pytest.raises(TypeError, match="got.+int"):
+        true_negative_not_native_series = nw.from_native(not_array_like, series_only=True)  # type: ignore[call-overload] # noqa: F841


### PR DESCRIPTION
## Tracking
- [x] #2109
- [x] https://github.com/vega/altair/pull/3811

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- #1412
- #1930
- https://narwhals-dev.github.io/narwhals/backcompat/#breaking-changes-carried-out-so-far

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
- Hoping to see if I can reproduce whatever downstream errors were seen in (https://github.com/narwhals-dev/narwhals/pull/1412#issuecomment-2492258956)
- The issue appears to be the same as (#1930)
  - Didn't show up for `v1.(Data|Lazy)Frame` because they use a different `TypeVar` to their parent