### PR TITLE
ci: fixup cudf test failures, support rolling_std/rolling_var/rolling_mean for pandas in grouped context

### DIFF
--- a/narwhals/_compliant/expr.py
+++ b/narwhals/_compliant/expr.py
@@ -775,9 +775,7 @@ class EagerExpr(
     def is_finite(self) -> Self:
         return self._reuse_series("is_finite")
 
-    def rolling_mean(
-        self, window_size: int, *, min_samples: int | None, center: bool
-    ) -> Self:
+    def rolling_mean(self, window_size: int, *, min_samples: int, center: bool) -> Self:
         return self._reuse_series(
             "rolling_mean",
             window_size=window_size,
@@ -786,7 +784,7 @@ class EagerExpr(
         )
 
     def rolling_std(
-        self, window_size: int, *, min_samples: int | None, center: bool, ddof: int
+        self, window_size: int, *, min_samples: int, center: bool, ddof: int
     ) -> Self:
         return self._reuse_series(
             "rolling_std",
@@ -802,7 +800,7 @@ class EagerExpr(
         )
 
     def rolling_var(
-        self, window_size: int, *, min_samples: int | None, center: bool, ddof: int
+        self, window_size: int, *, min_samples: int, center: bool, ddof: int
     ) -> Self:
         return self._reuse_series(
             "rolling_var",

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -33,6 +33,9 @@ WINDOW_FUNCTIONS_TO_PANDAS_EQUIVALENT = {
     # So, instead of using "cumcount" we use "cumsum" on notna() to get the same result
     "cum_count": "cumsum",
     "rolling_sum": "sum",
+    "rolling_mean": "mean",
+    "rolling_std": "std",
+    "rolling_var": "var",
     "shift": "shift",
     "rank": "rank",
     "diff": "diff",
@@ -265,7 +268,12 @@ class PandasLikeExpr(EagerExpr["PandasLikeDataFrame", PandasLikeSeries]):
                         list(output_names)
                     ].rolling(**pandas_kwargs)
                     assert pandas_function_name is not None  # help mypy  # noqa: S101
-                    res_native = getattr(rolling, pandas_function_name)()
+                    if pandas_function_name in {"std", "var"}:
+                        res_native = getattr(rolling, pandas_function_name)(
+                            ddof=self._call_kwargs["ddof"]
+                        )
+                    else:
+                        res_native = getattr(rolling, pandas_function_name)()
                 else:
                     res_native = df._native_frame.groupby(partition_by)[
                         list(output_names)
@@ -314,6 +322,44 @@ class PandasLikeExpr(EagerExpr["PandasLikeDataFrame", PandasLikeSeries]):
                 "window_size": window_size,
                 "min_samples": min_samples,
                 "center": center,
+            },
+        )
+
+    def rolling_mean(
+        self: Self, window_size: int, *, min_samples: int, center: bool
+    ) -> Self:
+        return self._reuse_series(
+            "rolling_mean",
+            call_kwargs={
+                "window_size": window_size,
+                "min_samples": min_samples,
+                "center": center,
+            },
+        )
+
+    def rolling_std(
+        self: Self, window_size: int, *, min_samples: int, center: bool, ddof: int
+    ) -> Self:
+        return self._reuse_series(
+            "rolling_std",
+            call_kwargs={
+                "window_size": window_size,
+                "min_samples": min_samples,
+                "center": center,
+                "ddof": ddof,
+            },
+        )
+
+    def rolling_var(
+        self: Self, window_size: int, *, min_samples: int, center: bool, ddof: int
+    ) -> Self:
+        return self._reuse_series(
+            "rolling_var",
+            call_kwargs={
+                "window_size": window_size,
+                "min_samples": min_samples,
+                "center": center,
+                "ddof": ddof,
             },
         )
 

--- a/tests/expr_and_series/rolling_std_test.py
+++ b/tests/expr_and_series/rolling_std_test.py
@@ -7,6 +7,7 @@ import pytest
 
 import narwhals.stable.v1 as nw
 from tests.utils import DUCKDB_VERSION
+from tests.utils import PANDAS_VERSION
 from tests.utils import POLARS_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
@@ -319,8 +320,10 @@ def test_rolling_std_expr_lazy_grouped(
     center: bool,
     ddof: int,
 ) -> None:
-    if ("polars" in str(constructor) and POLARS_VERSION < (1, 10)) or (
-        "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3)
+    if (
+        ("polars" in str(constructor) and POLARS_VERSION < (1, 10))
+        or ("duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3))
+        or ("pandas" in str(constructor) and PANDAS_VERSION < (1, 2))
     ):
         pytest.skip()
     if any(x in str(constructor) for x in ("dask", "pyarrow_table")):

--- a/tests/expr_and_series/rolling_std_test.py
+++ b/tests/expr_and_series/rolling_std_test.py
@@ -323,8 +323,6 @@ def test_rolling_std_expr_lazy_grouped(
         "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3)
     ):
         pytest.skip()
-    if "pandas" in str(constructor):
-        pytest.skip()
     if any(x in str(constructor) for x in ("dask", "pyarrow_table")):
         request.applymarker(pytest.mark.xfail)
     if "cudf" in str(constructor) and center:

--- a/tests/expr_and_series/rolling_var_test.py
+++ b/tests/expr_and_series/rolling_var_test.py
@@ -285,8 +285,6 @@ def test_rolling_var_expr_lazy_grouped(
         "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3)
     ):
         pytest.skip()
-    if "pandas" in str(constructor):
-        pytest.skip()
     if any(x in str(constructor) for x in ("dask", "pyarrow_table")):
         request.applymarker(pytest.mark.xfail)
     if "cudf" in str(constructor) and center:

--- a/tests/expr_and_series/rolling_var_test.py
+++ b/tests/expr_and_series/rolling_var_test.py
@@ -281,8 +281,10 @@ def test_rolling_var_expr_lazy_grouped(
     center: bool,
     ddof: int,
 ) -> None:
-    if ("polars" in str(constructor) and POLARS_VERSION < (1, 10)) or (
-        "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3)
+    if (
+        ("polars" in str(constructor) and POLARS_VERSION < (1, 10))
+        or ("duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3))
+        or ("pandas" in str(constructor) and PANDAS_VERSION < (1, 2))
     ):
         pytest.skip()
     if any(x in str(constructor) for x in ("dask", "pyarrow_table")):


### PR DESCRIPTION
closes #2320 

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
