### PR TITLE
fix!: align `Series.filter` param name with Polars

### DIFF
--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -236,8 +236,8 @@ class ArrowExpr(CompliantExpr["ArrowDataFrame", ArrowSeries]):
 
     def filter(self: Self, *predicates: ArrowExpr) -> Self:
         plx = self.__narwhals_namespace__()
-        other = plx.all_horizontal(*predicates)
-        return reuse_series_implementation(self, "filter", other=other)
+        predicate = plx.all_horizontal(*predicates)
+        return reuse_series_implementation(self, "filter", predicate=predicate)
 
     def mean(self: Self) -> Self:
         return reuse_series_implementation(self, "mean", returns_scalar=True)

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -271,11 +271,13 @@ class ArrowSeries(CompliantSeries):
     def len(self: Self, *, _return_py_scalar: bool = True) -> int:
         return maybe_extract_py_scalar(len(self._native_series), _return_py_scalar)
 
-    def filter(self: Self, other: ArrowSeries | list[bool | None]) -> Self:
-        if not (isinstance(other, list) and all(isinstance(x, bool) for x in other)):
-            _, other_native = extract_native(self, other)
+    def filter(self: Self, predicate: ArrowSeries | list[bool | None]) -> Self:
+        if not (
+            isinstance(predicate, list) and all(isinstance(x, bool) for x in predicate)
+        ):
+            _, other_native = extract_native(self, predicate)
         else:
-            other_native = other
+            other_native = predicate
         return self._from_native_series(self._native_series.filter(other_native))  # pyright: ignore[reportArgumentType]
 
     def mean(self: Self, *, _return_py_scalar: bool = True) -> float:

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -380,8 +380,8 @@ class PandasLikeExpr(CompliantExpr["PandasLikeDataFrame", PandasLikeSeries]):
 
     def filter(self: Self, *predicates: PandasLikeExpr) -> Self:
         plx = self.__narwhals_namespace__()
-        other = plx.all_horizontal(*predicates)
-        return reuse_series_implementation(self, "filter", other=other)
+        predicate = plx.all_horizontal(*predicates)
+        return reuse_series_implementation(self, "filter", predicate=predicate)
 
     def drop_nulls(self: Self) -> Self:
         return reuse_series_implementation(self, "drop_nulls")

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -328,11 +328,13 @@ class PandasLikeSeries(CompliantSeries):
 
     # Binary comparisons
 
-    def filter(self: Self, other: Any) -> PandasLikeSeries:
-        if not (isinstance(other, list) and all(isinstance(x, bool) for x in other)):
-            _, other_native = align_and_extract_native(self, other)
+    def filter(self: Self, predicate: Any) -> PandasLikeSeries:
+        if not (
+            isinstance(predicate, list) and all(isinstance(x, bool) for x in predicate)
+        ):
+            _, other_native = align_and_extract_native(self, predicate)
         else:
-            other_native = other
+            other_native = predicate
         return self._from_native_series(self._native_series.loc[other_native]).alias(
             self.name
         )

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -1578,7 +1578,7 @@ class Series(Generic[IntoSeriesT]):
     def __invert__(self: Self) -> Self:
         return self._from_compliant_series(self._compliant_series.__invert__())
 
-    def filter(self: Self, other: Any) -> Self:
+    def filter(self: Self, predicate: Any) -> Self:
         """Filter elements in the Series based on a condition.
 
         Returns:
@@ -1597,7 +1597,7 @@ class Series(Generic[IntoSeriesT]):
             dtype: int64
         """
         return self._from_compliant_series(
-            self._compliant_series.filter(self._extract_native(other))
+            self._compliant_series.filter(self._extract_native(predicate))
         )
 
     # --- descriptive ---


### PR DESCRIPTION
Technically breaking, but I don't think it should affect anyone - if the downstream tests pass maybe we can silently get this through

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
