### PR TITLE
test: ensure `expected` data has every column of the`result` data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ If you want to run PySpark-related tests, you'll need to have Java installed. Re
 
 2. Install Narwhals: `uv pip install -e . --group local-dev"`. This will include fast-ish core libraries and dev dependencies.
    If you also want to test other libraries like Dask , PySpark, and Modin, you can install them too with
-   `uv pip install -e ".[dask, pyspark, modin]" --group local-dev"`.
+   `uv pip install -e ".[dask, pyspark, modin]" --group local-dev`.
 
 You should also install pre-commit:
 

--- a/tests/expr_and_series/cum_count_test.py
+++ b/tests/expr_and_series/cum_count_test.py
@@ -84,5 +84,10 @@ def test_lazy_cum_count_grouped(
     result = df.with_columns(
         nw.col("arg entina").cum_count(reverse=reverse).over("g", order_by="ban gkock")
     ).sort("i ran")
-    expected = {"arg entina": expected_a, "ban gkock": [1, 0, 2], "i ran": [0, 1, 2]}
+    expected = {
+        "arg entina": expected_a,
+        "ban gkock": [1, 0, 2],
+        "i ran": [0, 1, 2],
+        "g": [1, 1, 1],
+    }
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/cum_count_test.py
+++ b/tests/expr_and_series/cum_count_test.py
@@ -75,18 +75,18 @@ def test_lazy_cum_count_grouped(
         constructor(
             {
                 "arg entina": [None, 2, 3],
-                "ban gkock": [1, 0, 2],
+                "ban gkok": [1, 0, 2],
                 "i ran": [0, 1, 2],
                 "g": [1, 1, 1],
             }
         )
     )
     result = df.with_columns(
-        nw.col("arg entina").cum_count(reverse=reverse).over("g", order_by="ban gkock")
+        nw.col("arg entina").cum_count(reverse=reverse).over("g", order_by="ban gkok")
     ).sort("i ran")
     expected = {
         "arg entina": expected_a,
-        "ban gkock": [1, 0, 2],
+        "ban gkok": [1, 0, 2],
         "i ran": [0, 1, 2],
         "g": [1, 1, 1],
     }

--- a/tests/expr_and_series/cum_max_test.py
+++ b/tests/expr_and_series/cum_max_test.py
@@ -83,7 +83,7 @@ def test_lazy_cum_max_grouped(
     result = df.with_columns(
         nw.col("a").cum_max(reverse=reverse).over("g", order_by="b")
     ).sort("i")
-    expected = {"a": expected_a, "b": [1, 0, 2], "i": [0, 1, 2]}
+    expected = {"a": expected_a, "b": [1, 0, 2], "i": [0, 1, 2], "g": [1, 1, 1]}
     assert_equal_data(result, expected)
 
 
@@ -134,6 +134,7 @@ def test_lazy_cum_max_ordered_by_nulls(
         "a": expected_a,
         "b": [1, -1, 3, 2, 5, 0, None],
         "i": [0, 1, 2, 3, 4, 5, 6],
+        "g": [1, 1, 1, 1, 1, 1, 1],
     }
     assert_equal_data(result, expected)
 

--- a/tests/expr_and_series/cum_min_test.py
+++ b/tests/expr_and_series/cum_min_test.py
@@ -83,7 +83,7 @@ def test_lazy_cum_min_grouped(
     result = df.with_columns(
         nw.col("a").cum_min(reverse=reverse).over("g", order_by="b")
     ).sort("i")
-    expected = {"a": expected_a, "b": [1, 0, 2], "i": [0, 1, 2]}
+    expected = {"a": expected_a, "b": [1, 0, 2], "i": [0, 1, 2], "g": [1, 1, 1]}
     assert_equal_data(result, expected)
 
 
@@ -134,6 +134,7 @@ def test_lazy_cum_min_ordered_by_nulls(
         "a": expected_a,
         "b": [1, -1, 3, 2, 5, 0, None],
         "i": [0, 1, 2, 3, 4, 5, 6],
+        "g": [1, 1, 1, 1, 1, 1, 1],
     }
     assert_equal_data(result, expected)
 

--- a/tests/expr_and_series/cum_prod_test.py
+++ b/tests/expr_and_series/cum_prod_test.py
@@ -88,9 +88,6 @@ def test_lazy_cum_prod_grouped(
     if "cudf" in str(constructor):
         # https://github.com/rapidsai/cudf/issues/18159
         request.applymarker(pytest.mark.xfail)
-    if "sqlframe" in str(constructor):
-        # https://github.com/eakmanrq/sqlframe/issues/348
-        request.applymarker(pytest.mark.xfail)
 
     df = nw.from_native(
         constructor(

--- a/tests/expr_and_series/cum_prod_test.py
+++ b/tests/expr_and_series/cum_prod_test.py
@@ -105,5 +105,10 @@ def test_lazy_cum_prod_grouped(
     result = df.with_columns(
         nw.col("arg entina").cum_prod(reverse=reverse).over("g", order_by="ban gkock")
     ).sort("i ran")
-    expected = {"arg entina": expected_a, "ban gkock": [1, 0, 2], "i ran": [0, 1, 2]}
+    expected = {
+        "arg entina": expected_a,
+        "ban gkock": [1, 0, 2],
+        "i ran": [0, 1, 2],
+        "g": [1, 1, 1],
+    }
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/cum_prod_test.py
+++ b/tests/expr_and_series/cum_prod_test.py
@@ -96,18 +96,18 @@ def test_lazy_cum_prod_grouped(
         constructor(
             {
                 "arg entina": [1, 2, 3],
-                "ban gkock": [1, 0, 2],
+                "ban gkok": [1, 0, 2],
                 "i ran": [0, 1, 2],
                 "g": [1, 1, 1],
             }
         )
     )
     result = df.with_columns(
-        nw.col("arg entina").cum_prod(reverse=reverse).over("g", order_by="ban gkock")
+        nw.col("arg entina").cum_prod(reverse=reverse).over("g", order_by="ban gkok")
     ).sort("i ran")
     expected = {
         "arg entina": expected_a,
-        "ban gkock": [1, 0, 2],
+        "ban gkok": [1, 0, 2],
         "i ran": [0, 1, 2],
         "g": [1, 1, 1],
     }

--- a/tests/expr_and_series/cum_sum_test.py
+++ b/tests/expr_and_series/cum_sum_test.py
@@ -62,18 +62,18 @@ def test_lazy_cum_sum_grouped(
         constructor(
             {
                 "arg entina": [1, 2, 3],
-                "ban gkock": [1, 0, 2],
+                "ban gkok": [1, 0, 2],
                 "i ran": [0, 1, 2],
                 "g": [1, 1, 1],
             }
         )
     )
     result = df.with_columns(
-        nw.col("arg entina").cum_sum(reverse=reverse).over("g", order_by="ban gkock")
+        nw.col("arg entina").cum_sum(reverse=reverse).over("g", order_by="ban gkok")
     ).sort("i ran")
     expected = {
         "arg entina": expected_a,
-        "ban gkock": [1, 0, 2],
+        "ban gkok": [1, 0, 2],
         "i ran": [0, 1, 2],
         "g": [1, 1, 1],
     }
@@ -115,18 +115,18 @@ def test_lazy_cum_sum_ordered_by_nulls(
         constructor(
             {
                 "arg entina": [1, 2, 3, 1, 2, 3, 4],
-                "ban gkock": [1, -1, 3, 2, 5, 0, None],
+                "ban gkok": [1, -1, 3, 2, 5, 0, None],
                 "i ran": [0, 1, 2, 3, 4, 5, 6],
                 "g": [1, 1, 1, 1, 1, 1, 1],
             }
         )
     )
     result = df.with_columns(
-        nw.col("arg entina").cum_sum(reverse=reverse).over("g", order_by="ban gkock")
+        nw.col("arg entina").cum_sum(reverse=reverse).over("g", order_by="ban gkok")
     ).sort("i ran")
     expected = {
         "arg entina": expected_a,
-        "ban gkock": [1, -1, 3, 2, 5, 0, None],
+        "ban gkok": [1, -1, 3, 2, 5, 0, None],
         "i ran": [0, 1, 2, 3, 4, 5, 6],
         "g": [1, 1, 1, 1, 1, 1, 1],
     }
@@ -162,15 +162,15 @@ def test_lazy_cum_sum_ungrouped(
         constructor(
             {
                 "arg entina": [2, 3, 1],
-                "ban gkock": [0, 2, 1],
+                "ban gkok": [0, 2, 1],
                 "i ran": [1, 2, 0],
             }
         )
     ).sort("i ran")
     result = df.with_columns(
-        nw.col("arg entina").cum_sum(reverse=reverse).over(order_by="ban gkock")
+        nw.col("arg entina").cum_sum(reverse=reverse).over(order_by="ban gkok")
     ).sort("i ran")
-    expected = {"arg entina": expected_a, "ban gkock": [1, 0, 2], "i ran": [0, 1, 2]}
+    expected = {"arg entina": expected_a, "ban gkok": [1, 0, 2], "i ran": [0, 1, 2]}
     assert_equal_data(result, expected)
 
 
@@ -203,17 +203,17 @@ def test_lazy_cum_sum_ungrouped_ordered_by_nulls(
         constructor(
             {
                 "arg entina": [1, 2, 3, 1, 2, 3, 4],
-                "ban gkock": [1, -1, 3, 2, 5, 0, None],
+                "ban gkok": [1, -1, 3, 2, 5, 0, None],
                 "i ran": [0, 1, 2, 3, 4, 5, 6],
             }
         )
     ).sort("i ran")
     result = df.with_columns(
-        nw.col("arg entina").cum_sum(reverse=reverse).over(order_by="ban gkock")
+        nw.col("arg entina").cum_sum(reverse=reverse).over(order_by="ban gkok")
     ).sort("i ran")
     expected = {
         "arg entina": expected_a,
-        "ban gkock": [1, -1, 3, 2, 5, 0, None],
+        "ban gkok": [1, -1, 3, 2, 5, 0, None],
         "i ran": [0, 1, 2, 3, 4, 5, 6],
     }
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/cum_sum_test.py
+++ b/tests/expr_and_series/cum_sum_test.py
@@ -71,7 +71,12 @@ def test_lazy_cum_sum_grouped(
     result = df.with_columns(
         nw.col("arg entina").cum_sum(reverse=reverse).over("g", order_by="ban gkock")
     ).sort("i ran")
-    expected = {"arg entina": expected_a, "ban gkock": [1, 0, 2], "i ran": [0, 1, 2]}
+    expected = {
+        "arg entina": expected_a,
+        "ban gkock": [1, 0, 2],
+        "i ran": [0, 1, 2],
+        "g": [1, 1, 1],
+    }
     assert_equal_data(result, expected)
 
 
@@ -123,6 +128,7 @@ def test_lazy_cum_sum_ordered_by_nulls(
         "arg entina": expected_a,
         "ban gkock": [1, -1, 3, 2, 5, 0, None],
         "i ran": [0, 1, 2, 3, 4, 5, 6],
+        "g": [1, 1, 1, 1, 1, 1, 1],
     }
     assert_equal_data(result, expected)
 

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -90,8 +90,8 @@ def test_over_multiple(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     expected = {
         "a": ["a", "a", "b", "b", "b"],
-        "b": [1, 2, 3, 3, 5],
-        "c": [5, 4, 3, 1, 2],
+        "b": [1, 2, 3, 5, 3],
+        "c": [5, 4, 3, 2, 1],
         "i": list(range(5)),
         "c_min": [5, 4, 1, 2, 1],
     }

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -93,7 +93,7 @@ def test_over_multiple(constructor: Constructor) -> None:
         "b": [1, 2, 3, 3, 5],
         "c": [5, 4, 3, 1, 2],
         "i": list(range(5)),
-        "c_min": [5, 4, 1, 1, 2],
+        "c_min": [5, 4, 1, 2, 1],
     }
 
     result = df.with_columns(c_min=nw.col("c").min().over("a", "b")).sort("i")

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -92,14 +92,9 @@ def test_over_multiple(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     expected = {
         "a": ["a", "a", "b", "b", "b"],
-        "b": [1, 2, 3, 3, 5],
-        "c": [5, 4, 3, 1, 2],
-        "c_min": [5, 4, 1, 1, 2],
-    }
-    expected = {
-        "a": ["a", "a", "b", "b", "b"],
         "b": [1, 2, 3, 5, 3],
         "c": [5, 4, 3, 2, 1],
+        "c_min": [5, 4, 1, 2, 1],
     }
 
     result = df.with_columns(c_min=nw.col("c").min().over("a", "b")).sort("i").drop("i")


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other


## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

I noticed that some `expected` dicts didn't have the whole data. Not sure if it was intentional but I think it is safer this way. If we don't want certain columns to be checked we could still `drop` them before the assert.

What do you think?