### PR TITLE
test(typing): Narrow  `Constructor`, `ConstructorEager` aliases

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,13 +17,15 @@ import pyarrow as pa
 
 import narwhals as nw
 from narwhals.translate import from_native
-from narwhals.typing import IntoDataFrame
-from narwhals.typing import IntoFrame
 from narwhals.utils import Implementation
 from narwhals.utils import parse_version
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
+
+    from narwhals.typing import DataFrameLike
+    from narwhals.typing import NativeFrame
+    from narwhals.typing import NativeLazyFrame
 
 
 def get_module_version_as_tuple(module_name: str) -> tuple[int, ...]:
@@ -42,8 +44,8 @@ DASK_VERSION: tuple[int, ...] = get_module_version_as_tuple("dask")
 PYARROW_VERSION: tuple[int, ...] = get_module_version_as_tuple("pyarrow")
 PYSPARK_VERSION: tuple[int, ...] = get_module_version_as_tuple("pyspark")
 
-Constructor: TypeAlias = Callable[[Any], IntoFrame]
-ConstructorEager: TypeAlias = Callable[[Any], IntoDataFrame]
+Constructor: TypeAlias = Callable[[Any], "NativeLazyFrame | NativeFrame | DataFrameLike"]
+ConstructorEager: TypeAlias = Callable[[Any], "NativeFrame | DataFrameLike"]
 
 
 def zip_strict(left: Sequence[Any], right: Sequence[Any]) -> Iterator[Any]:


### PR DESCRIPTION
Will close #2346

<details><summary>Description (copied from issue)</summary>
<p>


When I initially tried to fix this in (https://github.com/narwhals-dev/narwhals/pull/2232#discussion_r2001807332) - most of the **795** errors were from tests using `IntoFrame`/`IntoDataFrame`.


https://github.com/narwhals-dev/narwhals/blob/d2a9f423688c14e524d28e7d282bfa5de3c888be/tests/utils.py#L45-L46

AFAICT, none of these constructors should need to use a `TypeAlias` that mentions `nw.DataFrame` or `nw.LazyFrame`.
They all return a **native** object

<details><summary><code>conftest.py</code></summary>
<p>


https://github.com/narwhals-dev/narwhals/blob/d2a9f423688c14e524d28e7d282bfa5de3c888be/tests/conftest.py#L72-L222

</p>
</details> 

https://github.com/narwhals-dev/narwhals/blob/d2a9f423688c14e524d28e7d282bfa5de3c888be/narwhals/typing.py#L60

https://github.com/narwhals-dev/narwhals/blob/d2a9f423688c14e524d28e7d282bfa5de3c888be/narwhals/typing.py#L75-L77

</p>
</details> 