### PR TITLE
perf: Optimize, generalize `_DelayedCategories` -> `_DeferredIterable`

### DIFF
--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -319,7 +319,9 @@ def native_categorical_to_narwhals_dtype(
     return dtypes.Categorical()
 
 
-def _cudf_categorical_to_list(native_dtype: Any) -> Callable[[], list[Any]]:
+def _cudf_categorical_to_list(
+    native_dtype: Any,
+) -> Callable[[], list[Any]]:  # pragma: no cover
     # NOTE: https://docs.rapids.ai/api/cudf/stable/user_guide/api_docs/api/cudf.core.dtypes.categoricaldtype/#cudf.core.dtypes.CategoricalDtype
     def fn() -> list[Any]:
         return native_dtype.categories.to_arrow().to_pylist()

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -328,7 +328,9 @@ def native_to_narwhals_dtype(
         return arrow_native_to_narwhals_dtype(native_dtype.pyarrow_dtype, version)
     if str_dtype == "category" and implementation.is_cudf():
         # https://github.com/rapidsai/cudf/issues/18536
-        return native_categorical_to_narwhals_dtype(native_dtype, version)
+        # https://github.com/rapidsai/cudf/issues/14027
+        # https://docs.rapids.ai/api/cudf/stable/user_guide/api_docs/api/cudf.core.dtypes.categoricaldtype/#cudf.core.dtypes.CategoricalDtype
+        native_dtype = native_dtype.to_pandas()
     if str_dtype != "object":
         return non_object_native_to_narwhals_dtype(native_dtype, version)
     elif implementation is Implementation.DASK:

--- a/narwhals/_polars/utils.py
+++ b/narwhals/_polars/utils.py
@@ -11,7 +11,6 @@ from typing import overload
 
 import polars as pl
 
-from narwhals.dtypes import _DelayedCategories
 from narwhals.exceptions import ColumnNotFoundError
 from narwhals.exceptions import ComputeError
 from narwhals.exceptions import DuplicateError
@@ -19,6 +18,7 @@ from narwhals.exceptions import InvalidOperationError
 from narwhals.exceptions import NarwhalsError
 from narwhals.exceptions import ShapeError
 from narwhals.utils import Version
+from narwhals.utils import _DeferredIterable
 from narwhals.utils import import_dtypes_module
 from narwhals.utils import isinstance_or_issubclass
 
@@ -114,7 +114,7 @@ def native_to_narwhals_dtype(
     if isinstance_or_issubclass(dtype, pl.Enum):
         if version is Version.V1:
             return dtypes.Enum()  # type: ignore[call-arg]
-        return dtypes.Enum(_DelayedCategories(lambda: tuple(dtype.categories)))
+        return dtypes.Enum(_DeferredIterable(dtype.categories.to_list))
     if dtype == pl.Date:
         return dtypes.Date()
     if isinstance_or_issubclass(dtype, pl.Datetime):

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -486,13 +486,14 @@ class Enum(DType):
 
     @property
     def categories(self) -> tuple[str, ...]:
-        if self._cached_categories is None:
-            if categories := self._delayed_categories:
-                self._cached_categories = tuple(categories)
-            else:  # pragma: no cover
-                msg = f"Internal structure of {type(self).__name__!r} is invalid."
-                raise TypeError(msg)
-        return self._cached_categories
+        if cached := self._cached_categories:
+            return cached
+        elif delayed := self._delayed_categories:
+            self._cached_categories = tuple(delayed)
+            return self._cached_categories
+        else:  # pragma: no cover
+            msg = f"Internal structure of {type(self).__name__!r} is invalid."
+            raise TypeError(msg)
 
     def __eq__(self, other: object) -> bool:
         # allow comparing object instances to class

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -487,8 +487,11 @@ class Enum(DType):
     @property
     def categories(self) -> tuple[str, ...]:
         if self._cached_categories is None:
-            assert self._delayed_categories is not None  # noqa: S101
-            self._cached_categories = tuple(self._delayed_categories)
+            if categories := self._delayed_categories:
+                self._cached_categories = tuple(categories)
+            else:  # pragma: no cover
+                msg = f"Internal structure of {type(self).__name__!r} is invalid."
+                raise TypeError(msg)
         return self._cached_categories
 
     def __eq__(self, other: object) -> bool:

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -489,7 +489,7 @@ class Enum(DType):
         if cached := self._cached_categories:
             return cached
         elif delayed := self._delayed_categories:
-            self._cached_categories = tuple(delayed)
+            self._cached_categories = delayed.to_tuple()
             return self._cached_categories
         else:  # pragma: no cover
             msg = f"Internal structure of {type(self).__name__!r} is invalid."

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -1961,6 +1961,6 @@ class _DeferredIterable(Generic[_T]):
         yield from self._into_iter()
 
     def to_tuple(self) -> tuple[_T, ...]:
-        """Collect and return as a `tuple`."""
+        # Collect and return as a `tuple`.
         it = self._into_iter()
         return it if isinstance(it, tuple) else tuple(it)

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -1959,3 +1959,8 @@ class _DeferredIterable(Generic[_T]):
 
     def __iter__(self) -> Iterator[_T]:
         yield from self._into_iter()
+
+    def to_tuple(self) -> tuple[_T, ...]:
+        """Collect and return as a `tuple`."""
+        it = self._into_iter()
+        return it if isinstance(it, tuple) else tuple(it)

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -13,7 +13,9 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import Container
+from typing import Generic
 from typing import Iterable
+from typing import Iterator
 from typing import Literal
 from typing import Protocol
 from typing import Sequence
@@ -99,7 +101,7 @@ if TYPE_CHECKING:
     FrameOrSeriesT = TypeVar(
         "FrameOrSeriesT", bound=Union[LazyFrame[Any], DataFrame[Any], Series[Any]]
     )
-    _T = TypeVar("_T")
+
     _T1 = TypeVar("_T1")
     _T2 = TypeVar("_T2")
     _T3 = TypeVar("_T3")
@@ -145,6 +147,7 @@ if TYPE_CHECKING:
         def columns(self) -> Sequence[str]: ...
 
 
+_T = TypeVar("_T")
 NativeT_co = TypeVar("NativeT_co", covariant=True)
 CompliantT_co = TypeVar("CompliantT_co", covariant=True)
 _ContextT = TypeVar("_ContextT", bound="_FullContext")
@@ -1891,3 +1894,13 @@ def convert_str_slice_to_int_slice(
     stop = columns.index(str_slice.stop) + 1 if str_slice.stop is not None else None
     step = str_slice.step
     return (start, stop, step)
+
+
+class _DeferredIterable(Generic[_T]):
+    """Store a callable producing an iterable to defer collection until we need it."""
+
+    def __init__(self, into_iter: Callable[[], Iterable[_T]], /) -> None:
+        self._into_iter: Callable[[], Iterable[_T]] = into_iter
+
+    def __iter__(self) -> Iterator[_T]:
+        yield from self._into_iter()

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -435,6 +435,8 @@ def test_enum_categories_immutable() -> None:
     dtype = nw.Enum(["a", "b"])
     with pytest.raises(TypeError, match="does not support item assignment"):
         dtype.categories[0] = "c"  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        dtype.categories = "a", "b", "c"  # type: ignore[misc]
 
 
 def test_enum_repr_pd() -> None:

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -444,7 +444,8 @@ def test_enum_repr_pd() -> None:
         )
     )
     dtype = df.schema["a"]
-    assert dtype.categories == ("broccoli", "cabbage")  # type: ignore[attr-defined]
+    assert isinstance(dtype, nw.Enum)
+    assert dtype.categories == ("broccoli", "cabbage")
     assert "Enum(categories=['broccoli', 'cabbage'])" in str(dtype)
 
 
@@ -458,7 +459,8 @@ def test_enum_repr_pl() -> None:
         )
     )
     dtype = df.schema["a"]
-    assert dtype.categories == ("broccoli", "cabbage")  # type: ignore[attr-defined]
+    assert isinstance(dtype, nw.Enum)
+    assert dtype.categories == ("broccoli", "cabbage")
     assert "Enum(categories=['broccoli', 'cabbage'])" in repr(dtype)
 
 


### PR DESCRIPTION
Closes #2412

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- #2414
- https://github.com/narwhals-dev/narwhals/pull/2414#issuecomment-2823734330

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below
Related to the name change from `_Delayed*` -> `_Deferred`.
I think that's a more common term for a lazy operation. When I see *delay*, it makes me think of time delay instead

- https://peps.python.org/pep-0749/
- https://github.com/ibis-project/ibis/blob/bd926f0fbda023124453b824aa24dc4a50e27d72/ibis/common/deferred.py
- https://discuss.python.org/t/backquotes-for-deferred-expression/70577