### PR TITLE
perf: Add `pa.Table` rename fastpath for `>=17`

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -648,7 +648,7 @@ class ArrowDataFrame(
         names: dict[str, str] | list[str]
         if self._backend_version >= (17,):
             names = cast("dict[str, str]", mapping)
-        else:
+        else:  # pragma: no cover
             names = [mapping.get(c, c) for c in self.columns]
         return self._with_native(self.native.rename_columns(names))
 

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -652,9 +652,12 @@ class ArrowDataFrame(
         return maybe_extract_py_scalar(self.native[_col][row], return_py_scalar=True)
 
     def rename(self, mapping: Mapping[str, str]) -> Self:
-        df = self.native
-        new_cols = [mapping.get(c, c) for c in df.column_names]
-        return self._with_native(df.rename_columns(new_cols))
+        names: dict[str, str] | list[str]
+        if self._backend_version >= (17,):
+            names = cast("dict[str, str]", mapping)
+        else:
+            names = [mapping.get(c, c) for c in self.columns]
+        return self._with_native(self.native.rename_columns(names))
 
     def write_parquet(self, file: str | Path | BytesIO) -> None:
         import pyarrow.parquet as pp

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -325,7 +325,7 @@ class ArrowDataFrame(
 
     @property
     def columns(self) -> list[str]:
-        return self.native.schema.names
+        return self.native.column_names
 
     def simple_select(self, *column_names: str) -> Self:
         return self._with_native(

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -496,15 +496,8 @@ class ArrowDataFrame(
     def to_dict(
         self, *, as_series: bool
     ) -> dict[str, ArrowSeries] | dict[str, list[Any]]:
-        df = self.native
-        names_and_values = zip(df.column_names, df.columns)
-        if as_series:
-            return {
-                name: ArrowSeries.from_native(col, context=self, name=name)
-                for name, col in names_and_values
-            }
-        else:
-            return {name: col.to_pylist() for name, col in names_and_values}
+        it = self.iter_columns()
+        return {s.name: s for s in it} if as_series else {s.name: s.to_list() for s in it}
 
     def with_row_index(self, name: str) -> Self:
         df = self.native

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -497,7 +497,9 @@ class ArrowDataFrame(
         self, *, as_series: bool
     ) -> dict[str, ArrowSeries] | dict[str, list[Any]]:
         it = self.iter_columns()
-        return {s.name: s for s in it} if as_series else {s.name: s.to_list() for s in it}
+        if as_series:
+            return {ser.name: ser for ser in it}
+        return {ser.name: ser.to_list() for ser in it}
 
     def with_row_index(self, name: str) -> Self:
         df = self.native


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
We don't need to convert to `list` since a `dict` is [supported](https://arrow.apache.org/docs/17.0/python/generated/pyarrow.Table.html#pyarrow.Table.rename_columns)

While adding this, I noticed we used [ `pa.Table.column_names`](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.column_names) here, but not in `ArrowDataFrame.columns`.
Wasn't clear why (#350) chose to use `schema.names`.
Searching for other usage led me to `to_dict` where I spotted a nice rewrite 😎