### PR TITLE
chore: Remap '1q' to '3mo' in `IbisExpr.dt.truncate`

### DIFF
--- a/narwhals/_ibis/expr_dt.py
+++ b/narwhals/_ibis/expr_dt.py
@@ -74,6 +74,8 @@ class IbisExprDateTimeNamespace:
 
     def truncate(self, every: str) -> IbisExpr:
         multiple, unit = parse_interval_string(every)
+        if unit == "q":
+            multiple, unit = 3 * multiple, "mo"
         if multiple != 1:
             if self._compliant_expr._backend_version < (7, 1):  # pragma: no cover
                 msg = "Truncating datetimes with multiples of the unit is only supported in Ibis >= 7.1."

--- a/tests/expr_and_series/dt/truncate_test.py
+++ b/tests/expr_and_series/dt/truncate_test.py
@@ -191,32 +191,20 @@ def test_truncate_multiples(
     every: str,
     expected: list[datetime],
 ) -> None:
-    if any(x in str(constructor) for x in ("sqlframe",)):
-        request.applymarker(
-            pytest.mark.xfail(reason="https://github.com/eakmanrq/sqlframe/issues/383")
-        )
+    if any(x in str(constructor) for x in ("sqlframe", "cudf", "pyspark")):
+        # Reasons:
+        # - sqlframe: https://github.com/eakmanrq/sqlframe/issues/383
+        # - cudf: https://github.com/rapidsai/cudf/issues/18654
+        # - pyspark: Only multiple 1 is currently supported
+        request.applymarker(pytest.mark.xfail())
     if every.endswith("ns") and any(
         x in str(constructor) for x in ("polars", "duckdb", "ibis")
     ):
         request.applymarker(pytest.mark.xfail())
-    if "cudf" in str(constructor):
-        # https://github.com/rapidsai/cudf/issues/18654
-        request.applymarker(pytest.mark.xfail(reason="Not implemented"))
     if any(every.endswith(x) for x in ("mo", "q", "y")) and any(
         x in str(constructor) for x in ("dask",)
     ):
         request.applymarker(pytest.mark.xfail(reason="Not implemented"))
-    if any(every.endswith(x) for x in ("q",)) and any(
-        x in str(constructor) for x in ("ibis",)
-    ):
-        request.applymarker(pytest.mark.xfail(reason="Not implemented"))
-    request.applymarker(
-        pytest.mark.xfail(
-            "pyspark" in str(constructor),
-            raises=ValueError,
-            reason="Only multiple 1 is currently supported",
-        )
-    )
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a").dt.truncate(every))
     assert_equal_data(result, {"a": expected})


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Towards #2525 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

