### PR TITLE
patch: Avoid pyspark no partition for window ops warning

### DIFF
--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -577,17 +577,15 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
 
         return self._with_callable(_n_unique)
 
-    def over(
-        self,
-        partition_by: Sequence[str],
-        order_by: Sequence[str] | None,
-    ) -> Self:
+    def over(self, partition_by: Sequence[str], order_by: Sequence[str] | None) -> Self:
         if (window_function := self._window_function) is not None:
             assert order_by is not None  # noqa: S101
 
             def func(df: SparkLikeLazyFrame) -> list[Column]:
                 return [
-                    window_function(WindowInputs(expr, partition_by, order_by))
+                    window_function(
+                        WindowInputs(expr, partition_by or [self._F.lit(1)], order_by)
+                    )
                     for expr in self._call(df)
                 ]
         else:

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -32,7 +32,7 @@ class WindowInputs:
     def __init__(
         self,
         expr: Column,
-        partition_by: Sequence[str],
+        partition_by: Sequence[str] | Sequence[Column],
         order_by: Sequence[str],
     ) -> None:
         self.expr = expr


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

First noticed in [#2417 comment](https://github.com/narwhals-dev/narwhals/pull/2417#discussion_r2054858516)

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Depending on pyspark and python version I started to get the following warning:

> No Partition Defined for Window operation! Moving all data to a single partition, this can cause serious performance degradation.