### PR TITLE
test: make `polars` optional in `truncate_test`

### DIFF
--- a/tests/expr_and_series/dt/truncate_test.py
+++ b/tests/expr_and_series/dt/truncate_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import datetime
 
 import pandas as pd
-import polars as pl
 import pytest
 
 import narwhals as nw
@@ -227,6 +226,10 @@ def test_truncate_custom(
     ],
 )
 def test_truncate_polars_ns(every: str, expected: list[datetime]) -> None:
+    pytest.importorskip("polars")
+
+    import polars as pl
+
     df_pl = pl.DataFrame(data, schema={"a": pl.Datetime(time_unit="ns")})
     df = nw.from_native(df_pl)
     result = df.select(nw.col("a").dt.truncate(every))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
I'll try adding a workflow to test this use case (separately).