### PR TITLE
docs: Store similar values in one variable instead of passing similar value in translate.py docstrings

### DIFF
--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -813,10 +813,13 @@ def get_native_namespace(
         >>> import polars as pl
         >>> import pandas as pd
         >>> import narwhals as nw
-        >>> df = nw.from_native(pd.DataFrame({"a": [1, 2, 3]}))
+        >>>
+        >>> data = {"a": [1, 2, 3]}
+        >>>
+        >>> df = nw.from_native(pd.DataFrame(data))
         >>> nw.get_native_namespace(df)
         <module 'pandas'...>
-        >>> df = nw.from_native(pl.DataFrame({"a": [1, 2, 3]}))
+        >>> df = nw.from_native(pl.DataFrame(data))
         >>> nw.get_native_namespace(df)
         <module 'polars'...>
     """
@@ -974,11 +977,14 @@ def to_py_scalar(scalar_like: Any) -> Any:
     Examples:
         >>> import narwhals as nw
         >>> import pandas as pd
-        >>> df = nw.from_native(pd.DataFrame({"a": [1, 2, 3]}))
+        >>>
+        >>> data = {"a": [1, 2, 3]}
+        >>>
+        >>> df = nw.from_native(pd.DataFrame(data))
         >>> nw.to_py_scalar(df["a"].item(0))
         1
         >>> import pyarrow as pa
-        >>> df = nw.from_native(pa.table({"a": [1, 2, 3]}))
+        >>> df = nw.from_native(pa.table(data))
         >>> nw.to_py_scalar(df["a"].item(0))
         1
         >>> nw.to_py_scalar(1)


### PR DESCRIPTION
This is a simple modification to the docstrings found in the `translate.py` file. Similar values are stored into a single variable. This helps somehow in solving the Issue #2068.


<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #2068
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
