### PR TITLE
chore: Cache ibis columns property

### DIFF
--- a/narwhals/_ibis/dataframe.py
+++ b/narwhals/_ibis/dataframe.py
@@ -65,6 +65,7 @@ class IbisLazyFrame(
         self._version = version
         self._backend_version = backend_version
         self._cached_schema: dict[str, DType] | None = None
+        self._cached_columns: list[str] | None = None
         validate_backend_version(self._implementation, self._backend_version)
 
     @staticmethod
@@ -213,7 +214,13 @@ class IbisLazyFrame(
 
     @property
     def columns(self) -> list[str]:
-        return list(self.native.columns)
+        if self._cached_columns is None:
+            self._cached_columns = (
+                list(self.schema)
+                if self._cached_schema is not None
+                else list(self.native.columns)
+            )
+        return self._cached_columns
 
     def to_pandas(self) -> pd.DataFrame:
         # only if version is v1, keep around for backcompat


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #2525

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

This is a quick fix

@MarcoGorelli @dangotbanned I think we start to have a few piece of the code base (such as this one) which can be abstracted for duckdb, ibis and spark-like (dask tbd). I am having a hard time to come up with a name for such compliant class, mostly because `EagerDataFrame` inherits from `CompliantLazyFrame` 😂 `LazyDataFrame` does not sound right for some reason.