### PR TITLE
chore: move dev dependencies to `dependency-groups`

### DIFF
--- a/.github/workflows/check_docs_build.yml
+++ b/.github/workflows/check_docs_build.yml
@@ -25,7 +25,7 @@ jobs:
           cache-suffix: ${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
       - name: local-install
-        run: uv pip install -e .[docs] --system
+        run: uv pip install -e . --group docs --system
       - name: check-no-errors
         run: |
           python -m mkdocs build 2>&1 | tee output.txt

--- a/.github/workflows/check_tpch_queries.yml
+++ b/.github/workflows/check_tpch_queries.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # once https://github.com/duckdb/duckdb/issues/16445
           # is addressed, try using `--pre`
-          uv pip install -U -e ".[core, dask]" --group tests --system
+          uv pip install -U -e ".[dask]" --group core-tests --system
       - name: generate-data
         run: cd tpch && python generate_data.py
       - name: tpch-tests 

--- a/.github/workflows/check_tpch_queries.yml
+++ b/.github/workflows/check_tpch_queries.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # once https://github.com/duckdb/duckdb/issues/16445
           # is addressed, try using `--pre`
-          uv pip install -U -e ".[tests, core, dask]" --system
+          uv pip install -U -e ".[core, dask]" --group tests --system
       - name: generate-data
         run: cd tpch && python generate_data.py
       - name: tpch-tests 

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -236,7 +236,7 @@ jobs:
       - name: run-pytest
         run: |
           cd tea-tasting
-          export PYTEST_ADDOPTS="--rootdir=tea-tasting"
+          export PYTEST_ADDOPTS="--rootdir=$(pwd)"
           pdm run test
 
   # temporarily commented out until they address the `new_series` deprecation

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -236,6 +236,7 @@ jobs:
       - name: run-pytest
         run: |
           cd tea-tasting
+          # empty pytest.ini to avoid pytest using narwhals configs
           touch pytest.ini
           pdm run test
 

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -236,6 +236,7 @@ jobs:
       - name: run-pytest
         run: |
           cd tea-tasting
+          export PYTEST_ADDOPTS="--rootdir=tea-tasting"
           pdm run test
 
   # temporarily commented out until they address the `new_series` deprecation

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -228,7 +228,7 @@ jobs:
         run: |
           cd tea-tasting
           pdm remove narwhals
-          pdm add ./..[tests]
+          pdm add ./..
       - name: show-deps
         run: |
           cd tea-tasting

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -236,7 +236,7 @@ jobs:
       - name: run-pytest
         run: |
           cd tea-tasting
-          export PYTEST_ADDOPTS="--rootdir=$(pwd)"
+          touch pytest.ini
           pdm run test
 
   # temporarily commented out until they address the `new_series` deprecation

--- a/.github/workflows/extremes.yml
+++ b/.github/workflows/extremes.yml
@@ -28,7 +28,7 @@ jobs:
         run: uv pip install pipdeptree tox virtualenv setuptools pandas==0.25.3 polars==0.20.3 numpy==1.17.5 pyarrow==11.0.0 "pyarrow-stubs<17" scipy==1.5.0 scikit-learn==1.1.0 duckdb==1.0 tzdata backports.zoneinfo --system
       - name: install-reqs
         run: |
-          uv pip install -e ".[tests]" --system
+          uv pip install -e . --group tests --system
       - name: show-deps
         run: uv pip freeze
       - name: Assert dependencies
@@ -64,7 +64,7 @@ jobs:
       - name: install-pretty-old-versions
         run: uv pip install pipdeptree tox virtualenv setuptools pandas==1.1.5 polars==0.20.3 numpy==1.17.5 pyarrow==11.0.0 "pyarrow-stubs<17" pyspark==3.5.0 scipy==1.5.0 scikit-learn==1.1.0 duckdb==1.0 tzdata backports.zoneinfo --system
       - name: install-reqs
-        run: uv pip install -e ".[tests]" --system
+        run: uv pip install -e . --group tests --system
       - name: show-deps
         run: uv pip freeze
       - name: show-deptree
@@ -103,7 +103,7 @@ jobs:
       - name: install-not-so-old-versions
         run: uv pip install tox virtualenv setuptools pandas==2.0.3 polars==0.20.8 numpy==1.24.4 pyarrow==15.0.0 "pyarrow-stubs<17" pyspark==3.5.0 scipy==1.8.0 scikit-learn==1.3.0 duckdb==1.0 dask[dataframe]==2024.10 tzdata --system
       - name: install-reqs
-        run: uv pip install -e ".[tests]" --system
+        run: uv pip install -e . --group tests --system
       - name: show-deps
         run: uv pip freeze
       - name: Assert not so old versions dependencies
@@ -140,7 +140,7 @@ jobs:
           cache-suffix: ${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
       - name: install-reqs
-        run: uv pip install -e ".[tests]" --system
+        run: uv pip install -e . --group tests --system
       - name: install-kaggle
         run: uv pip install kaggle --system
       - name: Download Kaggle notebook artifact

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: install-reqs
         # Python3.8 is technically at end-of-life, so we don't test everything
-        run: uv pip install -e ".[core]" backports.zoneinfo --group tests --system
+        run: uv pip install -e . backports.zoneinfo --group core-tests --system
       - name: show-deps
         run: uv pip freeze
       - name: Run pytest
@@ -53,7 +53,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: install-reqs
         # we are not testing pyspark on Windows here because it is very slow
-        run: uv pip install -e ".[core, dask, modin]" --group tests --group extra --system
+        run: uv pip install -e ".[dask, modin]" --group core-tests --group extra --system
       - name: show-deps
         run: uv pip freeze
       - name: Run pytest
@@ -83,7 +83,7 @@ jobs:
           cache-suffix: ${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
       - name: install-reqs
-        run: uv pip install -e ".[core, modin, dask]" --group tests --group extra --system
+        run: uv pip install -e ".[modin, dask]" --group core-tests --group extra --system
       - name: install pyspark
         run: uv pip install -e ".[pyspark]" --system
         # PySpark is not yet available on Python3.12+

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: install-reqs
         # Python3.8 is technically at end-of-life, so we don't test everything
-        run: uv pip install -e . backports.zoneinfo --group core-tests --system
+        run: uv pip install -e ".[pandas,polars,pyarrow]" backports.zoneinfo --group tests --system
       - name: show-deps
         run: uv pip freeze
       - name: Run pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: install-reqs
         # Python3.8 is technically at end-of-life, so we don't test everything
-        run: uv pip install -e ".[tests, core]" backports.zoneinfo --system
+        run: uv pip install -e ".[core]" backports.zoneinfo --group tests --system
       - name: show-deps
         run: uv pip freeze
       - name: Run pytest
@@ -53,7 +53,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: install-reqs
         # we are not testing pyspark on Windows here because it is very slow
-        run: uv pip install -e ".[tests, core, extra, dask, modin]" --system
+        run: uv pip install -e ".[core, dask, modin]" --group tests --group extra --system
       - name: show-deps
         run: uv pip freeze
       - name: Run pytest
@@ -83,7 +83,7 @@ jobs:
           cache-suffix: ${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
       - name: install-reqs
-        run: uv pip install -e ".[tests, core, extra, modin, dask]" --system
+        run: uv pip install -e ".[core, modin, dask]" --group tests --group extra --system
       - name: install pyspark
         run: uv pip install -e ".[pyspark]" --system
         # PySpark is not yet available on Python3.12+

--- a/.github/workflows/random_ci_pytest.yml
+++ b/.github/workflows/random_ci_pytest.yml
@@ -30,7 +30,7 @@ jobs:
       - name: install-random-verions
         run: uv pip install -r random-requirements.txt --system
       - name: install-narwhals
-        run: uv pip install -e ".[tests]" --system
+        run: uv pip install -e . --group tests --system
       - name: show versions
         run: uv pip freeze
       - name: Run pytest

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -32,7 +32,7 @@ jobs:
         # TODO: add more dependencies/backends incrementally
         run: |
           source .venv/bin/activate
-          uv pip install -e ".[typing, core, pyspark]"
+          uv pip install -e ".[core, pyspark]" --group typing
       - name: show-deps
         run: |
           source .venv/bin/activate

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -32,7 +32,7 @@ jobs:
         # TODO: add more dependencies/backends incrementally
         run: |
           source .venv/bin/activate
-          uv pip install -e ".[core, pyspark]" --group typing
+          uv pip install -e ".[pyspark]" --group core --group typing
       - name: show-deps
         run: |
           source .venv/bin/activate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,6 @@ If you want to run PySpark-related tests, you'll need to have Java installed. Re
 You should also install pre-commit:
 
 ```terminal
-uv pip install pre-commit
 pre-commit install
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,9 +107,9 @@ If you want to run PySpark-related tests, you'll need to have Java installed. Re
 
    4. Activate it. On Linux, this is `. .venv/bin/activate`, on Windows `.\.venv\Scripts\activate`.
 
-2. Install Narwhals: `uv pip install -e ".[core] --group dev-docs"`. This will include fast-ish core libraries.
+2. Install Narwhals: `uv pip install -e . --group local-dev"`. This will include fast-ish core libraries and dev dependencies.
    If you also want to test other libraries like Dask , PySpark, and Modin, you can install them too with
-   `uv pip install -e ".[core, dask, pyspark, modin]" --group dev-docs"`.
+   `uv pip install -e ".[dask, pyspark, modin]" --group local-dev"`.
 
 You should also install pre-commit:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,9 +107,9 @@ If you want to run PySpark-related tests, you'll need to have Java installed. Re
 
    4. Activate it. On Linux, this is `. .venv/bin/activate`, on Windows `.\.venv\Scripts\activate`.
 
-2. Install Narwhals: `uv pip install -e ".[dev, core, docs]"`. This will include fast-ish core libraries.
+2. Install Narwhals: `uv pip install -e ".[core] --group dev-docs"`. This will include fast-ish core libraries.
    If you also want to test other libraries like Dask , PySpark, and Modin, you can install them too with
-   `uv pip install -e ".[dev, core, docs, dask, pyspark, modin]"`.
+   `uv pip install -e ".[core, dask, pyspark, modin]" --group dev-docs"`.
 
 You should also install pre-commit:
 

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ help:  ## Display this help screen
 
 .PHONY: typing
 typing: ## Run typing checks
-	$(VENV_BIN)/uv pip install -e .[typing]
+	$(VENV_BIN)/uv pip install -e . --group typing
 	$(VENV_BIN)/mypy

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,11 +15,11 @@ PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 def run_common(session: Session, coverage_threshold: float) -> None:
     if session.python == "3.8":
-        session.install("-e .[core] --group dev")
+        session.install("-e . --group dev-core")
     elif session.python == "3.12":
-        session.install("-e .[core,dask,modin] --group dev --group extra")
+        session.install("-e .[dask,modin] --group dev-core --group extra")
     else:
-        session.install("-e .[core,dask,modin,pyspark,ibis] --group dev --group extra")
+        session.install("-e .[dask,modin,pyspark,ibis] --group dev-core --group extra")
 
     session.run(
         "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,11 +15,11 @@ PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 def run_common(session: Session, coverage_threshold: float) -> None:
     if session.python == "3.8":
-        session.install("-e .[dev,core]")
+        session.install("-e .[core] --group dev")
     elif session.python == "3.12":
-        session.install("-e .[dev,core,extra,dask,modin]")
+        session.install("-e .[core,dask,modin] --group dev --group extra")
     else:
-        session.install("-e .[dev,core,extra,dask,modin,pyspark,ibis]")
+        session.install("-e .[core,dask,modin,pyspark,ibis] --group dev --group extra")
 
     session.run(
         "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,6 @@ core = [
   "sqlframe"
 ]
 
-[tool.uv]
-default-groups = ["dev", "tests", "typing"]
-
 [dependency-groups]
 dev = [
   "pre-commit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,10 @@ dev = [
   {include-group = "tests"},
   {include-group = "typing"},
 ]
+dev-docs = [
+  {include-group = "dev"},
+  {include-group = "docs"}
+]
 tests = [
   "covdefaults",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,6 @@ dask = ["dask[dataframe]>=2024.8"]
 duckdb = ["duckdb>=1.0"]
 ibis = ["ibis-framework>=6.0.0", "rich", "packaging", "pyarrow_hotfix"]
 sqlframe = ["sqlframe>=3.22.0"]
-core = [
-  "duckdb",
-  "pandas",
-  "polars",
-  "pyarrow",
-  "sqlframe"
-]
 
 [dependency-groups]
 dev = [
@@ -58,10 +51,22 @@ dev = [
   {include-group = "tests"},
   {include-group = "typing"},
 ]
-dev-docs = [
+dev-core = [
   {include-group = "dev"},
+  {include-group = "core"},
+]
+core-tests = [
+  {include-group = "core"},
+  {include-group = "tests"},
+]
+local-dev = [
+  {include-group = "dev"},
+  {include-group = "core"},
   {include-group = "docs"}
 ]
+core = [
+  "narwhals[duckdb,pandas,polars,pyarrow,sqlframe]"
+] 
 tests = [
   "covdefaults",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,12 @@ classifiers = [
   "Typing :: Typed",
 ]
 
+[project.urls]
+Homepage = "https://github.com/narwhals-dev/narwhals"
+Documentation = "https://narwhals-dev.github.io/narwhals/"
+Repository = "https://github.com/narwhals-dev/narwhals"
+"Bug Tracker" = "https://github.com/narwhals-dev/narwhals/issues"
+
 [project.optional-dependencies]
 # These should be aligned with MIN_VERSIONS in narwhals/utils.py
 # Exception: modin, because `modin.__version__` isn't aligned with
@@ -38,6 +44,21 @@ dask = ["dask[dataframe]>=2024.8"]
 duckdb = ["duckdb>=1.0"]
 ibis = ["ibis-framework>=6.0.0", "rich", "packaging", "pyarrow_hotfix"]
 sqlframe = ["sqlframe>=3.22.0"]
+core = [
+  "duckdb",
+  "pandas",
+  "polars",
+  "pyarrow",
+  "sqlframe"
+]
+
+[tool.uv]
+default-groups = ["dev", "tests", "typing"]
+
+[dependency-groups]
+dev = [
+  "pre-commit"
+]
 tests = [
   "covdefaults",
   "pytest",
@@ -45,6 +66,9 @@ tests = [
   "pytest-randomly",
   "pytest-env",
   "hypothesis",
+]
+extra = [  # heavier dependencies we don't necessarily need in every testing job
+  "scikit-learn",
 ]
 typing = [
   "hypothesis",
@@ -57,21 +81,6 @@ typing = [
   "sqlframe==3.24.1",
   "polars==1.25.2",
   "uv",
-]
-dev = [
-  "pre-commit",
-  "narwhals[tests]",
-  "narwhals[typing]",
-]
-core = [
-  "duckdb",
-  "pandas",
-  "polars",
-  "pyarrow",
-  "sqlframe"
-]
-extra = [  # heavier dependencies we don't necessarily need in every testing job
-  "scikit-learn",
 ]
 docs = [
   "black",  # required by mkdocstrings_handlers
@@ -88,12 +97,6 @@ docs = [
   "pyarrow",
 ]
 
-[project.urls]
-Homepage = "https://github.com/narwhals-dev/narwhals"
-Documentation = "https://narwhals-dev.github.io/narwhals/"
-Repository = "https://github.com/narwhals-dev/narwhals"
-"Bug Tracker" = "https://github.com/narwhals-dev/narwhals/issues"
-
 [tool.hatch.build]
 exclude = [
   "/.*",
@@ -106,7 +109,6 @@ exclude = [
   "mkdocs.yml",
   "noxfile.py",
 ]
-
 
 [tool.ruff]
 line-length = 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,9 @@ core = [
 
 [dependency-groups]
 dev = [
-  "pre-commit"
+  "pre-commit",
+  {include-group = "tests"},
+  {include-group = "typing"},
 ]
 tests = [
   "covdefaults",


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

I propose moving all the dev dependencies from `optional-dependencies` to [`dependency-groups`](https://packaging.python.org/en/latest/specifications/dependency-groups/). I think this is a bit cleaner what do you think? :)

uv related resources:
- https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups
- https://docs.astral.sh/uv/reference/cli/#uv-pip-install--group

