### PR TITLE
feat: Generate nicer-looking SQL when grouping by expressions

### DIFF
--- a/narwhals/_compliant/group_by.py
+++ b/narwhals/_compliant/group_by.py
@@ -126,7 +126,8 @@ class ParseKeysGroupBy(
 
         def _temporary_name(key: str) -> str:
             # 5 is the length of `__tmp`
-            return f"_{key}_tmp{'_' * (tmp_name_length - len(key) - 5)}"
+            key_str = str(key)  # pandas allows non-string column names :sob:
+            return f"_{key_str}_tmp{'_' * (tmp_name_length - len(key_str) - 5)}"
 
         output_names = compliant_frame._evaluate_aliases(*keys)
 

--- a/narwhals/_compliant/group_by.py
+++ b/narwhals/_compliant/group_by.py
@@ -122,15 +122,20 @@ class ParseKeysGroupBy(
             no overlap with any existing column name.
         - Add these temporary columns to the compliant dataframe.
         """
-        suffix_token = "_" * (max(len(str(c)) for c in compliant_frame.columns) + 1)
+        tmp_name_length = max(len(str(c)) for c in compliant_frame.columns) + 1
+
+        def _temporary_name(key: str) -> str:
+            # 5 is the length of `__tmp`
+            return f"_{key}_tmp{'_' * (tmp_name_length - len(key) - 5)}"
+
         output_names = compliant_frame._evaluate_aliases(*keys)
 
         safe_keys = [
             # multi-output expression cannot have duplicate names, hence it's safe to suffix
-            key.name.suffix(suffix_token)
+            key.name.map(_temporary_name)
             if (metadata := key._metadata) and metadata.expansion_kind.is_multi_output()
             # otherwise it's single named and we can use Expr.alias
-            else key.alias(f"{new_name}{suffix_token}")
+            else key.alias(_temporary_name(new_name))
             for key, new_name in zip(keys, output_names)
         ]
         return (

--- a/tests/group_by_test.py
+++ b/tests/group_by_test.py
@@ -584,3 +584,10 @@ def test_group_by_selector(constructor: Constructor) -> None:
     )
     expected = {"a": [1, 1], "b": [4, 6], "c": [8.0, 9.0]}
     assert_equal_data(result, expected)
+
+
+def test_renaming_edge_case(constructor: Constructor) -> None:
+    data = {"a": [0, 0, 0], "_a_tmp": [1, 2, 3], "b": [4, 5, 6]}
+    result = nw.from_native(constructor(data)).group_by(nw.col("a")).agg(nw.all().min())
+    expected = {"a": [0], "_a_tmp": [1], "b": [4]}
+    assert_equal_data(result, expected)


### PR DESCRIPTION
Like this we get
```sql
WITH "t27701520" AS (
  SELECT
    "penguins"."island_name" AS "_island_name_tmp",
    ROUND("penguins"."height", 10) AS "_height_tmp_",
    AVG("penguins"."weight") AS "weight"
  FROM "penguins" AS "penguins"
  JOIN "islands" AS "islands"
    ON "islands"."name" = "penguins"."island_name"
  GROUP BY
    "penguins"."island_name",
    ROUND("penguins"."height", 10)
)
SELECT
  "t27701520"."_island_name_tmp" AS "island_name",
  "t27701520"."_height_tmp_" AS "height",
  "t27701520"."weight" AS "weight"
FROM "t27701520" AS "t27701520"
```

instead of
```sql
WITH "t36714377" AS (
  SELECT
    "penguins"."island_name" AS "island_name____________",
    ROUND("penguins"."height", 10) AS "height____________",
    AVG("penguins"."weight") AS "weight"
  FROM "penguins" AS "penguins"
  JOIN "islands" AS "islands"
    ON "islands"."name" = "penguins"."island_name"
  GROUP BY
    "penguins"."island_name",
    ROUND("penguins"."height", 10)
)
SELECT
  "t36714377"."island_name____________" AS "island_name",
  "t36714377"."height____________" AS "height",
  "t36714377"."weight" AS "weight"
FROM "t36714377" AS "t36714377"
```

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
