### PR TITLE
chore: Remove name-preserving Dask operations

### DIFF
--- a/narwhals/_dask/utils.py
+++ b/narwhals/_dask/utils.py
@@ -159,11 +159,3 @@ def narwhals_to_native_dtype(dtype: DType | type[DType], version: Version) -> An
 
     msg = f"Unknown dtype: {dtype}"  # pragma: no cover
     raise AssertionError(msg)
-
-
-def name_preserving_sum(s1: dx.Series, s2: dx.Series) -> dx.Series:
-    return (s1 + s2).rename(s1.name)  # pyright: ignore[reportOperatorIssue]
-
-
-def name_preserving_div(s1: dx.Series, s2: dx.Series) -> dx.Series:
-    return (s1 / s2).rename(s1.name)  # pyright: ignore[reportOperatorIssue]


### PR DESCRIPTION
We don't need these name-preserving ops any more as aliases are set as late as possible anyway

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
