### PR TITLE
fix: Expr.mode broadcasting

### DIFF
--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -135,11 +135,6 @@ class ArrowSeries(EagerSeries["ArrowChunkedArray"]):
         *,
         preserve_broadcast: bool = False,
     ) -> Self:
-        # In cases when operations are known to not affect whether a result should
-        # be broadcast, we can pass `preverse_broadcast=True`.
-        # Set this with care - it should only be set for unary expressions which don't
-        # change length or order, such as `.alias` or `.fill_null`. If in doubt, don't
-        # set it, you probably don't need it.
         result = self.__class__(
             chunked_array(series),
             name=self._name,

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -13,6 +13,7 @@ from typing import overload
 import pyarrow as pa
 import pyarrow.compute as pc
 
+from narwhals.exceptions import ShapeError
 from narwhals.utils import _SeriesNamespace
 from narwhals.utils import import_dtypes_module
 from narwhals.utils import isinstance_or_issubclass
@@ -260,10 +261,9 @@ def align_series_full_broadcast(*series: ArrowSeries) -> Sequence[ArrowSeries]:
     if fast_path:
         return series
 
-    is_max_length_gt_1 = max_length > 1
     reshaped = []
-    for s, length in zip(series, lengths):
-        if is_max_length_gt_1 and length == 1:
+    for s in series:
+        if s._broadcast:
             value = s.native[0]
             if s._backend_version < (13,) and hasattr(value, "as_py"):
                 value = value.as_py()
@@ -271,6 +271,9 @@ def align_series_full_broadcast(*series: ArrowSeries) -> Sequence[ArrowSeries]:
                 s._from_native_series(pa.array([value] * max_length, type=s._type))
             )
         else:
+            if (actual_len := len(s)) != max_length:
+                msg = f"Expected object of length {max_length}, got {actual_len}."
+                raise ShapeError(msg)
             reshaped.append(s)
 
     return reshaped

--- a/narwhals/_compliant/series.py
+++ b/narwhals/_compliant/series.py
@@ -280,6 +280,19 @@ class EagerSeries(CompliantSeries[NativeSeriesT_co], Protocol[NativeSeriesT_co])
     def _from_scalar(self, value: Any) -> Self:
         return self.from_iterable([value], name=self.name, context=self)
 
+    def _from_native_series(
+        self, series: Any, *, preserve_broadcast: bool = False
+    ) -> Self:
+        """Return a new `CompliantSeries`, wrapping the native `series`.
+
+        In cases when operations are known to not affect whether a result should
+        be broadcast, we can pass `preverse_broadcast=True`.
+        Set this with care - it should only be set for unary expressions which don't
+        change length or order, such as `.alias` or `.fill_null`. If in doubt, don't
+        set it, you probably don't need it.
+        """
+        ...
+
     def __narwhals_namespace__(self) -> EagerNamespace[Any, Self, Any]: ...
 
     def _to_expr(self) -> EagerExpr[Any, Any]:

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -421,7 +421,7 @@ def apply_n_ary_operation(
     )
     kinds = [infer_kind(comparand, str_as_lit=str_as_lit) for comparand in comparands]
 
-    broadcast = any(kind.preserves_length() for kind in kinds)
+    broadcast = any(not kind.is_scalar_like() for kind in kinds)
     compliant_exprs = (
         compliant_expr.broadcast(kind)
         if broadcast and is_compliant_expr(compliant_expr) and is_scalar_like(kind)

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -292,7 +292,10 @@ class PandasLikeSeries(EagerSeries[Any]):
             backend_version=self._backend_version,
             version=self._version,
         )
-        return self._from_native_series(ser.astype(pd_dtype))
+        result = self._from_native_series(ser.astype(pd_dtype))
+        if self._broadcast:
+            result._broadcast = True
+        return result
 
     def item(self: Self, index: int | None) -> Any:
         # cuDF doesn't have Series.item().
@@ -555,7 +558,10 @@ class PandasLikeSeries(EagerSeries[Any]):
     # Transformations
 
     def is_null(self: Self) -> PandasLikeSeries:
-        return self._from_native_series(self._native_series.isna())
+        result = self._from_native_series(self._native_series.isna())
+        if self._broadcast:
+            result._broadcast = True
+        return result
 
     def is_nan(self: Self) -> PandasLikeSeries:
         ser = self._native_series

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -161,11 +161,6 @@ class PandasLikeSeries(EagerSeries[Any]):
     def _from_native_series(
         self: Self, series: Any, *, preserve_broadcast: bool = False
     ) -> Self:
-        # In cases when operations are known to not affect whether a result should
-        # be broadcast, we can pass `preverse_broadcast=True`.
-        # Set this with care - it should only be set for unary expressions which don't
-        # change length or order, such as `.alias` or `.fill_null`. If in doubt, don't
-        # set it, you probably don't need it.
         result = self.__class__(
             series,
             implementation=self._implementation,

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -15,6 +15,7 @@ import pandas as pd
 
 from narwhals.exceptions import ColumnNotFoundError
 from narwhals.exceptions import DuplicateError
+from narwhals.exceptions import ShapeError
 from narwhals.utils import Implementation
 from narwhals.utils import Version
 from narwhals.utils import import_dtypes_module
@@ -251,6 +252,11 @@ def set_index(
 
     We can set `copy` / `inplace` based on implementation/version.
     """
+    if isinstance(index, implementation.to_native_namespace().Index) and (
+        expected_len := len(index)
+    ) != (actual_len := len(obj)):
+        msg = f"Expected object of length {expected_len}, got length: {actual_len}"
+        raise ShapeError(msg)
     if implementation is Implementation.CUDF:  # pragma: no cover
         obj = obj.copy(deep=False)  # type: ignore[attr-defined]
         obj.index = index  # type: ignore[attr-defined]
@@ -613,10 +619,9 @@ def align_series_full_broadcast(
 
     idx = series[lengths.index(max_length)]._native_series.index
     reindexed = []
-    max_length_gt_1 = max_length > 1
-    for s, length in zip(series, lengths):
+    for s in series:
         s_native = s._native_series
-        if max_length_gt_1 and length == 1:
+        if s._broadcast:
             reindexed.append(
                 s._from_native_series(
                     native_namespace.Series(

--- a/tests/expr_and_series/mode_test.py
+++ b/tests/expr_and_series/mode_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import narwhals.stable.v1 as nw
+from narwhals.exceptions import ShapeError
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -12,25 +13,21 @@ data = {
 }
 
 
-def test_mode_single_expr(
-    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
-) -> None:
-    if "pyarrow_table" in str(constructor_eager):
-        # TODO(unassigned): reimplement mode for pyarrow
-        request.applymarker(pytest.mark.xfail)
+def test_mode_single_expr(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data))
     result = df.select(nw.col("a").mode()).sort("a")
     expected = {"a": [1, 2]}
     assert_equal_data(result, expected)
 
 
-def test_mode_series(
-    constructor_eager: ConstructorEager, request: pytest.FixtureRequest
-) -> None:
-    if "pyarrow_table" in str(constructor_eager):
-        # TODO(unassigned): reimplement mode for pyarrow
-        request.applymarker(pytest.mark.xfail)
+def test_mode_series(constructor_eager: ConstructorEager) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)["a"]
     result = series.mode().sort()
     expected = {"a": [1, 2]}
     assert_equal_data({"a": result}, expected)
+
+
+def test_mode_different_lengths(constructor_eager: ConstructorEager) -> None:
+    df = nw.from_native(constructor_eager({"a": [1, 1, 2], "b": [4, 5, 6]}))
+    with pytest.raises(ShapeError):
+        df.select(nw.col("a", "b").mode())

--- a/tests/expr_and_series/mode_test.py
+++ b/tests/expr_and_series/mode_test.py
@@ -4,6 +4,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from narwhals.exceptions import ShapeError
+from tests.utils import POLARS_VERSION
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -28,6 +29,8 @@ def test_mode_series(constructor_eager: ConstructorEager) -> None:
 
 
 def test_mode_different_lengths(constructor_eager: ConstructorEager) -> None:
+    if "polars" in str(constructor_eager) and POLARS_VERSION < (1, 10):
+        pytest.skip()
     df = nw.from_native(constructor_eager({"a": [1, 1, 2], "b": [4, 5, 6]}))
     with pytest.raises(ShapeError):
         df.select(nw.col("a", "b").mode())


### PR DESCRIPTION
closes #2273

This is definitely not THE solution, we need to find a better way of preserving the `_broadcast` attribute in some cases

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
