### PR TITLE
test: Fix more tests to work without polars (and pandas, pyarrow)

### DIFF
--- a/tests/hypothesis/basic_arithmetic_test.py
+++ b/tests/hypothesis/basic_arithmetic_test.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 from typing import Any
 from typing import Mapping
 
-import pandas as pd
-import polars as pl
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 from numpy.testing import assert_allclose
 
 import narwhals.stable.v1 as nw
+
+pd = pytest.importorskip("pandas")
+pl = pytest.importorskip("polars")
 
 
 @given(

--- a/tests/hypothesis/getitem_test.py
+++ b/tests/hypothesis/getitem_test.py
@@ -7,7 +7,6 @@ from typing import cast
 
 import hypothesis.strategies as st
 import numpy as np
-import polars as pl
 import pytest
 from hypothesis import assume
 from hypothesis import given
@@ -22,6 +21,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from narwhals.typing import IntoDataFrame
+
+pl = pytest.importorskip("polars")
 
 
 @pytest.fixture(

--- a/tests/hypothesis/join_test.py
+++ b/tests/hypothesis/join_test.py
@@ -4,9 +4,6 @@ from typing import Any
 from typing import Mapping
 from typing import cast
 
-import pandas as pd
-import polars as pl
-import pyarrow as pa
 import pytest
 from hypothesis import assume
 from hypothesis import given
@@ -17,6 +14,10 @@ import narwhals.stable.v1 as nw
 from tests.utils import PANDAS_VERSION
 from tests.utils import POLARS_VERSION
 from tests.utils import assert_equal_data
+
+pd = pytest.importorskip("pandas")
+pl = pytest.importorskip("polars")
+pa = pytest.importorskip("pyarrow")
 
 
 @given(

--- a/tests/implementation_test.py
+++ b/tests/implementation_test.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import pandas as pd
-import polars as pl
+import pytest
 
 import narwhals.stable.v1 as nw
 
 
-def test_implementation() -> None:
+def test_implementation_pandas() -> None:
+    pd = pytest.importorskip("pandas")
+
     assert (
         nw.from_native(pd.DataFrame({"a": [1, 2, 3]})).implementation
         is nw.Implementation.PANDAS
@@ -17,6 +18,11 @@ def test_implementation() -> None:
     )
     assert nw.from_native(pd.DataFrame({"a": [1, 2, 3]})).implementation.is_pandas()
     assert nw.from_native(pd.DataFrame({"a": [1, 2, 3]})).implementation.is_pandas_like()
+
+
+def test_implementation_polars() -> None:
+    pl = pytest.importorskip("polars")
+
     assert not nw.from_native(pl.DataFrame({"a": [1, 2, 3]})).implementation.is_pandas()
     assert not nw.from_native(pl.DataFrame({"a": [1, 2, 3]}))[
         "a"

--- a/tests/pickle_test.py
+++ b/tests/pickle_test.py
@@ -4,20 +4,28 @@ from dataclasses import asdict
 from dataclasses import dataclass
 from typing import Sequence
 
-import pandas as pd
-import polars as pl
+import pytest
 
 import narwhals.stable.v1 as nw
 
 
-def test_dataclass() -> None:
-    # https://github.com/narwhals-dev/narwhals/issues/1486
-    @dataclass
-    class Foo:
-        a: Sequence[int]
+# https://github.com/narwhals-dev/narwhals/issues/1486
+@dataclass
+class Foo:
+    a: Sequence[int]
+
+
+def test_dataclass_pandas() -> None:
+    pd = pytest.importorskip("pandas")
 
     # dry-run to check that none of these error
     asdict(Foo(pd.Series([1, 2, 3])))  # type: ignore[arg-type]
+    asdict(Foo(nw.from_native(pd.Series([1, 2, 3]), series_only=True)))  # type: ignore[arg-type]
+
+
+def test_dataclass_polars() -> None:
+    pl = pytest.importorskip("polars")
+
+    # dry-run to check that none of these error
     asdict(Foo(pl.Series([1, 2, 3])))  # type: ignore[arg-type]
     asdict(Foo(nw.from_native(pl.Series([1, 2, 3]), series_only=True)))  # type: ignore[arg-type]
-    asdict(Foo(nw.from_native(pd.Series([1, 2, 3]), series_only=True)))  # type: ignore[arg-type]

--- a/tests/series_only/arrow_c_stream_test.py
+++ b/tests/series_only/arrow_c_stream_test.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-import polars as pl
-import pyarrow as pa
-import pyarrow.compute as pc
 import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import POLARS_VERSION
 from tests.utils import PYARROW_VERSION
+
+pa = pytest.importorskip("pyarrow")
+pc = pytest.importorskip("pyarrow.compute")
+pl = pytest.importorskip("polars")
 
 
 @pytest.mark.skipif(POLARS_VERSION < (1, 3), reason="too old for pycapsule in Polars")

--- a/tests/series_only/hist_test.py
+++ b/tests/series_only/hist_test.py
@@ -272,7 +272,7 @@ def test_hist_count_no_spread(
     "ignore:`Series.hist` is being called from the stable API although considered an unstable feature."
 )
 def test_hist_bin_and_bin_count() -> None:
-    import polars as pl
+    pl = pytest.importorskip("polars")
 
     s = nw.from_native(pl.Series([1, 2, 3]), series_only=True)
     result = s.hist(bins=None, bin_count=None)

--- a/tests/series_only/is_ordered_categorical_test.py
+++ b/tests/series_only/is_ordered_categorical_test.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 
-import pandas as pd
-import polars as pl
-import pyarrow as pa
 import pytest
 
 import narwhals.stable.v1 as nw
@@ -16,7 +13,9 @@ if TYPE_CHECKING:
     from tests.utils import ConstructorEager
 
 
-def test_is_ordered_categorical() -> None:
+def test_is_ordered_categorical_polars() -> None:
+    pl = pytest.importorskip("polars")
+
     s: IntoSeries | Any
     s = pl.Series(["a", "b"], dtype=pl.Categorical)
     assert nw.is_ordered_categorical(nw.from_native(s, series_only=True))
@@ -24,10 +23,20 @@ def test_is_ordered_categorical() -> None:
     assert not nw.is_ordered_categorical(nw.from_native(s, series_only=True))
     s = pl.Series(["a", "b"], dtype=pl.Enum(["a", "b"]))
     assert nw.is_ordered_categorical(nw.from_native(s, series_only=True))
+
+
+def test_is_ordered_categorical_pandas() -> None:
+    pd = pytest.importorskip("pandas")
+
     s = pd.Series(["a", "b"], dtype=pd.CategoricalDtype(ordered=True))
     assert nw.is_ordered_categorical(nw.from_native(s, series_only=True))
     s = pd.Series(["a", "b"], dtype=pd.CategoricalDtype(ordered=False))
     assert not nw.is_ordered_categorical(nw.from_native(s, series_only=True))
+
+
+def test_is_ordered_categorical_pyarrow_string() -> None:
+    pa = pytest.importorskip("pyarrow")
+
     tp = pa.dictionary(pa.int32(), pa.string())
     s = pa.chunked_array([pa.array(["a", "b"], type=tp)], type=tp)
     assert not nw.is_ordered_categorical(nw.from_native(s, series_only=True))
@@ -35,6 +44,8 @@ def test_is_ordered_categorical() -> None:
 
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="requires interchange protocol")
 def test_is_ordered_categorical_interchange_protocol() -> None:
+    pd = pytest.importorskip("pandas")
+
     df = pd.DataFrame(
         {"a": ["a", "b"]}, dtype=pd.CategoricalDtype(ordered=True)
     ).__dataframe__()
@@ -53,6 +64,8 @@ def test_is_definitely_not_ordered_categorical(
 
 @pytest.mark.xfail(reason="https://github.com/apache/arrow/issues/41017")
 def test_is_ordered_categorical_pyarrow() -> None:
+    pa = pytest.importorskip("pyarrow")
+
     tp = pa.dictionary(pa.int32(), pa.string(), ordered=True)
     arr = pa.array(["a", "b"], type=tp)
     s = pa.chunked_array([arr], type=tp)

--- a/tests/series_only/to_polars_test.py
+++ b/tests/series_only/to_polars_test.py
@@ -2,18 +2,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import polars as pl
-from polars.testing import assert_series_equal
+import pytest
 
 import narwhals.stable.v1 as nw
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
 
+pl = pytest.importorskip("polars")
+
 data = [1, 3, 2]
 
 
 def test_series_to_polars(constructor_eager: ConstructorEager) -> None:
+    from polars.testing import assert_series_equal
+
     result = (
         nw.from_native(constructor_eager({"a": data}), eager_only=True)["a"]
         .alias("a")

--- a/tests/translate/narwhalify_test.py
+++ b/tests/translate/narwhalify_test.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from contextlib import nullcontext as does_not_raise
 from typing import TYPE_CHECKING
 from typing import Any
 
-import pandas as pd
-import polars as pl
 import pytest
 
 import narwhals as nw
@@ -19,6 +16,8 @@ data = {"a": [2, 3, 4]}
 
 
 def test_narwhalify() -> None:
+    pd = pytest.importorskip("pandas")
+
     @nw.narwhalify
     def func(df: nw.DataFrame[IntoDataFrameT]) -> nw.DataFrame[IntoDataFrameT]:
         return df.with_columns(nw.all() + 1)
@@ -31,6 +30,8 @@ def test_narwhalify() -> None:
 
 
 def test_narwhalify_method() -> None:
+    pd = pytest.importorskip("pandas")
+
     class Foo:
         @nw.narwhalify
         def func(
@@ -46,6 +47,8 @@ def test_narwhalify_method() -> None:
 
 
 def test_narwhalify_method_called() -> None:
+    pd = pytest.importorskip("pandas")
+
     class Foo:
         @nw.narwhalify
         def func(
@@ -87,35 +90,59 @@ def test_narwhalify_invalid() -> None:
         func()
 
 
-@pytest.mark.parametrize(
-    ("arg1", "arg2", "context"),
-    [
-        (pd.DataFrame(data), pd.Series(data["a"]), does_not_raise()),
-        (pl.DataFrame(data), pl.Series(data["a"]), does_not_raise()),
-        (
-            pd.DataFrame(data),
-            pl.DataFrame(data),
-            pytest.raises(
-                ValueError,
-                match="Found multiple backends. Make sure that all dataframe/series inputs come from the same backend.",
-            ),
-        ),
-        (
-            pl.DataFrame(data),
-            pd.Series(data["a"]),
-            pytest.raises(
-                ValueError,
-                match="Found multiple backends. Make sure that all dataframe/series inputs come from the same backend.",
-            ),
-        ),
-    ],
-)
-def test_narwhalify_backends(arg1: Any, arg2: Any, context: Any) -> None:
+def test_narwhalify_backends_pandas() -> None:
+    pd = pytest.importorskip("pandas")
+
     @nw.narwhalify
     def func(
         arg1: Any, arg2: Any, extra: int = 1
     ) -> tuple[Any, Any, int]:  # pragma: no cover
         return arg1, arg2, extra
 
-    with context:
-        func(arg1, arg2)
+    func(pd.DataFrame(data), pd.Series(data["a"]))
+
+
+def test_narwhalify_backends_polars() -> None:
+    pl = pytest.importorskip("polars")
+
+    @nw.narwhalify
+    def func(
+        arg1: Any, arg2: Any, extra: int = 1
+    ) -> tuple[Any, Any, int]:  # pragma: no cover
+        return arg1, arg2, extra
+
+    func(pl.DataFrame(data), pl.Series(data["a"]))
+
+
+def test_narwhalify_backends_cross() -> None:
+    pd = pytest.importorskip("pandas")
+    pl = pytest.importorskip("polars")
+
+    @nw.narwhalify
+    def func(
+        arg1: Any, arg2: Any, extra: int = 1
+    ) -> tuple[Any, Any, int]:  # pragma: no cover
+        return arg1, arg2, extra
+
+    with pytest.raises(
+        ValueError,
+        match="Found multiple backends. Make sure that all dataframe/series inputs come from the same backend.",
+    ):
+        func(pd.DataFrame(data), pl.DataFrame(data))
+
+
+def test_narwhalify_backends_cross2() -> None:
+    pd = pytest.importorskip("pandas")
+    pl = pytest.importorskip("polars")
+
+    @nw.narwhalify
+    def func(
+        arg1: Any, arg2: Any, extra: int = 1
+    ) -> tuple[Any, Any, int]:  # pragma: no cover
+        return arg1, arg2, extra
+
+    with pytest.raises(
+        ValueError,
+        match="Found multiple backends. Make sure that all dataframe/series inputs come from the same backend.",
+    ):
+        func(pl.DataFrame(data), pd.Series(data["a"]))

--- a/tests/translate/stable_narwhalify_test.py
+++ b/tests/translate/stable_narwhalify_test.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from contextlib import nullcontext as does_not_raise
 from typing import TYPE_CHECKING
 from typing import Any
 
-import pandas as pd
-import polars as pl
 import pytest
 
 import narwhals.stable.v1 as nw
@@ -19,6 +16,8 @@ data = {"a": [2, 3, 4]}
 
 
 def test_narwhalify() -> None:
+    pd = pytest.importorskip("pandas")
+
     @nw.narwhalify
     def func(df: nw.DataFrame[IntoDataFrameT]) -> nw.DataFrame[IntoDataFrameT]:
         return df.with_columns(nw.all() + 1)
@@ -31,6 +30,8 @@ def test_narwhalify() -> None:
 
 
 def test_narwhalify_method() -> None:
+    pd = pytest.importorskip("pandas")
+
     class Foo:
         @nw.narwhalify
         def func(
@@ -46,6 +47,8 @@ def test_narwhalify_method() -> None:
 
 
 def test_narwhalify_method_called() -> None:
+    pd = pytest.importorskip("pandas")
+
     class Foo:
         @nw.narwhalify
         def func(
@@ -85,35 +88,59 @@ def test_narwhalify_invalid() -> None:
         func()
 
 
-@pytest.mark.parametrize(
-    ("arg1", "arg2", "context"),
-    [
-        (pd.DataFrame(data), pd.Series(data["a"]), does_not_raise()),
-        (pl.DataFrame(data), pl.Series(data["a"]), does_not_raise()),
-        (
-            pd.DataFrame(data),
-            pl.DataFrame(data),
-            pytest.raises(
-                ValueError,
-                match="Found multiple backends. Make sure that all dataframe/series inputs come from the same backend.",
-            ),
-        ),
-        (
-            pl.DataFrame(data),
-            pd.Series(data["a"]),
-            pytest.raises(
-                ValueError,
-                match="Found multiple backends. Make sure that all dataframe/series inputs come from the same backend.",
-            ),
-        ),
-    ],
-)
-def test_narwhalify_backends(arg1: Any, arg2: Any, context: Any) -> None:
+def test_narwhalify_backends_pandas() -> None:
+    pd = pytest.importorskip("pandas")
+
     @nw.narwhalify
     def func(
         arg1: Any, arg2: Any, extra: int = 1
     ) -> tuple[Any, Any, int]:  # pragma: no cover
         return arg1, arg2, extra
 
-    with context:
-        func(arg1, arg2)
+    func(pd.DataFrame(data), pd.Series(data["a"]))
+
+
+def test_narwhalify_backends_polars() -> None:
+    pl = pytest.importorskip("polars")
+
+    @nw.narwhalify
+    def func(
+        arg1: Any, arg2: Any, extra: int = 1
+    ) -> tuple[Any, Any, int]:  # pragma: no cover
+        return arg1, arg2, extra
+
+    func(pl.DataFrame(data), pl.Series(data["a"]))
+
+
+def test_narwhalify_backends_cross() -> None:
+    pd = pytest.importorskip("pandas")
+    pl = pytest.importorskip("polars")
+
+    @nw.narwhalify
+    def func(
+        arg1: Any, arg2: Any, extra: int = 1
+    ) -> tuple[Any, Any, int]:  # pragma: no cover
+        return arg1, arg2, extra
+
+    with pytest.raises(
+        ValueError,
+        match="Found multiple backends. Make sure that all dataframe/series inputs come from the same backend.",
+    ):
+        func(pd.DataFrame(data), pl.DataFrame(data))
+
+
+def test_narwhalify_backends_cross2() -> None:
+    pd = pytest.importorskip("pandas")
+    pl = pytest.importorskip("polars")
+
+    @nw.narwhalify
+    def func(
+        arg1: Any, arg2: Any, extra: int = 1
+    ) -> tuple[Any, Any, int]:  # pragma: no cover
+        return arg1, arg2, extra
+
+    with pytest.raises(
+        ValueError,
+        match="Found multiple backends. Make sure that all dataframe/series inputs come from the same backend.",
+    ):
+        func(pl.DataFrame(data), pd.Series(data["a"]))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #1726

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Split and/or skip tests requiring `polars` when they are unavailable. Whenever that was a low-hanging fruit, also imports of `pandas` and `pyarrow` were made optional.