### PR TITLE
refactor: Use `chain.from_iterable` more

### DIFF
--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -77,11 +77,7 @@ def evaluate_into_exprs(
     *exprs: CompliantExpr[CompliantFrameT, CompliantSeriesT_co],
 ) -> list[CompliantSeriesT_co]:
     """Evaluate each expr into Series."""
-    return [
-        item
-        for sublist in (evaluate_into_expr(df, into_expr) for into_expr in exprs)
-        for item in sublist
-    ]
+    return list(chain.from_iterable(evaluate_into_expr(df, expr) for expr in exprs))
 
 
 @overload


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- https://github.com/astral-sh/ruff/pull/16131
- https://github.com/narwhals-dev/narwhals/pull/2028#discussion_r1957854827

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
- https://docs.python.org/3/library/itertools.html#itertools.chain.from_iterable
- Even if there were no performance benefit, I find this much easier to read than nested comprehensions
- There are likely a lot more places we could do this
  - Kinda difficult to search for