### PR TITLE
chore: downstream CI cleanup (`validoopsie` and `pointblank`) and re-order dependency groups

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -472,26 +472,21 @@ jobs:
       - name: install-validoopsie-dev
         run: |
           cd validoopsie
-          uv venv
-          . .venv/bin/activate
           uv sync --dev
-          uv pip install pytest-env
-          which python
       - name: show-deps
         run: |
           cd validoopsie
-          . .venv/bin/activate
+          which python
           uv pip freeze
       - name: install-narwhals-dev
         run: |
           cd validoopsie
-          . .venv/bin/activate
           uv pip uninstall narwhals
           uv pip install -e ./..
       - name: Run tests
         run: |
           cd validoopsie
-          . .venv/bin/activate
+          touch pytest.ini       
           touch tests/__init__.py
           touch tests/utils/__init__.py
           pytest tests

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -486,6 +486,7 @@ jobs:
       - name: Run tests
         run: |
           cd validoopsie
+          # empty pytest.ini to avoid pytest using narwhals configs
           touch pytest.ini       
           touch tests/__init__.py
           touch tests/utils/__init__.py

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -481,15 +481,15 @@ jobs:
       - name: install-narwhals-dev
         run: |
           cd validoopsie
-          uv pip uninstall narwhals
-          uv pip install -e ./..
+          uv remove narwhals
+          uv add ./..
       - name: Run tests
         run: |
           cd validoopsie
           touch pytest.ini       
           touch tests/__init__.py
           touch tests/utils/__init__.py
-          pytest tests
+          uv run pytest tests
         timeout-minutes: 15
   
   darts:

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -473,16 +473,16 @@ jobs:
         run: |
           cd validoopsie
           uv sync --dev
-      - name: show-deps
-        run: |
-          cd validoopsie
-          which python
-          uv pip freeze
       - name: install-narwhals-dev
         run: |
           cd validoopsie
           uv remove narwhals
           uv add ./..
+      - name: show-deps
+        run: |
+          cd validoopsie
+          which python
+          uv pip freeze
       - name: Run tests
         run: |
           cd validoopsie

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -435,7 +435,7 @@ jobs:
         run: |
           cd pointblank
           uv pip install --system ".[dev]"
-          uv pip install pytest pytest-cov pytest-snapshot pandas polars "ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0" chatlas --system    
+          uv pip install pytest pytest-cov pytest-snapshot pandas polars "ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0" chatlas shiny --system    
       - name: install-narwhals-dev
         run: |
           uv pip uninstall narwhals --system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,24 +46,6 @@ ibis = ["ibis-framework>=6.0.0", "rich", "packaging", "pyarrow_hotfix"]
 sqlframe = ["sqlframe>=3.22.0"]
 
 [dependency-groups]
-dev = [
-  "pre-commit",
-  {include-group = "tests"},
-  {include-group = "typing"},
-]
-dev-core = [
-  {include-group = "dev"},
-  {include-group = "core"},
-]
-core-tests = [
-  {include-group = "core"},
-  {include-group = "tests"},
-]
-local-dev = [
-  {include-group = "dev"},
-  {include-group = "core"},
-  {include-group = "docs"}
-]
 core = [
   "narwhals[duckdb,pandas,polars,pyarrow,sqlframe]"
 ] 
@@ -103,6 +85,24 @@ docs = [
   "pandas",
   "polars>=1.0.0",
   "pyarrow",
+]
+dev = [
+  "pre-commit",
+  {include-group = "tests"},
+  {include-group = "typing"},
+]
+dev-core = [
+  {include-group = "dev"},
+  {include-group = "core"},
+]
+core-tests = [
+  {include-group = "core"},
+  {include-group = "tests"},
+]
+local-dev = [
+  {include-group = "dev"},
+  {include-group = "core"},
+  {include-group = "docs"}
 ]
 
 [tool.hatch.build]


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues



## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

I noticed the same problem we had for `tea-tasting` for `validoopsie`. If we don't add a `pytest` config, `pytest` will try to use the one of `narwhals`

Plus reordered the dependency groups as in @dangotbanned comment https://github.com/narwhals-dev/narwhals/pull/2238#discussion_r2003306918. 
It is the same ordering as in the [packaging docs](https://packaging.python.org/en/latest/specifications/dependency-groups/#dependency-group-include) with the `groups-include` at the end