### PR TITLE
docs: Add API example docs for Field dtype

### DIFF
--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -639,6 +639,19 @@ class Field:
     Arguments:
         name: The name of the field within its parent `Struct`.
         dtype: The `DataType` of the field's values.
+
+    Examples:
+       >>> import polars as pl
+       >>> import pyarrow as pa
+       >>> import narwhals as nw
+       >>> data = [{"a": 1, "b": ["narwhal", "beluga"]}, {"a": 2, "b": ["orca"]}]
+       >>> ser_pl = pl.Series(data)
+       >>> ser_pa = pa.chunked_array([data])
+
+       >>> nw.from_native(ser_pl, series_only=True).dtype.fields
+       [Field('a', Int64), Field('b', List(String))]
+       >>> nw.from_native(ser_pa, series_only=True).dtype.fields
+       [Field('a', Int64), Field('b', List(String))]
     """
 
     name: str

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -641,15 +641,10 @@ class Field:
         dtype: The `DataType` of the field's values.
 
     Examples:
-       >>> import polars as pl
        >>> import pyarrow as pa
        >>> import narwhals as nw
        >>> data = [{"a": 1, "b": ["narwhal", "beluga"]}, {"a": 2, "b": ["orca"]}]
-       >>> ser_pl = pl.Series(data)
        >>> ser_pa = pa.chunked_array([data])
-
-       >>> nw.from_native(ser_pl, series_only=True).dtype.fields
-       [Field('a', Int64), Field('b', List(String))]
        >>> nw.from_native(ser_pa, series_only=True).dtype.fields
        [Field('a', Int64), Field('b', List(String))]
     """


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue https://github.com/narwhals-dev/narwhals/issues/1077

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

This PR adds an example for the Field dtype. (Basically, the same as the Struct example, but accessing showing the fields)