### PR TITLE
TYP: Make `FrameT` more precise

### DIFF
--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -9,7 +9,6 @@ from typing import Iterable
 from typing import Literal
 from typing import Mapping
 from typing import Sequence
-from typing import TypeVar
 from typing import cast
 
 from narwhals._expression_parsing import ExprKind
@@ -54,6 +53,7 @@ if TYPE_CHECKING:
     from narwhals.schema import Schema
     from narwhals.series import Series
     from narwhals.typing import ConcatMethod
+    from narwhals.typing import FrameT
     from narwhals.typing import IntoExpr
     from narwhals.typing import IntoSeriesT
     from narwhals.typing import NativeFrame
@@ -64,7 +64,6 @@ if TYPE_CHECKING:
     from narwhals.typing import _2DArray
 
     _IntoSchema: TypeAlias = "Mapping[str, DType] | Schema | Sequence[str] | None"
-    FrameT = TypeVar("FrameT", "DataFrame[Any]", "LazyFrame[Any]")
 
 
 def concat(items: Iterable[FrameT], *, how: ConcatMethod = "vertical") -> FrameT:

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -95,6 +95,7 @@ if TYPE_CHECKING:
     from narwhals.dataframe import MultiColSelector
     from narwhals.dataframe import MultiIndexSelector
     from narwhals.dtypes import DType
+    from narwhals.stable.v1.typing import FrameT
     from narwhals.typing import ConcatMethod
     from narwhals.typing import IntoExpr
     from narwhals.typing import IntoFrame
@@ -106,7 +107,6 @@ if TYPE_CHECKING:
     from narwhals.typing import _1DArray
     from narwhals.typing import _2DArray
 
-    FrameT = TypeVar("FrameT", "DataFrame[Any]", "LazyFrame[Any]")
     DataFrameT = TypeVar("DataFrameT", bound="DataFrame[Any]")
     LazyFrameT = TypeVar("LazyFrameT", bound="LazyFrame[Any]")
     SeriesT = TypeVar("SeriesT", bound="Series[Any]")

--- a/narwhals/stable/v1/typing.py
+++ b/narwhals/stable/v1/typing.py
@@ -6,6 +6,9 @@ from typing import Protocol
 from typing import TypeVar
 from typing import Union
 
+from narwhals.stable.v1 import DataFrame
+from narwhals.stable.v1 import LazyFrame
+
 if TYPE_CHECKING:
     import sys
 
@@ -14,9 +17,7 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import TypeAlias
 
-    from narwhals.stable.v1 import DataFrame
     from narwhals.stable.v1 import Expr
-    from narwhals.stable.v1 import LazyFrame
     from narwhals.stable.v1 import Series
     from narwhals.stable.v1 import dtypes
 
@@ -132,7 +133,7 @@ Examples:
     ...     return df.with_columns(c=df["a"] + 1).to_native()
 """
 
-FrameT = TypeVar("FrameT", bound="Frame")
+FrameT = TypeVar("FrameT", DataFrame[Any], LazyFrame[Any])
 """TypeVar bound to Narwhals DataFrame or Narwhals LazyFrame.
 
 Use this if your function accepts either `nw.DataFrame` or `nw.LazyFrame` and returns

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -11,6 +11,8 @@ from typing import Union
 from narwhals._compliant import CompliantDataFrame
 from narwhals._compliant import CompliantLazyFrame
 from narwhals._compliant import CompliantSeries
+from narwhals.dataframe import DataFrame
+from narwhals.dataframe import LazyFrame
 
 if TYPE_CHECKING:
     import datetime as dt
@@ -23,8 +25,6 @@ if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
     from narwhals import dtypes
-    from narwhals.dataframe import DataFrame
-    from narwhals.dataframe import LazyFrame
     from narwhals.expr import Expr
     from narwhals.series import Series
 
@@ -148,7 +148,7 @@ Examples:
 
 IntoLazyFrameT = TypeVar("IntoLazyFrameT", bound="IntoLazyFrame")
 
-FrameT = TypeVar("FrameT", bound="Frame")
+FrameT = TypeVar("FrameT", DataFrame[Any], LazyFrame[Any])
 """TypeVar bound to Narwhals DataFrame or Narwhals LazyFrame.
 
 Use this if your function accepts either `nw.DataFrame` or `nw.LazyFrame` and returns

--- a/tpch/__init__.py
+++ b/tpch/__init__.py
@@ -1,5 +1,0 @@
-from __future__ import annotations
-
-from tpch import _typing
-
-__all__ = ["_typing"]

--- a/tpch/_typing.py
+++ b/tpch/_typing.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-from typing import Any
-from typing import TypeVar
-
-from narwhals import DataFrame
-from narwhals import LazyFrame
-
-FrameT = TypeVar("FrameT", DataFrame[Any], LazyFrame[Any])

--- a/tpch/queries/q1.py
+++ b/tpch/queries/q1.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(lineitem: FrameT) -> FrameT:

--- a/tpch/queries/q10.py
+++ b/tpch/queries/q10.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(

--- a/tpch/queries/q11.py
+++ b/tpch/queries/q11.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(

--- a/tpch/queries/q12.py
+++ b/tpch/queries/q12.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(line_item_ds: FrameT, orders_ds: FrameT) -> FrameT:

--- a/tpch/queries/q13.py
+++ b/tpch/queries/q13.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(customer_ds: FrameT, orders_ds: FrameT) -> FrameT:

--- a/tpch/queries/q14.py
+++ b/tpch/queries/q14.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(line_item_ds: FrameT, part_ds: FrameT) -> FrameT:

--- a/tpch/queries/q15.py
+++ b/tpch/queries/q15.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(

--- a/tpch/queries/q16.py
+++ b/tpch/queries/q16.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(part_ds: FrameT, partsupp_ds: FrameT, supplier_ds: FrameT) -> FrameT:

--- a/tpch/queries/q17.py
+++ b/tpch/queries/q17.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(lineitem_ds: FrameT, part_ds: FrameT) -> FrameT:

--- a/tpch/queries/q18.py
+++ b/tpch/queries/q18.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(customer_ds: FrameT, lineitem_ds: FrameT, orders_ds: FrameT) -> FrameT:

--- a/tpch/queries/q19.py
+++ b/tpch/queries/q19.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(lineitem_ds: FrameT, part_ds: FrameT) -> FrameT:

--- a/tpch/queries/q2.py
+++ b/tpch/queries/q2.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(

--- a/tpch/queries/q20.py
+++ b/tpch/queries/q20.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(

--- a/tpch/queries/q21.py
+++ b/tpch/queries/q21.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(

--- a/tpch/queries/q22.py
+++ b/tpch/queries/q22.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(customer_ds: FrameT, orders_ds: FrameT) -> FrameT:

--- a/tpch/queries/q3.py
+++ b/tpch/queries/q3.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(

--- a/tpch/queries/q4.py
+++ b/tpch/queries/q4.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(line_item_ds: FrameT, orders_ds: FrameT) -> FrameT:

--- a/tpch/queries/q5.py
+++ b/tpch/queries/q5.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(

--- a/tpch/queries/q6.py
+++ b/tpch/queries/q6.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(line_item_ds: FrameT) -> FrameT:

--- a/tpch/queries/q7.py
+++ b/tpch/queries/q7.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(

--- a/tpch/queries/q8.py
+++ b/tpch/queries/q8.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(

--- a/tpch/queries/q9.py
+++ b/tpch/queries/q9.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import narwhals as nw
 
 if TYPE_CHECKING:
-    from tpch._typing import FrameT
+    from narwhals.typing import FrameT
 
 
 def query(


### PR DESCRIPTION
closes #2537 

We do carve out an exception for this in https://narwhals-dev.github.io/narwhals/backcompat/#exceptions, and it doesn't look like it affects any downstream libraries

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
