### PR TITLE
feat!: remove `maintain_order` from `LazyFrame.unique`, as it was never supported

### DIFF
--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -217,7 +217,7 @@ class DaskLazyFrame(CompliantLazyFrame):
         self: Self,
         subset: list[str] | None,
         *,
-        keep: Literal["any", "none"] = "any",
+        keep: Literal["any", "none"],
     ) -> Self:
         check_column_exists(self.columns, subset)
         native_frame = self._native_frame

--- a/narwhals/_dask/group_by.py
+++ b/narwhals/_dask/group_by.py
@@ -116,7 +116,7 @@ def agg_dask(
     """
     if not exprs:
         # No aggregation provided
-        return df.simple_select(*keys).unique(subset=keys)
+        return df.simple_select(*keys).unique(subset=keys, keep="any")
 
     all_simple_aggs = True
     for expr in exprs:

--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -346,7 +346,9 @@ class DuckDBLazyFrame(CompliantLazyFrame):
             )
         }
 
-    def unique(self: Self, subset: Sequence[str] | None, keep: str) -> Self:
+    def unique(
+        self: Self, subset: Sequence[str] | None, keep: Literal["any", "none"]
+    ) -> Self:
         if subset is not None:
             rel = self._native_frame
             # Sanitise input

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -2674,20 +2674,17 @@ class LazyFrame(BaseFrame[FrameT]):
         subset: str | list[str] | None = None,
         *,
         keep: Literal["any", "none"] = "any",
-        maintain_order: bool | None = None,
     ) -> Self:
         """Drop duplicate rows from this LazyFrame.
 
         Arguments:
             subset: Column name(s) to consider when identifying duplicate rows.
                      If set to `None`, use all columns.
-            keep: {'first', 'none'}
+            keep: {'any', 'none'}
                 Which of the duplicate rows to keep.
 
                 * 'any': Does not give any guarantee of which row is kept.
-                        This allows more optimizations.
                 * 'none': Don't keep duplicate rows.
-            maintain_order: Has no effect and is kept around only for backwards-compatibility.
 
         Returns:
             The LazyFrame with unique rows.
@@ -2715,15 +2712,6 @@ class LazyFrame(BaseFrame[FrameT]):
                 f"'any' and 'none' are supported for `keep` in `unique`. Got: {keep}."
             )
             raise ValueError(msg)
-        if maintain_order:
-            msg = "`maintain_order=True` is not supported for LazyFrame.unique."
-            raise ValueError(msg)
-        if maintain_order is not None:
-            msg = (
-                "`maintain_order` has no effect and is only kept around for backwards-compatibility. "
-                "You can safely remove this argument."
-            )
-            warn(message=msg, category=UserWarning, stacklevel=find_stacklevel())
         if isinstance(subset, str):
             subset = [subset]
         return self._from_compliant_dataframe(

--- a/tests/frame/unique_test.py
+++ b/tests/frame/unique_test.py
@@ -66,12 +66,9 @@ def test_unique_none(constructor: Constructor) -> None:
     df_raw = constructor(data)
     df = nw.from_native(df_raw)
 
-    result = df.unique(maintain_order=False).sort("z")
+    result = df.unique().sort("z")
     assert_equal_data(result, data)
 
-    if isinstance(df, nw.LazyFrame):
-        with pytest.raises(ValueError, match="not supported"):
-            result = df.unique(maintain_order=True).sort("z")
-    else:
+    if not isinstance(df, nw.LazyFrame):
         result = df.unique(maintain_order=True)
         assert_equal_data(result, data)


### PR DESCRIPTION
If this affects anyone, we could backport `maintain_order` as a no-op to `stable.v1`

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- https://github.com/narwhals-dev/narwhals/pull/2232#discussion_r2001877791
- https://github.com/narwhals-dev/narwhals/pull/2232#discussion_r2003019826

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
