### PR TITLE
fix: unpivot was unnecessary failing for PySpark/SQLFrame when neither `on` nor `index` were passed

### DIFF
--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -495,7 +495,7 @@ class SparkLikeLazyFrame(CompliantLazyFrame["SparkLikeExpr", "SQLFrameDataFrame"
         else:  # pragma: no cover
             pass
 
-        ids = () if index is None else tuple(index)
+        ids = tuple(index) if index else ()
         values = (
             tuple(set(self.columns).difference(set(ids))) if on is None else tuple(on)
         )

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -495,7 +495,7 @@ class SparkLikeLazyFrame(CompliantLazyFrame["SparkLikeExpr", "SQLFrameDataFrame"
         else:  # pragma: no cover
             pass
 
-        ids = tuple(self.columns) if index is None else tuple(index)
+        ids = () if index is None else tuple(index)
         values = (
             tuple(set(self.columns).difference(set(ids))) if on is None else tuple(on)
         )

--- a/tests/frame/unpivot_test.py
+++ b/tests/frame/unpivot_test.py
@@ -15,25 +15,25 @@ if TYPE_CHECKING:
     from narwhals.stable.v1.dtypes import DType
 
 data = {
-    "a": ["x", "y", "z"],
+    "a": [7, 8, 9],
     "b": [1, 3, 5],
     "c": [2, 4, 6],
 }
 
 expected_on_b_idx_a = {
-    "a": ["x", "y", "z"],
+    "a": [7, 8, 9],
     "variable": ["b", "b", "b"],
     "value": [1, 3, 5],
 }
 
 expected_on_b_c_idx_a = {
-    "a": ["x", "y", "z", "x", "y", "z"],
+    "a": [7, 8, 9, 7, 8, 9],
     "variable": ["b", "b", "b", "c", "c", "c"],
     "value": [1, 3, 5, 2, 4, 6],
 }
 
 expected_on_none_idx_a = {
-    "a": ["x", "y", "z", "x", "y", "z"],
+    "a": [7, 8, 9, 7, 8, 9],
     "variable": ["b", "b", "b", "c", "c", "c"],
     "value": [1, 3, 5, 2, 4, 6],
 }
@@ -45,7 +45,7 @@ expected_on_b_c_idx_none = {
 
 expected_on_none_idx_none = {
     "variable": ["a", "a", "a", "b", "b", "b", "c", "c", "c"],
-    "value": ["x", "y", "z", "1", "3", "5", "2", "4", "6"],
+    "value": [7, 8, 9, 1, 3, 5, 2, 4, 6],
 }
 
 
@@ -64,11 +64,7 @@ def test_unpivot(
     on: str | list[str] | None,
     index: list[str] | None,
     expected: dict[str, list[float]],
-    request: pytest.FixtureRequest,
 ) -> None:
-    if on is None and index is None and "polars" not in str(constructor):
-        # TODO(2082): add support in other backends
-        request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     sort_columns = ["variable"] if index is None else ["variable", "a"]
     result = df.unpivot(on=on, index=index).sort(by=sort_columns)


### PR DESCRIPTION


<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
