### PR TITLE
Fix issue with missing TypeVar when using older versions of typing_extensions

### DIFF
--- a/narwhals/_translate.py
+++ b/narwhals/_translate.py
@@ -16,11 +16,12 @@ if TYPE_CHECKING:
 
 else:  # pragma: no cover
     import sys
+    from importlib.metadata import version
     from importlib.util import find_spec
 
     if sys.version_info >= (3, 13):
         from typing import TypeVar
-    elif find_spec("typing_extensions"):
+    elif find_spec("typing_extensions") and version("typing_extensions") >= "4.4.0":
         from typing_extensions import TypeVar
     else:
         from typing import TypeVar as _TypeVar


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [X] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
It's a simple fix so I didn't go through the hassle of setting up the environment, please feel free to reformat if you already have it installed.
The problem I'm addressing is an import error when the version of `typing_extensions` present is below 4.4.0 where `TypeVar` was added. I do so by using the else-clause fallback which worked in my case (I monkey-patched the `typing_extensions` package to make my HoloViews visualizations work again)
