### PR TITLE
fix(typing): Narrow `NativeSeries` Protocol

### DIFF
--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -27,7 +27,9 @@ else:
 
 if TYPE_CHECKING:
     from types import ModuleType
+    from typing import Iterable
     from typing import Mapping
+    from typing import Sized
 
     import numpy as np
     from typing_extensions import Self
@@ -53,8 +55,8 @@ if TYPE_CHECKING:
 
         def join(self, *args: Any, **kwargs: Any) -> Any: ...
 
-    class NativeSeries(Protocol):
-        def __len__(self) -> int: ...
+    class NativeSeries(Sized, Iterable[Any], Protocol):
+        def filter(self, *args: Any, **kwargs: Any) -> Any: ...
 
     class DataFrameLike(Protocol):
         def __dataframe__(self, *args: Any, **kwargs: Any) -> Any: ...

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -292,16 +292,20 @@ def test_from_mock_interchange_protocol_non_strict() -> None:
     assert result is mockdf
 
 
-def test_from_native_altair_array_like() -> None:
+def test_from_native_strict_native_series() -> None:
     obj: list[int] = [1, 2, 3, 4]
     array_like = cast("Iterable[Any]", obj)
     not_array_like: Literal[1] = 1
+    np_array = pl.Series(obj).to_numpy()
 
     with pytest.raises(TypeError, match="got.+list"):
-        false_positive_native_series = nw.from_native(obj, series_only=True)  # noqa: F841
+        nw.from_native(obj, series_only=True)  # type: ignore[call-overload]
 
     with pytest.raises(TypeError, match="got.+list"):
-        true_negative_iterable = nw.from_native(array_like, series_only=True)  # type: ignore[call-overload] # noqa: F841
+        nw.from_native(array_like, series_only=True)  # type: ignore[call-overload]
 
     with pytest.raises(TypeError, match="got.+int"):
-        true_negative_not_native_series = nw.from_native(not_array_like, series_only=True)  # type: ignore[call-overload] # noqa: F841
+        nw.from_native(not_array_like, series_only=True)  # type: ignore[call-overload]
+
+    with pytest.raises(TypeError, match="got.+numpy.ndarray"):
+        nw.from_native(np_array, series_only=True)  # type: ignore[call-overload]


### PR DESCRIPTION
Closes #2111

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [x] 🐳 Other

## Related issues

- Related issue https://github.com/narwhals-dev/narwhals/pull/2110#discussion_r1973726417
- Closes #2111

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below
Of the possible common methods, this avoid `np.ndarray` matching - as well as builtins.

### Common methods
- `filter`
- `unique`
- `value_counts`
- `equals`
- `take` (numpy)
- `to_numpy`
- `__array__` (numpy)
- `__len__` (numpy)
- `__iter__` (numpy)