### PR TITLE
Fix `noxfile.py` syntax for nox-2025.2.9

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from nox.sessions import Session
 
 nox.options.default_venv_backend = "uv"
-nox.options.reuse_venv = True
+nox.options.reuse_venv = "yes"
 
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues


## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

nox-2025.2.9 failed with:

```
ValueError: ("'reuse_venv' must be in ['no', 'yes', 'never', 'always'] (got True)", Attribute(name='reuse_venv', default=NOTHING, validator=<optional validator for <in_ validator with options ['no', 'yes', 'never', 'always']> or None>, repr=True, eq=True, eq_key=None, order=True, order_key=None, hash=None, init=True, metadata=mappingproxy({}), type="None | Literal['no', 'yes', 'never', 'always']", converter=None, kw_only=True, inherited=False, on_setattr=None, alias='reuse_venv'), ['no', 'yes', 'never', 'always'], True)
```