### PR TITLE
ci: fix typing for pyspark 4.0

### DIFF
--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -545,6 +545,6 @@ def test_pyspark_connect_deps_2517() -> None:  # pragma: no cover
 
     import narwhals as nw
 
-    spark = SparkSession.builder.getOrCreate()  # pyright: ignore[reportAttributeAccessIssue]
+    spark = SparkSession.builder.getOrCreate()
     # Check this doesn't raise
-    nw.from_native(spark.createDataFrame([{"a": 1}]))
+    nw.from_native(spark.createDataFrame([(1,)], ["a"]))


### PR DESCRIPTION
this just fixes the typing part, so please don't add the pyspark label (we can fix the pyspark test failures separately)