### PR TITLE
chore(typing): Rename, unleak `_arrow.typing` aliases

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from narwhals._arrow.expr import ArrowExpr
     from narwhals._arrow.group_by import ArrowGroupBy
     from narwhals._arrow.namespace import ArrowNamespace
-    from narwhals._arrow.typing import ArrowChunkedArray
+    from narwhals._arrow.typing import ChunkedArrayAny
     from narwhals._arrow.typing import Mask  # type: ignore[attr-defined]
     from narwhals._arrow.typing import Order  # type: ignore[attr-defined]
     from narwhals._translate import IntoArrowTable
@@ -82,7 +82,7 @@ if TYPE_CHECKING:
 
 
 class ArrowDataFrame(
-    EagerDataFrame["ArrowSeries", "ArrowExpr", "pa.Table", "pa.ChunkedArray[Any]"]
+    EagerDataFrame["ArrowSeries", "ArrowExpr", "pa.Table", "ChunkedArrayAny"]
 ):
     def __init__(
         self,
@@ -250,7 +250,7 @@ class ArrowDataFrame(
     def __array__(self, dtype: Any, *, copy: bool | None) -> _2DArray:
         return self.native.__array__(dtype, copy=copy)
 
-    def _gather(self, rows: SizedMultiIndexSelector[ArrowChunkedArray]) -> Self:
+    def _gather(self, rows: SizedMultiIndexSelector[ChunkedArrayAny]) -> Self:
         if len(rows) == 0:
             return self._with_native(self.native.slice(0, 0))
         if self._backend_version < (18,) and isinstance(rows, tuple):
@@ -279,7 +279,7 @@ class ArrowDataFrame(
         )
 
     def _select_multi_index(
-        self, columns: SizedMultiIndexSelector[ArrowChunkedArray]
+        self, columns: SizedMultiIndexSelector[ChunkedArrayAny]
     ) -> Self:
         selector: Sequence[int]
         if isinstance(columns, pa.ChunkedArray):
@@ -294,7 +294,7 @@ class ArrowDataFrame(
         return self._with_native(self.native.select(selector))
 
     def _select_multi_name(
-        self, columns: SizedMultiNameSelector[ArrowChunkedArray]
+        self, columns: SizedMultiNameSelector[ChunkedArrayAny]
     ) -> Self:
         selector: Sequence[str] | _1DArray
         if isinstance(columns, pa.ChunkedArray):
@@ -344,7 +344,7 @@ class ArrowDataFrame(
         df = pa.Table.from_arrays([s.native for s in reshaped], names=names)
         return self._with_native(df, validate_column_names=True)
 
-    def _extract_comparand(self, other: ArrowSeries) -> ArrowChunkedArray:
+    def _extract_comparand(self, other: ArrowSeries) -> ChunkedArrayAny:
         length = len(self)
         if not other._broadcast:
             if (len_other := len(other)) != length:
@@ -516,7 +516,7 @@ class ArrowDataFrame(
         self: ArrowDataFrame, predicate: ArrowExpr | list[bool | None]
     ) -> ArrowDataFrame:
         if isinstance(predicate, list):
-            mask_native: Mask | ArrowChunkedArray = predicate
+            mask_native: Mask | ChunkedArrayAny = predicate
         else:
             # `[0]` is safe as the predicate's expression only returns a single column
             mask_native = self._evaluate_into_exprs(predicate)[0].native
@@ -773,7 +773,7 @@ class ArrowDataFrame(
                         [
                             *(self.native.column(idx_col) for idx_col in index_),
                             cast(
-                                "ArrowChunkedArray",
+                                "ChunkedArrayAny",
                                 pa.array([on_col] * n_rows, pa.string()),
                             ),
                             self.native.column(on_col),

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -24,8 +24,8 @@ from narwhals._expression_parsing import combine_evaluate_output_names
 from narwhals.utils import Implementation
 
 if TYPE_CHECKING:
-    from narwhals._arrow.typing import ArrayOrScalarAny
-    from narwhals._arrow.typing import ArrowChunkedArray
+    from narwhals._arrow.typing import ArrayOrScalar
+    from narwhals._arrow.typing import ChunkedArrayAny
     from narwhals._arrow.typing import Incomplete
     from narwhals.dtypes import DType
     from narwhals.typing import NonNestedLiteral
@@ -33,9 +33,7 @@ if TYPE_CHECKING:
 
 
 class ArrowNamespace(
-    EagerNamespace[
-        ArrowDataFrame, ArrowSeries, ArrowExpr, "pa.Table", "ArrowChunkedArray"
-    ]
+    EagerNamespace[ArrowDataFrame, ArrowSeries, ArrowExpr, "pa.Table", "ChunkedArrayAny"]
 ):
     @property
     def _dataframe(self) -> type[ArrowDataFrame]:
@@ -274,18 +272,18 @@ class ArrowNamespace(
         )
 
 
-class ArrowWhen(EagerWhen[ArrowDataFrame, ArrowSeries, ArrowExpr, "ArrowChunkedArray"]):
+class ArrowWhen(EagerWhen[ArrowDataFrame, ArrowSeries, ArrowExpr, "ChunkedArrayAny"]):
     @property
     def _then(self) -> type[ArrowThen]:
         return ArrowThen
 
     def _if_then_else(
         self,
-        when: ArrowChunkedArray,
-        then: ArrowChunkedArray,
-        otherwise: ArrayOrScalarAny | NonNestedLiteral,
+        when: ChunkedArrayAny,
+        then: ChunkedArrayAny,
+        otherwise: ArrayOrScalar | NonNestedLiteral,
         /,
-    ) -> ArrowChunkedArray:
+    ) -> ChunkedArrayAny:
         otherwise = pa.nulls(len(when), then.type) if otherwise is None else otherwise
         return pc.if_else(when, then, otherwise)
 

--- a/narwhals/_arrow/typing.py
+++ b/narwhals/_arrow/typing.py
@@ -32,13 +32,13 @@ if TYPE_CHECKING:
     TieBreaker: TypeAlias = Literal["min", "max", "first", "dense"]
     NullPlacement: TypeAlias = Literal["at_start", "at_end"]
 
-    ArrowChunkedArray: TypeAlias = pa.ChunkedArray[Any]
-    ArrowArray: TypeAlias = pa.Array[Any]
-    ArrayAny: TypeAlias = "ArrowArray | ArrowChunkedArray"
+    ChunkedArrayAny: TypeAlias = pa.ChunkedArray[Any]
+    ArrayAny: TypeAlias = pa.Array[Any]
+    ArrayOrChunkedArray: TypeAlias = "ArrayAny | ChunkedArrayAny"
     ScalarAny: TypeAlias = pa.Scalar[Any]
-    ArrayOrScalarAny: TypeAlias = "ArrayAny | ScalarAny"
-    ArrayOrScalarT1 = TypeVar("ArrayOrScalarT1", ArrowArray, ArrowChunkedArray, ScalarAny)
-    ArrayOrScalarT2 = TypeVar("ArrayOrScalarT2", ArrowArray, ArrowChunkedArray, ScalarAny)
+    ArrayOrScalar: TypeAlias = "ArrayOrChunkedArray | ScalarAny"
+    ArrayOrScalarT1 = TypeVar("ArrayOrScalarT1", ArrayAny, ChunkedArrayAny, ScalarAny)
+    ArrayOrScalarT2 = TypeVar("ArrayOrScalarT2", ArrayAny, ChunkedArrayAny, ScalarAny)
     _AsPyType = TypeVar("_AsPyType")
 
     class _BasicDataType(pa.DataType, Generic[_AsPyType]): ...

--- a/narwhals/_compliant/series.py
+++ b/narwhals/_compliant/series.py
@@ -32,9 +32,9 @@ if TYPE_CHECKING:
 
     import pandas as pd
     import polars as pl
+    import pyarrow as pa
     from typing_extensions import Self
 
-    from narwhals._arrow.typing import ArrowArray
     from narwhals._compliant.dataframe import CompliantDataFrame
     from narwhals._compliant.expr import CompliantExpr
     from narwhals._compliant.expr import EagerExpr
@@ -259,7 +259,7 @@ class CompliantSeries(
     def std(self, *, ddof: int) -> float: ...
     def sum(self) -> float: ...
     def tail(self, n: int) -> Self: ...
-    def to_arrow(self) -> ArrowArray: ...
+    def to_arrow(self) -> pa.Array[Any]: ...
     def to_dummies(
         self, *, separator: str, drop_first: bool
     ) -> CompliantDataFrame[Self, Any, Any]: ...

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -38,10 +38,10 @@ if TYPE_CHECKING:
 
     import pandas as pd
     import polars as pl
+    import pyarrow as pa
     from typing_extensions import Self
     from typing_extensions import TypeIs
 
-    from narwhals._arrow.typing import ArrowArray
     from narwhals._pandas_like.dataframe import PandasLikeDataFrame
     from narwhals._pandas_like.namespace import PandasLikeNamespace
     from narwhals.dtypes import DType
@@ -824,7 +824,7 @@ class PandasLikeSeries(EagerSeries[Any]):
         kwargs = {"axis": 0} if self._implementation is Implementation.MODIN else {}
         return self._with_native(self.native.clip(lower, upper, **kwargs))
 
-    def to_arrow(self) -> ArrowArray:
+    def to_arrow(self) -> pa.Array[Any]:
         if self._implementation is Implementation.CUDF:
             return self.native.to_arrow()
 

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -26,10 +26,10 @@ if TYPE_CHECKING:
     from typing import TypeVar
 
     import pandas as pd
+    import pyarrow as pa
     from typing_extensions import Self
     from typing_extensions import TypeIs
 
-    from narwhals._arrow.typing import ArrowArray
     from narwhals._polars.dataframe import Method
     from narwhals._polars.dataframe import PolarsDataFrame
     from narwhals._polars.expr import PolarsExpr
@@ -628,7 +628,7 @@ class PolarsSeries:
     std: Method[float]
     sum: Method[float]
     tail: Method[Self]
-    to_arrow: Method[ArrowArray]
+    to_arrow: Method[pa.Array[Any]]
     to_frame: Method[PolarsDataFrame]
     to_list: Method[list[Any]]
     to_pandas: Method[pd.Series[Any]]

--- a/narwhals/dependencies.py
+++ b/narwhals/dependencies.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
     from typing_extensions import TypeGuard
     from typing_extensions import TypeIs
 
-    from narwhals._arrow.typing import ArrowChunkedArray
     from narwhals._spark_like.dataframe import SQLFrameDataFrame
     from narwhals.dataframe import DataFrame
     from narwhals.dataframe import LazyFrame
@@ -216,9 +215,7 @@ def is_polars_series(ser: Any) -> TypeIs[pl.Series]:
     return (pl := get_polars()) is not None and isinstance(ser, pl.Series)
 
 
-def is_pyarrow_chunked_array(
-    ser: Any | ArrowChunkedArray,
-) -> TypeIs[ArrowChunkedArray]:
+def is_pyarrow_chunked_array(ser: Any) -> TypeIs[pa.ChunkedArray[Any]]:
     """Check whether `ser` is a PyArrow ChunkedArray without importing PyArrow."""
     return (pa := get_pyarrow()) is not None and isinstance(ser, pa.ChunkedArray)
 

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -34,9 +34,9 @@ if TYPE_CHECKING:
 
     import pandas as pd
     import polars as pl
+    import pyarrow as pa
     from typing_extensions import Self
 
-    from narwhals._arrow.typing import ArrowArray
     from narwhals._compliant import CompliantSeries
     from narwhals.dataframe import DataFrame
     from narwhals.dataframe import MultiIndexSelector
@@ -2069,7 +2069,7 @@ class Series(Generic[IntoSeriesT]):
             self._compliant_series.gather_every(n=n, offset=offset)
         )
 
-    def to_arrow(self) -> ArrowArray:
+    def to_arrow(self) -> pa.Array[Any]:
         r"""Convert to arrow.
 
         Returns:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
- Mainly trying to be consistent with the convention from (https://github.com/narwhals-dev/narwhals/blob/857b08ad270d723fe391277611a0d7d00df5fdef/narwhals/_compliant/typing.py)
  - Use `*Any` for an alias to simplify `*[Any*]`
- Removes the `Arrow*` prefix
  - That clashes with how our **compliant** classes are named
  - The aliases are for **native** types
- Replaces all usage outside of `_arrow` with `pa.*`
  - Shouldn't have been exposed, especially as they aren't available at runtime