### PR TITLE
chore: use `Expression` instead of `duckdb.Expression` for typing

### DIFF
--- a/narwhals/_duckdb/expr_str.py
+++ b/narwhals/_duckdb/expr_str.py
@@ -8,7 +8,7 @@ from narwhals._duckdb.utils import lit
 from narwhals.utils import not_implemented
 
 if TYPE_CHECKING:
-    import duckdb
+    from duckdb import Expression
 
     from narwhals._duckdb.expr import DuckDBExpr
 
@@ -28,7 +28,7 @@ class DuckDBExprStringNamespace:
         )
 
     def contains(self, pattern: str, *, literal: bool) -> DuckDBExpr:
-        def func(_input: duckdb.Expression) -> duckdb.Expression:
+        def func(_input: Expression) -> Expression:
             if literal:
                 return FunctionExpression("contains", _input, lit(pattern))
             return FunctionExpression("regexp_matches", _input, lit(pattern))
@@ -36,7 +36,7 @@ class DuckDBExprStringNamespace:
         return self._compliant_expr._with_callable(func)
 
     def slice(self, offset: int, length: int) -> DuckDBExpr:
-        def func(_input: duckdb.Expression) -> duckdb.Expression:
+        def func(_input: Expression) -> Expression:
             offset_lit = lit(offset)
             return FunctionExpression(
                 "array_slice",

--- a/narwhals/_duckdb/selectors.py
+++ b/narwhals/_duckdb/selectors.py
@@ -7,21 +7,19 @@ from narwhals._compliant import LazySelectorNamespace
 from narwhals._duckdb.expr import DuckDBExpr
 
 if TYPE_CHECKING:
-    import duckdb  # noqa: F401
+    from duckdb import Expression  # noqa: F401
 
     from narwhals._duckdb.dataframe import DuckDBLazyFrame  # noqa: F401
 
 
-class DuckDBSelectorNamespace(
-    LazySelectorNamespace["DuckDBLazyFrame", "duckdb.Expression"]
-):
+class DuckDBSelectorNamespace(LazySelectorNamespace["DuckDBLazyFrame", "Expression"]):
     @property
     def _selector(self) -> type[DuckDBSelector]:
         return DuckDBSelector
 
 
 class DuckDBSelector(  # type: ignore[misc]
-    CompliantSelector["DuckDBLazyFrame", "duckdb.Expression"], DuckDBExpr
+    CompliantSelector["DuckDBLazyFrame", "Expression"], DuckDBExpr
 ):
     def _to_expr(self) -> DuckDBExpr:
         return DuckDBExpr(

--- a/narwhals/_duckdb/typing.py
+++ b/narwhals/_duckdb/typing.py
@@ -4,15 +4,13 @@ from typing import TYPE_CHECKING
 from typing import Protocol
 
 if TYPE_CHECKING:
-    import duckdb
+    from duckdb import Expression
 
     from narwhals._duckdb.utils import UnorderableWindowInputs
     from narwhals._duckdb.utils import WindowInputs
 
     class WindowFunction(Protocol):
-        def __call__(self, window_inputs: WindowInputs) -> duckdb.Expression: ...
+        def __call__(self, window_inputs: WindowInputs) -> Expression: ...
 
     class UnorderableWindowFunction(Protocol):
-        def __call__(
-            self, window_inputs: UnorderableWindowInputs
-        ) -> duckdb.Expression: ...
+        def __call__(self, window_inputs: UnorderableWindowInputs) -> Expression: ...

--- a/narwhals/_duckdb/utils.py
+++ b/narwhals/_duckdb/utils.py
@@ -11,6 +11,7 @@ from narwhals.utils import Version
 from narwhals.utils import isinstance_or_issubclass
 
 if TYPE_CHECKING:
+    from duckdb import Expression
     from duckdb.typing import DuckDBPyType
 
     from narwhals._duckdb.dataframe import DuckDBLazyFrame
@@ -45,7 +46,7 @@ class WindowInputs:
 
     def __init__(
         self,
-        expr: duckdb.Expression,
+        expr: Expression,
         partition_by: Sequence[str],
         order_by: Sequence[str],
     ) -> None:
@@ -59,14 +60,14 @@ class UnorderableWindowInputs:
 
     def __init__(
         self,
-        expr: duckdb.Expression,
+        expr: Expression,
         partition_by: Sequence[str],
     ) -> None:
         self.expr = expr
         self.partition_by = partition_by
 
 
-def concat_str(*exprs: duckdb.Expression, separator: str = "") -> duckdb.Expression:
+def concat_str(*exprs: Expression, separator: str = "") -> Expression:
     """Concatenate many strings, NULL inputs are skipped.
 
     Wraps [concat] and [concat_ws] `FunctionExpression`(s).
@@ -90,8 +91,8 @@ def concat_str(*exprs: duckdb.Expression, separator: str = "") -> duckdb.Express
 
 def evaluate_exprs(
     df: DuckDBLazyFrame, /, *exprs: DuckDBExpr
-) -> list[tuple[str, duckdb.Expression]]:
-    native_results: list[tuple[str, duckdb.Expression]] = []
+) -> list[tuple[str, Expression]]:
+    native_results: list[tuple[str, Expression]] = []
     for expr in exprs:
         native_series_list = expr._call(df)
         output_names = expr._evaluate_output_names(df)
@@ -256,7 +257,7 @@ def narwhals_to_native_dtype(dtype: DType | type[DType], version: Version) -> st
     raise AssertionError(msg)
 
 
-def generate_partition_by_sql(*partition_by: str | duckdb.Expression) -> str:
+def generate_partition_by_sql(*partition_by: str | Expression) -> str:
     if not partition_by:
         return ""
     by_sql = ", ".join([f"{col(x) if isinstance(x, str) else x}" for x in partition_by])


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
