### PR TITLE
docs: Use `separate_signature: true`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ plugins:
         options:
           show_signature_annotations: true
           members_order: alphabetical
+          separate_signature: true
     enable_inventory: true
 
 hooks:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues
- https://github.com/narwhals-dev/narwhals/issues/1943#issuecomment-2637599110

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below
- https://mkdocstrings.github.io/python/usage/configuration/signatures/#separate_signature


# Examples
## `read_parquet`
### Before

![image](https://github.com/user-attachments/assets/ab70b802-7443-4864-8bfa-f35aeae3a8a6)

### After
![image](https://github.com/user-attachments/assets/1d4fc15d-03f1-4fc6-b2c7-ee7d87e8d0f3)

## `from_native`
### Before
![image](https://github.com/user-attachments/assets/0b5ddf71-c785-4380-8981-25d830a3a290)

### After
![image](https://github.com/user-attachments/assets/ff7094cc-a011-4ae7-afed-ac538d0ebc55)

The signature that was a heading *before*, becomes the final overload
![image](https://github.com/user-attachments/assets/dc34f094-1822-4e42-8e22-8824e4249367)

