### PR TITLE
fix: safety assertion was being thrown for Expr.is_last_distinct with over and _order_by by pandas and pyarrow

### DIFF
--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -159,7 +159,7 @@ class ArrowExpr(EagerExpr["ArrowDataFrame", ArrowSeries]):
                 df = df.with_row_index(token).sort(
                     *order_by, descending=False, nulls_last=False
                 )
-                result = self(df)
+                result = self(df.drop([token], strict=True))
                 # TODO(marco): is there a way to do this efficiently without
                 # doing 2 sorts? Here we're sorting the dataframe and then
                 # again calling `sort_indices`. `ArrowSeries.scatter` would also sort.

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -209,7 +209,7 @@ class PandasLikeExpr(EagerExpr["PandasLikeDataFrame", PandasLikeSeries]):
                 df = df.with_row_index(token).sort(
                     *order_by, descending=False, nulls_last=False
                 )
-                results = self(df)
+                results = self(df.drop([token], strict=True))
                 sorting_indices = df[token]
                 for s in results:
                     s._scatter_in_place(sorting_indices, s)

--- a/tests/expr_and_series/is_last_distinct_test.py
+++ b/tests/expr_and_series/is_last_distinct_test.py
@@ -20,6 +20,19 @@ def test_is_last_distinct_expr(constructor_eager: ConstructorEager) -> None:
     assert_equal_data(result, expected)
 
 
+def test_is_last_distinct_expr_all(constructor_eager: ConstructorEager) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/2268
+    data = {"a": [1, 1, 2, 3, 2], "b": [1, 2, 3, 2, 1], "i": [0, 1, 2, 3, 4]}
+    df = nw.from_native(constructor_eager(data))
+    result = df.select(nw.all().is_last_distinct().over(_order_by="i"))
+    expected = {
+        "a": [False, True, False, True, True],
+        "b": [False, False, True, True, True],
+        "i": [True, True, True, True, True],
+    }
+    assert_equal_data(result, expected)
+
+
 def test_is_last_distinct_series(constructor_eager: ConstructorEager) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)["a"]
     result = series.is_last_distinct()

--- a/tests/expr_and_series/is_last_distinct_test.py
+++ b/tests/expr_and_series/is_last_distinct_test.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 import narwhals.stable.v1 as nw
+from tests.utils import POLARS_VERSION
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -22,6 +25,8 @@ def test_is_last_distinct_expr(constructor_eager: ConstructorEager) -> None:
 
 def test_is_last_distinct_expr_all(constructor_eager: ConstructorEager) -> None:
     # https://github.com/narwhals-dev/narwhals/issues/2268
+    if "polars" in str(constructor_eager) and POLARS_VERSION < (1, 9):
+        pytest.skip(reason="too old version")
     data = {"a": [1, 1, 2, 3, 2], "b": [1, 2, 3, 2, 1], "i": [0, 1, 2, 3, 4]}
     df = nw.from_native(constructor_eager(data))
     result = df.select(nw.all().is_last_distinct().over(_order_by="i"))


### PR DESCRIPTION


closes https://github.com/narwhals-dev/narwhals/issues/2268

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
