### PR TITLE
chore(ruff): Add `tool.ruff.lint.typing-modules`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ extend-exclude = ["**/this.py"]
 [tool.ruff.lint]
 preview = true
 explicit-preview-rules = true
+typing-modules = ["narwhals._typing_compat"]
 
 extend-safe-fixes = [
   "C419",    # unnecessary-comprehension-in-call


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- Related https://github.com/narwhals-dev/narwhals/pull/2572#discussion_r2104768749

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
I discovered the hard way why this config was needed.

It avoids this (unused import) false positive on forward references used in `TypeVar`

![image](https://github.com/user-attachments/assets/3e537f4e-ca98-48b6-8234-570c6318193e)
