### PR TITLE
ci: Remove `sqlframe` pin from `--group typing`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ typing = [
   "mypy~=1.15.0",
   "pyright",
   "pyarrow-stubs==17.18",
-  "sqlframe==3.24.1",
+  "sqlframe",
   "polars==1.25.2",
   "uv",
 ]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- Fixes https://github.com/narwhals-dev/narwhals/pull/2296#issuecomment-2754336489
- #2286

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
No longer getting the failures from missing `product` in `sqlframe`