### PR TITLE
feat: Allow non-null strategy in `fill_null` for DuckDB and SparkLike

### DIFF
--- a/.github/workflows/pytest-pyspark.yml
+++ b/.github/workflows/pytest-pyspark.yml
@@ -10,7 +10,7 @@ env:
 jobs:
 
   pytest-pyspark-constructor:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'pyspark') || contains(github.event.pull_request.labels.*.name, 'release') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'pyspark') || contains(github.event.pull_request.labels.*.name, 'spark-like') || contains(github.event.pull_request.labels.*.name, 'release')}}
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from narwhals._duckdb.typing import WindowFunction
     from narwhals._expression_parsing import ExprMetadata
     from narwhals.dtypes import DType
+    from narwhals.typing import FillNullStrategy
     from narwhals.typing import NonNestedLiteral
     from narwhals.typing import NumericLiteral
     from narwhals.typing import RankMethod
@@ -676,16 +677,41 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "duckdb.Expression"]):
         )
 
     def fill_null(
-        self, value: Self | NonNestedLiteral, strategy: Any, limit: int | None
+        self,
+        value: Self | NonNestedLiteral,
+        strategy: FillNullStrategy | None,
+        limit: int | None,
     ) -> Self:
         if strategy is not None:
-            msg = "todo"
-            raise NotImplementedError(msg)
+            if self._backend_version < (1, 3):
+                msg = f"`fill_null` with `strategy={strategy} is only available in DuckDB>=1.3.0."
+                raise NotImplementedError(msg)
 
-        def func(_input: duckdb.Expression, value: Any) -> duckdb.Expression:
+            def _fill_with_strategy(window_inputs: WindowInputs) -> duckdb.Expression:
+                order_by_sql = generate_order_by_sql(
+                    *window_inputs.order_by, ascending=True
+                )
+                partition_by_sql = generate_partition_by_sql(*window_inputs.partition_by)
+
+                fill_func = "last_value" if strategy == "forward" else "first_value"
+                _limit = "unbounded" if limit is None else limit
+                rows_between = (
+                    f"{_limit} preceding and current row"
+                    if strategy == "forward"
+                    else f"current row and {_limit} following"
+                )
+                sql = (
+                    f"{fill_func}({window_inputs.expr} ignore nulls) over "
+                    f"({partition_by_sql} {order_by_sql} rows between {rows_between})"
+                )
+                return SQLExpression(sql)  # type: ignore[no-any-return, unused-ignore]
+
+            return self._with_window_function(_fill_with_strategy)
+
+        def _fill_constant(_input: duckdb.Expression, value: Any) -> duckdb.Expression:
             return CoalesceOperator(_input, value)
 
-        return self._with_callable(func, value=value)
+        return self._with_callable(_fill_constant, value=value)
 
     def cast(self, dtype: DType | type[DType]) -> Self:
         def func(_input: duckdb.Expression) -> duckdb.Expression:

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -683,7 +683,7 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "duckdb.Expression"]):
         limit: int | None,
     ) -> Self:
         if strategy is not None:
-            if self._backend_version < (1, 3):
+            if self._backend_version < (1, 3):  # pragma: no cover
                 msg = f"`fill_null` with `strategy={strategy} is only available in DuckDB>=1.3.0."
                 raise NotImplementedError(msg)
 

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -678,7 +678,7 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "duckdb.Expression"]):
     ) -> Self:
         if strategy is not None:
             if self._backend_version < (1, 3):  # pragma: no cover
-                msg = f"`fill_null` with `strategy={strategy} is only available in DuckDB>=1.3.0."
+                msg = f"`fill_null` with `strategy={strategy}` is only available in DuckDB>=1.3.0."
                 raise NotImplementedError(msg)
 
             def _fill_with_strategy(window_inputs: WindowInputs) -> duckdb.Expression:

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -705,8 +705,10 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         strategy: FillNullStrategy | None,
         limit: int | None,
     ) -> Self:
-        if strategy is not None:
-
+        if strategy is not None:  # pragma: no cover
+            # TODO(Fbruzzesi): This is covered by pyspark, which however we do not run in
+            # the main CI suite. On the other hand, SQLFrame fails. We should figure out
+            # why and how to fix it, either upstream or from our side!
             def _fill_with_strategy(window_inputs: WindowInputs) -> Column:
                 fill_func = self._F.last if strategy == "forward" else self._F.first
 

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -703,10 +703,8 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         strategy: FillNullStrategy | None,
         limit: int | None,
     ) -> Self:
-        if strategy is not None:  # pragma: no cover
-            # TODO(Fbruzzesi): This is covered by pyspark, which however we do not run in
-            # the main CI suite. On the other hand, SQLFrame fails. We should figure out
-            # why and how to fix it, either upstream or from our side!
+        if strategy is not None:
+
             def _fill_with_strategy(window_inputs: WindowInputs) -> Column:
                 fill_func = (
                     self._F.last_value if strategy == "forward" else self._F.first_value

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -707,14 +707,19 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
     ) -> Self:
         if strategy is not None:
 
-            def _fill_null_with_strategy(window_inputs: WindowInputs) -> Column:
+            def _fill_with_strategy(window_inputs: WindowInputs) -> Column:
                 fill_func = self._F.last if strategy == "forward" else self._F.first
 
-                rows_between = (
-                    (self._Window().unboundedPreceding, self._Window().currentRow)
-                    if strategy == "forward"
-                    else (self._Window().currentRow, self._Window().unboundedFollowing)
-                )
+                if strategy == "forward":
+                    start = (
+                        -limit if limit is not None else self._Window().unboundedPreceding
+                    )
+                    end = self._Window().currentRow
+                else:
+                    start = self._Window().currentRow
+                    end = (
+                        limit if limit is not None else self._Window().unboundedFollowing
+                    )
 
                 window = (
                     self._Window()
@@ -722,18 +727,17 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
                     .orderBy(
                         [self._F.col(x).asc_nulls_first() for x in window_inputs.order_by]
                     )
-                    .rowsBetween(*rows_between)
+                    .rowsBetween(start, end)
                 )
 
                 return fill_func(window_inputs.expr, ignorenulls=True).over(window)
 
-            return self._with_window_function(_fill_null_with_strategy)
+            return self._with_window_function(_fill_with_strategy)
 
-        else:
-            def _fill_null(_input: Column, value: Column) -> Column:
-                return self._F.ifnull(_input, value)
+        def _fill_constant(_input: Column, value: Column) -> Column:
+            return self._F.ifnull(_input, value)
 
-            return self._with_callable(_fill_null, value=value)
+        return self._with_callable(_fill_constant, value=value)
 
     def rolling_sum(self, window_size: int, *, min_samples: int, center: bool) -> Self:
         return self._with_window_function(

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -1440,12 +1440,16 @@ class Expr:
         if strategy is not None and strategy not in {"forward", "backward"}:
             msg = f"strategy not supported: {strategy}"
             raise ValueError(msg)
-        return self._with_callable(
+
+        return self.__class__(
             lambda plx: self._to_compliant_expr(plx).fill_null(
                 value=extract_compliant(plx, value, str_as_lit=True),
                 strategy=strategy,
                 limit=limit,
-            )
+            ),
+            self._metadata.with_kind_and_closeable_window(ExprKind.WINDOW)
+            if strategy is not None
+            else self._metadata,
         )
 
     # --- partial reduction ---

--- a/tests/expr_and_series/fill_null_test.py
+++ b/tests/expr_and_series/fill_null_test.py
@@ -66,16 +66,11 @@ def test_fill_null_exceptions(constructor: Constructor) -> None:
         df.with_columns(nw.col("a").fill_null(strategy="invalid"))  # type: ignore  # noqa: PGH003
 
 
-def test_fill_null_strategies_with_limit_as_none(
-    constructor: Constructor, request: pytest.FixtureRequest
-) -> None:
+def test_fill_null_strategies_with_limit_as_none(constructor: Constructor) -> None:
     if ("duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3)) or (
         "polars" in str(constructor) and POLARS_VERSION < (1, 10)
     ):
         pytest.skip()
-
-    if "sqlframe" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
 
     data_limits = {
         "a": [1, None, None, None, 5, 6, None, None, None, 10],
@@ -153,16 +148,11 @@ def test_fill_null_strategies_with_limit_as_none(
         assert_equal_data(result_backward, expected_backward)
 
 
-def test_fill_null_limits(
-    constructor: Constructor, request: pytest.FixtureRequest
-) -> None:
+def test_fill_null_limits(constructor: Constructor) -> None:
     if ("duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3)) or (
         "polars" in str(constructor) and POLARS_VERSION < (1, 10)
     ):
         pytest.skip()
-
-    if "sqlframe" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
 
     context: Any = (
         pytest.raises(NotImplementedError, match="The limit keyword is not supported")

--- a/tests/expr_and_series/fill_null_test.py
+++ b/tests/expr_and_series/fill_null_test.py
@@ -354,6 +354,3 @@ def test_fill_null_series_exceptions(constructor_eager: ConstructorEager) -> Non
         df_float.select(
             a_zero_digit=df_float["a"].fill_null(strategy="invalid"),  # type: ignore  # noqa: PGH003
         )
-
-
-# def lazy_fill_null_strategy(constructor: Constructor)

--- a/tests/expr_and_series/fill_null_test.py
+++ b/tests/expr_and_series/fill_null_test.py
@@ -7,6 +7,8 @@ from typing import Any
 import pytest
 
 import narwhals as nw
+from tests.utils import DUCKDB_VERSION
+from tests.utils import POLARS_VERSION
 from tests.utils import Constructor
 from tests.utils import ConstructorEager
 from tests.utils import assert_equal_data
@@ -64,7 +66,17 @@ def test_fill_null_exceptions(constructor: Constructor) -> None:
         df.with_columns(nw.col("a").fill_null(strategy="invalid"))  # type: ignore  # noqa: PGH003
 
 
-def test_fill_null_strategies_with_limit_as_none(constructor: Constructor) -> None:
+def test_fill_null_strategies_with_limit_as_none(
+    constructor: Constructor, request: pytest.FixtureRequest
+) -> None:
+    if ("duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3)) or (
+        "polars" in str(constructor) and POLARS_VERSION < (1, 10)
+    ):
+        pytest.skip()
+
+    if "sqlframe" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
+
     data_limits = {
         "a": [1, None, None, None, 5, 6, None, None, None, 10],
         "b": ["a", None, None, None, "b", "c", None, None, None, "d"],
@@ -141,7 +153,17 @@ def test_fill_null_strategies_with_limit_as_none(constructor: Constructor) -> No
         assert_equal_data(result_backward, expected_backward)
 
 
-def test_fill_null_limits(constructor: Constructor) -> None:
+def test_fill_null_limits(
+    constructor: Constructor, request: pytest.FixtureRequest
+) -> None:
+    if ("duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3)) or (
+        "polars" in str(constructor) and POLARS_VERSION < (1, 10)
+    ):
+        pytest.skip()
+
+    if "sqlframe" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
+
     context: Any = (
         pytest.raises(NotImplementedError, match="The limit keyword is not supported")
         if "cudf" in str(constructor)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related #2388

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes
