### PR TITLE
Spark expr replace strict

### DIFF
--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -496,21 +496,17 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
 
         def _replace_strict(
             _input: Column,
-            old: Column,  # should be Sequence[Any]
-            new: Column,  # should be Sequence[Any]
+            old: Column,  # or a Sequence[Column]
+            new: Column,  # or a Sequence[Column]
         ) -> Column:
-            mapper = self._F.create_map(old, new)
-            return mapper[_input]
+            mapping_expr = self._F.create_map(old, new)
+            return mapping_expr[_input]
 
-        result = self._from_call(
-            _replace_strict,
-            "replace_strict",
-            old=old,
-            new=new,
-        )
+        result = self._from_call(_replace_strict, "replace_strict", old=old, new=new)
 
         if return_dtype is not None:
             result = result.cast(return_dtype)
+
         return result
 
     def round(self: Self, decimals: int) -> Self:

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -486,7 +486,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         old: ExprKind | Sequence[Any] | Mapping[Any, Any],
         new: ExprKind | Sequence[Any] | None = None,
         default: ExprKind | None = None,
-        return_dtype: DType | None = None,
+        return_dtype: DType | type[DType] | None = None,
     ) -> Self:
         if new is None:
             if not isinstance(old, Mapping):
@@ -501,9 +501,9 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
             old: Sequence[Any],
             new: Sequence[Any],
             default: ExprKind,
-            return_dtype: DType,
+            return_dtype: DType | type[DType],
         ) -> Column:
-            mapper = self._F.create_map(chain(*zip(old, new)))
+            mapper = self._F.create_map(*chain(*zip(old, new)))
             mapping_expr = mapper[_input]
 
             if default is not None:

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -484,6 +484,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         self: Self,
         old: ExprKind | Sequence[Any] | Mapping[Any, Any],
         new: ExprKind | Sequence[Any] | None = None,
+        return_dtype: DType | type[DType] | None = None,
     ) -> Self:
         if new is None:
             if not isinstance(old, Mapping):
@@ -501,12 +502,16 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
             mapper = self._F.create_map(old, new)
             return mapper[_input]
 
-        return self._from_call(
+        result = self._from_call(
             _replace_strict,
             "replace_strict",
             old=old,
             new=new,
         )
+
+        if return_dtype is not None:
+            result = result.cast(return_dtype)
+        return result
 
     def round(self: Self, decimals: int) -> Self:
         def _round(_input: Column) -> Column:

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -479,6 +479,18 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
 
         return self._from_call(_len, "len")
 
+    def replace_strict(
+        self: Self,
+        old: ExprKind | Sequence[Any] | dict[Any, Any],
+        new: ExprKind | Sequence[Any] | None = None,
+        default: ExprKind | None = None,
+        return_dtype: DType | None = None,
+    ) -> Self:
+        def _replace_strict(_input: Column) -> Column:
+            return _input
+        return self._from_call(_replace_strict, "replace_strict")
+
+
     def round(self: Self, decimals: int) -> Self:
         def _round(_input: Column) -> Column:
             return self._F.round(_input, decimals)

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -497,9 +497,13 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
             old = list(old.keys())
 
         def _replace_strict(
-            _input: Column, old: Sequence[Any], new: Sequence[Any]
+            _input: Column,
+            old: Sequence[Any],
+            new: Sequence[Any],
+            default: ExprKind,
+            return_dtype: DType,
         ) -> Column:
-            mapper = self._F.create_map([self._F.lit(x) for x in chain(*zip(new, old))])
+            mapper = self._F.create_map([self._F.lit(x) for x in chain(*zip(old, new))])
             mapping_expr = mapper[_input]
 
             if default is not None:
@@ -510,7 +514,14 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
 
             return mapping_expr
 
-        return self._from_call(_replace_strict, "replace_strict", new=new, old=old)
+        return self._from_call(
+            _replace_strict,
+            "replace_strict",
+            old=old,
+            new=new,
+            default=default,
+            return_dtype=return_dtype,
+        )
 
     def round(self: Self, decimals: int) -> Self:
         def _round(_input: Column) -> Column:

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -503,7 +503,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
             default: ExprKind,
             return_dtype: DType,
         ) -> Column:
-            mapper = self._F.create_map([self._F.lit(x) for x in chain(*zip(old, new))])
+            mapper = self._F.create_map(chain(*zip(old, new)))
             mapping_expr = mapper[_input]
 
             if default is not None:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #2253 

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Currently supports replacing one value with another value and specifying `return_dtype`. See comments for issue I'm running into.