### PR TITLE
chore: use Python API more in DuckDB

### DIFF
--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -317,15 +317,14 @@ class DuckDBLazyFrame(CompliantLazyFrame["DuckDBExpr", "duckdb.DuckDBPyRelation"
             ):
                 select.append(f'rhs."{col}" as "{col}{suffix}"')
             elif right_on is None or col not in {right_on, *by_right}:
-                select.append(col)
+                select.append(f'"{col}"')
         query = f"""
             SELECT {",".join(select)}
             FROM lhs
             ASOF LEFT JOIN rhs
             ON {condition}
             """  # noqa: S608
-        res = duckdb.sql(query)
-        return self._with_native(res)
+        return self._with_native(duckdb.sql(query))
 
     def collect_schema(self: Self) -> dict[str, DType]:
         return {

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -9,7 +9,6 @@ from typing import Literal
 from typing import Sequence
 from typing import cast
 
-from duckdb import CaseExpression
 from duckdb import CoalesceOperator
 from duckdb import ColumnExpression
 from duckdb import FunctionExpression
@@ -25,6 +24,7 @@ from narwhals._duckdb.utils import generate_order_by_sql
 from narwhals._duckdb.utils import generate_partition_by_sql
 from narwhals._duckdb.utils import lit
 from narwhals._duckdb.utils import narwhals_to_native_dtype
+from narwhals._duckdb.utils import when
 from narwhals._expression_parsing import ExprKind
 from narwhals.utils import Implementation
 from narwhals.utils import not_implemented
@@ -360,16 +360,15 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "duckdb.Expression"]):
     def skew(self: Self) -> Self:
         def func(_input: duckdb.Expression) -> duckdb.Expression:
             count = FunctionExpression("count", _input)
-            return CaseExpression(condition=(count == lit(0)), value=lit(None)).otherwise(
-                CaseExpression(
-                    condition=(count == lit(1)), value=lit(float("nan"))
-                ).otherwise(
-                    CaseExpression(condition=(count == lit(2)), value=lit(0.0)).otherwise(
-                        # Adjust population skewness by correction factor to get sample skewness
-                        FunctionExpression("skewness", _input)
-                        * (count - lit(2))
-                        / FunctionExpression("sqrt", count * (count - lit(1)))
-                    )
+            # Adjust population skewness by correction factor to get sample skewness
+            sample_skewness = (
+                FunctionExpression("skewness", _input)
+                * (count - lit(2))
+                / FunctionExpression("sqrt", count * (count - lit(1)))
+            )
+            return when(count == lit(0), lit(None)).otherwise(
+                when(count == lit(1), lit(float("nan"))).otherwise(
+                    when(count == lit(2), lit(0.0)).otherwise(sample_skewness)
                 )
             )
 
@@ -429,9 +428,7 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "duckdb.Expression"]):
                 "array_unique", FunctionExpression("array_agg", _input)
             ) + FunctionExpression(
                 "max",
-                CaseExpression(condition=_input.isnotnull(), value=lit(0)).otherwise(
-                    lit(1)
-                ),
+                when(_input.isnotnull(), lit(0)).otherwise(lit(1)),
             )
 
         return self._with_callable(func)
@@ -712,7 +709,7 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "duckdb.Expression"]):
             else:
                 by_sql = f"{_input} asc nulls last"
             sql = f"{func_name}() OVER (order by {by_sql})"
-            return CaseExpression(_input.isnotnull(), SQLExpression(sql))
+            return when(_input.isnotnull(), SQLExpression(sql))
 
         return self._with_callable(_rank)
 

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -427,8 +427,7 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "duckdb.Expression"]):
             return FunctionExpression(
                 "array_unique", FunctionExpression("array_agg", _input)
             ) + FunctionExpression(
-                "max",
-                when(_input.isnotnull(), lit(0)).otherwise(lit(1)),
+                "max", when(_input.isnotnull(), lit(0)).otherwise(lit(1))
             )
 
         return self._with_callable(func)


### PR DESCRIPTION
If we use the Python  API more, we can get more validation (and possibly safety from injections?) than if we use hand-written sql

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
