### PR TITLE
refactor: allow callable in `CompliantExpr.from_column_names` to reuse for `CompliantNamespace.<all|col|exclude>`

### DIFF
--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -87,12 +87,11 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
     @classmethod
     def from_column_names(
         cls: type[Self],
-        *column_names: str,
+        get_column_names: Callable[[ArrowDataFrame], Sequence[str]],
+        function_name: str,
         backend_version: tuple[int, ...],
         version: Version,
     ) -> Self:
-        from narwhals._arrow.series import ArrowSeries
-
         def func(df: ArrowDataFrame) -> list[ArrowSeries]:
             try:
                 return [
@@ -102,10 +101,10 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
                         backend_version=df._backend_version,
                         version=df._version,
                     )
-                    for column_name in column_names
+                    for column_name in get_column_names(df)
                 ]
             except KeyError as e:
-                missing_columns = [x for x in column_names if x not in df.columns]
+                missing_columns = [x for x in get_column_names(df) if x not in df.columns]
                 raise ColumnNotFoundError.from_missing_and_available_column_names(
                     missing_columns=missing_columns, available_columns=df.columns
                 ) from e
@@ -113,8 +112,8 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
         return cls(
             func,
             depth=0,
-            function_name="col",
-            evaluate_output_names=lambda _df: column_names,
+            function_name=function_name,
+            evaluate_output_names=get_column_names,
             alias_output_names=None,
             backend_version=backend_version,
             version=version,

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -87,7 +87,7 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
     @classmethod
     def from_column_names(
         cls: type[Self],
-        get_column_names: Callable[[ArrowDataFrame], Sequence[str]],
+        evaluate_column_names: Callable[[ArrowDataFrame], Sequence[str]],
         function_name: str,
         backend_version: tuple[int, ...],
         version: Version,
@@ -101,10 +101,12 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
                         backend_version=df._backend_version,
                         version=df._version,
                     )
-                    for column_name in get_column_names(df)
+                    for column_name in evaluate_column_names(df)
                 ]
             except KeyError as e:
-                missing_columns = [x for x in get_column_names(df) if x not in df.columns]
+                missing_columns = [
+                    x for x in evaluate_column_names(df) if x not in df.columns
+                ]
                 raise ColumnNotFoundError.from_missing_and_available_column_names(
                     missing_columns=missing_columns, available_columns=df.columns
                 ) from e
@@ -113,7 +115,7 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
             func,
             depth=0,
             function_name=function_name,
-            evaluate_output_names=get_column_names,
+            evaluate_output_names=evaluate_column_names,
             alias_output_names=None,
             backend_version=backend_version,
             version=version,

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -88,6 +88,8 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
     def from_column_names(
         cls: type[Self],
         evaluate_column_names: Callable[[ArrowDataFrame], Sequence[str]],
+        /,
+        *,
         function_name: str,
         backend_version: tuple[int, ...],
         version: Version,

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -117,18 +117,18 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
     def col(self: Self, *column_names: str) -> ArrowExpr:
         from narwhals._arrow.expr import ArrowExpr
 
-        def get_column_names(_: ArrowDataFrame) -> Sequence[str]:
+        def evaluate_column_names(_: ArrowDataFrame) -> Sequence[str]:
             return column_names
 
         return ArrowExpr.from_column_names(
-            get_column_names=get_column_names,
+            evaluate_column_names=evaluate_column_names,
             function_name="col",
             backend_version=self._backend_version,
             version=self._version,
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> ArrowExpr:
-        def get_column_names(df: ArrowDataFrame) -> Sequence[str]:
+        def evaluate_column_names(df: ArrowDataFrame) -> Sequence[str]:
             return [
                 column_name
                 for column_name in df.columns
@@ -136,7 +136,7 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
             ]
 
         return ArrowExpr.from_column_names(
-            get_column_names=get_column_names,
+            evaluate_column_names=evaluate_column_names,
             function_name="exclude",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -121,16 +121,15 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
         from narwhals._arrow.expr import ArrowExpr
 
         return ArrowExpr.from_column_names(
-            evaluate_column_names=passthrough_column_names(column_names),
+            passthrough_column_names(column_names),
             function_name="col",
             backend_version=self._backend_version,
             version=self._version,
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> ArrowExpr:
-        evaluate_column_names = partial(exclude_column_names, names=excluded_names)
         return ArrowExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            partial(exclude_column_names, names=excluded_names),
             function_name="exclude",
             backend_version=self._backend_version,
             version=self._version,
@@ -164,7 +163,7 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
 
     def all(self: Self) -> ArrowExpr:
         return ArrowExpr.from_column_names(
-            evaluate_column_names=get_column_names,
+            get_column_names,
             function_name="all",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -31,6 +31,7 @@ from narwhals.utils import Implementation
 from narwhals.utils import exclude_column_names
 from narwhals.utils import get_column_names
 from narwhals.utils import import_dtypes_module
+from narwhals.utils import passthrough_column_names
 
 if TYPE_CHECKING:
     from typing import Callable
@@ -119,11 +120,8 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
     def col(self: Self, *column_names: str) -> ArrowExpr:
         from narwhals._arrow.expr import ArrowExpr
 
-        def evaluate_column_names(_: ArrowDataFrame) -> Sequence[str]:
-            return column_names
-
         return ArrowExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            evaluate_column_names=passthrough_column_names(column_names),
             function_name="col",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -130,8 +130,9 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> ArrowExpr:
+        evaluate_column_names = partial(exclude_column_names, names=excluded_names)
         return ArrowExpr.from_column_names(
-            evaluate_column_names=partial(exclude_column_names, names=excluded_names),
+            evaluate_column_names=evaluate_column_names,
             function_name="exclude",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import operator
+from functools import partial
 from functools import reduce
 from typing import TYPE_CHECKING
 from typing import Any
@@ -27,6 +28,7 @@ from narwhals._expression_parsing import combine_alias_output_names
 from narwhals._expression_parsing import combine_evaluate_output_names
 from narwhals.typing import CompliantNamespace
 from narwhals.utils import Implementation
+from narwhals.utils import exclude_column_names
 from narwhals.utils import get_column_names
 from narwhals.utils import import_dtypes_module
 
@@ -128,15 +130,8 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> ArrowExpr:
-        def evaluate_column_names(df: ArrowDataFrame) -> Sequence[str]:
-            return [
-                column_name
-                for column_name in df.columns
-                if column_name not in excluded_names
-            ]
-
         return ArrowExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            evaluate_column_names=partial(exclude_column_names, names=excluded_names),
             function_name="exclude",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -164,23 +164,9 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
         )
 
     def all(self: Self) -> ArrowExpr:
-        from narwhals._arrow.expr import ArrowExpr
-        from narwhals._arrow.series import ArrowSeries
-
-        return ArrowExpr(
-            lambda df: [
-                ArrowSeries(
-                    df._native_frame[column_name],
-                    name=column_name,
-                    backend_version=df._backend_version,
-                    version=df._version,
-                )
-                for column_name in df.columns
-            ],
-            depth=0,
+        return ArrowExpr.from_column_names(
+            evaluate_column_names=get_column_names,
             function_name="all",
-            evaluate_output_names=get_column_names,
-            alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,
         )

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -117,37 +117,29 @@ class ArrowNamespace(CompliantNamespace[ArrowDataFrame, ArrowSeries]):
     def col(self: Self, *column_names: str) -> ArrowExpr:
         from narwhals._arrow.expr import ArrowExpr
 
+        def get_column_names(_: ArrowDataFrame) -> Sequence[str]:
+            return column_names
+
         return ArrowExpr.from_column_names(
-            *column_names, backend_version=self._backend_version, version=self._version
+            get_column_names=get_column_names,
+            function_name="col",
+            backend_version=self._backend_version,
+            version=self._version,
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> ArrowExpr:
-        from narwhals._arrow.series import ArrowSeries
-
-        def evaluate_output_names(df: ArrowDataFrame) -> Sequence[str]:
+        def get_column_names(df: ArrowDataFrame) -> Sequence[str]:
             return [
                 column_name
                 for column_name in df.columns
                 if column_name not in excluded_names
             ]
 
-        def func(df: ArrowDataFrame) -> list[ArrowSeries]:
-            return [
-                ArrowSeries(
-                    df._native_frame[column_name],
-                    name=column_name,
-                    backend_version=df._backend_version,
-                    version=df._version,
-                )
-                for column_name in evaluate_output_names(df)
-            ]
-
-        return self._create_expr_from_callable(
-            func,
-            depth=0,
+        return ArrowExpr.from_column_names(
+            get_column_names=get_column_names,
             function_name="exclude",
-            evaluate_output_names=evaluate_output_names,
-            alias_output_names=None,
+            backend_version=self._backend_version,
+            version=self._version,
         )
 
     def nth(self: Self, *column_indices: int) -> ArrowExpr:

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -90,7 +90,7 @@ class DaskExpr(CompliantExpr["DaskLazyFrame", "dx.Series"]):  # pyright: ignore[
     @classmethod
     def from_column_names(
         cls: type[Self],
-        get_column_names: Callable[[DaskLazyFrame], Sequence[str]],
+        evaluate_column_names: Callable[[DaskLazyFrame], Sequence[str]],
         function_name: str,
         backend_version: tuple[int, ...],
         version: Version,
@@ -98,10 +98,13 @@ class DaskExpr(CompliantExpr["DaskLazyFrame", "dx.Series"]):  # pyright: ignore[
         def func(df: DaskLazyFrame) -> list[dx.Series]:
             try:
                 return [
-                    df._native_frame[column_name] for column_name in get_column_names(df)
+                    df._native_frame[column_name]
+                    for column_name in evaluate_column_names(df)
                 ]
             except KeyError as e:
-                missing_columns = [x for x in get_column_names(df) if x not in df.columns]
+                missing_columns = [
+                    x for x in evaluate_column_names(df) if x not in df.columns
+                ]
                 raise ColumnNotFoundError.from_missing_and_available_column_names(
                     missing_columns=missing_columns,
                     available_columns=df.columns,
@@ -111,7 +114,7 @@ class DaskExpr(CompliantExpr["DaskLazyFrame", "dx.Series"]):  # pyright: ignore[
             func,
             depth=0,
             function_name=function_name,
-            evaluate_output_names=get_column_names,
+            evaluate_output_names=evaluate_column_names,
             alias_output_names=None,
             backend_version=backend_version,
             version=version,

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -90,15 +90,18 @@ class DaskExpr(CompliantExpr["DaskLazyFrame", "dx.Series"]):  # pyright: ignore[
     @classmethod
     def from_column_names(
         cls: type[Self],
-        *column_names: str,
+        get_column_names: Callable[[DaskLazyFrame], Sequence[str]],
+        function_name: str,
         backend_version: tuple[int, ...],
         version: Version,
     ) -> Self:
         def func(df: DaskLazyFrame) -> list[dx.Series]:
             try:
-                return [df._native_frame[column_name] for column_name in column_names]
+                return [
+                    df._native_frame[column_name] for column_name in get_column_names(df)
+                ]
             except KeyError as e:
-                missing_columns = [x for x in column_names if x not in df.columns]
+                missing_columns = [x for x in get_column_names(df) if x not in df.columns]
                 raise ColumnNotFoundError.from_missing_and_available_column_names(
                     missing_columns=missing_columns,
                     available_columns=df.columns,
@@ -107,8 +110,8 @@ class DaskExpr(CompliantExpr["DaskLazyFrame", "dx.Series"]):  # pyright: ignore[
         return cls(
             func,
             depth=0,
-            function_name="col",
-            evaluate_output_names=lambda _df: column_names,
+            function_name=function_name,
+            evaluate_output_names=get_column_names,
             alias_output_names=None,
             backend_version=backend_version,
             version=version,

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -91,6 +91,8 @@ class DaskExpr(CompliantExpr["DaskLazyFrame", "dx.Series"]):  # pyright: ignore[
     def from_column_names(
         cls: type[Self],
         evaluate_column_names: Callable[[DaskLazyFrame], Sequence[str]],
+        /,
+        *,
         function_name: str,
         backend_version: tuple[int, ...],
         version: Version,

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import operator
+from functools import partial
 from functools import reduce
 from typing import TYPE_CHECKING
 from typing import Any
@@ -25,6 +26,7 @@ from narwhals._expression_parsing import combine_alias_output_names
 from narwhals._expression_parsing import combine_evaluate_output_names
 from narwhals.typing import CompliantNamespace
 from narwhals.utils import Implementation
+from narwhals.utils import exclude_column_names
 from narwhals.utils import get_column_names
 
 if TYPE_CHECKING:
@@ -78,15 +80,8 @@ class DaskNamespace(CompliantNamespace[DaskLazyFrame, "dx.Series"]):  # pyright:
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> DaskExpr:
-        def evaluate_column_names(df: DaskLazyFrame) -> Sequence[str]:
-            return [
-                column_name
-                for column_name in df.columns
-                if column_name not in excluded_names
-            ]
-
         return DaskExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            evaluate_column_names=partial(exclude_column_names, names=excluded_names),
             function_name="exclude",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -67,29 +67,27 @@ class DaskNamespace(CompliantNamespace[DaskLazyFrame, "dx.Series"]):  # pyright:
         )
 
     def col(self: Self, *column_names: str) -> DaskExpr:
+        def get_column_names(_: DaskLazyFrame) -> Sequence[str]:
+            return column_names
+
         return DaskExpr.from_column_names(
-            *column_names, backend_version=self._backend_version, version=self._version
+            get_column_names=get_column_names,
+            function_name="col",
+            backend_version=self._backend_version,
+            version=self._version,
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> DaskExpr:
-        def evaluate_output_names(df: DaskLazyFrame) -> Sequence[str]:
+        def get_column_names(df: DaskLazyFrame) -> Sequence[str]:
             return [
                 column_name
                 for column_name in df.columns
                 if column_name not in excluded_names
             ]
 
-        def func(df: DaskLazyFrame) -> list[dx.Series]:
-            return [
-                df._native_frame[column_name] for column_name in evaluate_output_names(df)
-            ]
-
-        return DaskExpr(
-            func,
-            depth=0,
+        return DaskExpr.from_column_names(
+            get_column_names=get_column_names,
             function_name="exclude",
-            evaluate_output_names=evaluate_output_names,
-            alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,
         )

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -28,6 +28,7 @@ from narwhals.typing import CompliantNamespace
 from narwhals.utils import Implementation
 from narwhals.utils import exclude_column_names
 from narwhals.utils import get_column_names
+from narwhals.utils import passthrough_column_names
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -63,11 +64,8 @@ class DaskNamespace(CompliantNamespace[DaskLazyFrame, "dx.Series"]):  # pyright:
         )
 
     def col(self: Self, *column_names: str) -> DaskExpr:
-        def evaluate_column_names(_: DaskLazyFrame) -> Sequence[str]:
-            return column_names
-
         return DaskExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            evaluate_column_names=passthrough_column_names(column_names),
             function_name="col",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -74,8 +74,9 @@ class DaskNamespace(CompliantNamespace[DaskLazyFrame, "dx.Series"]):  # pyright:
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> DaskExpr:
+        evaluate_column_names = partial(exclude_column_names, names=excluded_names)
         return DaskExpr.from_column_names(
-            evaluate_column_names=partial(exclude_column_names, names=excluded_names),
+            evaluate_column_names=evaluate_column_names,
             function_name="exclude",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -67,18 +67,18 @@ class DaskNamespace(CompliantNamespace[DaskLazyFrame, "dx.Series"]):  # pyright:
         )
 
     def col(self: Self, *column_names: str) -> DaskExpr:
-        def get_column_names(_: DaskLazyFrame) -> Sequence[str]:
+        def evaluate_column_names(_: DaskLazyFrame) -> Sequence[str]:
             return column_names
 
         return DaskExpr.from_column_names(
-            get_column_names=get_column_names,
+            evaluate_column_names=evaluate_column_names,
             function_name="col",
             backend_version=self._backend_version,
             version=self._version,
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> DaskExpr:
-        def get_column_names(df: DaskLazyFrame) -> Sequence[str]:
+        def evaluate_column_names(df: DaskLazyFrame) -> Sequence[str]:
             return [
                 column_name
                 for column_name in df.columns
@@ -86,7 +86,7 @@ class DaskNamespace(CompliantNamespace[DaskLazyFrame, "dx.Series"]):  # pyright:
             ]
 
         return DaskExpr.from_column_names(
-            get_column_names=get_column_names,
+            evaluate_column_names=evaluate_column_names,
             function_name="exclude",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -55,15 +55,9 @@ class DaskNamespace(CompliantNamespace[DaskLazyFrame, "dx.Series"]):  # pyright:
         self._version = version
 
     def all(self: Self) -> DaskExpr:
-        def func(df: DaskLazyFrame) -> list[dx.Series]:
-            return [df._native_frame[column_name] for column_name in df.columns]
-
-        return DaskExpr(
-            func,
-            depth=0,
+        return DaskExpr.from_column_names(
+            evaluate_column_names=get_column_names,
             function_name="all",
-            evaluate_output_names=get_column_names,
-            alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,
         )

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -57,7 +57,7 @@ class DaskNamespace(CompliantNamespace[DaskLazyFrame, "dx.Series"]):  # pyright:
 
     def all(self: Self) -> DaskExpr:
         return DaskExpr.from_column_names(
-            evaluate_column_names=get_column_names,
+            get_column_names,
             function_name="all",
             backend_version=self._backend_version,
             version=self._version,
@@ -65,16 +65,15 @@ class DaskNamespace(CompliantNamespace[DaskLazyFrame, "dx.Series"]):  # pyright:
 
     def col(self: Self, *column_names: str) -> DaskExpr:
         return DaskExpr.from_column_names(
-            evaluate_column_names=passthrough_column_names(column_names),
+            passthrough_column_names(column_names),
             function_name="col",
             backend_version=self._backend_version,
             version=self._version,
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> DaskExpr:
-        evaluate_column_names = partial(exclude_column_names, names=excluded_names)
         return DaskExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            partial(exclude_column_names, names=excluded_names),
             function_name="exclude",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -80,6 +80,8 @@ class DuckDBExpr(CompliantExpr["DuckDBLazyFrame", "duckdb.Expression"]):  # type
     def from_column_names(
         cls: type[Self],
         evaluate_column_names: Callable[[DuckDBLazyFrame], Sequence[str]],
+        /,
+        *,
         function_name: str,
         backend_version: tuple[int, ...],
         version: Version,

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -79,18 +79,18 @@ class DuckDBExpr(CompliantExpr["DuckDBLazyFrame", "duckdb.Expression"]):  # type
     @classmethod
     def from_column_names(
         cls: type[Self],
-        get_column_names: Callable[[DuckDBLazyFrame], Sequence[str]],
+        evaluate_column_names: Callable[[DuckDBLazyFrame], Sequence[str]],
         function_name: str,
         backend_version: tuple[int, ...],
         version: Version,
     ) -> Self:
         def func(df: DuckDBLazyFrame) -> list[duckdb.Expression]:
-            return [ColumnExpression(col_name) for col_name in get_column_names(df)]
+            return [ColumnExpression(col_name) for col_name in evaluate_column_names(df)]
 
         return cls(
             func,
             function_name=function_name,
-            evaluate_output_names=get_column_names,
+            evaluate_output_names=evaluate_column_names,
             alias_output_names=None,
             backend_version=backend_version,
             version=version,

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -79,17 +79,18 @@ class DuckDBExpr(CompliantExpr["DuckDBLazyFrame", "duckdb.Expression"]):  # type
     @classmethod
     def from_column_names(
         cls: type[Self],
-        *column_names: str,
+        get_column_names: Callable[[DuckDBLazyFrame], Sequence[str]],
+        function_name: str,
         backend_version: tuple[int, ...],
         version: Version,
     ) -> Self:
-        def func(_: DuckDBLazyFrame) -> list[duckdb.Expression]:
-            return [ColumnExpression(col_name) for col_name in column_names]
+        def func(df: DuckDBLazyFrame) -> list[duckdb.Expression]:
+            return [ColumnExpression(col_name) for col_name in get_column_names(df)]
 
         return cls(
             func,
-            function_name="col",
-            evaluate_output_names=lambda _df: column_names,
+            function_name=function_name,
+            evaluate_output_names=get_column_names,
             alias_output_names=None,
             backend_version=backend_version,
             version=version,

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -53,7 +53,7 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "duckdb.Expression"]
 
     def all(self: Self) -> DuckDBExpr:
         return DuckDBExpr.from_column_names(
-            evaluate_column_names=get_column_names,
+            get_column_names,
             function_name="all",
             backend_version=self._backend_version,
             version=self._version,
@@ -232,16 +232,15 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "duckdb.Expression"]
 
     def col(self: Self, *column_names: str) -> DuckDBExpr:
         return DuckDBExpr.from_column_names(
-            evaluate_column_names=passthrough_column_names(column_names),
+            passthrough_column_names(column_names),
             function_name="col",
             backend_version=self._backend_version,
             version=self._version,
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> DuckDBExpr:
-        evaluate_column_names = partial(exclude_column_names, names=excluded_names)
         return DuckDBExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            partial(exclude_column_names, names=excluded_names),
             function_name="exclude",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -12,7 +12,6 @@ from typing import Sequence
 
 from duckdb import CaseExpression
 from duckdb import CoalesceOperator
-from duckdb import ColumnExpression
 from duckdb import FunctionExpression
 from duckdb.typing import BIGINT
 from duckdb.typing import VARCHAR
@@ -52,14 +51,9 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "duckdb.Expression"]
         return DuckDBSelectorNamespace(self)
 
     def all(self: Self) -> DuckDBExpr:
-        def _all(df: DuckDBLazyFrame) -> list[duckdb.Expression]:
-            return [ColumnExpression(col_name) for col_name in df.columns]
-
-        return DuckDBExpr(
-            call=_all,
+        return DuckDBExpr.from_column_names(
+            evaluate_column_names=get_column_names,
             function_name="all",
-            evaluate_output_names=get_column_names,
-            alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,
         )

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -27,6 +27,7 @@ from narwhals.typing import CompliantNamespace
 from narwhals.utils import Implementation
 from narwhals.utils import exclude_column_names
 from narwhals.utils import get_column_names
+from narwhals.utils import passthrough_column_names
 
 if TYPE_CHECKING:
     import duckdb
@@ -230,11 +231,8 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "duckdb.Expression"]
         )
 
     def col(self: Self, *column_names: str) -> DuckDBExpr:
-        def evaluate_column_names(_: DuckDBLazyFrame) -> Sequence[str]:
-            return column_names
-
         return DuckDBExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            evaluate_column_names=passthrough_column_names(column_names),
             function_name="col",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -237,18 +237,18 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "duckdb.Expression"]
         )
 
     def col(self: Self, *column_names: str) -> DuckDBExpr:
-        def get_column_names(_: DuckDBLazyFrame) -> Sequence[str]:
+        def evaluate_column_names(_: DuckDBLazyFrame) -> Sequence[str]:
             return column_names
 
         return DuckDBExpr.from_column_names(
-            get_column_names=get_column_names,
+            evaluate_column_names=evaluate_column_names,
             function_name="col",
             backend_version=self._backend_version,
             version=self._version,
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> DuckDBExpr:
-        def get_column_names(df: DuckDBLazyFrame) -> Sequence[str]:
+        def evaluate_column_names(df: DuckDBLazyFrame) -> Sequence[str]:
             return [
                 column_name
                 for column_name in df.columns
@@ -256,7 +256,7 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "duckdb.Expression"]
             ]
 
         return DuckDBExpr.from_column_names(
-            get_column_names=get_column_names,
+            evaluate_column_names=evaluate_column_names,
             function_name="exclude",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -237,28 +237,27 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "duckdb.Expression"]
         )
 
     def col(self: Self, *column_names: str) -> DuckDBExpr:
+        def get_column_names(_: DuckDBLazyFrame) -> Sequence[str]:
+            return column_names
+
         return DuckDBExpr.from_column_names(
-            *column_names, backend_version=self._backend_version, version=self._version
+            get_column_names=get_column_names,
+            function_name="col",
+            backend_version=self._backend_version,
+            version=self._version,
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> DuckDBExpr:
-        def evaluate_output_names(df: DuckDBLazyFrame) -> Sequence[str]:
+        def get_column_names(df: DuckDBLazyFrame) -> Sequence[str]:
             return [
                 column_name
                 for column_name in df.columns
                 if column_name not in excluded_names
             ]
 
-        def func(df: DuckDBLazyFrame) -> list[duckdb.Expression]:
-            return [
-                ColumnExpression(column_name) for column_name in evaluate_output_names(df)
-            ]
-
-        return DuckDBExpr(
-            func,
+        return DuckDBExpr.from_column_names(
+            get_column_names=get_column_names,
             function_name="exclude",
-            evaluate_output_names=evaluate_output_names,
-            alias_output_names=None,
             backend_version=self._backend_version,
             version=self._version,
         )

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -241,8 +241,9 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "duckdb.Expression"]
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> DuckDBExpr:
+        evaluate_column_names = partial(exclude_column_names, names=excluded_names)
         return DuckDBExpr.from_column_names(
-            evaluate_column_names=partial(exclude_column_names, names=excluded_names),
+            evaluate_column_names=evaluate_column_names,
             function_name="exclude",
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -116,6 +116,8 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
     def from_column_names(
         cls: type[Self],
         evaluate_column_names: Callable[[PandasLikeDataFrame], Sequence[str]],
+        /,
+        *,
         function_name: str,
         implementation: Implementation,
         backend_version: tuple[int, ...],

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -115,7 +115,8 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
     @classmethod
     def from_column_names(
         cls: type[Self],
-        *column_names: str,
+        get_column_names: Callable[[PandasLikeDataFrame], Sequence[str]],
+        function_name: str,
         implementation: Implementation,
         backend_version: tuple[int, ...],
         version: Version,
@@ -129,10 +130,10 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
                         backend_version=df._backend_version,
                         version=df._version,
                     )
-                    for column_name in column_names
+                    for column_name in get_column_names(df)
                 ]
             except KeyError as e:
-                missing_columns = [x for x in column_names if x not in df.columns]
+                missing_columns = [x for x in get_column_names(df) if x not in df.columns]
                 raise ColumnNotFoundError.from_missing_and_available_column_names(
                     missing_columns=missing_columns,
                     available_columns=df.columns,
@@ -141,8 +142,8 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
         return cls(
             func,
             depth=0,
-            function_name="col",
-            evaluate_output_names=lambda _df: column_names,
+            function_name=function_name,
+            evaluate_output_names=get_column_names,
             alias_output_names=None,
             implementation=implementation,
             backend_version=backend_version,

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -115,7 +115,7 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
     @classmethod
     def from_column_names(
         cls: type[Self],
-        get_column_names: Callable[[PandasLikeDataFrame], Sequence[str]],
+        evaluate_column_names: Callable[[PandasLikeDataFrame], Sequence[str]],
         function_name: str,
         implementation: Implementation,
         backend_version: tuple[int, ...],
@@ -130,10 +130,12 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
                         backend_version=df._backend_version,
                         version=df._version,
                     )
-                    for column_name in get_column_names(df)
+                    for column_name in evaluate_column_names(df)
                 ]
             except KeyError as e:
-                missing_columns = [x for x in get_column_names(df) if x not in df.columns]
+                missing_columns = [
+                    x for x in evaluate_column_names(df) if x not in df.columns
+                ]
                 raise ColumnNotFoundError.from_missing_and_available_column_names(
                     missing_columns=missing_columns,
                     available_columns=df.columns,
@@ -143,7 +145,7 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
             func,
             depth=0,
             function_name=function_name,
-            evaluate_output_names=get_column_names,
+            evaluate_output_names=evaluate_column_names,
             alias_output_names=None,
             implementation=implementation,
             backend_version=backend_version,

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -109,11 +109,11 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
 
     # --- selection ---
     def col(self: Self, *column_names: str) -> PandasLikeExpr:
-        def get_column_names(_: PandasLikeDataFrame) -> Sequence[str]:
+        def evaluate_column_names(_: PandasLikeDataFrame) -> Sequence[str]:
             return column_names
 
         return PandasLikeExpr.from_column_names(
-            get_column_names=get_column_names,
+            evaluate_column_names=evaluate_column_names,
             function_name="col",
             implementation=self._implementation,
             backend_version=self._backend_version,
@@ -121,7 +121,7 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> PandasLikeExpr:
-        def get_column_names(df: PandasLikeDataFrame) -> Sequence[str]:
+        def evaluate_column_names(df: PandasLikeDataFrame) -> Sequence[str]:
             return [
                 column_name
                 for column_name in df.columns
@@ -129,7 +129,7 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
             ]
 
         return PandasLikeExpr.from_column_names(
-            get_column_names=get_column_names,
+            evaluate_column_names=evaluate_column_names,
             function_name="exclude",
             implementation=self._implementation,
             backend_version=self._backend_version,

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -123,8 +123,9 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> PandasLikeExpr:
+        evaluate_column_names = partial(exclude_column_names, names=excluded_names)
         return PandasLikeExpr.from_column_names(
-            evaluate_column_names=partial(exclude_column_names, names=excluded_names),
+            evaluate_column_names=evaluate_column_names,
             function_name="exclude",
             implementation=self._implementation,
             backend_version=self._backend_version,

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -140,20 +140,9 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
         )
 
     def all(self: Self) -> PandasLikeExpr:
-        return PandasLikeExpr(
-            lambda df: [
-                PandasLikeSeries(
-                    df._native_frame[column_name],
-                    implementation=self._implementation,
-                    backend_version=self._backend_version,
-                    version=self._version,
-                )
-                for column_name in df.columns
-            ],
-            depth=0,
+        return PandasLikeExpr.from_column_names(
+            evaluate_column_names=get_column_names,
             function_name="all",
-            evaluate_output_names=get_column_names,
-            alias_output_names=None,
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -113,7 +113,7 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
     # --- selection ---
     def col(self: Self, *column_names: str) -> PandasLikeExpr:
         return PandasLikeExpr.from_column_names(
-            evaluate_column_names=passthrough_column_names(column_names),
+            passthrough_column_names(column_names),
             function_name="col",
             implementation=self._implementation,
             backend_version=self._backend_version,
@@ -121,9 +121,8 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> PandasLikeExpr:
-        evaluate_column_names = partial(exclude_column_names, names=excluded_names)
         return PandasLikeExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            partial(exclude_column_names, names=excluded_names),
             function_name="exclude",
             implementation=self._implementation,
             backend_version=self._backend_version,
@@ -140,7 +139,7 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
 
     def all(self: Self) -> PandasLikeExpr:
         return PandasLikeExpr.from_column_names(
-            evaluate_column_names=get_column_names,
+            get_column_names,
             function_name="all",
             implementation=self._implementation,
             backend_version=self._backend_version,

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -27,6 +27,7 @@ from narwhals.typing import CompliantNamespace
 from narwhals.utils import exclude_column_names
 from narwhals.utils import get_column_names
 from narwhals.utils import import_dtypes_module
+from narwhals.utils import passthrough_column_names
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -111,11 +112,8 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
 
     # --- selection ---
     def col(self: Self, *column_names: str) -> PandasLikeExpr:
-        def evaluate_column_names(_: PandasLikeDataFrame) -> Sequence[str]:
-            return column_names
-
         return PandasLikeExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            evaluate_column_names=passthrough_column_names(column_names),
             function_name="col",
             implementation=self._implementation,
             backend_version=self._backend_version,

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -109,38 +109,31 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
 
     # --- selection ---
     def col(self: Self, *column_names: str) -> PandasLikeExpr:
+        def get_column_names(_: PandasLikeDataFrame) -> Sequence[str]:
+            return column_names
+
         return PandasLikeExpr.from_column_names(
-            *column_names,
+            get_column_names=get_column_names,
+            function_name="col",
             implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> PandasLikeExpr:
-        def evaluate_output_names(df: PandasLikeDataFrame) -> Sequence[str]:
+        def get_column_names(df: PandasLikeDataFrame) -> Sequence[str]:
             return [
                 column_name
                 for column_name in df.columns
                 if column_name not in excluded_names
             ]
 
-        def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
-            return [
-                PandasLikeSeries(
-                    df._native_frame[column_name],
-                    implementation=df._implementation,
-                    backend_version=df._backend_version,
-                    version=df._version,
-                )
-                for column_name in evaluate_output_names(df)
-            ]
-
-        return self._create_expr_from_callable(
-            func,
-            depth=0,
-            evaluate_output_names=evaluate_output_names,
+        return PandasLikeExpr.from_column_names(
+            get_column_names=get_column_names,
             function_name="exclude",
-            alias_output_names=None,
+            implementation=self._implementation,
+            backend_version=self._backend_version,
+            version=self._version,
         )
 
     def nth(self: Self, *column_indices: int) -> PandasLikeExpr:

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import operator
+from functools import partial
 from functools import reduce
 from typing import TYPE_CHECKING
 from typing import Any
@@ -23,6 +24,7 @@ from narwhals._pandas_like.utils import extract_dataframe_comparand
 from narwhals._pandas_like.utils import horizontal_concat
 from narwhals._pandas_like.utils import vertical_concat
 from narwhals.typing import CompliantNamespace
+from narwhals.utils import exclude_column_names
 from narwhals.utils import get_column_names
 from narwhals.utils import import_dtypes_module
 
@@ -121,15 +123,8 @@ class PandasLikeNamespace(CompliantNamespace[PandasLikeDataFrame, PandasLikeSeri
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> PandasLikeExpr:
-        def evaluate_column_names(df: PandasLikeDataFrame) -> Sequence[str]:
-            return [
-                column_name
-                for column_name in df.columns
-                if column_name not in excluded_names
-            ]
-
         return PandasLikeExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            evaluate_column_names=partial(exclude_column_names, names=excluded_names),
             function_name="exclude",
             implementation=self._implementation,
             backend_version=self._backend_version,

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -131,18 +131,19 @@ class SparkLikeExpr(CompliantExpr["SparkLikeLazyFrame", "Column"]):  # type: ign
     @classmethod
     def from_column_names(
         cls: type[Self],
-        *column_names: str,
+        get_column_names: Callable[[SparkLikeLazyFrame], Sequence[str]],
+        function_name: str,
+        implementation: Implementation,
         backend_version: tuple[int, ...],
         version: Version,
-        implementation: Implementation,
     ) -> Self:
         def func(df: SparkLikeLazyFrame) -> list[Column]:
-            return [df._F.col(col_name) for col_name in column_names]
+            return [df._F.col(col_name) for col_name in get_column_names(df)]
 
         return cls(
             func,
-            function_name="col",
-            evaluate_output_names=lambda _df: column_names,
+            function_name=function_name,
+            evaluate_output_names=get_column_names,
             alias_output_names=None,
             backend_version=backend_version,
             version=version,

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -131,19 +131,19 @@ class SparkLikeExpr(CompliantExpr["SparkLikeLazyFrame", "Column"]):  # type: ign
     @classmethod
     def from_column_names(
         cls: type[Self],
-        get_column_names: Callable[[SparkLikeLazyFrame], Sequence[str]],
+        evaluate_column_names: Callable[[SparkLikeLazyFrame], Sequence[str]],
         function_name: str,
         implementation: Implementation,
         backend_version: tuple[int, ...],
         version: Version,
     ) -> Self:
         def func(df: SparkLikeLazyFrame) -> list[Column]:
-            return [df._F.col(col_name) for col_name in get_column_names(df)]
+            return [df._F.col(col_name) for col_name in evaluate_column_names(df)]
 
         return cls(
             func,
             function_name=function_name,
-            evaluate_output_names=get_column_names,
+            evaluate_output_names=evaluate_column_names,
             alias_output_names=None,
             backend_version=backend_version,
             version=version,

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -132,6 +132,8 @@ class SparkLikeExpr(CompliantExpr["SparkLikeLazyFrame", "Column"]):  # type: ign
     def from_column_names(
         cls: type[Self],
         evaluate_column_names: Callable[[SparkLikeLazyFrame], Sequence[str]],
+        /,
+        *,
         function_name: str,
         implementation: Implementation,
         backend_version: tuple[int, ...],

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -52,7 +52,7 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "Column"]):  #
 
     def all(self: Self) -> SparkLikeExpr:
         return SparkLikeExpr.from_column_names(
-            evaluate_column_names=get_column_names,
+            get_column_names,
             function_name="all",
             implementation=self._implementation,
             backend_version=self._backend_version,
@@ -61,7 +61,7 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "Column"]):  #
 
     def col(self: Self, *column_names: str) -> SparkLikeExpr:
         return SparkLikeExpr.from_column_names(
-            evaluate_column_names=passthrough_column_names(column_names),
+            passthrough_column_names(column_names),
             function_name="col",
             implementation=self._implementation,
             backend_version=self._backend_version,
@@ -69,9 +69,8 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "Column"]):  #
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> SparkLikeExpr:
-        evaluate_column_names = partial(exclude_column_names, names=excluded_names)
         return SparkLikeExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            partial(exclude_column_names, names=excluded_names),
             function_name="exclude",
             implementation=self._implementation,
             backend_version=self._backend_version,

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -22,6 +22,7 @@ from narwhals._spark_like.utils import narwhals_to_native_dtype
 from narwhals.typing import CompliantNamespace
 from narwhals.utils import exclude_column_names
 from narwhals.utils import get_column_names
+from narwhals.utils import passthrough_column_names
 
 if TYPE_CHECKING:
     from pyspark.sql import Column
@@ -59,11 +60,8 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "Column"]):  #
         )
 
     def col(self: Self, *column_names: str) -> SparkLikeExpr:
-        def evaluate_column_names(_: SparkLikeLazyFrame) -> Sequence[str]:
-            return column_names
-
         return SparkLikeExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            evaluate_column_names=passthrough_column_names(column_names),
             function_name="col",
             implementation=self._implementation,
             backend_version=self._backend_version,

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -50,17 +50,12 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "Column"]):  #
         return SparkLikeSelectorNamespace(self)
 
     def all(self: Self) -> SparkLikeExpr:
-        def _all(df: SparkLikeLazyFrame) -> list[Column]:
-            return [df._F.col(col_name) for col_name in df.columns]
-
-        return SparkLikeExpr(
-            call=_all,
+        return SparkLikeExpr.from_column_names(
+            evaluate_column_names=get_column_names,
             function_name="all",
-            evaluate_output_names=get_column_names,
-            alias_output_names=None,
+            implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            implementation=self._implementation,
         )
 
     def col(self: Self, *column_names: str) -> SparkLikeExpr:

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -62,32 +62,31 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "Column"]):  #
         )
 
     def col(self: Self, *column_names: str) -> SparkLikeExpr:
+        def get_column_names(_: SparkLikeLazyFrame) -> Sequence[str]:
+            return column_names
+
         return SparkLikeExpr.from_column_names(
-            *column_names,
+            get_column_names=get_column_names,
+            function_name="col",
+            implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            implementation=self._implementation,
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> SparkLikeExpr:
-        def evaluate_output_names(df: SparkLikeLazyFrame) -> Sequence[str]:
+        def get_column_names(df: SparkLikeLazyFrame) -> Sequence[str]:
             return [
                 column_name
                 for column_name in df.columns
                 if column_name not in excluded_names
             ]
 
-        def func(df: SparkLikeLazyFrame) -> list[Column]:
-            return [df._F.col(column_name) for column_name in evaluate_output_names(df)]
-
-        return SparkLikeExpr(
-            func,
+        return SparkLikeExpr.from_column_names(
+            get_column_names=get_column_names,
             function_name="exclude",
-            evaluate_output_names=evaluate_output_names,
-            alias_output_names=None,
+            implementation=self._implementation,
             backend_version=self._backend_version,
             version=self._version,
-            implementation=self._implementation,
         )
 
     def nth(self: Self, *column_indices: int) -> SparkLikeExpr:

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -71,8 +71,9 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "Column"]):  #
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> SparkLikeExpr:
+        evaluate_column_names = partial(exclude_column_names, names=excluded_names)
         return SparkLikeExpr.from_column_names(
-            evaluate_column_names=partial(exclude_column_names, names=excluded_names),
+            evaluate_column_names=evaluate_column_names,
             function_name="exclude",
             implementation=self._implementation,
             backend_version=self._backend_version,

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -62,11 +62,11 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "Column"]):  #
         )
 
     def col(self: Self, *column_names: str) -> SparkLikeExpr:
-        def get_column_names(_: SparkLikeLazyFrame) -> Sequence[str]:
+        def evaluate_column_names(_: SparkLikeLazyFrame) -> Sequence[str]:
             return column_names
 
         return SparkLikeExpr.from_column_names(
-            get_column_names=get_column_names,
+            evaluate_column_names=evaluate_column_names,
             function_name="col",
             implementation=self._implementation,
             backend_version=self._backend_version,
@@ -74,7 +74,7 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "Column"]):  #
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> SparkLikeExpr:
-        def get_column_names(df: SparkLikeLazyFrame) -> Sequence[str]:
+        def evaluate_column_names(df: SparkLikeLazyFrame) -> Sequence[str]:
             return [
                 column_name
                 for column_name in df.columns
@@ -82,7 +82,7 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "Column"]):  #
             ]
 
         return SparkLikeExpr.from_column_names(
-            get_column_names=get_column_names,
+            evaluate_column_names=evaluate_column_names,
             function_name="exclude",
             implementation=self._implementation,
             backend_version=self._backend_version,

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import operator
+from functools import partial
 from functools import reduce
 from typing import TYPE_CHECKING
 from typing import Any
@@ -19,6 +20,7 @@ from narwhals._spark_like.selectors import SparkLikeSelectorNamespace
 from narwhals._spark_like.utils import maybe_evaluate_expr
 from narwhals._spark_like.utils import narwhals_to_native_dtype
 from narwhals.typing import CompliantNamespace
+from narwhals.utils import exclude_column_names
 from narwhals.utils import get_column_names
 
 if TYPE_CHECKING:
@@ -74,15 +76,8 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "Column"]):  #
         )
 
     def exclude(self: Self, excluded_names: Container[str]) -> SparkLikeExpr:
-        def evaluate_column_names(df: SparkLikeLazyFrame) -> Sequence[str]:
-            return [
-                column_name
-                for column_name in df.columns
-                if column_name not in excluded_names
-            ]
-
         return SparkLikeExpr.from_column_names(
-            evaluate_column_names=evaluate_column_names,
+            evaluate_column_names=partial(exclude_column_names, names=excluded_names),
             function_name="exclude",
             implementation=self._implementation,
             backend_version=self._backend_version,

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -9,6 +9,7 @@ from inspect import getattr_static
 from secrets import token_hex
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Container
 from typing import Iterable
 from typing import Literal
 from typing import Sequence
@@ -1354,6 +1355,10 @@ def dtype_matches_time_unit_and_time_zone(
 
 def get_column_names(frame: _StoresColumns, /) -> Sequence[str]:
     return frame.columns
+
+
+def exclude_column_names(frame: _StoresColumns, names: Container[str]) -> Sequence[str]:
+    return [col_name for col_name in frame.columns if col_name not in names]
 
 
 def _hasattr_static(obj: Any, attr: str) -> bool:

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -9,6 +9,7 @@ from inspect import getattr_static
 from secrets import token_hex
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Callable
 from typing import Container
 from typing import Iterable
 from typing import Literal
@@ -1359,6 +1360,13 @@ def get_column_names(frame: _StoresColumns, /) -> Sequence[str]:
 
 def exclude_column_names(frame: _StoresColumns, names: Container[str]) -> Sequence[str]:
     return [col_name for col_name in frame.columns if col_name not in names]
+
+
+def passthrough_column_names(names: Sequence[str], /) -> Callable[[Any], Sequence[str]]:
+    def fn(_frame: Any, /) -> Sequence[str]:
+        return names
+
+    return fn
 
 
 def _hasattr_static(obj: Any, attr: str) -> bool:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

Follow-up on [comment](https://github.com/narwhals-dev/narwhals/pull/2122#discussion_r1976370057)
