### PR TITLE
docs: add docstrings examples for Int128 and UInt128

### DIFF
--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -122,15 +122,14 @@ class Int128(SignedIntegerType):
         >>> s_native = pl.Series([2, 1, 3, 7])
         >>> s = nw.from_native(s_native, series_only=True)
         >>> df_native = pa.table({"a": [2, 1, 3, 7]})
-        >>> rel = duckdb.sql(
-        ...    " SELECT CAST (a AS INT128) AS a FROM df_native "
-        ...    )
+        >>> rel = duckdb.sql(" SELECT CAST (a AS INT128) AS a FROM df_native ")
 
         >>> s.cast(nw.Int128).dtype
         Int128
         >>> nw.from_native(rel).schema["a"]
         Int128
     """
+
 
 class Int64(SignedIntegerType):
     """64-bit signed integer type.
@@ -192,9 +191,7 @@ class UInt128(UnsignedIntegerType):
         >>> import narwhals as nw
         >>> import duckdb
         >>> df_native = pd.DataFrame({"a": [2, 1, 3, 7]})
-        >>> rel = duckdb.sql(
-        ...    " SELECT CAST (a AS UINT128) AS a FROM df_native "
-        ...    )
+        >>> rel = duckdb.sql(" SELECT CAST (a AS UINT128) AS a FROM df_native ")
         >>> nw.from_native(rel).schema["a"]
         UInt128
     """

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -112,8 +112,25 @@ class Decimal(NumericType):
 
 
 class Int128(SignedIntegerType):
-    """128-bit signed integer type."""
+    """128-bit signed integer type.
 
+    Examples:
+        >>> import polars as pl
+        >>> import pyarrow as pa
+        >>> import narwhals as nw
+        >>> import duckdb
+        >>> s_native = pl.Series([2, 1, 3, 7])
+        >>> s = nw.from_native(s_native, series_only=True)
+        >>> df_native = pa.table({"a": [2, 1, 3, 7]})
+        >>> rel = duckdb.sql(
+        ...    " SELECT CAST (a AS INT128) AS a FROM df_native "
+        ...    )
+
+        >>> s.cast(nw.Int128).dtype
+        Int128
+        >>> nw.from_native(rel).schema["a"]
+        Int128
+    """
 
 class Int64(SignedIntegerType):
     """64-bit signed integer type.
@@ -168,7 +185,19 @@ class Int8(SignedIntegerType):
 
 
 class UInt128(UnsignedIntegerType):
-    """128-bit unsigned integer type."""
+    """128-bit unsigned integer type.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import narwhals as nw
+        >>> import duckdb
+        >>> df_native = pd.DataFrame({"a": [2, 1, 3, 7]})
+        >>> rel = duckdb.sql(
+        ...    " SELECT CAST (a AS UINT128) AS a FROM df_native "
+        ...    )
+        >>> nw.from_native(rel).schema["a"]
+        UInt128
+    """
 
 
 class UInt64(UnsignedIntegerType):


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #1077
- Closes #1077

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

Added docstring examples for last two dtypes missing them:
- Int128 (polars, pyarrow + duckdb)
- UInt128 (pandas df + duckdb, maybe the only backend supporting this dtype?)

I used the other dtypes as an example to follow, but I'm happy to make any changes if these don't match what you're looking for!