### PR TITLE
feat: support anonymous expressions in `over` context for pandas-like, support `over` for multi-partitioned dask

### DIFF
--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -12,7 +12,7 @@ import pyarrow.compute as pc
 
 from narwhals._arrow.utils import extract_py_scalar
 from narwhals._expression_parsing import evaluate_output_names_and_aliases
-from narwhals._expression_parsing import is_simple_aggregation
+from narwhals._expression_parsing import is_elementary_expression
 from narwhals.utils import generate_temporary_column_name
 
 if TYPE_CHECKING:
@@ -51,7 +51,7 @@ class ArrowGroupBy:
         all_simple_aggs = True
         for expr in exprs:
             if not (
-                is_simple_aggregation(expr)
+                is_elementary_expression(expr)
                 and re.sub(r"(\w+->)", "", expr._function_name)
                 in POLARS_TO_ARROW_AGGREGATIONS
             ):

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -534,9 +534,9 @@ class DaskExpr(CompliantExpr["DaskLazyFrame", "dx.Series"]):  # pyright: ignore[
         # pandas is a required dependency of dask so it's safe to import this
         from narwhals._pandas_like.group_by import AGGREGATIONS_TO_PANDAS_EQUIVALENT
 
-        if not is_elementary_expression(self):
+        if not is_elementary_expression(self):  # pragma: no cover
             msg = (
-                "Only elementary expressions are supported for `.over` in pandas-like backends.\n\n"
+                "Only elementary expressions are supported for `.over` in dask.\n\n"
                 "Please see: "
                 "https://narwhals-dev.github.io/narwhals/pandas_like_concepts/improve_group_by_operation/"
             )

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+import warnings
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -14,6 +16,7 @@ from narwhals._dask.utils import maybe_evaluate_expr
 from narwhals._dask.utils import narwhals_to_native_dtype
 from narwhals._expression_parsing import ExprKind
 from narwhals._expression_parsing import evaluate_output_names_and_aliases
+from narwhals._expression_parsing import is_elementary_expression
 from narwhals._pandas_like.utils import native_to_narwhals_dtype
 from narwhals.exceptions import ColumnNotFoundError
 from narwhals.exceptions import InvalidOperationError
@@ -528,29 +531,40 @@ class DaskExpr(CompliantExpr["DaskLazyFrame", "dx.Series"]):  # pyright: ignore[
         )
 
     def over(self: Self, keys: list[str], kind: ExprKind) -> Self:
-        def func(df: DaskLazyFrame) -> list[Any]:
-            output_names, aliases = evaluate_output_names_and_aliases(self, df, [])
-            if overlap := set(output_names).intersection(keys):
-                # E.g. `df.select(nw.all().sum().over('a'))`. This is well-defined,
-                # we just don't support it yet.
-                msg = (
-                    f"Column names {overlap} appear in both expression output names and in `over` keys.\n"
-                    "This is not yet supported."
-                )
-                raise NotImplementedError(msg)
-            if df._native_frame.npartitions == 1:  # pragma: no cover
-                tmp = df.group_by(*keys, drop_null_keys=False).agg(self)
-                tmp_native = (
-                    df.simple_select(*keys)
-                    .join(tmp, how="left", left_on=keys, right_on=keys, suffix="_right")
-                    ._native_frame
-                )
-                return [tmp_native[name] for name in aliases]
-            # https://github.com/dask/dask/issues/6659
+        # pandas is a required dependency of dask so it's safe to import this
+        from narwhals._pandas_like.group_by import AGGREGATIONS_TO_PANDAS_EQUIVALENT
+
+        if not is_elementary_expression(self):
             msg = (
-                "`Expr.over` is not supported for Dask backend with multiple partitions."
+                "Only elementary expressions are supported for `.over` in pandas-like backends.\n\n"
+                "Please see: "
+                "https://narwhals-dev.github.io/narwhals/pandas_like_concepts/improve_group_by_operation/"
             )
             raise NotImplementedError(msg)
+        function_name = re.sub(r"(\w+->)", "", self._function_name)
+        try:
+            dask_function_name = AGGREGATIONS_TO_PANDAS_EQUIVALENT[function_name]
+        except KeyError:
+            msg = (
+                f"Unsupported function: {function_name} in `over` context.\n\n."
+                f"Supported functions are {', '.join(AGGREGATIONS_TO_PANDAS_EQUIVALENT)}\n"
+            )
+            raise NotImplementedError(msg) from None
+
+        def func(df: DaskLazyFrame) -> list[dx.Series]:
+            output_names, aliases = evaluate_output_names_and_aliases(self, df, [])
+
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore", message=".*`meta` is not specified", category=UserWarning
+                )
+                res_native = df._native_frame.groupby(keys)[list(output_names)].transform(
+                    dask_function_name, **self._call_kwargs
+                )
+            result_frame = df._from_native_frame(
+                res_native.rename(columns=dict(zip(output_names, aliases)))
+            )._native_frame
+            return [result_frame[name] for name in aliases]
 
         return self.__class__(
             func,
@@ -560,7 +574,6 @@ class DaskExpr(CompliantExpr["DaskLazyFrame", "dx.Series"]):  # pyright: ignore[
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
             version=self._version,
-            call_kwargs=self._call_kwargs,
         )
 
     def cast(self: Self, dtype: DType | type[DType]) -> Self:

--- a/narwhals/_dask/group_by.py
+++ b/narwhals/_dask/group_by.py
@@ -11,7 +11,7 @@ from typing import Sequence
 import dask.dataframe as dd
 
 from narwhals._expression_parsing import evaluate_output_names_and_aliases
-from narwhals._expression_parsing import is_simple_aggregation
+from narwhals._expression_parsing import is_elementary_expression
 
 try:
     import dask.dataframe.dask_expr as dx
@@ -121,7 +121,7 @@ def agg_dask(
     all_simple_aggs = True
     for expr in exprs:
         if not (
-            is_simple_aggregation(expr)
+            is_elementary_expression(expr)
             and re.sub(r"(\w+->)", "", expr._function_name) in POLARS_TO_DASK_AGGREGATIONS
         ):
             all_simple_aggs = False

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -238,8 +238,8 @@ def reuse_series_namespace_implementation(
     )
 
 
-def is_simple_aggregation(expr: CompliantExpr[Any, Any]) -> bool:
-    """Check if expr is a very simple one.
+def is_elementary_expression(expr: CompliantExpr[Any, Any]) -> bool:
+    """Check if expr is elementary.
 
     Examples:
         - nw.col('a').mean()  # depth 1
@@ -250,7 +250,8 @@ def is_simple_aggregation(expr: CompliantExpr[Any, Any]) -> bool:
 
         - nw.col('a').filter(nw.col('b')>nw.col('c')).max()
 
-    because then, we can use a fastpath in pandas.
+    Elementary ones are the only ones supported properly in
+    pandas, PyArrow, and Dask.
     """
     return expr._depth < 2
 

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -250,7 +250,7 @@ def is_elementary_expression(expr: CompliantExpr[Any, Any]) -> bool:
 
         - nw.col('a').filter(nw.col('b')>nw.col('c')).max()
 
-    Elementary ones are the only ones supported properly in
+    Elementary expressions are the only ones supported properly in
     pandas, PyArrow, and Dask.
     """
     return expr._depth < 2

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -469,7 +469,7 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
                 pandas_function_name = AGGREGATIONS_TO_PANDAS_EQUIVALENT[function_name]
             except KeyError:
                 msg = (
-                    f"Unsupported function: {function_name} in `over` context.\n\n."
+                    f"Unsupported function: {function_name} in `over` context.\n\n"
                     f"Supported functions are {', '.join(WINDOW_FUNCTIONS_TO_PANDAS_EQUIVALENT)}\n"
                     f"and {', '.join(AGGREGATIONS_TO_PANDAS_EQUIVALENT)}."
                 )

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -9,14 +9,14 @@ from typing import Sequence
 
 from narwhals._expression_parsing import ExprKind
 from narwhals._expression_parsing import evaluate_output_names_and_aliases
-from narwhals._expression_parsing import is_scalar_like
-from narwhals._expression_parsing import is_simple_aggregation
+from narwhals._expression_parsing import is_elementary_expression
 from narwhals._expression_parsing import reuse_series_implementation
 from narwhals._pandas_like.expr_cat import PandasLikeExprCatNamespace
 from narwhals._pandas_like.expr_dt import PandasLikeExprDateTimeNamespace
 from narwhals._pandas_like.expr_list import PandasLikeExprListNamespace
 from narwhals._pandas_like.expr_name import PandasLikeExprNameNamespace
 from narwhals._pandas_like.expr_str import PandasLikeExprStringNamespace
+from narwhals._pandas_like.group_by import AGGREGATIONS_TO_PANDAS_EQUIVALENT
 from narwhals._pandas_like.series import PandasLikeSeries
 from narwhals._pandas_like.utils import rename
 from narwhals.dependencies import get_numpy
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from narwhals.utils import Implementation
     from narwhals.utils import Version
 
-MANY_TO_MANY_AGG_FUNCTIONS_TO_PANDAS_EQUIVALENT = {
+WINDOW_FUNCTIONS_TO_PANDAS_EQUIVALENT = {
     "cum_sum": "cumsum",
     "cum_min": "cummin",
     "cum_max": "cummax",
@@ -46,6 +46,32 @@ MANY_TO_MANY_AGG_FUNCTIONS_TO_PANDAS_EQUIVALENT = {
     "rank": "rank",
     "diff": "diff",
 }
+
+
+def window_kwargs_to_pandas_equivalent(
+    function_name: str, kwargs: dict[str, object]
+) -> dict[str, object]:
+    unsupported_reverse_msg = (
+        "Cumulative operation with `reverse=True` is not supported in "
+        "over context for pandas-like backend."
+    )
+    if function_name == "shift":
+        pandas_kwargs: dict[str, object] = {"periods": kwargs["n"]}
+    elif function_name == "rank":
+        _method = kwargs["method"]
+        pandas_kwargs = {
+            "method": "first" if _method == "ordinal" else _method,
+            "ascending": not kwargs["descending"],
+            "na_option": "keep",
+            "pct": False,
+        }
+    elif function_name.startswith("cum_"):  # Cumulative operation
+        if kwargs["reverse"]:
+            raise NotImplementedError(unsupported_reverse_msg)
+        pandas_kwargs = {"skipna": True}
+    else:
+        pandas_kwargs = {}
+    return pandas_kwargs
 
 
 class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
@@ -428,80 +454,49 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
         )
 
     def over(self: Self, keys: list[str], kind: ExprKind) -> Self:
-        if (
-            is_simple_aggregation(self)
-            and (function_name := re.sub(r"(\w+->)", "", self._function_name))
-            in MANY_TO_MANY_AGG_FUNCTIONS_TO_PANDAS_EQUIVALENT
-        ):
-
-            def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
-                output_names, aliases = evaluate_output_names_and_aliases(self, df, [])
-
-                unsupported_reverse_msg = (
-                    "Cumulative operation with `reverse=True` is not supported in "
-                    "over context for pandas-like backend."
-                )
-                if function_name == "cum_count":
-                    if self._call_kwargs["reverse"]:
-                        raise NotImplementedError(unsupported_reverse_msg)
-                    plx = self.__narwhals_namespace__()
-                    df = df.with_columns(~plx.col(*output_names).is_null())
-
-                if function_name == "shift":
-                    kwargs = {"periods": self._call_kwargs["n"]}
-                elif function_name == "rank":
-                    _method = self._call_kwargs["method"]
-                    kwargs = {
-                        "method": "first" if _method == "ordinal" else _method,
-                        "ascending": not self._call_kwargs["descending"],
-                        "na_option": "keep",
-                        "pct": False,
-                    }
-                elif function_name.startswith("cum_"):  # Cumulative operation
-                    if self._call_kwargs["reverse"]:
-                        raise NotImplementedError(unsupported_reverse_msg)
-                    kwargs = {"skipna": True}
-                else:
-                    kwargs = {}
-
-                res_native = getattr(
-                    df._native_frame.groupby(keys)[list(output_names)],
-                    MANY_TO_MANY_AGG_FUNCTIONS_TO_PANDAS_EQUIVALENT[function_name],
-                )(**kwargs)
-                result_frame = df._from_native_frame(
-                    rename(
-                        res_native,
-                        columns=dict(zip(output_names, aliases)),
-                        implementation=self._implementation,
-                        backend_version=self._backend_version,
-                    )
-                )
-                return [result_frame[name] for name in aliases]
-        elif not is_scalar_like(kind):
+        if not is_elementary_expression(self):
             msg = (
-                "Length-preserving operations are only supported in `over` context "
-                "for pandas if they are elementary "
-                "(e.g. `nw.col('a').cum_sum().over('b'))`)."
+                "Only elementary expressions are supported for `.over` in pandas-like backends.\n\n"
+                "Please see: "
+                "https://narwhals-dev.github.io/narwhals/pandas_like_concepts/improve_group_by_operation/"
             )
             raise NotImplementedError(msg)
-        else:
-
-            def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
-                output_names, aliases = evaluate_output_names_and_aliases(self, df, [])
-                if overlap := set(output_names).intersection(keys):
-                    # E.g. `df.select(nw.all().sum().over('a'))`. This is well-defined,
-                    # we just don't support it yet.
-                    msg = (
-                        f"Column names {overlap} appear in both expression output names and in `over` keys.\n"
-                        "This is not yet supported."
-                    )
-                    raise NotImplementedError(msg)
-
-                tmp = df.group_by(*keys, drop_null_keys=False).agg(self)
-                tmp = df.simple_select(*keys).join(
-                    tmp, how="left", left_on=keys, right_on=keys, suffix="_right"
+        function_name = re.sub(r"(\w+->)", "", self._function_name)
+        try:
+            pandas_function_name = WINDOW_FUNCTIONS_TO_PANDAS_EQUIVALENT[function_name]
+        except KeyError:
+            try:
+                pandas_function_name = AGGREGATIONS_TO_PANDAS_EQUIVALENT[function_name]
+            except KeyError:
+                msg = (
+                    f"Unsupported function: {function_name} in `over` context.\n\n."
+                    f"Supported functions are {', '.join(WINDOW_FUNCTIONS_TO_PANDAS_EQUIVALENT)}\n"
+                    f"and {', '.join(AGGREGATIONS_TO_PANDAS_EQUIVALENT)}."
                 )
-                return [tmp[name] for name in aliases]
+                raise NotImplementedError(msg) from None
+
+        def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
+            output_names, aliases = evaluate_output_names_and_aliases(self, df, [])
+            pandas_kwargs = window_kwargs_to_pandas_equivalent(
+                function_name, self._call_kwargs
+            )
+
+            if function_name == "cum_count":
+                plx = self.__narwhals_namespace__()
+                df = df.with_columns(~plx.col(*output_names).is_null())
+
+            res_native = df._native_frame.groupby(keys)[list(output_names)].transform(
+                pandas_function_name, **pandas_kwargs
+            )
+            result_frame = df._from_native_frame(
+                rename(
+                    res_native,
+                    columns=dict(zip(output_names, aliases)),
+                    implementation=self._implementation,
+                    backend_version=self._backend_version,
+                )
+            )
+            return [result_frame[name] for name in aliases]
 
         return self.__class__(
             func,

--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -8,7 +8,7 @@ from typing import Any
 from typing import Iterator
 
 from narwhals._expression_parsing import evaluate_output_names_and_aliases
-from narwhals._expression_parsing import is_simple_aggregation
+from narwhals._expression_parsing import is_elementary_expression
 from narwhals._pandas_like.utils import horizontal_concat
 from narwhals._pandas_like.utils import native_series_from_iterable
 from narwhals._pandas_like.utils import select_columns_by_name
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from narwhals._pandas_like.dataframe import PandasLikeDataFrame
     from narwhals._pandas_like.expr import PandasLikeExpr
 
-POLARS_TO_PANDAS_AGGREGATIONS = {
+AGGREGATIONS_TO_PANDAS_EQUIVALENT = {
     "sum": "sum",
     "mean": "mean",
     "median": "median",
@@ -84,9 +84,9 @@ class PandasLikeGroupBy:
             new_names.extend(aliases)
 
             if not (
-                is_simple_aggregation(expr)
+                is_elementary_expression(expr)
                 and re.sub(r"(\w+->)", "", expr._function_name)
-                in POLARS_TO_PANDAS_AGGREGATIONS
+                in AGGREGATIONS_TO_PANDAS_EQUIVALENT
             ):
                 all_aggs_are_simple = False
 
@@ -115,7 +115,7 @@ class PandasLikeGroupBy:
                 )
                 if expr._depth == 0:
                     # e.g. agg(nw.len()) # noqa: ERA001
-                    function_name = POLARS_TO_PANDAS_AGGREGATIONS.get(
+                    function_name = AGGREGATIONS_TO_PANDAS_EQUIVALENT.get(
                         expr._function_name, expr._function_name
                     )
                     simple_aggs_functions.add(function_name)
@@ -128,7 +128,7 @@ class PandasLikeGroupBy:
 
                 # e.g. agg(nw.mean('a')) # noqa: ERA001
                 function_name = re.sub(r"(\w+->)", "", expr._function_name)
-                function_name = POLARS_TO_PANDAS_AGGREGATIONS.get(
+                function_name = AGGREGATIONS_TO_PANDAS_EQUIVALENT.get(
                     function_name, function_name
                 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,8 @@ exclude_also = [
   'request.applymarker\(pytest.mark.xfail',
   'backend_version <',
   'if "cudf" in str\(constructor',
-  'if "pyspark" in str\(constructor'
+  'if "pyspark" in str\(constructor',
+  'pytest.skip\('
 ]
 
 [tool.mypy]

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -264,6 +264,8 @@ def test_over_diff(
 ) -> None:
     if "pyarrow_table" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
+    if "pandas" in str(constructor_eager) and PANDAS_VERSION < (1, 1):
+        pytest.skip(reason="bug in old version")
 
     df = nw.from_native(constructor_eager(data))
     expected = {

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -30,8 +30,6 @@ data_cum = {
 
 
 def test_over_single(request: pytest.FixtureRequest, constructor: Constructor) -> None:
-    if "dask_lazy_p2" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
     if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
 
@@ -50,8 +48,6 @@ def test_over_single(request: pytest.FixtureRequest, constructor: Constructor) -
 
 
 def test_over_multiple(request: pytest.FixtureRequest, constructor: Constructor) -> None:
-    if "dask_lazy_p2" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
     if "duckdb" in str(constructor):
         request.applymarker(pytest.mark.xfail)
 
@@ -229,8 +225,6 @@ def test_over_anonymous_reduction(
     context = (
         pytest.raises(NotImplementedError)
         if df.implementation.is_pyarrow()
-        or df.implementation.is_pandas_like()
-        or df.implementation.is_dask()
         else does_not_raise()
     )
     with context:

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -245,6 +245,21 @@ def test_over_anonymous_reduction(
         assert_equal_data(result, expected)
 
 
+def test_over_unsupported() -> None:
+    dfpd = pd.DataFrame({"a": [1, 1, 2], "b": [4, 5, 6]})
+    with pytest.raises(NotImplementedError):
+        nw.from_native(dfpd).select(nw.col("a").round().over("a"))
+
+
+def test_over_unsupported_dask() -> None:
+    pytest.importorskip("dask")
+    import dask.dataframe as dd
+
+    df = dd.from_pandas(pd.DataFrame({"a": [1, 1, 2], "b": [4, 5, 6]}))
+    with pytest.raises(NotImplementedError):
+        nw.from_native(df).select(nw.col("a").round().over("a"))
+
+
 def test_over_shift(
     request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -220,6 +220,9 @@ def test_over_anonymous_reduction(
     if "duckdb" in str(constructor):
         # TODO(unassigned): we should be able to support these
         request.applymarker(pytest.mark.xfail)
+    if "modin" in str(constructor):
+        # probably bugged
+        request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor({"a": [1, 1, 2], "b": [4, 5, 6]}))
     context = (

--- a/tests/expr_and_series/rank_test.py
+++ b/tests/expr_and_series/rank_test.py
@@ -110,6 +110,8 @@ def test_rank_expr_in_over_context(
 
     if "pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2, 1):
         request.applymarker(pytest.mark.xfail)
+    if "pandas" in str(constructor_eager) and PANDAS_VERSION < (1, 1):
+        request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(constructor_eager(data_float))
 

--- a/tests/expr_and_series/rank_test.py
+++ b/tests/expr_and_series/rank_test.py
@@ -109,9 +109,9 @@ def test_rank_expr_in_over_context(
         request.applymarker(pytest.mark.xfail)
 
     if "pandas_pyarrow" in str(constructor_eager) and PANDAS_VERSION < (2, 1):
-        request.applymarker(pytest.mark.xfail)
+        pytest.skip(reason="bug in old version")
     if "pandas" in str(constructor_eager) and PANDAS_VERSION < (1, 1):
-        request.applymarker(pytest.mark.xfail)
+        pytest.skip(reason="bug in old version")
 
     df = nw.from_native(constructor_eager(data_float))
 


### PR DESCRIPTION
This simplifies a lot on the pandas side, and unlocks `.over` for dask

On the downside, for some very old versions of pandas (pre 1.1), some tests would fail...but tbh those versions are so old i'm not overly bothered. pandas 1.0 is >5 years old...

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
