### PR TITLE
Fix: Align ``Series.hist`` with new Polars behaviour

### DIFF
--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -1064,6 +1064,9 @@ class ArrowSeries(EagerSeries["ArrowChunkedArray"]):
         from narwhals._arrow.dataframe import ArrowDataFrame
 
         def _hist_from_bin_count(bin_count: int):  # type: ignore[no-untyped-def] # noqa: ANN202
+            if pc.count(self._native_series) == pa.scalar(0):
+                return np.zeros(bin_count), np.linspace(0, 1, bin_count + 1)[1:]
+
             d = pc.min_max(self.native)
             lower, upper = d["min"], d["max"]
             pa_float = pa.type_for_alias("float")

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -1117,6 +1117,11 @@ class ArrowSeries(EagerSeries["ArrowChunkedArray"]):
 
         def _hist_from_bins(bins: Sequence[int | float]):  # type: ignore[no-untyped-def] # noqa: ANN202
             bin_indices = np.searchsorted(bins, self.native, side="left")
+            bin_indices = pc.if_else(  # lowest bin is inclusive
+                pc.equal(self.native, lit(bins[0])), 1, bin_indices
+            )
+
+            # align unique categories and counts appropriately
             obs_cats, obs_counts = np.unique(bin_indices, return_counts=True)
             obj_cats = np.arange(1, len(bins))
             counts = np.zeros_like(obj_cats)

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -983,11 +983,21 @@ class PandasLikeSeries(EagerSeries[Any]):
                 del data["breakpoint"]
             return PandasLikeDataFrame.from_native(ns.DataFrame(data), context=self)
 
-        if bin_count is not None:  # use Polars binning behavior
+        if bin_count is not None:
+            # use Polars binning behavior
             lower, upper = self.native.min(), self.native.max()
             if lower == upper:
                 lower -= 0.5
                 upper += 0.5
+
+            if bin_count == 1:
+                data = {
+                    "breakpoint": [upper],
+                    "count": [self.native.count()],
+                }
+                if not include_breakpoint:
+                    del data["breakpoint"]
+                return PandasLikeDataFrame.from_native(ns.DataFrame(data), context=self)
 
             bins = linspace(lower, upper, bin_count + 1)
             bin_count = None

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -966,7 +966,8 @@ class PandasLikeSeries(EagerSeries[Any]):
                 data["breakpoint"] = []
             data["count"] = []
             return PandasLikeDataFrame.from_native(ns.DataFrame(data), context=self)
-        elif self.native.count() < 1:
+
+        if self.native.count() < 1:
             if bins is not None:
                 data = {"breakpoint": bins[1:], "count": zeros(shape=len(bins) - 1)}
             else:
@@ -976,24 +977,23 @@ class PandasLikeSeries(EagerSeries[Any]):
                 del data["breakpoint"]
             return PandasLikeDataFrame.from_native(ns.DataFrame(data), context=self)
 
-        elif bin_count is not None:  # use Polars binning behavior
+        if bin_count is not None:  # use Polars binning behavior
             lower, upper = self.native.min(), self.native.max()
-            pad_lowest_bin = False
             if lower == upper:
                 lower -= 0.5
                 upper += 0.5
-            else:
-                pad_lowest_bin = True
 
             bins = linspace(lower, upper, bin_count + 1)
-            if pad_lowest_bin and bins is not None:
-                bins[0] -= 0.001 * abs(bins[0]) if bins[0] != 0 else 0.001
             bin_count = None
 
         # pandas (2.2.*) .value_counts(bins=int) adjusts the lowest bin twice, result in improper counts.
         # pandas (2.2.*) .value_counts(bins=[...]) adjusts the lowest bin which should not happen since
         #   the bins were explicitly passed in.
-        categories = ns.cut(self.native, bins=bins if bin_count is None else bin_count)
+        categories = ns.cut(
+            self.native,
+            bins=bins if bin_count is None else bin_count,
+            include_lowest=True,  # Polars 1.27.0 always includes the lowest bin
+        )
         # modin (0.32.0) .value_counts(...) silently drops bins with empty observations, .reindex
         #   is necessary to restore these bins.
         result = categories.value_counts(dropna=True, sort=False).reindex(

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -972,7 +972,13 @@ class PandasLikeSeries(EagerSeries[Any]):
                 data = {"breakpoint": bins[1:], "count": zeros(shape=len(bins) - 1)}
             else:
                 count = cast("int", bin_count)
-                data = {"breakpoint": linspace(0, 1, count), "count": zeros(shape=count)}
+                if bin_count == 1:
+                    data = {"breakpoint": [1.0], "count": [0]}
+                else:
+                    data = {
+                        "breakpoint": linspace(0, 1, count + 1)[1:],
+                        "count": zeros(shape=count),
+                    }
             if not include_breakpoint:
                 del data["breakpoint"]
             return PandasLikeDataFrame.from_native(ns.DataFrame(data), context=self)

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -514,6 +514,11 @@ class PolarsSeries:
                     "breakpoint": pl.int_range(1, bin_count + 1, eager=True) / bin_count,
                     "count": pl.zeros(n=bin_count, dtype=pl.Int64, eager=True),
                 }
+            else:  # pragma: no cover
+                msg = (
+                    "congratulations, you entered unreachable code - please report a bug"
+                )
+                raise AssertionError(msg)
             if not include_breakpoint:
                 del data_dict["breakpoint"]
             return PolarsDataFrame.from_native(pl.DataFrame(data_dict), context=self)

--- a/tests/series_only/hist_test.py
+++ b/tests/series_only/hist_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from random import Random
 from typing import Any
 
 import hypothesis.strategies as st
@@ -14,8 +15,13 @@ from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
 
-data = {
+rnd = Random(0)  # noqa: S311
+
+data: dict[str, list[int | float]] = {
     "int": [0, 1, 2, 3, 4, 5, 6],
+    "float": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+    "int_shuffled": [1, 0, 2, 3, 6, 5, 4],
+    "float_shuffled": [1.0, 0.0, 2.0, 3.0, 6.0, 5.0, 4.0],
 }
 
 bins_and_expected = [

--- a/tests/series_only/hist_test.py
+++ b/tests/series_only/hist_test.py
@@ -29,11 +29,11 @@ bins_and_expected = [
     },
     {
         "bins": [1.0, 2.5, 5.5, float("inf")],
-        "expected": [1, 3, 1],
+        "expected": [2, 3, 1],
     },
     {
         "bins": [1.0, 2.5, 5.5],
-        "expected": [1, 3],
+        "expected": [2, 3],
     },
     {
         "bins": [-10.0, -1.0, 2.5, 5.5],
@@ -41,23 +41,27 @@ bins_and_expected = [
     },
     {
         "bins": [1.0, 2.0625],
-        "expected": [1],
+        "expected": [2],
     },
     {
         "bins": [1],
         "expected": [],
     },
+    {
+        "bins": [0, 10],
+        "expected": [7],
+    },
 ]
 counts_and_expected = [
     {
         "bin_count": 4,
-        "expected_bins": [-0.006, 1.5, 3.0, 4.5, 6.0],
+        "expected_bins": [0, 1.5, 3.0, 4.5, 6.0],
         "expected_count": [2, 2, 1, 2],
     },
     {
         "bin_count": 12,
         "expected_bins": [
-            -0.006,
+            0,
             0.5,
             1.0,
             1.5,
@@ -382,8 +386,8 @@ def test_hist_non_monotonic(constructor_eager: ConstructorEager) -> None:
     "ignore:invalid value encountered in cast:RuntimeWarning",
 )
 @pytest.mark.skipif(
-    POLARS_VERSION < (1, 15),
-    reason="hist(bins=...) cannot be used for compatibility checks since narwhals aims to mimic polars>=1.2.0 behavior",
+    POLARS_VERSION < (1, 27),
+    reason="polars cannot be used for compatibility checks since narwhals aims to mimic polars>=1.27 behavior",
 )
 @pytest.mark.slow
 def test_hist_bin_hypotheis(
@@ -435,8 +439,8 @@ def test_hist_bin_hypotheis(
 )
 @xfail_hist
 @pytest.mark.skipif(
-    POLARS_VERSION < (1, 15),
-    reason="hist(bin_count=...) behavior significantly changed after this version",
+    POLARS_VERSION < (1, 27),
+    reason="polars cannot be used for compatibility checks since narwhals aims to mimic polars>=1.27 behavior",
 )
 @pytest.mark.filterwarnings(
     "ignore:`Series.hist` is being called from the stable API although considered an unstable feature.",

--- a/tests/series_only/hist_test.py
+++ b/tests/series_only/hist_test.py
@@ -14,7 +14,6 @@ from tests.utils import PYARROW_VERSION
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
-
 rnd = Random(0)  # noqa: S311
 
 data: dict[str, list[int | float]] = {


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

1. All narwhals hist behavior should follow Polars 1.27
2. Add histogram fastpaths for no data, or singly binned hists for perf and smooth differences across backends  
3. Slim down the hypothesis testing, as spurious errors would pop up due to floating point precision differences for the compute backends.