### PR TITLE
fix `truncate` for timezone-aware timestamps for DuckDB

### DIFF
--- a/narwhals/_duckdb/expr_dt.py
+++ b/narwhals/_duckdb/expr_dt.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 from duckdb import FunctionExpression
@@ -11,6 +10,8 @@ from narwhals._duration import parse_interval_string
 from narwhals.utils import not_implemented
 
 if TYPE_CHECKING:
+    from duckdb import Expression
+
     from narwhals._duckdb.expr import DuckDBExpr
 
 
@@ -111,14 +112,18 @@ class DuckDBExprDateTimeNamespace:
 
     def truncate(self, every: str) -> DuckDBExpr:
         multiple, unit = parse_interval_string(every)
+        if multiple != 1:
+            # https://github.com/duckdb/duckdb/issues/17554
+            msg = f"Only multiple 1 is currently supported for DuckDB.\nGot {multiple!s}."
+            raise ValueError(msg)
         if unit == "ns":
             msg = "Truncating to nanoseconds is not yet supported for DuckDB."
             raise NotImplementedError(msg)
-        every = f"{multiple!s} {UNITS_DICT[unit]}"
-        return self._compliant_expr._with_callable(
-            lambda _input: FunctionExpression(
-                "time_bucket", lit(every), _input, lit(datetime(1970, 1, 1))
-            )
-        )
+        format = lit(UNITS_DICT[unit])
+
+        def _truncate(expr: Expression) -> Expression:
+            return FunctionExpression("date_trunc", format, expr)
+
+        return self._compliant_expr._with_callable(_truncate)
 
     total_nanoseconds = not_implemented()

--- a/tests/expr_and_series/dt/truncate_test.py
+++ b/tests/expr_and_series/dt/truncate_test.py
@@ -191,7 +191,7 @@ def test_truncate_multiples(
     every: str,
     expected: list[datetime],
 ) -> None:
-    if any(x in str(constructor) for x in ("sqlframe", "cudf", "pyspark")):
+    if any(x in str(constructor) for x in ("sqlframe", "cudf", "pyspark", "duckdb")):
         # Reasons:
         # - sqlframe: https://github.com/eakmanrq/sqlframe/issues/383
         # - cudf: https://github.com/rapidsai/cudf/issues/18654
@@ -282,3 +282,20 @@ def test_pandas_numpy_nat() -> None:
     expected = {"a": [datetime(2020, 1, 1), None, datetime(2020, 1, 1)]}
     assert_equal_data(result, expected)
     assert result.item(1, 0) is pd.NaT
+
+
+def test_truncate_tz_aware_duckdb() -> None:
+    pytest.importorskip("duckdb")
+    pytest.importorskip("zoneinfo")
+    import duckdb
+    from zoneinfo import ZoneInfo
+
+    duckdb.sql("""set timezone = 'Europe/Amsterdam'""")
+    rel = duckdb.sql("""select * from values (timestamptz '2020-10-25') df(a)""")
+    result = nw.from_native(rel).with_columns(a_truncated=nw.col("a").dt.truncate("1mo"))
+    expected = {
+        "a": [datetime(2020, 10, 25, tzinfo=ZoneInfo("Europe/Amsterdam"))],
+        "a_truncated": [datetime(2020, 10, 1, tzinfo=ZoneInfo("Europe/Amsterdam"))],
+    }
+    assert_equal_data(result, expected)
+    duckdb.sql("""set timezone = 'UTC'""")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,8 @@ import math
 import os
 import sys
 import warnings
+from datetime import date
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -124,8 +126,11 @@ def assert_equal_data(result: Any, expected: Mapping[str, Any]) -> None:
                 )
             elif pd.isna(lhs):
                 are_equivalent_values = pd.isna(rhs)
+            elif type(lhs) is date and type(rhs) is datetime:
+                are_equivalent_values = datetime(lhs.year, lhs.month, lhs.day) == rhs
             else:
                 are_equivalent_values = lhs == rhs
+
             assert are_equivalent_values, (
                 f"Mismatch at index {i}: {lhs} != {rhs}\nExpected: {expected}\nGot: {result}"
             )


### PR DESCRIPTION
closes #2575 

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
