### PR TITLE
feat(sqlframe): Allow options in `scan_parquet` function

### DIFF
--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -22,6 +22,7 @@ from narwhals._expression_parsing import combine_metadata_horizontal_op
 from narwhals._expression_parsing import extract_compliant
 from narwhals._expression_parsing import infer_kind
 from narwhals._expression_parsing import is_scalar_like
+from narwhals.dependencies import get_sqlframe
 from narwhals.dependencies import is_numpy_array
 from narwhals.dependencies import is_numpy_array_2d
 from narwhals.expr import Expr
@@ -1138,12 +1139,14 @@ def _scan_parquet_impl(
         if (session := kwargs.pop("session", None)) is None:
             msg = "Spark like backends require a session object to be passed in `kwargs`."
             raise ValueError(msg)
-
         native_frame = (
             session.read.format("parquet").load(source)
             # passing `options` currently not possible in SQLFrame: see
             # https://github.com/eakmanrq/sqlframe/issues/341
-            if implementation is Implementation.SQLFRAME
+            if (
+                implementation is Implementation.SQLFRAME
+                and (parse_version(get_sqlframe()._version)) < (3, 27, 0)
+            )
             else session.read.format("parquet").options(**kwargs).load(source)
         )
 

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import platform
 import sys
+from importlib.metadata import version
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterable
@@ -22,7 +23,6 @@ from narwhals._expression_parsing import combine_metadata_horizontal_op
 from narwhals._expression_parsing import extract_compliant
 from narwhals._expression_parsing import infer_kind
 from narwhals._expression_parsing import is_scalar_like
-from narwhals.dependencies import get_sqlframe
 from narwhals.dependencies import is_numpy_array
 from narwhals.dependencies import is_numpy_array_2d
 from narwhals.expr import Expr
@@ -1141,11 +1141,9 @@ def _scan_parquet_impl(
             raise ValueError(msg)
         native_frame = (
             session.read.format("parquet").load(source)
-            # passing `options` currently not possible in SQLFrame: see
-            # https://github.com/eakmanrq/sqlframe/issues/341
             if (
                 implementation is Implementation.SQLFRAME
-                and (parse_version(get_sqlframe()._version)) < (3, 27, 0)
+                and (parse_version(version("sqlframe"))) < (3, 27, 0)
             )
             else session.read.format("parquet").options(**kwargs).load(source)
         )

--- a/tests/expr_and_series/cum_prod_test.py
+++ b/tests/expr_and_series/cum_prod_test.py
@@ -88,9 +88,6 @@ def test_lazy_cum_prod_grouped(
     if "cudf" in str(constructor):
         # https://github.com/rapidsai/cudf/issues/18159
         request.applymarker(pytest.mark.xfail)
-    if "sqlframe" in str(constructor):
-        # https://github.com/eakmanrq/sqlframe/issues/348
-        request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(
         constructor(

--- a/tests/read_scan_test.py
+++ b/tests/read_scan_test.py
@@ -158,7 +158,7 @@ def test_scan_parquet(
     if "sqlframe" in str(constructor):
         from sqlframe.duckdb import DuckDBSession
 
-        kwargs = {"session": DuckDBSession()}
+        kwargs = {"session": DuckDBSession(), "inferSchema": True}
     elif "pyspark" in str(constructor):
         from pyspark.sql import SparkSession
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

[SQLFrame#349](https://github.com/eakmanrq/sqlframe/pull/349) added support to pass options in reader and there is already a release out 🙌🏼

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
