### PR TITLE
chore(typing): remove unused `pandas-stubs` ignores

### DIFF
--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -984,9 +984,9 @@ def _has_default_index(
     index = native_frame_or_series.index
     return (
         _is_range_index(index, native_namespace)
-        and index.start == 0  # type: ignore[comparison-overlap]
-        and index.stop == len(index)  # type: ignore[comparison-overlap]
-        and index.step == 1  # type: ignore[comparison-overlap]
+        and index.start == 0
+        and index.stop == len(index)
+        and index.step == 1
     )
 
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -140,7 +140,7 @@ def test_maybe_set_index_pandas_direct_index(
         native_df_or_series.index = pandas_index  # type: ignore[assignment]
         assert_series_equal(nw.to_native(result), native_df_or_series)
     else:
-        expected = native_df_or_series.set_index(pandas_index)  # type: ignore[type-var]
+        expected = native_df_or_series.set_index(pandas_index)  # type: ignore[arg-type]
         assert_frame_equal(nw.to_native(result), expected)
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- https://github.com/pandas-dev/pandas-stubs/commit/6db30fc168beb804e18583a5ad2774987fab5397
- https://github.com/narwhals-dev/narwhals/actions/runs/13747014405/job/38443181887
- https://github.com/narwhals-dev/narwhals/actions/runs/13749535089/job/38448716053?pr=2149
- https://github.com/pandas-dev/pandas-stubs/pull/1115

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Resolves `mypy` warnings that started appearing yesterday - after the stubs were updated.

Great to see your work upstream paying off @MarcoGorelli :tada:


