### PR TITLE
docs: Update installation guide to reflect use of `dependency-groups`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,17 +107,11 @@ If you want to run PySpark-related tests, you'll need to have Java installed. Re
 
    4. Activate it. On Linux, this is `. .venv/bin/activate`, on Windows `.\.venv\Scripts\activate`.
 
-2. Install Narwhals: `uv pip install -e . --group local-dev"`. This will include fast-ish core libraries and dev dependencies.
+2. Install Narwhals: `uv pip install -e . --group local-dev`. This will include fast-ish core libraries and dev dependencies.
    If you also want to test other libraries like Dask , PySpark, and Modin, you can install them too with
    `uv pip install -e ".[dask, pyspark, modin]" --group local-dev`.
 
-You should also install pre-commit:
-
-```terminal
-pre-commit install
-```
-
-This will automatically format and lint your code before each commit, and it will block the commit if any issues are found.
+The pre-commit tool is installed as part of the local-dev dependency group. This will automatically format and lint your code before each commit, and it will block the commit if any issues are found.
 
 #### Option 2: use python3-venv
 
@@ -208,13 +202,9 @@ We can't currently test in CI against cuDF, but you can test it manually in Kagg
 
 ### Static typing
 
-We run both `mypy` and `pyright` in CI. To run them locally, make sure to install
+We run both `mypy` and `pyright` in CI. Both of these tools are included when installing Narwhals with the local-dev dependency group.
 
-```terminal
-uv pip install -U -e ".[typing]"
-```
-
-You can then run
+Run them with:
 - `mypy narwhals tests`
 - `pyright narwhals tests`
 


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

The syntax for installing from `optional-dependencies` vs. `dependency-groups` is different, so the old instructions for e.g. `typing` no longer work. Everything suggested to be installed for the `test` and `typing` groups, along with installing pre-commit, is already done via the `local-dev` group too.

By the way, pip's current release v25.0.1 doesn't _yet_ support dependency groups, but [the upcoming 25.1.0 release will](https://pip.pypa.io/en/latest/user_guide/#dependency-groups), using identical syntax. So in the near future these commands should work for both uv and pip.