### PR TITLE
fix: Add `new_version.strip()` in `bump_version.py`, otherwise the tag will be invalid

### DIFF
--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -53,7 +53,7 @@ how = sys.argv[1]
 
 new_version = sp.run(
     [UV, VERSION, "--bump", how, "--short"], capture_output=True, text=True, check=False
-).stdout
+).stdout.strip()
 
 sp.run([GIT, COMMIT, "-a", "-m", f"release: Bump version to {new_version}"], check=False)
 sp.run([GIT, TAG, "-a", f"v{new_version}", "-m", f"v{new_version}"], check=False)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

