### PR TITLE
enh: reflect connection time zone in Datetime for pyspark, support convert_time_zone and replace_time_zone

### DIFF
--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -281,9 +281,10 @@ class SparkLikeLazyFrame(
         if self._cached_schema is None:
             self._cached_schema = {
                 field.name: native_to_narwhals_dtype(
-                    dtype=field.dataType,
-                    version=self._version,
-                    spark_types=self._native_dtypes,
+                    field.dataType,
+                    self._version,
+                    self._native_dtypes,
+                    self.native.sparkSession,
                 )
                 for field in self.native.schema
             }

--- a/narwhals/_spark_like/expr_dt.py
+++ b/narwhals/_spark_like/expr_dt.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence
 
 from narwhals._duration import parse_interval_string
-from narwhals._spark_like.utils import UNITS_DICT, fetch_session_time_zone, strptime_to_pyspark_format
+from narwhals._spark_like.utils import (
+    UNITS_DICT,
+    fetch_session_time_zone,
+    strptime_to_pyspark_format,
+)
 
 if TYPE_CHECKING:
     from sqlframe.base.column import Column

--- a/narwhals/_spark_like/expr_dt.py
+++ b/narwhals/_spark_like/expr_dt.py
@@ -82,7 +82,7 @@ class SparkLikeExprDateTimeNamespace:
 
         return self._compliant_expr._with_callable(_truncate)
 
-    def _no_op_time_zone(self, time_zone: str) -> SparkLikeExpr:
+    def _no_op_time_zone(self, time_zone: str) -> SparkLikeExpr:  # pragma: no cover
         def func(df: SparkLikeLazyFrame) -> Sequence[Column]:
             native_series_list = self._compliant_expr(df)
             conn_time_zone = fetch_session_time_zone(df.native.sparkSession)
@@ -104,10 +104,12 @@ class SparkLikeExprDateTimeNamespace:
             implementation=self._compliant_expr._implementation,
         )
 
-    def convert_time_zone(self, time_zone: str) -> SparkLikeExpr:
+    def convert_time_zone(self, time_zone: str) -> SparkLikeExpr:  # pragma: no cover
         return self._no_op_time_zone(time_zone)
 
-    def replace_time_zone(self, time_zone: str | None) -> SparkLikeExpr:
+    def replace_time_zone(
+        self, time_zone: str | None
+    ) -> SparkLikeExpr:  # pragma: no cover
         if time_zone is None:
             return self._compliant_expr._with_callable(
                 lambda _input: _input.cast("timestamp_ntz")

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -119,7 +119,7 @@ def fetch_session_time_zone(session: Session[Any, Any, Any, Any, Any, Any, Any])
     # Timezone can't be changed in PySpark session, so this can be cached.
     try:
         return session.conf.get("spark.sql.session.timeZone")  # type: ignore[attr-defined]
-    except:  # noqa: E722
+    except Exception:  # noqa: BLE001
         # https://github.com/eakmanrq/sqlframe/issues/406
         return "<unknown>"
 

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -115,7 +115,7 @@ def native_to_narwhals_dtype(  # noqa: C901, PLR0912
 
 
 @lru_cache(maxsize=4)
-def fetch_session_time_zone(session: Session) -> str:
+def fetch_session_time_zone(session: Session[Any, Any, Any, Any, Any, Any, Any]) -> str:
     # Timezone can't be changed in PySpark session, so this can be cached.
     try:
         return session.conf.get("spark.sql.session.timeZone")  # type: ignore[attr-defined]

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from narwhals.utils import Version
 
     _NativeDType: TypeAlias = sqlframe_types.DataType
+    SparkSession = Session[Any, Any, Any, Any, Any, Any, Any]
 
 UNITS_DICT = {
     "y": "year",
@@ -57,7 +58,7 @@ class UnorderableWindowInputs:
 
 # NOTE: don't lru_cache this as `ModuleType` isn't hashable
 def native_to_narwhals_dtype(  # noqa: C901, PLR0912
-    dtype: _NativeDType, version: Version, spark_types: ModuleType, session: Session
+    dtype: _NativeDType, version: Version, spark_types: ModuleType, session: SparkSession
 ) -> DType:
     dtypes = version.dtypes
     if TYPE_CHECKING:
@@ -115,7 +116,7 @@ def native_to_narwhals_dtype(  # noqa: C901, PLR0912
 
 
 @lru_cache(maxsize=4)
-def fetch_session_time_zone(session: Session[Any, Any, Any, Any, Any, Any, Any]) -> str:
+def fetch_session_time_zone(session: SparkSession) -> str:
     # Timezone can't be changed in PySpark session, so this can be cached.
     try:
         return session.conf.get("spark.sql.session.timeZone")  # type: ignore[attr-defined]

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -482,3 +482,26 @@ def test_datetime_w_tz_duckdb() -> None:
     result = df.collect_schema()
     assert result["a"] == nw.Datetime("us", "Asia/Kathmandu")
     assert result["b"] == nw.List(nw.List(nw.Datetime("us", "Asia/Kathmandu")))
+
+
+def test_datetime_w_tz_pyspark(constructor: Constructor) -> None:  # pragma: no cover
+    if "pyspark" not in str(constructor):
+        pytest.skip()
+    pytest.importorskip("pyspark")
+    pytest.importorskip("zoneinfo")
+    from pyspark.sql import SparkSession
+
+    session = SparkSession.builder.config(
+        "spark.sql.session.timeZone", "UTC"
+    ).getOrCreate()
+
+    df = nw.from_native(
+        session.createDataFrame([(datetime(2020, 1, 1, tzinfo=timezone.utc),)], ["a"])
+    )
+    result = df.collect_schema()
+    assert result["a"] == nw.Datetime("us", "UTC")
+    df = nw.from_native(
+        session.createDataFrame([([datetime(2020, 1, 1, tzinfo=timezone.utc)],)], ["a"])
+    )
+    result = df.collect_schema()
+    assert result["a"] == nw.List(nw.Datetime("us", "UTC"))

--- a/tests/expr_and_series/dt/convert_time_zone_test.py
+++ b/tests/expr_and_series/dt/convert_time_zone_test.py
@@ -155,7 +155,9 @@ def test_convert_time_zone_to_connection_tz_duckdb() -> None:
         )
 
 
-def test_convert_time_zone_to_connection_tz_pyspark(constructor: Constructor) -> None:
+def test_convert_time_zone_to_connection_tz_pyspark(
+    constructor: Constructor,
+) -> None:  # pragma: no cover
     if "pyspark" not in str(constructor):
         pytest.skip()
     pytest.importorskip("pyspark")

--- a/tests/expr_and_series/dt/convert_time_zone_test.py
+++ b/tests/expr_and_series/dt/convert_time_zone_test.py
@@ -153,3 +153,25 @@ def test_convert_time_zone_to_connection_tz_duckdb() -> None:
         result = nw.from_native(rel).with_columns(
             nw.col("a").dt.convert_time_zone("Asia/Kathmandu")
         )
+
+
+def test_convert_time_zone_to_connection_tz_pyspark(constructor: Constructor) -> None:
+    if "pyspark" not in str(constructor):
+        pytest.skip()
+    pytest.importorskip("pyspark")
+    pytest.importorskip("zoneinfo")
+    from pyspark.sql import SparkSession
+
+    session = SparkSession.builder.config(
+        "spark.sql.session.timeZone", "UTC"
+    ).getOrCreate()
+    df = nw.from_native(
+        session.createDataFrame([(datetime(2020, 1, 1, tzinfo=timezone.utc),)], ["a"])
+    )
+    result = nw.from_native(df).with_columns(nw.col("a").dt.convert_time_zone("UTC"))
+    expected = {"a": [datetime(2020, 1, 1, tzinfo=timezone.utc)]}
+    assert_equal_data(result, expected)
+    with pytest.raises(NotImplementedError):
+        result = nw.from_native(df).with_columns(
+            nw.col("a").dt.convert_time_zone("Asia/Kathmandu")
+        )

--- a/tests/expr_and_series/dt/replace_time_zone_test.py
+++ b/tests/expr_and_series/dt/replace_time_zone_test.py
@@ -151,7 +151,9 @@ def test_replace_time_zone_to_connection_tz_duckdb() -> None:
         )
 
 
-def test_replace_time_zone_to_connection_tz_pyspark(constructor: Constructor) -> None:
+def test_replace_time_zone_to_connection_tz_pyspark(
+    constructor: Constructor,
+) -> None:  # pragma: no cover
     if "pyspark" not in str(constructor):
         pytest.skip()
     pytest.importorskip("pyspark")

--- a/tests/expr_and_series/dt/replace_time_zone_test.py
+++ b/tests/expr_and_series/dt/replace_time_zone_test.py
@@ -149,3 +149,25 @@ def test_replace_time_zone_to_connection_tz_duckdb() -> None:
         result = nw.from_native(rel).with_columns(
             nw.col("a").dt.replace_time_zone("Asia/Kathmandu")
         )
+
+
+def test_replace_time_zone_to_connection_tz_pyspark(constructor: Constructor) -> None:
+    if "pyspark" not in str(constructor):
+        pytest.skip()
+    pytest.importorskip("pyspark")
+    pytest.importorskip("zoneinfo")
+    from pyspark.sql import SparkSession
+
+    session = SparkSession.builder.config(
+        "spark.sql.session.timeZone", "UTC"
+    ).getOrCreate()
+    df = nw.from_native(
+        session.createDataFrame([(datetime(2020, 1, 1, tzinfo=timezone.utc),)], ["a"])
+    )
+    result = nw.from_native(df).with_columns(nw.col("a").dt.replace_time_zone("UTC"))
+    expected = {"a": [datetime(2020, 1, 1, tzinfo=timezone.utc)]}
+    assert_equal_data(result, expected)
+    with pytest.raises(NotImplementedError):
+        result = nw.from_native(df).with_columns(
+            nw.col("a").dt.replace_time_zone("Asia/Kathmandu")
+        )


### PR DESCRIPTION
intended as follow-up to #2590

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
