### PR TITLE
test: Fix yet more tests to work without polars (pandas, pyarrow)

### DIFF
--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 import hypothesis.strategies as st
-import pandas as pd
-import polars as pl
-import pyarrow as pa
 import pytest
 from hypothesis import assume
 from hypothesis import given
@@ -161,7 +158,10 @@ def test_truediv_same_dims(
 @pytest.mark.slow
 @given(left=st.integers(-100, 100), right=st.integers(-100, 100))
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
-def test_floordiv(left: int, right: int) -> None:
+def test_floordiv_pandas(left: int, right: int) -> None:
+    pytest.importorskip("pandas")
+    import pandas as pd
+
     # hypothesis complains if we add `constructor` as an argument, so this
     # test is a bit manual unfortunately
     assume(right != 0)
@@ -183,10 +183,36 @@ def test_floordiv(left: int, right: int) -> None:
         pd.DataFrame({"a": [left]}).convert_dtypes(), eager_only=True
     ).select(nw.col("a") // right)
     assert_equal_data(result, expected)
+
+
+@pytest.mark.slow
+@given(left=st.integers(-100, 100), right=st.integers(-100, 100))
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
+def test_floordiv_polars(left: int, right: int) -> None:
+    pytest.importorskip("polars")
+    import polars as pl
+
+    # hypothesis complains if we add `constructor` as an argument, so this
+    # test is a bit manual unfortunately
+    assume(right != 0)
+    expected = {"a": [left // right]}
     result = nw.from_native(pl.DataFrame({"a": [left]}), eager_only=True).select(
         nw.col("a") // right
     )
     assert_equal_data(result, expected)
+
+
+@pytest.mark.slow
+@given(left=st.integers(-100, 100), right=st.integers(-100, 100))
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
+def test_floordiv_pyarrow(left: int, right: int) -> None:
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa
+
+    # hypothesis complains if we add `constructor` as an argument, so this
+    # test is a bit manual unfortunately
+    assume(right != 0)
+    expected = {"a": [left // right]}
     result = nw.from_native(pa.table({"a": [left]}), eager_only=True).select(
         nw.col("a") // right
     )
@@ -196,7 +222,10 @@ def test_floordiv(left: int, right: int) -> None:
 @pytest.mark.slow
 @given(left=st.integers(-100, 100), right=st.integers(-100, 100))
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
-def test_mod(left: int, right: int) -> None:
+def test_mod_pandas(left: int, right: int) -> None:
+    pytest.importorskip("pandas")
+    import pandas as pd
+
     # hypothesis complains if we add `constructor` as an argument, so this
     # test is a bit manual unfortunately
     assume(right != 0)
@@ -209,10 +238,36 @@ def test_mod(left: int, right: int) -> None:
         pd.DataFrame({"a": [left]}).convert_dtypes(), eager_only=True
     ).select(nw.col("a") % right)
     assert_equal_data(result, expected)
+
+
+@pytest.mark.slow
+@given(left=st.integers(-100, 100), right=st.integers(-100, 100))
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
+def test_mod_polars(left: int, right: int) -> None:
+    pytest.importorskip("polars")
+    import polars as pl
+
+    # hypothesis complains if we add `constructor` as an argument, so this
+    # test is a bit manual unfortunately
+    assume(right != 0)
+    expected = {"a": [left % right]}
     result = nw.from_native(pl.DataFrame({"a": [left]}), eager_only=True).select(
         nw.col("a") % right
     )
     assert_equal_data(result, expected)
+
+
+@pytest.mark.slow
+@given(left=st.integers(-100, 100), right=st.integers(-100, 100))
+@pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
+def test_mod_pyarrow(left: int, right: int) -> None:
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa
+
+    # hypothesis complains if we add `constructor` as an argument, so this
+    # test is a bit manual unfortunately
+    assume(right != 0)
+    expected = {"a": [left % right]}
     result = nw.from_native(pa.table({"a": [left]}), eager_only=True).select(
         nw.col("a") % right
     )

--- a/tests/expr_and_series/dt/ordinal_day_test.py
+++ b/tests/expr_and_series/dt/ordinal_day_test.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from datetime import datetime
 
 import hypothesis.strategies as st
-import pandas as pd
-import polars as pl
 import pytest
 from hypothesis import given
 
 import narwhals.stable.v1 as nw
 from tests.utils import PANDAS_VERSION
+
+pytest.importorskip("pandas")
+import pandas as pd
 
 
 @given(dates=st.datetimes(min_value=datetime(1960, 1, 1), max_value=datetime(1980, 1, 1)))
@@ -30,8 +31,21 @@ def test_ordinal_day(dates: datetime) -> None:
         pd.Series([dates]).convert_dtypes(dtype_backend="numpy_nullable"),
         series_only=True,
     ).dt.ordinal_day()[0]
+    assert result_pda == result_pd
+    assert result_pdn == result_pd
+    assert result_pdms == result_pd
+
+
+@given(dates=st.datetimes(min_value=datetime(1960, 1, 1), max_value=datetime(1980, 1, 1)))
+@pytest.mark.skipif(
+    PANDAS_VERSION < (2, 0, 0),
+    reason="pyarrow dtype not available",
+)
+@pytest.mark.slow
+def test_ordinal_day_polars(dates: datetime) -> None:
+    pytest.importorskip("polars")
+    import polars as pl
+
+    result_pd = nw.from_native(pd.Series([dates]), series_only=True).dt.ordinal_day()[0]
     result_pl = nw.from_native(pl.Series([dates]), series_only=True).dt.ordinal_day()[0]
-    assert result_pd == result_pl
-    assert result_pda == result_pl
-    assert result_pdn == result_pl
-    assert result_pdms == result_pl
+    assert result_pl == result_pd

--- a/tests/expr_and_series/dt/total_minutes_test.py
+++ b/tests/expr_and_series/dt/total_minutes_test.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from datetime import timedelta
 
 import hypothesis.strategies as st
-import pandas as pd
-import polars as pl
 import pytest
 from hypothesis import given
 
 import narwhals.stable.v1 as nw
 from tests.utils import PANDAS_VERSION
+
+pytest.importorskip("pandas")
+import pandas as pd
 
 
 @given(
@@ -34,10 +35,27 @@ def test_total_minutes(timedeltas: timedelta) -> None:
         pd.Series([timedeltas]).convert_dtypes(dtype_backend="numpy_nullable"),
         series_only=True,
     ).dt.total_minutes()[0]
+    assert result_pda == result_pd
+    assert result_pdn == result_pd
+    assert result_pdns == result_pd
+
+
+@given(
+    timedeltas=st.timedeltas(
+        min_value=-timedelta(days=5, minutes=70, seconds=10),
+        max_value=timedelta(days=3, minutes=90, seconds=60),
+    )
+)
+@pytest.mark.skipif(PANDAS_VERSION < (2, 2, 0), reason="pyarrow dtype not available")
+@pytest.mark.slow
+def test_total_minutes_polars(timedeltas: timedelta) -> None:
+    pytest.importorskip("polars")
+    import polars as pl
+
+    result_pd = nw.from_native(
+        pd.Series([timedeltas]), series_only=True
+    ).dt.total_minutes()[0]
     result_pl = nw.from_native(
         pl.Series([timedeltas]), series_only=True
     ).dt.total_minutes()[0]
-    assert result_pd == result_pl
-    assert result_pda == result_pl
-    assert result_pdn == result_pl
-    assert result_pdns == result_pl
+    assert result_pl == result_pd

--- a/tests/expr_and_series/rolling_var_test.py
+++ b/tests/expr_and_series/rolling_var_test.py
@@ -5,9 +5,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 import hypothesis.strategies as st
-import pandas as pd
-import polars as pl
-import pyarrow as pa
 import pytest
 from hypothesis import given
 
@@ -19,6 +16,10 @@ from tests.utils import assert_equal_data
 
 if TYPE_CHECKING:
     from narwhals.typing import Frame
+
+pytest.importorskip("pandas")
+import pandas as pd
+
 
 data = {"a": [1.0, 2.0, 1.0, 3.0, 1.0, 4.0, 1.0]}
 
@@ -112,6 +113,9 @@ def test_rolling_var_series(
 @pytest.mark.filterwarnings("ignore:.*is_sparse is deprecated:DeprecationWarning")
 @pytest.mark.filterwarnings("ignore:.*:narwhals.exceptions.NarwhalsUnstableWarning")
 def test_rolling_var_hypothesis(center: bool, values: list[float]) -> None:  # noqa: FBT001
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa
+
     s = pd.Series(values)
     window_size = random.randint(2, len(s))  # noqa: S311
     min_samples = random.randint(2, window_size)  # noqa: S311
@@ -133,6 +137,33 @@ def test_rolling_var_hypothesis(center: bool, values: list[float]) -> None:  # n
     )
     expected_dict = nw.from_native(expected, eager_only=True).to_dict(as_series=False)
     assert_equal_data(result, expected_dict)
+
+
+@given(
+    center=st.booleans(),
+    values=st.lists(st.floats(-10, 10), min_size=5, max_size=10),
+)
+@pytest.mark.skipif(PANDAS_VERSION < (1,), reason="too old for pyarrow")
+@pytest.mark.skipif(POLARS_VERSION < (1,), reason="different null behavior")
+@pytest.mark.filterwarnings("ignore:.*is_sparse is deprecated:DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:.*:narwhals.exceptions.NarwhalsUnstableWarning")
+def test_rolling_var_hypothesis_polars(center: bool, values: list[float]) -> None:  # noqa: FBT001
+    pytest.importorskip("polars")
+    import polars as pl
+
+    s = pd.Series(values)
+    window_size = random.randint(2, len(s))  # noqa: S311
+    min_samples = random.randint(2, window_size)  # noqa: S311
+    ddof = random.randint(0, min_samples - 1)  # noqa: S311
+    mask = random.sample(range(len(s)), 2)
+
+    s[mask] = None
+    df = pd.DataFrame({"a": s})
+    expected = (
+        s.rolling(window=window_size, center=center, min_periods=min_samples)
+        .var(ddof=ddof)
+        .to_frame("a")
+    )
 
     result = nw.from_native(pl.from_pandas(df)).select(
         nw.col("a").rolling_var(

--- a/tests/expr_and_series/rolling_var_test.py
+++ b/tests/expr_and_series/rolling_var_test.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
 pytest.importorskip("pandas")
 import pandas as pd
 
-
 data = {"a": [1.0, 2.0, 1.0, 3.0, 1.0, 4.0, 1.0]}
 
 kwargs_and_expected = (

--- a/tests/from_dict_test.py
+++ b/tests/from_dict_test.py
@@ -19,16 +19,22 @@ if find_spec("polars") is not None:
         Implementation.POLARS,
         "polars",
     ]
+else:  # pragma: no cover
+    pass
 if find_spec("pandas") is not None:
     TEST_EAGER_BACKENDS += [
         Implementation.PANDAS,
         "pandas",
     ]
+else:  # pragma: no cover
+    pass
 if find_spec("pyarrow") is not None:
     TEST_EAGER_BACKENDS += [
         Implementation.PYARROW,
         "pyarrow",
     ]
+else:  # pragma: no cover
+    pass
 
 
 @pytest.mark.parametrize(

--- a/tests/from_dict_test.py
+++ b/tests/from_dict_test.py
@@ -13,28 +13,15 @@ from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
 TEST_EAGER_BACKENDS = []
-
-if find_spec("polars") is not None:
-    TEST_EAGER_BACKENDS += [
-        Implementation.POLARS,
-        "polars",
-    ]
-else:  # pragma: no cover
-    pass
-if find_spec("pandas") is not None:
-    TEST_EAGER_BACKENDS += [
-        Implementation.PANDAS,
-        "pandas",
-    ]
-else:  # pragma: no cover
-    pass
-if find_spec("pyarrow") is not None:
-    TEST_EAGER_BACKENDS += [
-        Implementation.PYARROW,
-        "pyarrow",
-    ]
-else:  # pragma: no cover
-    pass
+TEST_EAGER_BACKENDS.extend(
+    (Implementation.POLARS, "polars") if find_spec("polars") is not None else ()
+)
+TEST_EAGER_BACKENDS.extend(
+    (Implementation.PANDAS, "pandas") if find_spec("pandas") is not None else ()
+)
+TEST_EAGER_BACKENDS.extend(
+    (Implementation.PYARROW, "pyarrow") if find_spec("pyarrow") is not None else ()
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/from_dict_test.py
+++ b/tests/from_dict_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from importlib.util import find_spec
 
 import pandas as pd
 import pytest
@@ -11,14 +12,23 @@ from narwhals.utils import Implementation
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
-TEST_EAGER_BACKENDS = [
-    Implementation.POLARS,
-    Implementation.PANDAS,
-    Implementation.PYARROW,
-    "polars",
-    "pandas",
-    "pyarrow",
-]
+TEST_EAGER_BACKENDS = []
+
+if find_spec("polars") is not None:
+    TEST_EAGER_BACKENDS += [
+        Implementation.POLARS,
+        "polars",
+    ]
+if find_spec("pandas") is not None:
+    TEST_EAGER_BACKENDS += [
+        Implementation.PANDAS,
+        "pandas",
+    ]
+if find_spec("pyarrow") is not None:
+    TEST_EAGER_BACKENDS += [
+        Implementation.PYARROW,
+        "pyarrow",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -56,6 +66,8 @@ def test_from_dict_schema(
 def test_from_dict_without_backend(
     constructor: Constructor, backend: Implementation | str
 ) -> None:
+    pytest.importorskip("polars")
+
     df = (
         nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]}))
         .lazy()
@@ -115,6 +127,8 @@ def test_from_dict_both_backend_and_namespace_v1(
 def test_from_dict_one_native_one_narwhals(
     constructor: Constructor, backend: Implementation | str
 ) -> None:
+    pytest.importorskip("polars")
+
     df = (
         nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]}))
         .lazy()

--- a/tests/from_dict_test.py
+++ b/tests/from_dict_test.py
@@ -12,7 +12,7 @@ from narwhals.utils import Implementation
 from tests.utils import Constructor
 from tests.utils import assert_equal_data
 
-TEST_EAGER_BACKENDS = []
+TEST_EAGER_BACKENDS: list[Implementation | str] = []
 TEST_EAGER_BACKENDS.extend(
     (Implementation.POLARS, "polars") if find_spec("polars") is not None else ()
 )

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from contextlib import nullcontext as does_not_raise
+from importlib.util import find_spec
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterable
@@ -9,9 +10,6 @@ from typing import Literal
 from typing import cast
 
 import numpy as np
-import pandas as pd
-import polars as pl
-import pyarrow as pa
 import pytest
 
 import narwhals as unstable_nw
@@ -22,19 +20,6 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from narwhals.utils import Version
-
-data: dict[str, Any] = {"a": [1, 2, 3]}
-
-df_pd = pd.DataFrame(data)
-df_pl = pl.DataFrame(data)
-lf_pl = pl.LazyFrame(data)
-df_mpd = maybe_get_modin_df(df_pd)
-df_pa = pa.table(data)
-
-series_pd = pd.Series(data["a"])
-series_pl = pl.Series(data["a"])
-series_mpd = df_mpd["a"]
-series_pa = pa.chunked_array([data["a"]])
 
 
 class MockDataFrame:
@@ -61,28 +46,71 @@ class MockSeries:
         return self
 
 
-eager_frames = [
-    df_pd,
-    df_pl,
-    df_mpd,
-    df_pa,
+data: dict[str, Any] = {"a": [1, 2, 3]}
+
+eager_frames: list[Any] = [
     MockDataFrame(),
 ]
-
-lazy_frames = [
-    lf_pl,
+lazy_frames: list[Any] = [
     MockLazyFrame(),
 ]
-
-all_frames = [*eager_frames, *lazy_frames]
-
-all_series = [
-    series_pd,
-    series_pl,
-    series_mpd,
-    series_pa,
+all_series: list[Any] = [
     MockSeries(),
 ]
+
+if find_spec("pandas") is not None:
+    import pandas as pd
+
+    df_pd: pd.DataFrame | None = pd.DataFrame(data)
+    assert df_pd is not None
+    df_mpd = maybe_get_modin_df(df_pd)
+    series_pd = pd.Series(data["a"])
+    series_mpd = df_mpd["a"]
+
+    eager_frames += [
+        df_pd,
+        df_mpd,
+    ]
+    all_series += [
+        series_pd,
+        series_mpd,
+    ]
+else:
+    df_pd = None
+
+if find_spec("polars") is not None:
+    import polars as pl
+
+    df_pl = pl.DataFrame(data)
+    lf_pl: pl.LazyFrame | None = pl.LazyFrame(data)
+    series_pl = pl.Series(data["a"])
+
+    all_series += [
+        series_pl,
+    ]
+    eager_frames += [
+        df_pl,
+    ]
+    lazy_frames += [
+        lf_pl,
+    ]
+else:
+    lf_pl = None
+
+if find_spec("pyarrow") is not None:
+    import pyarrow as pa
+
+    df_pa = pa.table(data)
+    series_pa = pa.chunked_array([data["a"]])
+
+    eager_frames += [
+        df_pa,
+    ]
+    all_series += [
+        series_pa,
+    ]
+
+all_frames = [*eager_frames, *lazy_frames]
 
 
 @pytest.mark.parametrize(
@@ -177,6 +205,7 @@ def test_invalid_series_combination() -> None:
         nw.from_native(MockSeries(), series_only=True, allow_series=False)  # type: ignore[call-overload]
 
 
+@pytest.mark.skipif(df_pd is None, reason="pandas not found")
 def test_pandas_like_validate() -> None:
     df1 = pd.DataFrame({"a": [1, 2, 3]})
     df2 = pd.DataFrame({"b": [1, 2, 3]})
@@ -188,6 +217,7 @@ def test_pandas_like_validate() -> None:
         nw.from_native(df)
 
 
+@pytest.mark.skipif(lf_pl is None, reason="polars not found")
 def test_init_already_narwhals() -> None:
     df = nw.from_native(pl.DataFrame({"a": [1, 2, 3]}))
     result = nw.from_native(df)
@@ -197,6 +227,7 @@ def test_init_already_narwhals() -> None:
     assert result_s is s
 
 
+@pytest.mark.skipif(lf_pl is None, reason="polars not found")
 def test_init_already_narwhals_unstable() -> None:
     df = unstable_nw.from_native(pl.DataFrame({"a": [1, 2, 3]}))
     result = unstable_nw.from_native(df)
@@ -206,6 +237,7 @@ def test_init_already_narwhals_unstable() -> None:
     assert result_s is s
 
 
+@pytest.mark.skipif(df_pd is None, reason="pandas not found")
 def test_series_only_dask() -> None:
     pytest.importorskip("dask")
     import dask.dataframe as dd
@@ -217,6 +249,7 @@ def test_series_only_dask() -> None:
     assert nw.from_native(dframe, series_only=True, strict=False) is dframe
 
 
+@pytest.mark.skipif(df_pd is None, reason="pandas not found")
 @pytest.mark.parametrize(
     ("eager_only", "context"),
     [
@@ -269,6 +302,7 @@ def test_eager_only_sqlframe(eager_only: Any, context: Any) -> None:  # pragma: 
         assert isinstance(res, nw.LazyFrame)
 
 
+@pytest.mark.skipif(lf_pl is None, reason="polars not found")
 def test_from_native_strict_false_typing() -> None:
     df = pl.DataFrame()
     nw.from_native(df, strict=False)
@@ -299,7 +333,6 @@ def test_from_native_strict_native_series() -> None:
     obj: list[int] = [1, 2, 3, 4]
     array_like = cast("Iterable[Any]", obj)
     not_array_like: Literal[1] = 1
-    np_array = pl.Series(obj).to_numpy()
 
     with pytest.raises(TypeError, match="got.+list"):
         nw.from_native(obj, series_only=True)  # type: ignore[call-overload]
@@ -310,11 +343,18 @@ def test_from_native_strict_native_series() -> None:
     with pytest.raises(TypeError, match="got.+int"):
         nw.from_native(not_array_like, series_only=True)  # type: ignore[call-overload]
 
+
+@pytest.mark.skipif(lf_pl is None, reason="polars not found")
+def test_from_native_strict_native_series_polars() -> None:
+    obj: list[int] = [1, 2, 3, 4]
+    np_array = pl.Series(obj).to_numpy()
     with pytest.raises(TypeError, match="got.+numpy.ndarray"):
         nw.from_native(np_array, series_only=True)  # type: ignore[call-overload]
 
 
+@pytest.mark.skipif(lf_pl is None, reason="polars not found")
 def test_from_native_lazyframe() -> None:
+    assert lf_pl is not None
     stable_lazy = nw.from_native(lf_pl)
     unstable_lazy = unstable_nw.from_native(lf_pl)
     if TYPE_CHECKING:

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -75,7 +75,7 @@ if find_spec("pandas") is not None:
         series_pd,
         series_mpd,
     ]
-else:
+else:  # pragma: no cover
     df_pd = None
 
 if find_spec("polars") is not None:
@@ -94,10 +94,10 @@ if find_spec("polars") is not None:
     lazy_frames += [
         lf_pl,
     ]
-else:
+else:  # pragma: no cover
     lf_pl = None
 
-if find_spec("pyarrow") is not None:
+if find_spec("pyarrow") is not None:  # pragma: no cover
     import pyarrow as pa
 
     df_pa = pa.table(data)


### PR DESCRIPTION

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #1726
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Split and/or skip tests requiring `polars` when they are unavailable. Whenever that was a low-hanging fruit, also imports of `pandas` and `pyarrow` were made optional.
