### PR TITLE
enh: add `expr.dt.to_string` for SparkLikeExpr

### DIFF
--- a/narwhals/_spark_like/expr_dt.py
+++ b/narwhals/_spark_like/expr_dt.py
@@ -65,6 +65,15 @@ class SparkLikeExprDateTimeNamespace:
             return (self._compliant_expr._F.dayofweek(_input) + 6) % 7
 
         return self._compliant_expr._with_callable(_weekday)
+    
+    def to_string(self, format: str) -> SparkLikeExpr:
+        def _to_string(_input: Column) -> Column:
+            from narwhals._spark_like.expr_str import strptime_to_pyspark_format
+
+            _format = strptime_to_pyspark_format(format)
+            return self._compliant_expr._F.date_format(_input, _format)
+        
+        return self._compliant_expr._with_callable(_to_string)
 
     def truncate(self, every: str) -> SparkLikeExpr:
         multiple, unit = parse_interval_string(every)

--- a/narwhals/_spark_like/expr_dt.py
+++ b/narwhals/_spark_like/expr_dt.py
@@ -65,15 +65,14 @@ class SparkLikeExprDateTimeNamespace:
             return (self._compliant_expr._F.dayofweek(_input) + 6) % 7
 
         return self._compliant_expr._with_callable(_weekday)
-    
-    
+
     def to_string(self, format: str) -> SparkLikeExpr:
         def _to_string(_input: Column) -> Column:
             from narwhals._spark_like.expr_str import strptime_to_pyspark_format
 
             _format = strptime_to_pyspark_format(format)
             return self._compliant_expr._F.date_format(_input, _format)
-        
+
         return self._compliant_expr._with_callable(_to_string)
 
     def truncate(self, every: str) -> SparkLikeExpr:

--- a/narwhals/_spark_like/expr_dt.py
+++ b/narwhals/_spark_like/expr_dt.py
@@ -66,6 +66,7 @@ class SparkLikeExprDateTimeNamespace:
 
         return self._compliant_expr._with_callable(_weekday)
     
+    
     def to_string(self, format: str) -> SparkLikeExpr:
         def _to_string(_input: Column) -> Column:
             from narwhals._spark_like.expr_str import strptime_to_pyspark_format


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Implementation for `expr_dt.to_string` - *disclaimer: probably glossing over some dt/tz details, feel free to call me out*

Makes use of the convention mapping from `strptime_to_pyspark_format` - can move this to `_spark_like.utils` for `expr_dt` and `expr_str` to import from:

https://github.com/narwhals-dev/narwhals/blob/dd41833963acaf2641c6c4c8948ee7aa5f25734a/narwhals/_spark_like/expr_str.py#L119-L122

couple notes:
- some pyspark formats aren't zero-padded - e.g. the format "%Y-%m-%d" should evaluate to "yyyy-MM-dd" in pyspark but this returns "y-M-d" which causes some minor differences (instead of `2020-01-09` we get `2020-1-9`). wondering if we should update the pyspark mappings to their zero-padded equivalents?

https://github.com/narwhals-dev/narwhals/blob/dd41833963acaf2641c6c4c8948ee7aa5f25734a/narwhals/_spark_like/expr_str.py#L125-L141

- not all tests pass for a couple reasons:
    - pattern contains week-based patterns (`W`): `IllegalArgumentException: All week-based patterns are unsupported since Spark 3.0, detected: W, Please use the SQL function EXTRACT instead`
    - timestamp handling: two things going on here:
        - similar to above, `%f` shortchanges the milliseconds by only returning one decimal place. could default to higher number of places
        - `strptime_to_pyspark_format` removes all instances of "T" for timezones

let me know if there's anything else i'm missing that I can implement