### PR TITLE
chore: use nw_v1 / nw naming consistently in tests

### DIFF
--- a/tests/expr_and_series/gather_every_test.py
+++ b/tests/expr_and_series/gather_every_test.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-import narwhals as nw_main
-import narwhals.stable.v1 as nw
+import narwhals as nw
+import narwhals.stable.v1 as nw_v1
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -15,9 +15,9 @@ data = {"a": list(range(10))}
 def test_gather_every_expr(
     constructor_eager: ConstructorEager, n: int, offset: int
 ) -> None:
-    df = nw.from_native(constructor_eager(data))
+    df = nw_v1.from_native(constructor_eager(data))
 
-    result = df.select(nw.col("a").gather_every(n=n, offset=offset))
+    result = df.select(nw_v1.col("a").gather_every(n=n, offset=offset))
     expected = {"a": data["a"][offset::n]}
 
     assert_equal_data(result, expected)
@@ -25,7 +25,7 @@ def test_gather_every_expr(
     with pytest.deprecated_call(
         match="is deprecated and will be removed in a future version"
     ):
-        df.select(nw_main.col("a").gather_every(n=n, offset=offset))
+        df.select(nw.col("a").gather_every(n=n, offset=offset))
 
 
 @pytest.mark.parametrize("n", [1, 2, 3])
@@ -33,7 +33,7 @@ def test_gather_every_expr(
 def test_gather_every_series(
     constructor_eager: ConstructorEager, n: int, offset: int
 ) -> None:
-    series = nw.from_native(constructor_eager(data), eager_only=True)["a"]
+    series = nw_v1.from_native(constructor_eager(data), eager_only=True)["a"]
 
     result = series.gather_every(n=n, offset=offset)
     expected = data["a"][offset::n]

--- a/tests/expr_and_series/head_test.py
+++ b/tests/expr_and_series/head_test.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-import narwhals as nw_main
-import narwhals.stable.v1 as nw
+import narwhals as nw
+import narwhals.stable.v1 as nw_v1
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -14,20 +14,20 @@ def test_head(
 ) -> None:
     if "polars" in str(constructor_eager) and n < 0:
         request.applymarker(pytest.mark.xfail)
-    df = nw.from_native(constructor_eager({"a": [1, 2, 3]}))
-    result = df.select(nw.col("a").head(n))
+    df = nw_v1.from_native(constructor_eager({"a": [1, 2, 3]}))
+    result = df.select(nw_v1.col("a").head(n))
     expected = {"a": [1, 2]}
     assert_equal_data(result, expected)
 
     with pytest.deprecated_call(
         match="is deprecated and will be removed in a future version"
     ):
-        df.select(nw_main.col("a").head(5))
+        df.select(nw.col("a").head(5))
 
 
 @pytest.mark.parametrize("n", [2, -1])
 def test_head_series(constructor_eager: ConstructorEager, n: int) -> None:
-    df = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)
+    df = nw_v1.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)
     result = df.select(df["a"].head(n))
     expected = {"a": [1, 2]}
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/sample_test.py
+++ b/tests/expr_and_series/sample_test.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import pytest
 
-import narwhals as nw_main
-import narwhals.stable.v1 as nw
+import narwhals as nw
+import narwhals.stable.v1 as nw_v1
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
 
 def test_expr_sample(constructor_eager: ConstructorEager) -> None:
-    df = nw.from_native(
+    df = nw_v1.from_native(
         constructor_eager({"a": [1, 2, 3], "b": [4, 5, 6]}), eager_only=True
     )
 
-    result_expr = df.select(nw.col("a").sample(n=2)).shape
+    result_expr = df.select(nw_v1.col("a").sample(n=2)).shape
     expected_expr = (2, 1)
     assert result_expr == expected_expr
 
@@ -24,15 +24,15 @@ def test_expr_sample(constructor_eager: ConstructorEager) -> None:
     with pytest.deprecated_call(
         match="is deprecated and will be removed in a future version"
     ):
-        df.select(nw_main.col("a").sample(n=2))
+        df.select(nw.col("a").sample(n=2))
 
 
 def test_expr_sample_fraction(constructor_eager: ConstructorEager) -> None:
-    df = nw.from_native(
+    df = nw_v1.from_native(
         constructor_eager({"a": [1, 2, 3] * 10, "b": [4, 5, 6] * 10}), eager_only=True
     )
 
-    result_expr = df.select(nw.col("a").sample(fraction=0.1)).shape
+    result_expr = df.select(nw_v1.col("a").sample(fraction=0.1)).shape
     expected_expr = (3, 1)
     assert result_expr == expected_expr
 
@@ -43,15 +43,15 @@ def test_expr_sample_fraction(constructor_eager: ConstructorEager) -> None:
 
 def test_sample_with_seed(constructor_eager: ConstructorEager) -> None:
     size, n = 100, 10
-    df = nw.from_native(constructor_eager({"a": list(range(size))}))
+    df = nw_v1.from_native(constructor_eager({"a": list(range(size))}))
     expected = {"res1": [True], "res2": [False]}
     result = df.select(
-        seed1=nw.col("a").sample(n=n, seed=123),
-        seed2=nw.col("a").sample(n=n, seed=123),
-        seed3=nw.col("a").sample(n=n, seed=42),
+        seed1=nw_v1.col("a").sample(n=n, seed=123),
+        seed2=nw_v1.col("a").sample(n=n, seed=123),
+        seed3=nw_v1.col("a").sample(n=n, seed=42),
     ).select(
-        res1=(nw.col("seed1") == nw.col("seed2")).all(),
-        res2=(nw.col("seed1") == nw.col("seed3")).all(),
+        res1=(nw_v1.col("seed1") == nw_v1.col("seed2")).all(),
+        res2=(nw_v1.col("seed1") == nw_v1.col("seed3")).all(),
     )
 
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/sort_test.py
+++ b/tests/expr_and_series/sort_test.py
@@ -4,8 +4,8 @@ from typing import Any
 
 import pytest
 
-import narwhals as nw_main
-import narwhals.stable.v1 as nw
+import narwhals as nw
+import narwhals.stable.v1 as nw_v1
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -24,10 +24,10 @@ data = {"a": [0, 0, 2, -1], "b": [1, 3, 2, None]}
 def test_sort_expr(
     constructor_eager: ConstructorEager, descending: Any, nulls_last: Any, expected: Any
 ) -> None:
-    df = nw.from_native(constructor_eager(data), eager_only=True)
+    df = nw_v1.from_native(constructor_eager(data), eager_only=True)
     result = df.select(
         "a",
-        nw.col("b").sort(descending=descending, nulls_last=nulls_last),
+        nw_v1.col("b").sort(descending=descending, nulls_last=nulls_last),
     )
     assert_equal_data(result, expected)
     with pytest.deprecated_call(
@@ -35,7 +35,7 @@ def test_sort_expr(
     ):
         df.select(
             "a",
-            nw_main.col("b").sort(descending=descending, nulls_last=nulls_last),
+            nw.col("b").sort(descending=descending, nulls_last=nulls_last),
         )
 
 
@@ -51,8 +51,9 @@ def test_sort_expr(
 def test_sort_series(
     constructor_eager: ConstructorEager, descending: Any, nulls_last: Any, expected: Any
 ) -> None:
-    series = nw.from_native(constructor_eager(data), eager_only=True)["b"]
+    series = nw_v1.from_native(constructor_eager(data), eager_only=True)["b"]
     result = series.sort(descending=descending, nulls_last=nulls_last)
     assert (
-        result == nw.from_native(constructor_eager({"a": expected}), eager_only=True)["a"]
+        result
+        == nw_v1.from_native(constructor_eager({"a": expected}), eager_only=True)["a"]
     )

--- a/tests/expr_and_series/tail_test.py
+++ b/tests/expr_and_series/tail_test.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-import narwhals as nw_main
-import narwhals.stable.v1 as nw
+import narwhals as nw
+import narwhals.stable.v1 as nw_v1
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -14,20 +14,20 @@ def test_tail(
 ) -> None:
     if "polars" in str(constructor_eager) and n < 0:
         request.applymarker(pytest.mark.xfail)
-    df = nw.from_native(constructor_eager({"a": [1, 2, 3]}))
-    result = df.select(nw.col("a").tail(n))
+    df = nw_v1.from_native(constructor_eager({"a": [1, 2, 3]}))
+    result = df.select(nw_v1.col("a").tail(n))
     expected = {"a": [2, 3]}
     assert_equal_data(result, expected)
 
     with pytest.deprecated_call(
         match="is deprecated and will be removed in a future version"
     ):
-        df.select(nw_main.col("a").tail(5))
+        df.select(nw.col("a").tail(5))
 
 
 @pytest.mark.parametrize("n", [2, -1])
 def test_tail_series(constructor_eager: ConstructorEager, n: int) -> None:
-    df = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)
+    df = nw_v1.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)
     result = df.select(df["a"].tail(n))
     expected = {"a": [2, 3]}
     assert_equal_data(result, expected)

--- a/tests/frame/gather_every_test.py
+++ b/tests/frame/gather_every_test.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-import narwhals as nw_main
-import narwhals.stable.v1 as nw
+import narwhals as nw
+import narwhals.stable.v1 as nw_v1
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
 
@@ -14,13 +14,13 @@ data = {"a": list(range(10))}
 @pytest.mark.parametrize("n", [1, 2, 3])
 @pytest.mark.parametrize("offset", [1, 2, 3])
 def test_gather_every(constructor_eager: ConstructorEager, n: int, offset: int) -> None:
-    df_v1 = nw.from_native(constructor_eager(data))
+    df_v1 = nw_v1.from_native(constructor_eager(data))
     result = df_v1.gather_every(n=n, offset=offset)
     expected = {"a": data["a"][offset::n]}
     assert_equal_data(result, expected)
 
     # Test deprecation for LazyFrame in main namespace
-    lf = nw_main.from_native(constructor_eager(data)).lazy()
+    lf = nw.from_native(constructor_eager(data)).lazy()
     with pytest.deprecated_call(
         match="is deprecated and will be removed in a future version"
     ):
@@ -33,7 +33,7 @@ def test_gather_every_dask_v1(n: int, offset: int) -> None:
     pytest.importorskip("dask")
     import dask.dataframe as dd
 
-    df_v1 = nw.from_native(dd.from_pandas(pd.DataFrame(data)))
+    df_v1 = nw_v1.from_native(dd.from_pandas(pd.DataFrame(data)))
     result = df_v1.gather_every(n=n, offset=offset)
     expected = {"a": data["a"][offset::n]}
     assert_equal_data(result, expected)


### PR DESCRIPTION
Towards v2

The idea is:
- in tests which use both `v1` and main APIs, alias the v1 one to `nw_v1`

Later:
- always use the main API for tests
- make separate `v1_test.py` and `v2_test.py` which test methods which we overwrite from the stable apis 

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
