### PR TITLE
fix: change rank ExprKind to transform

### DIFF
--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -713,8 +713,8 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "duckdb.Expression"]):
                 by_sql = f"{_input} asc nulls last"
             order_by_sql = f"order by {by_sql}"
             sql = (
-                f"CASE WHEN {_input} IS NULL THEN NULL "
-                f"ELSE {func_name}() OVER ({order_by_sql}) END"
+                f"CASE WHEN {_input} IS NOT NULL THEN {func_name}() "
+                f"OVER ({order_by_sql}) END"
             )
             return SQLExpression(sql)
 

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -2543,11 +2543,10 @@ class Expr:
             )
             raise ValueError(msg)
 
-        return self.__class__(
+        return self._with_callable(
             lambda plx: self._to_compliant_expr(plx).rank(
                 method=method, descending=descending
-            ),
-            self._metadata.with_kind_and_extra_open_window(ExprKind.WINDOW),
+            )
         )
 
     @property

--- a/tests/expression_parsing_test.py
+++ b/tests/expression_parsing_test.py
@@ -27,3 +27,5 @@ def test_has_open_windows(expr: nw.Expr, expected: int) -> None:
 def test_misleading_order_by() -> None:
     with pytest.raises(InvalidOperationError):
         nw.col("a").mean().over(order_by="b")
+    with pytest.raises(InvalidOperationError):
+        nw.col("a").rank().over(order_by="b")


### PR DESCRIPTION
`rank` shouldn't have been classed as "window function"

it doesn't depend on the physical order of the data

in fact, it's forbidden to call `rank` with `over(order_by=...)`

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
