### PR TITLE
chore: Track ExpansionKind in ExprMetadata

### DIFF
--- a/narwhals/_compliant/expr.py
+++ b/narwhals/_compliant/expr.py
@@ -272,14 +272,6 @@ class CompliantExpr(Protocol38[CompliantFrameT, CompliantSeriesOrNativeExprT_co]
     def broadcast(
         self, kind: Literal[ExprKind.AGGREGATION, ExprKind.LITERAL]
     ) -> Self: ...
-    def _is_multi_output_agg(self) -> bool:
-        """Return `True` for multi-output aggregations.
-
-        Here we skip the keys, else they would appear duplicated in the output:
-
-            df.group_by("a").agg(nw.all().mean())
-        """
-        return self._function_name.split("->", maxsplit=1)[0] in {"all", "selector"}
 
 
 class EagerExpr(

--- a/narwhals/_compliant/group_by.py
+++ b/narwhals/_compliant/group_by.py
@@ -147,7 +147,11 @@ class LazyGroupBy(
             else output_names
         )
         native_exprs = expr(self.compliant)
-        if expr._is_multi_output_agg():
+        assert expr._metadata is not None  # noqa: S101
+        if expr._metadata.expansion_kind.is_multi_unnamed():
+            # Exclude keys from expansion. For example, in
+            # `df.group_by('a').agg(nw.all().sum())`, column 'a' only appears in the
+            # output as a grouping key - is does not get included in `nw.all().sum()`.
             for native_expr, name, alias in zip(native_exprs, output_names, aliases):
                 if name not in self._keys:
                     yield native_expr.alias(alias)

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -49,19 +49,20 @@ with contextlib.suppress(ImportError):  # requires duckdb>=1.3.0
 class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "duckdb.Expression"]):
     _implementation = Implementation.DUCKDB
     _depth = 0  # Unused, just for compatibility with CompliantExpr
+    _function_name = ""  # Unused, just for compatibility with CompliantExpr
 
     def __init__(
         self: Self,
         call: Callable[[DuckDBLazyFrame], Sequence[duckdb.Expression]],
         *,
-        function_name: str,
+        # Unused, just for compatibility with CompliantExpr
+        function_name: str = "",
         evaluate_output_names: Callable[[DuckDBLazyFrame], Sequence[str]],
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
         backend_version: tuple[int, ...],
         version: Version,
     ) -> None:
         self._call = call
-        self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names
         self._alias_output_names = alias_output_names
         self._backend_version = backend_version

--- a/narwhals/_duckdb/expr_name.py
+++ b/narwhals/_duckdb/expr_name.py
@@ -58,7 +58,6 @@ class DuckDBExprNameNamespace:
     ) -> DuckDBExpr:
         return self._compliant_expr.__class__(
             call=self._compliant_expr._call,
-            function_name=self._compliant_expr._function_name,
             evaluate_output_names=self._compliant_expr._evaluate_output_names,
             alias_output_names=alias_output_names,
             backend_version=self._compliant_expr._backend_version,

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -120,7 +120,6 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "DuckDBExpr"]):
 
         return self._expr(
             call=func,
-            function_name="concat_str",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -134,7 +133,6 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "DuckDBExpr"]):
 
         return self._expr(
             call=func,
-            function_name="all_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -148,7 +146,6 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "DuckDBExpr"]):
 
         return self._expr(
             call=func,
-            function_name="or_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -162,7 +159,6 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "DuckDBExpr"]):
 
         return self._expr(
             call=func,
-            function_name="max_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -176,7 +172,6 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "DuckDBExpr"]):
 
         return self._expr(
             call=func,
-            function_name="min_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -190,7 +185,6 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "DuckDBExpr"]):
 
         return self._expr(
             call=func,
-            function_name="sum_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -209,7 +203,6 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "DuckDBExpr"]):
 
         return DuckDBExpr(
             call=func,
-            function_name="mean_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -235,7 +228,6 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "DuckDBExpr"]):
 
         return self._expr(
             func,
-            function_name="lit",
             evaluate_output_names=lambda _df: ["literal"],
             alias_output_names=None,
             backend_version=self._backend_version,
@@ -248,7 +240,6 @@ class DuckDBNamespace(CompliantNamespace["DuckDBLazyFrame", "DuckDBExpr"]):
 
         return self._expr(
             call=func,
-            function_name="len",
             evaluate_output_names=lambda _df: ["len"],
             alias_output_names=None,
             backend_version=self._backend_version,
@@ -289,7 +280,6 @@ class DuckDBWhen:
 
         return DuckDBThen(
             self,
-            function_name="whenthen",
             evaluate_output_names=getattr(
                 value, "_evaluate_output_names", lambda _df: ["literal"]
             ),
@@ -304,7 +294,7 @@ class DuckDBThen(DuckDBExpr):
         self: Self,
         call: DuckDBWhen,
         *,
-        function_name: str,
+        function_name: str = '',
         evaluate_output_names: Callable[[DuckDBLazyFrame], Sequence[str]],
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
         backend_version: tuple[int, ...],
@@ -313,7 +303,6 @@ class DuckDBThen(DuckDBExpr):
         self._backend_version = backend_version
         self._version = version
         self._call = call
-        self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names
         self._alias_output_names = alias_output_names
 
@@ -322,5 +311,4 @@ class DuckDBThen(DuckDBExpr):
         # callable object of type `DuckDBWhen`, base class has the attribute as
         # only a `Callable`
         self._call._otherwise_value = value  # type: ignore[attr-defined]
-        self._function_name = "whenotherwise"
         return self

--- a/narwhals/_duckdb/selectors.py
+++ b/narwhals/_duckdb/selectors.py
@@ -27,7 +27,6 @@ class DuckDBSelectorNamespace(
     ) -> DuckDBSelector:
         return DuckDBSelector(
             call,
-            function_name="selector",
             evaluate_output_names=evaluate_output_names,
             alias_output_names=None,
             backend_version=self._backend_version,
@@ -46,7 +45,6 @@ class DuckDBSelector(  # type: ignore[misc]
     def _to_expr(self: Self) -> DuckDBExpr:
         return DuckDBExpr(
             self._call,
-            function_name=self._function_name,
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -41,12 +41,13 @@ if TYPE_CHECKING:
 
 class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
     _depth = 0  # Unused, just for compatibility with CompliantExpr
+    _function_name = ""  # Unused, just for compatibility with CompliantExpr
 
     def __init__(
         self: Self,
         call: Callable[[SparkLikeLazyFrame], Sequence[Column]],
         *,
-        function_name: str,
+        function_name: str = "",
         evaluate_output_names: Callable[[SparkLikeLazyFrame], Sequence[str]],
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
         backend_version: tuple[int, ...],
@@ -54,7 +55,6 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         implementation: Implementation,
     ) -> None:
         self._call = call
-        self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names
         self._alias_output_names = alias_output_names
         self._backend_version = backend_version
@@ -77,7 +77,6 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
 
         return self.__class__(
             func,
-            function_name=self._function_name,
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
@@ -127,7 +126,6 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
     def _with_metadata(self, metadata: ExprMetadata) -> Self:
         expr = self.__class__(
             self._call,
-            function_name=self._function_name,
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
@@ -145,7 +143,6 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
     ) -> Self:
         result = self.__class__(
             self._call,
-            function_name=self._function_name,
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
@@ -161,7 +158,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         evaluate_column_names: Callable[[SparkLikeLazyFrame], Sequence[str]],
         /,
         *,
-        function_name: str,
+        function_name: str = "",  # noqa: ARG003
         context: _FullContext,
     ) -> Self:
         def func(df: SparkLikeLazyFrame) -> list[Column]:
@@ -169,7 +166,6 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
 
         return cls(
             func,
-            function_name=function_name,
             evaluate_output_names=evaluate_column_names,
             alias_output_names=None,
             backend_version=context._backend_version,
@@ -187,7 +183,6 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
 
         return cls(
             func,
-            function_name="nth",
             evaluate_output_names=lambda df: [df.columns[i] for i in column_indices],
             alias_output_names=None,
             backend_version=context._backend_version,
@@ -214,7 +209,6 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
 
         return self.__class__(
             func,
-            function_name=f"{self._function_name}->{expr_name}",
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,
@@ -340,7 +334,6 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
 
         return self.__class__(
             self._call,
-            function_name=self._function_name,
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=alias_output_names,
             backend_version=self._backend_version,
@@ -535,7 +528,6 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
 
         return self.__class__(
             func,
-            function_name=self._function_name + "->over",
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,

--- a/narwhals/_spark_like/expr_name.py
+++ b/narwhals/_spark_like/expr_name.py
@@ -58,7 +58,6 @@ class SparkLikeExprNameNamespace:
     ) -> SparkLikeExpr:
         return self._compliant_expr.__class__(
             self._compliant_expr._call,
-            function_name=self._compliant_expr._function_name,
             evaluate_output_names=self._compliant_expr._evaluate_output_names,
             alias_output_names=alias_output_names,
             backend_version=self._compliant_expr._backend_version,

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -60,7 +60,6 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "SparkLikeExpr
 
         return self._expr(
             call=_lit,
-            function_name="lit",
             evaluate_output_names=lambda _df: ["literal"],
             alias_output_names=None,
             backend_version=self._backend_version,
@@ -74,7 +73,6 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "SparkLikeExpr
 
         return self._expr(
             func,
-            function_name="len",
             evaluate_output_names=lambda _df: ["len"],
             alias_output_names=None,
             backend_version=self._backend_version,
@@ -89,7 +87,6 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "SparkLikeExpr
 
         return self._expr(
             call=func,
-            function_name="all_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -104,7 +101,6 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "SparkLikeExpr
 
         return self._expr(
             call=func,
-            function_name="any_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -121,7 +117,6 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "SparkLikeExpr
 
         return self._expr(
             call=func,
-            function_name="sum_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -150,7 +145,6 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "SparkLikeExpr
 
         return self._expr(
             call=func,
-            function_name="mean_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -165,7 +159,6 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "SparkLikeExpr
 
         return self._expr(
             call=func,
-            function_name="max_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -180,7 +173,6 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "SparkLikeExpr
 
         return self._expr(
             call=func,
-            function_name="min_horizontal",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -275,7 +267,6 @@ class SparkLikeNamespace(CompliantNamespace["SparkLikeLazyFrame", "SparkLikeExpr
 
         return self._expr(
             call=func,
-            function_name="concat_str",
             evaluate_output_names=combine_evaluate_output_names(*exprs),
             alias_output_names=combine_alias_output_names(*exprs),
             backend_version=self._backend_version,
@@ -325,7 +316,6 @@ class SparkLikeWhen:
 
         return SparkLikeThen(
             self,
-            function_name="whenthen",
             evaluate_output_names=getattr(
                 value, "_evaluate_output_names", lambda _df: ["literal"]
             ),
@@ -341,7 +331,6 @@ class SparkLikeThen(SparkLikeExpr):
         self: Self,
         call: SparkLikeWhen,
         *,
-        function_name: str,
         evaluate_output_names: Callable[[SparkLikeLazyFrame], Sequence[str]],
         alias_output_names: Callable[[Sequence[str]], Sequence[str]] | None,
         backend_version: tuple[int, ...],
@@ -351,7 +340,6 @@ class SparkLikeThen(SparkLikeExpr):
         self._backend_version = backend_version
         self._version = version
         self._call = call
-        self._function_name = function_name
         self._evaluate_output_names = evaluate_output_names
         self._alias_output_names = alias_output_names
         self._implementation = implementation
@@ -361,5 +349,4 @@ class SparkLikeThen(SparkLikeExpr):
         # callable object of type `SparkLikeWhen`, base class has the attribute as
         # only a `Callable`
         self._call._otherwise_value = value  # type: ignore[attr-defined]
-        self._function_name = "whenotherwise"
         return self

--- a/narwhals/_spark_like/selectors.py
+++ b/narwhals/_spark_like/selectors.py
@@ -25,7 +25,6 @@ class SparkLikeSelectorNamespace(LazySelectorNamespace["SparkLikeLazyFrame", "Co
     ) -> SparkLikeSelector:
         return SparkLikeSelector(
             call,
-            function_name="selector",
             evaluate_output_names=evaluate_output_names,
             alias_output_names=None,
             backend_version=self._backend_version,
@@ -43,7 +42,6 @@ class SparkLikeSelector(CompliantSelector["SparkLikeLazyFrame", "Column"], Spark
     def _to_expr(self: Self) -> SparkLikeExpr:
         return SparkLikeExpr(
             self._call,
-            function_name=self._function_name,
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=self._alias_output_names,
             backend_version=self._backend_version,

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -1580,7 +1580,7 @@ class Expr:
         next_meta = ExprMetadata(
             kind,
             n_open_windows=n_open_windows,
-            is_multi_output=current_meta.is_multi_output,
+            expansion_kind=current_meta.expansion_kind,
         )
 
         return self.__class__(

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -12,6 +12,7 @@ from typing import Sequence
 from typing import cast
 from typing import overload
 
+from narwhals._expression_parsing import ExpansionKind
 from narwhals._expression_parsing import ExprKind
 from narwhals._expression_parsing import ExprMetadata
 from narwhals._expression_parsing import apply_n_ary_operation
@@ -1195,7 +1196,7 @@ def col(*names: str | Iterable[str]) -> Expr:
         func,
         ExprMetadata.simple_selector()
         if len(flat_names) == 1
-        else ExprMetadata.multi_output_selector(),
+        else ExprMetadata.multi_output_selector_named(),
     )
 
 
@@ -1233,7 +1234,7 @@ def exclude(*names: str | Iterable[str]) -> Expr:
     def func(plx: Any) -> Any:
         return plx.exclude(exclude_names)
 
-    return Expr(func, ExprMetadata.multi_output_selector())
+    return Expr(func, ExprMetadata.multi_output_selector_unnamed())
 
 
 def nth(*indices: int | Sequence[int]) -> Expr:
@@ -1275,7 +1276,7 @@ def nth(*indices: int | Sequence[int]) -> Expr:
         func,
         ExprMetadata.simple_selector()
         if len(flat_indices) == 1
-        else ExprMetadata.multi_output_selector(),
+        else ExprMetadata.multi_output_selector_unnamed(),
     )
 
 
@@ -1300,7 +1301,7 @@ def all_() -> Expr:
         |   1  4  0.246    |
         └──────────────────┘
     """
-    return Expr(lambda plx: plx.all(), ExprMetadata.multi_output_selector())
+    return Expr(lambda plx: plx.all(), ExprMetadata.multi_output_selector_unnamed())
 
 
 # Add underscore so it doesn't conflict with builtin `len`
@@ -1334,7 +1335,10 @@ def len_() -> Expr:
         return plx.len()
 
     return Expr(
-        func, ExprMetadata(ExprKind.AGGREGATION, n_open_windows=0, is_multi_output=False)
+        func,
+        ExprMetadata(
+            ExprKind.AGGREGATION, n_open_windows=0, expansion_kind=ExpansionKind.SINGLE
+        ),
     )
 
 
@@ -1804,7 +1808,9 @@ def lit(value: Any, dtype: DType | type[DType] | None = None) -> Expr:
 
     return Expr(
         lambda plx: plx.lit(value, dtype),
-        ExprMetadata(ExprKind.LITERAL, n_open_windows=0, is_multi_output=False),
+        ExprMetadata(
+            ExprKind.LITERAL, n_open_windows=0, expansion_kind=ExpansionKind.SINGLE
+        ),
     )
 
 

--- a/narwhals/group_by.py
+++ b/narwhals/group_by.py
@@ -84,9 +84,9 @@ class GroupBy(Generic[DataFrameT]):
             raise InvalidOperationError(msg)
         plx = self._df.__narwhals_namespace__()
         compliant_aggs = (
-            *(x._to_compliant_expr(plx) for x in flat_aggs),
+            *(x._to_compliant_expr(plx)._with_metadata(x._metadata) for x in flat_aggs),
             *(
-                value._to_compliant_expr(plx).alias(key)
+                value._to_compliant_expr(plx).alias(key)._with_metadata(value._metadata)
                 for key, value in named_aggs.items()
             ),
         )
@@ -174,9 +174,9 @@ class LazyGroupBy(Generic[LazyFrameT]):
             raise InvalidOperationError(msg)
         plx = self._df.__narwhals_namespace__()
         compliant_aggs = (
-            *(x._to_compliant_expr(plx) for x in flat_aggs),
+            *(x._to_compliant_expr(plx)._with_metadata(x._metadata) for x in flat_aggs),
             *(
-                value._to_compliant_expr(plx).alias(key)
+                value._to_compliant_expr(plx).alias(key)._with_metadata(value._metadata)
                 for key, value in named_aggs.items()
             ),
         )

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -96,7 +96,7 @@ def by_dtype(*dtypes: DType | type[DType] | Iterable[DType | type[DType]]) -> Se
     flattened = flatten(dtypes)
     return Selector(
         lambda plx: plx.selectors.by_dtype(flattened),
-        ExprMetadata.multi_output_selector(),
+        ExprMetadata.multi_output_selector_unnamed(),
     )
 
 
@@ -130,7 +130,8 @@ def matches(pattern: str) -> Selector:
         1  456  5.5
     """
     return Selector(
-        lambda plx: plx.selectors.matches(pattern), ExprMetadata.multi_output_selector()
+        lambda plx: plx.selectors.matches(pattern),
+        ExprMetadata.multi_output_selector_unnamed(),
     )
 
 
@@ -161,7 +162,7 @@ def numeric() -> Selector:
         └─────┴─────┘
     """
     return Selector(
-        lambda plx: plx.selectors.numeric(), ExprMetadata.multi_output_selector()
+        lambda plx: plx.selectors.numeric(), ExprMetadata.multi_output_selector_unnamed()
     )
 
 
@@ -196,7 +197,7 @@ def boolean() -> Selector:
         └──────────────────┘
     """
     return Selector(
-        lambda plx: plx.selectors.boolean(), ExprMetadata.multi_output_selector()
+        lambda plx: plx.selectors.boolean(), ExprMetadata.multi_output_selector_unnamed()
     )
 
 
@@ -227,7 +228,7 @@ def string() -> Selector:
         └─────┘
     """
     return Selector(
-        lambda plx: plx.selectors.string(), ExprMetadata.multi_output_selector()
+        lambda plx: plx.selectors.string(), ExprMetadata.multi_output_selector_unnamed()
     )
 
 
@@ -260,7 +261,8 @@ def categorical() -> Selector:
         └─────┘
     """
     return Selector(
-        lambda plx: plx.selectors.categorical(), ExprMetadata.multi_output_selector()
+        lambda plx: plx.selectors.categorical(),
+        ExprMetadata.multi_output_selector_unnamed(),
     )
 
 
@@ -284,7 +286,9 @@ def all() -> Selector:
         0  1  x  False
         1  2  y   True
     """
-    return Selector(lambda plx: plx.selectors.all(), ExprMetadata.multi_output_selector())
+    return Selector(
+        lambda plx: plx.selectors.all(), ExprMetadata.multi_output_selector_unnamed()
+    )
 
 
 def datetime(
@@ -344,7 +348,7 @@ def datetime(
     """
     return Selector(
         lambda plx: plx.selectors.datetime(time_unit=time_unit, time_zone=time_zone),
-        ExprMetadata.multi_output_selector(),
+        ExprMetadata.multi_output_selector_unnamed(),
     )
 
 


### PR DESCRIPTION
ref #2225 

I think that to properly close the issue, a section to "how it works" should be added

But this at least deals with the internals and gets rid of a hack I was really not proud of (behaviour based on `function_name`). There is still a bit of that, but we're on the path to removing it

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
