### PR TITLE
test: Add a GHA workflow testing against narrower dep set

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -99,3 +99,28 @@ jobs:
         # reprs differ between versions, so we only run doctests on the latest Python
         if: matrix.python-version == '3.13'
         run: pytest narwhals/*.py --doctest-modules
+
+  # Test against smaller dependency set, used e.g. on Gentoo.
+  pytest-narrower-deps:
+    strategy:
+      matrix:
+        python-version: ["3.13"]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: "true"
+          cache-suffix: ${{ matrix.python-version }}
+          cache-dependency-glob: "pyproject.toml"
+      - name: install-reqs
+        run: uv pip install -e ".[pandas, pyarrow]" --group tests --system
+      - name: show-deps
+        run: uv pip freeze
+      - name: Run pytest
+        run: pytest tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Related to #2501, this is meant to help detect regressions like that. As expected, it fails with `main` but passes once #2501 is merged (e.g. https://github.com/mgorny/narwhals/actions/runs/14852314516/job/41698095253).