### PR TITLE
patch: xfail `cast_test.py::test_cast_time` for cudf

### DIFF
--- a/tests/expr_and_series/cast_test.py
+++ b/tests/expr_and_series/cast_test.py
@@ -323,7 +323,9 @@ def test_cast_time(request: pytest.FixtureRequest, constructor: Constructor) -> 
     if "pandas" in str(constructor) and PANDAS_VERSION < (2, 2):
         request.applymarker(pytest.mark.xfail)
 
-    if any(backend in str(constructor) for backend in ("dask", "pyspark", "modin")):
+    if any(
+        backend in str(constructor) for backend in ("dask", "pyspark", "modin", "cudf")
+    ):
         request.applymarker(pytest.mark.xfail)
 
     data = {"a": [time(12, 0, 0), time(12, 0, 5)]}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

Given that we check specifically for pandas implementation in:

https://github.com/narwhals-dev/narwhals/blob/ac4ee8ab79c397608ba8d39f82a5a7195f7e2e57/narwhals/_pandas_like/utils.py#L595-L599

we should have xfailed cudf from the beginning