### PR TITLE
chore(typing): Remove `type` from `is_list_of` return

### DIFF
--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -1295,7 +1295,7 @@ def is_sequence_but_not_str(sequence: Any | Sequence[_T]) -> TypeIs[Sequence[_T]
     return isinstance(sequence, Sequence) and not isinstance(sequence, str)
 
 
-def is_list_of(obj: Any, tp: type[_T]) -> TypeIs[list[type[_T]]]:
+def is_list_of(obj: Any, tp: type[_T]) -> TypeIs[list[_T]]:
     # Check if an object is a list of `tp`, only sniffing the first element.
     return bool(isinstance(obj, list) and obj and isinstance(obj[0], tp))
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- https://github.com/narwhals-dev/narwhals/pull/2325#discussion_r2051112276
- https://github.com/narwhals-dev/narwhals/pull/2384#discussion_r2041188135

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
https://github.com/narwhals-dev/narwhals/pull/2325#discussion_r2051439200
> [#2325 (comment)](https://github.com/narwhals-dev/narwhals/pull/2325#discussion_r2051112276)
> 
> @FBruzzesi lol that's my bad for making a suggestion without an IDE in [#2325 (comment)](https://github.com/narwhals-dev/narwhals/pull/2325#discussion_r2051112276)
> 
> `is_list_of` wasn't supposed to have the `type` part in the return 🤦‍♂️:
> 
> ```python
> # def is_list_of(obj: Any, tp: type[_T]) -> TypeIs[list[type[_T]]]:
> def is_list_of(obj: Any, tp: type[_T]) -> TypeIs[list[_T]]:
> ```
> 
> Will fix this shortly

