### PR TITLE
perf: Avoid unnecessary calls in `Expr.clip` method

### DIFF
--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -806,20 +806,20 @@ class ArrowSeries(EagerSeries["ArrowChunkedArray"]):
     def clip(
         self: Self, lower_bound: Self | Any | None, upper_bound: Self | Any | None
     ) -> Self:
-        _, lower_bound_native = extract_native(self, lower_bound)
-        _, upper_bound_native = extract_native(self, upper_bound)
+        _, lower_bound = (
+            extract_native(self, lower_bound) if lower_bound else (None, None)
+        )
+        _, upper_bound = (
+            extract_native(self, upper_bound) if upper_bound else (None, None)
+        )
 
         if lower_bound is None:
-            return self._from_native_series(
-                pc.min_element_wise(self.native, upper_bound_native)
-            )
+            return self._from_native_series(pc.min_element_wise(self.native, upper_bound))
         if upper_bound is None:
-            return self._from_native_series(
-                pc.max_element_wise(self.native, lower_bound_native)
-            )
+            return self._from_native_series(pc.max_element_wise(self.native, lower_bound))
         return self._from_native_series(
             pc.max_element_wise(
-                pc.min_element_wise(self.native, upper_bound_native), lower_bound_native
+                pc.min_element_wise(self.native, upper_bound), lower_bound
             )
         )
 

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -232,7 +232,7 @@ def extract_native(
     from narwhals._arrow.dataframe import ArrowDataFrame
     from narwhals._arrow.series import ArrowSeries
 
-    if rhs is None:
+    if rhs is None:  # pragma: no cover
         return lhs.native, lit(None, type=lhs._type)
 
     if isinstance(rhs, ArrowDataFrame):

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -368,14 +368,26 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "duckdb.Expression"]):
         return self._from_call(func)
 
     def clip(self: Self, lower_bound: Any, upper_bound: Any) -> Self:
-        def func(
+        def _clip_lower(_input: duckdb.Expression, lower_bound: Any) -> duckdb.Expression:
+            return FunctionExpression("greatest", _input, lower_bound)
+
+        def _clip_upper(_input: duckdb.Expression, upper_bound: Any) -> duckdb.Expression:
+            return FunctionExpression("least", _input, upper_bound)
+
+        def _clip_both(
             _input: duckdb.Expression, lower_bound: Any, upper_bound: Any
         ) -> duckdb.Expression:
             return FunctionExpression(
                 "greatest", FunctionExpression("least", _input, upper_bound), lower_bound
             )
 
-        return self._from_call(func, lower_bound=lower_bound, upper_bound=upper_bound)
+        if lower_bound is None:
+            return self._from_call(_clip_upper, upper_bound=upper_bound)
+        if upper_bound is None:
+            return self._from_call(_clip_lower, lower_bound=lower_bound)
+        return self._from_call(
+            _clip_both, lower_bound=lower_bound, upper_bound=upper_bound
+        )
 
     def sum(self: Self) -> Self:
         return self._from_call(lambda _input: FunctionExpression("sum", _input))

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -839,8 +839,12 @@ class PandasLikeSeries(EagerSeries[Any]):
     def clip(
         self: Self, lower_bound: Self | Any | None, upper_bound: Self | Any | None
     ) -> Self:
-        _, lower_bound = align_and_extract_native(self, lower_bound)
-        _, upper_bound = align_and_extract_native(self, upper_bound)
+        _, lower_bound = (
+            align_and_extract_native(self, lower_bound) if lower_bound else (None, None)
+        )
+        _, upper_bound = (
+            align_and_extract_native(self, upper_bound) if upper_bound else (None, None)
+        )
         kwargs = {"axis": 0} if self._implementation is Implementation.MODIN else {}
         return self._from_native_series(
             self.native.clip(lower_bound, upper_bound, **kwargs)

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -454,9 +454,11 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         def _clip_both(
             _input: Column, lower_bound: Column, upper_bound: Column
         ) -> Column:
-            result = _input
-            result = self._F.when(result < lower_bound, lower_bound).otherwise(result)
-            return self._F.when(result > upper_bound, upper_bound).otherwise(result)
+            return (
+                self._F.when(_input < lower_bound, lower_bound)
+                .when(_input > upper_bound, upper_bound)
+                .otherwise(_input)
+            )
 
         if lower_bound is None:
             return self._from_call(_clip_upper, upper_bound=upper_bound)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #2201

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
