### PR TITLE
chore!: use Python API more for DuckDB support

### DIFF
--- a/.github/workflows/check_tpch_queries.yml
+++ b/.github/workflows/check_tpch_queries.yml
@@ -29,9 +29,8 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: local-install
         run: |
-          # once https://github.com/duckdb/duckdb/issues/16445
-          # is addressed, try using `--pre`
           uv pip install -U -e ".[dask]" --group core-tests --system
+          uv pip install -U --pre duckdb --system
       - name: generate-data
         run: cd tpch && python generate_data.py
       - name: tpch-tests 

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -564,7 +564,7 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "duckdb.Expression"]):
                 )
             else:
                 partition_by_sql = f"partition by {window_inputs.expr}"
-            sql = f"row_number() over({partition_by_sql} {order_by_sql})"
+            sql = f"{FunctionExpression('row_number')} over({partition_by_sql} {order_by_sql})"
             return SQLExpression(sql) == lit(1)  # type: ignore[no-any-return, unused-ignore]
 
         return self._with_window_function(func)
@@ -579,7 +579,7 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "duckdb.Expression"]):
                 )
             else:
                 partition_by_sql = f"partition by {window_inputs.expr}"
-            sql = f"row_number() over({partition_by_sql} {order_by_sql})"
+            sql = f"{FunctionExpression('row_number')} over({partition_by_sql} {order_by_sql})"
             return SQLExpression(sql) == lit(1)  # type: ignore[no-any-return, unused-ignore]
 
         return self._with_window_function(func)

--- a/narwhals/_duckdb/utils.py
+++ b/narwhals/_duckdb/utils.py
@@ -225,15 +225,15 @@ def narwhals_to_native_dtype(dtype: DType | type[DType], version: Version) -> st
 def generate_partition_by_sql(*partition_by: str) -> str:
     if not partition_by:
         return ""
-    by_sql = ", ".join([f'"{x}"' for x in partition_by])
+    by_sql = ", ".join([f"{col(x)}" for x in partition_by])
     return f"partition by {by_sql}"
 
 
 def generate_order_by_sql(*order_by: str, ascending: bool) -> str:
     if ascending:
-        by_sql = ", ".join([f'"{x}" asc nulls first' for x in order_by])
+        by_sql = ", ".join([f"{col(x)} asc nulls first" for x in order_by])
     else:
-        by_sql = ", ".join([f'"{x}" desc nulls last' for x in order_by])
+        by_sql = ", ".join([f"{col(x)} desc nulls last" for x in order_by])
     return f"order by {by_sql}"
 
 

--- a/tests/frame/unique_test.py
+++ b/tests/frame/unique_test.py
@@ -8,6 +8,7 @@ import pytest
 # becomes LazyFrame instead of DataFrame
 import narwhals as nw
 from narwhals.exceptions import ColumnNotFoundError
+from tests.utils import DUCKDB_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -36,6 +37,8 @@ def test_unique_eager(
 
 
 def test_unique_invalid_subset(constructor: Constructor) -> None:
+    if "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3):
+        pytest.skip()
     df_raw = constructor(data)
     df = nw.from_native(df_raw)
     with pytest.raises(ColumnNotFoundError):
@@ -56,6 +59,8 @@ def test_unique(
     keep: Literal["any", "none"],
     expected: dict[str, list[float]],
 ) -> None:
+    if "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3):
+        pytest.skip()
     df_raw = constructor(data)
     df = nw.from_native(df_raw)
     result = df.unique(subset, keep=keep).sort("z")
@@ -76,6 +81,8 @@ def test_unique_full_subset(
     keep: Literal["any", "none"],
     expected: dict[str, list[float]],
 ) -> None:
+    if "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3):
+        pytest.skip()
     data = {"a": [1, 1, 1, 2], "b": [3, 3, 4, 4]}
     df_raw = constructor(data)
     df = nw.from_native(df_raw)


### PR DESCRIPTION
Use Python API for instead of handwritten SQL

This does meaning raising the minimum duckdb required version for `unique` with `subset` specified, but I think that's OK

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
