### PR TITLE
chore: Simplify stable.v1 `_stableify`

### DIFF
--- a/narwhals/_interchange/dataframe.py
+++ b/narwhals/_interchange/dataframe.py
@@ -73,23 +73,10 @@ def map_interchange_dtype_to_narwhals_dtype(  # noqa: C901, PLR0911, PLR0912
     raise AssertionError(msg)
 
 
-class WrapInterchangeFrame:
-    def __init__(self, interchange_frame: InterchangeFrame) -> None:
-        self._interchange_frame = interchange_frame
-
-    def __dataframe__(self) -> InterchangeFrame:
-        return self._interchange_frame
-
-
 class InterchangeFrame:
     def __init__(self, df: DataFrameLike, version: Version) -> None:
         self._interchange_frame = df.__dataframe__()
         self._version = version
-
-    def _with_version(self, version: Version) -> Self:
-        return self.__class__(
-            WrapInterchangeFrame(self._interchange_frame), version=version
-        )
 
     def __narwhals_dataframe__(self) -> Self:
         return self

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -30,6 +30,7 @@ from narwhals.exceptions import (
     OrderDependentExprError,
 )
 from narwhals.schema import Schema
+from narwhals.series import Series
 from narwhals.translate import to_native
 from narwhals.utils import (
     Implementation,
@@ -60,7 +61,6 @@ if TYPE_CHECKING:
     from narwhals._compliant import CompliantDataFrame, CompliantLazyFrame
     from narwhals._compliant.typing import CompliantExprAny, EagerNamespaceAny
     from narwhals.group_by import GroupBy, LazyGroupBy
-    from narwhals.series import Series
     from narwhals.typing import (
         AsofJoinStrategy,
         IntoDataFrame,
@@ -454,8 +454,6 @@ class DataFrame(BaseFrame[DataFrameT]):
 
     @property
     def _series(self) -> type[Series[Any]]:
-        from narwhals.series import Series
-
         return Series
 
     @property

--- a/narwhals/dependencies.py
+++ b/narwhals/dependencies.py
@@ -160,11 +160,9 @@ def is_modin_series(ser: Any) -> TypeIs[mpd.Series]:
     return (mpd := get_modin()) is not None and isinstance(ser, mpd.Series)
 
 
-def is_modin_index(index: Any) -> TypeIs[mpd.Index]:
+def is_modin_index(index: Any) -> TypeIs[mpd.Index[Any]]:  # pragma: no cover
     """Check whether `index` is a modin Index without importing modin."""
-    return (mpd := get_modin()) is not None and isinstance(
-        index, mpd.Index
-    )  # pragma: no cover
+    return (mpd := get_modin()) is not None and isinstance(index, mpd.Index)
 
 
 def is_cudf_dataframe(df: Any) -> TypeIs[cudf.DataFrame]:

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -220,29 +220,20 @@ def new_series(
         └─────────────────────┘
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _new_series_impl(name, values, dtype, backend=backend, version=Version.MAIN)
-
-
-def _new_series_impl(
-    name: str,
-    values: Any,
-    dtype: DType | type[DType] | None = None,
-    *,
-    backend: ModuleType | Implementation | str,
-    version: Version,
-) -> Series[Any]:
     implementation = Implementation.from_backend(backend)
     if is_eager_allowed(implementation):
-        ns = version.namespace.from_backend(implementation).compliant
+        ns = Version.MAIN.namespace.from_backend(implementation).compliant
         series = ns._series.from_iterable(values, name=name, context=ns, dtype=dtype)
         return series.to_narwhals()
     elif implementation is Implementation.DASK:  # pragma: no cover
         msg = "Dask support in Narwhals is lazy-only, so `new_series` is not supported"
         raise NotImplementedError(msg)
     else:  # pragma: no cover
-        native_namespace = implementation.to_native_namespace()
+        _native_namespace = implementation.to_native_namespace()
         try:
-            native_series: NativeSeries = native_namespace.new_series(name, values, dtype)
+            native_series: NativeSeries = _native_namespace.new_series(
+                name, values, dtype
+            )
             return from_native(native_series, series_only=True).alias(name)
         except AttributeError as e:
             msg = "Unknown namespace is expected to implement `new_series` constructor."
@@ -303,16 +294,6 @@ def from_dict(
         |     1  2  4      |
         └──────────────────┘
     """
-    return _from_dict_impl(data, schema, backend=backend, version=Version.MAIN)
-
-
-def _from_dict_impl(
-    data: Mapping[str, Any],
-    schema: Mapping[str, DType] | Schema | None,
-    *,
-    backend: ModuleType | Implementation | str | None,
-    version: Version,
-) -> DataFrame[Any]:
     if not data:
         msg = "from_dict cannot be called with empty dictionary"
         raise ValueError(msg)
@@ -320,14 +301,14 @@ def _from_dict_impl(
         data, backend = _from_dict_no_backend(data)
     implementation = Implementation.from_backend(backend)
     if is_eager_allowed(implementation):
-        ns = version.namespace.from_backend(implementation).compliant
+        ns = Version.MAIN.namespace.from_backend(implementation).compliant
         return ns._dataframe.from_dict(data, schema=schema, context=ns).to_narwhals()
     elif implementation is Implementation.UNKNOWN:  # pragma: no cover
-        native_namespace = implementation.to_native_namespace()
+        _native_namespace = implementation.to_native_namespace()
         try:
             # implementation is UNKNOWN, Narwhals extension using this feature should
             # implement `from_dict` function in the top-level namespace.
-            native_frame: NativeFrame = native_namespace.from_dict(data, schema=schema)
+            native_frame: NativeFrame = _native_namespace.from_dict(data, schema=schema)
         except AttributeError as e:
             msg = "Unknown namespace is expected to implement `from_dict` function."
             raise AttributeError(msg) from e
@@ -414,16 +395,6 @@ def from_numpy(
         └──────────────────┘
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _from_numpy_impl(data, schema, backend=backend, version=Version.MAIN)
-
-
-def _from_numpy_impl(
-    data: _2DArray,
-    schema: Mapping[str, DType] | Schema | Sequence[str] | None = None,
-    *,
-    backend: ModuleType | Implementation | str,
-    version: Version,
-) -> DataFrame[Any]:
     if not is_numpy_array_2d(data):
         msg = "`from_numpy` only accepts 2D numpy arrays"
         raise ValueError(msg)
@@ -436,14 +407,14 @@ def _from_numpy_impl(
         raise TypeError(msg)
     implementation = Implementation.from_backend(backend)
     if is_eager_allowed(implementation):
-        ns = version.namespace.from_backend(implementation).compliant
+        ns = Version.MAIN.namespace.from_backend(implementation).compliant
         return ns.from_numpy(data, schema).to_narwhals()
     else:  # pragma: no cover
-        native_namespace = implementation.to_native_namespace()
+        _native_namespace = implementation.to_native_namespace()
         try:
             # implementation is UNKNOWN, Narwhals extension using this feature should
             # implement `from_numpy` function in the top-level namespace.
-            native_frame: NativeFrame = native_namespace.from_numpy(data, schema=schema)
+            native_frame: NativeFrame = _native_namespace.from_numpy(data, schema=schema)
         except AttributeError as e:
             msg = "Unknown namespace is expected to implement `from_numpy` function."
             raise AttributeError(msg) from e
@@ -510,29 +481,23 @@ def from_arrow(
         └──────────────────┘
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _from_arrow_impl(native_frame, backend=backend, version=Version.MAIN)
-
-
-def _from_arrow_impl(
-    data: IntoArrowTable, *, backend: ModuleType | Implementation | str, version: Version
-) -> DataFrame[Any]:
-    if not (supports_arrow_c_stream(data) or is_pyarrow_table(data)):
-        msg = f"Given object of type {type(data)} does not support PyCapsule interface"
+    if not (supports_arrow_c_stream(native_frame) or is_pyarrow_table(native_frame)):
+        msg = f"Given object of type {type(native_frame)} does not support PyCapsule interface"
         raise TypeError(msg)
     implementation = Implementation.from_backend(backend)
     if is_eager_allowed(implementation):
-        ns = version.namespace.from_backend(implementation).compliant
-        return ns._dataframe.from_arrow(data, context=ns).to_narwhals()
+        ns = Version.MAIN.namespace.from_backend(implementation).compliant
+        return ns._dataframe.from_arrow(native_frame, context=ns).to_narwhals()
     else:  # pragma: no cover
-        native_namespace = implementation.to_native_namespace()
+        _native_namespace = implementation.to_native_namespace()
         try:
             # implementation is UNKNOWN, Narwhals extension using this feature should
             # implement PyCapsule support
-            native_frame: NativeFrame = native_namespace.DataFrame(data)
+            native: NativeFrame = _native_namespace.DataFrame(native_frame)
         except AttributeError as e:
             msg = "Unknown namespace is expected to implement `DataFrame` class which accepts object which supports PyCapsule Interface."
             raise AttributeError(msg) from e
-        return from_native(native_frame, eager_only=True)
+        return from_native(native, eager_only=True)
 
 
 def _get_sys_info() -> dict[str, str]:
@@ -627,7 +592,7 @@ def read_csv(
     source: str,
     *,
     backend: ModuleType | Implementation | str | None = None,
-    native_namespace: ModuleType | None = None,  # noqa: ARG001
+    native_namespace: ModuleType | None = None,
     **kwargs: Any,
 ) -> DataFrame[Any]:
     """Read a CSV file into a DataFrame.
@@ -667,12 +632,6 @@ def read_csv(
         └──────────────────┘
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _read_csv_impl(source, backend=backend, **kwargs)
-
-
-def _read_csv_impl(
-    source: str, *, backend: ModuleType | Implementation | str, **kwargs: Any
-) -> DataFrame[Any]:
     eager_backend = Implementation.from_backend(backend)
     native_namespace = eager_backend.to_native_namespace()
     native_frame: NativeFrame
@@ -703,7 +662,7 @@ def scan_csv(
     source: str,
     *,
     backend: ModuleType | Implementation | str | None = None,
-    native_namespace: ModuleType | None = None,  # noqa: ARG001
+    native_namespace: ModuleType | None = None,
     **kwargs: Any,
 ) -> LazyFrame[Any]:
     """Lazily read from a CSV file.
@@ -749,12 +708,6 @@ def scan_csv(
         └─────────┴───────┘
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _scan_csv_impl(source, backend=backend, **kwargs)
-
-
-def _scan_csv_impl(
-    source: str, *, backend: ModuleType | Implementation | str, **kwargs: Any
-) -> LazyFrame[Any]:
     implementation = Implementation.from_backend(backend)
     native_namespace = implementation.to_native_namespace()
     native_frame: NativeFrame | NativeLazyFrame
@@ -803,7 +756,7 @@ def read_parquet(
     source: str,
     *,
     backend: ModuleType | Implementation | str | None = None,
-    native_namespace: ModuleType | None = None,  # noqa: ARG001
+    native_namespace: ModuleType | None = None,
     **kwargs: Any,
 ) -> DataFrame[Any]:
     """Read into a DataFrame from a parquet file.
@@ -848,12 +801,6 @@ def read_parquet(
         └──────────────────┘
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _read_parquet_impl(source, backend=backend, **kwargs)
-
-
-def _read_parquet_impl(
-    source: str, *, backend: ModuleType | Implementation | str, **kwargs: Any
-) -> DataFrame[Any]:
     implementation = Implementation.from_backend(backend)
     native_namespace = implementation.to_native_namespace()
     native_frame: NativeFrame
@@ -886,7 +833,7 @@ def scan_parquet(
     source: str,
     *,
     backend: ModuleType | Implementation | str | None = None,
-    native_namespace: ModuleType | None = None,  # noqa: ARG001
+    native_namespace: ModuleType | None = None,
     **kwargs: Any,
 ) -> LazyFrame[Any]:
     """Lazily read from a parquet file.
@@ -959,12 +906,6 @@ def scan_parquet(
         └──────────────────┘
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _scan_parquet_impl(source, backend=backend, **kwargs)
-
-
-def _scan_parquet_impl(
-    source: str, *, backend: ModuleType | Implementation | str, **kwargs: Any
-) -> LazyFrame[Any]:
     implementation = Implementation.from_backend(backend)
     native_namespace = implementation.to_native_namespace()
     native_frame: NativeFrame | NativeLazyFrame

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -15,27 +15,13 @@ from typing import (
 from warnings import warn
 
 import narwhals as nw
-from narwhals import dependencies, exceptions, selectors
+from narwhals import dependencies, exceptions, functions as nw_f, selectors
 from narwhals._typing_compat import TypeVar
 from narwhals.dataframe import DataFrame as NwDataFrame, LazyFrame as NwLazyFrame
 from narwhals.dependencies import get_polars
 from narwhals.exceptions import InvalidIntoExprError
 from narwhals.expr import Expr as NwExpr
-from narwhals.functions import (
-    Then as NwThen,
-    When as NwWhen,
-    _from_arrow_impl,
-    _from_dict_impl,
-    _from_numpy_impl,
-    _new_series_impl,
-    _read_csv_impl,
-    _read_parquet_impl,
-    _scan_csv_impl,
-    _scan_parquet_impl,
-    get_level,
-    show_versions,
-    when as nw_when,
-)
+from narwhals.functions import get_level, show_versions
 from narwhals.schema import Schema as NwSchema
 from narwhals.series import Series as NwSeries
 from narwhals.stable.v1 import dtypes
@@ -172,7 +158,7 @@ class DataFrame(NwDataFrame[IntoDataFrameT]):
     def lazy(
         self, backend: ModuleType | Implementation | str | None = None
     ) -> LazyFrame[Any]:
-        return super().lazy(backend=backend)  # type: ignore[return-value]
+        return _stableify(super().lazy(backend=backend))
 
     @overload  # type: ignore[override]
     def to_dict(self, *, as_series: Literal[True] = ...) -> dict[str, Series[Any]]: ...
@@ -190,10 +176,10 @@ class DataFrame(NwDataFrame[IntoDataFrameT]):
         return super().to_dict(as_series=as_series)  # type: ignore[return-value]
 
     def is_duplicated(self) -> Series[Any]:
-        return super().is_duplicated()  # type: ignore[return-value]
+        return _stableify(super().is_duplicated())
 
     def is_unique(self) -> Series[Any]:
-        return super().is_unique()  # type: ignore[return-value]
+        return _stableify(super().is_unique())
 
     def _l1_norm(self) -> Self:
         """Private, just used to test the stable API.
@@ -244,7 +230,7 @@ class LazyFrame(NwLazyFrame[IntoFrameT]):
     def collect(
         self, backend: ModuleType | Implementation | str | None = None, **kwargs: Any
     ) -> DataFrame[Any]:
-        return super().collect(backend=backend, **kwargs)  # type: ignore[return-value]
+        return _stableify(super().collect(backend=backend, **kwargs))
 
     def _l1_norm(self) -> Self:
         """Private, just used to test the stable API.
@@ -254,7 +240,7 @@ class LazyFrame(NwLazyFrame[IntoFrameT]):
         """
         return self.select(all()._l1_norm())
 
-    def tail(self, n: int = 5) -> Self:  # pragma: no cover
+    def tail(self, n: int = 5) -> Self:
         r"""Get the last `n` rows.
 
         Arguments:
@@ -295,7 +281,7 @@ class Series(NwSeries[IntoSeriesT]):
         return DataFrame
 
     def to_frame(self) -> DataFrame[Any]:
-        return super().to_frame()  # type: ignore[return-value]
+        return _stableify(super().to_frame())
 
     def value_counts(
         self,
@@ -305,8 +291,10 @@ class Series(NwSeries[IntoSeriesT]):
         name: str | None = None,
         normalize: bool = False,
     ) -> DataFrame[Any]:
-        return super().value_counts(  # type: ignore[return-value]
-            sort=sort, parallel=parallel, name=name, normalize=normalize
+        return _stableify(
+            super().value_counts(
+                sort=sort, parallel=parallel, name=name, normalize=normalize
+            )
         )
 
     def hist(
@@ -324,8 +312,10 @@ class Series(NwSeries[IntoSeriesT]):
             "an unstable feature."
         )
         warn(message=msg, category=NarwhalsUnstableWarning, stacklevel=find_stacklevel())
-        return super().hist(  # type: ignore[return-value]
-            bins=bins, bin_count=bin_count, include_breakpoint=include_breakpoint
+        return _stableify(
+            super().hist(
+                bins=bins, bin_count=bin_count, include_breakpoint=include_breakpoint
+            )
         )
 
 
@@ -463,17 +453,14 @@ def _stableify(obj: NwLazyFrame[IntoFrameT]) -> LazyFrame[IntoFrameT]: ...
 def _stableify(obj: NwSeries[IntoSeriesT]) -> Series[IntoSeriesT]: ...
 @overload
 def _stableify(obj: NwExpr) -> Expr: ...
-@overload
-def _stableify(obj: Any) -> Any: ...
 
 
 def _stableify(
     obj: NwDataFrame[IntoFrameT]
     | NwLazyFrame[IntoFrameT]
     | NwSeries[IntoSeriesT]
-    | NwExpr
-    | Any,
-) -> DataFrame[IntoFrameT] | LazyFrame[IntoFrameT] | Series[IntoSeriesT] | Expr | Any:
+    | NwExpr,
+) -> DataFrame[IntoFrameT] | LazyFrame[IntoFrameT] | Series[IntoSeriesT] | Expr:
     if isinstance(obj, NwDataFrame):
         return DataFrame(obj._compliant_frame._with_version(Version.V1), level=obj._level)
     if isinstance(obj, NwLazyFrame):
@@ -482,7 +469,8 @@ def _stableify(
         return Series(obj._compliant_series._with_version(Version.V1), level=obj._level)
     if isinstance(obj, NwExpr):
         return Expr(obj._to_compliant_expr, obj._metadata)
-    return obj
+    msg = f"unreachable code, got: {type(obj)}"  # pragma: no cover
+    raise AssertionError(msg)
 
 
 @overload
@@ -963,7 +951,7 @@ def from_native(  # noqa: D417
         msg = f"from_native() got an unexpected keyword argument {next(iter(kwds))!r}"
         raise TypeError(msg)
 
-    result = _from_native_impl(
+    return _from_native_impl(  # type: ignore[no-any-return]
         native_object,
         pass_through=pass_through,
         eager_only=eager_only,
@@ -972,7 +960,6 @@ def from_native(  # noqa: D417
         allow_series=allow_series,
         version=Version.V1,
     )
-    return _stableify(result)  # type: ignore[no-any-return]
 
 
 @overload
@@ -1426,7 +1413,7 @@ def concat(items: Iterable[FrameT], *, how: ConcatMethod = "vertical") -> FrameT
     Raises:
         TypeError: The items to concatenate should either all be eager, or all lazy
     """
-    return cast("FrameT", _stableify(nw.concat(items, how=how)))
+    return _stableify(nw.concat(items, how=how))
 
 
 def concat_str(
@@ -1456,18 +1443,18 @@ def concat_str(
     )
 
 
-class When(NwWhen):
+class When(nw_f.When):
     @classmethod
-    def from_when(cls, when: NwWhen) -> When:
+    def from_when(cls, when: nw_f.When) -> When:
         return cls(when._predicate)
 
     def then(self, value: IntoExpr | NonNestedLiteral | _1DArray) -> Then:
         return Then.from_then(super().then(value))
 
 
-class Then(NwThen, Expr):
+class Then(nw_f.Then, Expr):
     @classmethod
-    def from_then(cls, then: NwThen) -> Then:
+    def from_then(cls, then: nw_f.Then) -> Then:
         return cls(then._to_compliant_expr, then._metadata)
 
     def otherwise(self, value: IntoExpr | NonNestedLiteral | _1DArray) -> Expr:
@@ -1495,7 +1482,7 @@ def when(*predicates: IntoExpr | Iterable[IntoExpr]) -> When:
     Returns:
         A "when" object, which `.then` can be called on.
     """
-    return When.from_when(nw_when(*predicates))
+    return When.from_when(nw_f.when(*predicates))
 
 
 @deprecate_native_namespace(required=True)
@@ -1534,9 +1521,7 @@ def new_series(
         A new Series
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _stableify(  # type: ignore[no-any-return]
-        _new_series_impl(name, values, dtype, backend=backend, version=Version.V1)
-    )
+    return _stableify(nw_f.new_series(name, values, dtype, backend=backend))
 
 
 @deprecate_native_namespace(required=True)
@@ -1570,9 +1555,7 @@ def from_arrow(
         A new DataFrame.
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _stableify(  # type: ignore[no-any-return]
-        _from_arrow_impl(native_frame, backend=backend, version=Version.V1)
-    )
+    return _stableify(nw_f.from_arrow(native_frame, backend=backend))
 
 
 @deprecate_native_namespace()
@@ -1616,9 +1599,7 @@ def from_dict(
     Returns:
         A new DataFrame.
     """
-    return _stableify(  # type: ignore[no-any-return]
-        _from_dict_impl(data, schema, backend=backend, version=Version.V1)
-    )
+    return _stableify(nw_f.from_dict(data, schema, backend=backend))
 
 
 @deprecate_native_namespace(required=True)
@@ -1660,7 +1641,7 @@ def from_numpy(
         A new DataFrame.
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _stableify(_from_numpy_impl(data, schema, backend=backend, version=Version.V1))  # type: ignore[no-any-return]
+    return _stableify(nw_f.from_numpy(data, schema, backend=backend))
 
 
 @deprecate_native_namespace(required=True)
@@ -1697,9 +1678,7 @@ def read_csv(
         DataFrame.
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _stableify(  # type: ignore[no-any-return]
-        _read_csv_impl(source, backend=backend, **kwargs)
-    )
+    return _stableify(nw_f.read_csv(source, backend=backend, **kwargs))
 
 
 @deprecate_native_namespace(required=True)
@@ -1739,9 +1718,7 @@ def scan_csv(
         LazyFrame.
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _stableify(  # type: ignore[no-any-return]
-        _scan_csv_impl(source, backend=backend, **kwargs)
-    )
+    return _stableify(nw_f.scan_csv(source, backend=backend, **kwargs))
 
 
 @deprecate_native_namespace(required=True)
@@ -1778,9 +1755,7 @@ def read_parquet(
         DataFrame.
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _stableify(  # type: ignore[no-any-return]
-        _read_parquet_impl(source, backend=backend, **kwargs)
-    )
+    return _stableify(nw_f.read_parquet(source, backend=backend, **kwargs))
 
 
 @deprecate_native_namespace(required=True)
@@ -1834,9 +1809,7 @@ def scan_parquet(
         LazyFrame.
     """
     backend = cast("ModuleType | Implementation | str", backend)
-    return _stableify(  # type: ignore[no-any-return]
-        _scan_parquet_impl(source, backend=backend, **kwargs)
-    )
+    return _stableify(nw_f.scan_parquet(source, backend=backend, **kwargs))
 
 
 __all__ = [

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -21,7 +21,7 @@ from narwhals.dataframe import DataFrame as NwDataFrame, LazyFrame as NwLazyFram
 from narwhals.dependencies import get_polars
 from narwhals.exceptions import InvalidIntoExprError
 from narwhals.expr import Expr as NwExpr
-from narwhals.functions import get_level, show_versions
+from narwhals.functions import concat, get_level, show_versions
 from narwhals.schema import Schema as NwSchema
 from narwhals.series import Series as NwSeries
 from narwhals.stable.v1 import dtypes
@@ -55,8 +55,9 @@ from narwhals.stable.v1.dtypes import (
     UInt128,
     Unknown,
 )
+from narwhals.stable.v1.typing import FrameT
 from narwhals.translate import _from_native_impl, get_native_namespace, to_py_scalar
-from narwhals.typing import IntoDataFrameT, IntoFrameT
+from narwhals.typing import ConcatMethod, IntoDataFrameT, IntoFrameT
 from narwhals.utils import (
     Implementation,
     Version,
@@ -81,9 +82,7 @@ if TYPE_CHECKING:
     from narwhals._translate import IntoArrowTable
     from narwhals.dataframe import MultiColSelector, MultiIndexSelector
     from narwhals.dtypes import DType
-    from narwhals.stable.v1.typing import FrameT
     from narwhals.typing import (
-        ConcatMethod,
         IntoExpr,
         IntoFrame,
         IntoLazyFrameT,
@@ -1393,29 +1392,6 @@ def max_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     return _stableify(nw.max_horizontal(*exprs))
 
 
-def concat(items: Iterable[FrameT], *, how: ConcatMethod = "vertical") -> FrameT:
-    """Concatenate multiple DataFrames, LazyFrames into a single entity.
-
-    Arguments:
-        items: DataFrames, LazyFrames to concatenate.
-        how: concatenating strategy
-
-            - vertical: Concatenate vertically. Column names must match.
-            - horizontal: Concatenate horizontally. If lengths don't match, then
-                missing rows are filled with null values. This is only supported
-                when all inputs are (eager) DataFrames.
-            - diagonal: Finds a union between the column schemas and fills missing column
-                values with null.
-
-    Returns:
-        A new DataFrame or LazyFrame resulting from the concatenation.
-
-    Raises:
-        TypeError: The items to concatenate should either all be eager, or all lazy
-    """
-    return _stableify(nw.concat(items, how=how))
-
-
 def concat_str(
     exprs: IntoExpr | Iterable[IntoExpr],
     *more_exprs: IntoExpr,
@@ -1817,6 +1793,7 @@ __all__ = [
     "Binary",
     "Boolean",
     "Categorical",
+    "ConcatMethod",
     "DataFrame",
     "Date",
     "Datetime",
@@ -1827,6 +1804,7 @@ __all__ = [
     "Field",
     "Float32",
     "Float64",
+    "FrameT",
     "Implementation",
     "Int8",
     "Int16",

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -57,7 +57,7 @@ from narwhals.stable.v1.dtypes import (
 )
 from narwhals.stable.v1.typing import FrameT
 from narwhals.translate import _from_native_impl, get_native_namespace, to_py_scalar
-from narwhals.typing import ConcatMethod, IntoDataFrameT, IntoFrameT
+from narwhals.typing import IntoDataFrameT, IntoFrameT
 from narwhals.utils import (
     Implementation,
     Version,
@@ -1793,7 +1793,6 @@ __all__ = [
     "Binary",
     "Boolean",
     "Categorical",
-    "ConcatMethod",
     "DataFrame",
     "Date",
     "Datetime",

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -55,7 +55,6 @@ from narwhals.stable.v1.dtypes import (
     UInt128,
     Unknown,
 )
-from narwhals.stable.v1.typing import FrameT
 from narwhals.translate import _from_native_impl, get_native_namespace, to_py_scalar
 from narwhals.typing import IntoDataFrameT, IntoFrameT
 from narwhals.utils import (
@@ -1803,7 +1802,6 @@ __all__ = [
     "Field",
     "Float32",
     "Float64",
-    "FrameT",
     "Implementation",
     "Int8",
     "Int16",

--- a/narwhals/stable/v1/typing.py
+++ b/narwhals/stable/v1/typing.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar, Union
 
-from narwhals.stable.v1 import DataFrame, LazyFrame
-
 if TYPE_CHECKING:
     import sys
+
+    from narwhals.stable.v1 import DataFrame, LazyFrame
 
     if sys.version_info >= (3, 10):
         from typing import TypeAlias
@@ -126,7 +126,7 @@ Examples:
     ...     return df.with_columns(c=df["a"] + 1).to_native()
 """
 
-FrameT = TypeVar("FrameT", DataFrame[Any], LazyFrame[Any])
+FrameT = TypeVar("FrameT", "DataFrame[Any]", "LazyFrame[Any]")
 """TypeVar bound to Narwhals DataFrame or Narwhals LazyFrame.
 
 Use this if your function accepts either `nw.DataFrame` or `nw.LazyFrame` and returns

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -387,7 +387,9 @@ def _from_native_impl(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 msg = "Cannot only use `series_only` with dataframe"
                 raise TypeError(msg)
             return native_object
-        return DataFrame(native_object.__narwhals_dataframe__(), level="full")
+        return version.dataframe(
+            native_object.__narwhals_dataframe__()._with_version(version), level="full"
+        )
     elif is_compliant_lazyframe(native_object):
         if series_only:
             if not pass_through:
@@ -399,14 +401,18 @@ def _from_native_impl(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 msg = "Cannot only use `eager_only` or `eager_or_interchange_only` with lazyframe"
                 raise TypeError(msg)
             return native_object
-        return LazyFrame(native_object.__narwhals_lazyframe__(), level="full")
+        return version.lazyframe(
+            native_object.__narwhals_lazyframe__()._with_version(version), level="full"
+        )
     elif is_compliant_series(native_object):
         if not allow_series:
             if not pass_through:
                 msg = "Please set `allow_series=True` or `series_only=True`"
                 raise TypeError(msg)
             return native_object
-        return Series(native_object.__narwhals_series__(), level="full")
+        return version.series(
+            native_object.__narwhals_series__()._with_version(version), level="full"
+        )
 
     # Polars
     elif is_native_polars(native_object):

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -552,7 +552,7 @@ def _from_native_impl(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 )
                 raise TypeError(msg)
             return native_object
-        return DataFrame(
+        return version.dataframe(
             InterchangeFrame(native_object, version=version), level="interchange"
         )
 

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal, Protocol, Sequence, TypeVar, Union
 
 from narwhals._compliant import CompliantDataFrame, CompliantLazyFrame, CompliantSeries
-from narwhals.dataframe import DataFrame, LazyFrame
 
 if TYPE_CHECKING:
     import datetime as dt
@@ -15,6 +14,7 @@ if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
     from narwhals import dtypes
+    from narwhals.dataframe import DataFrame, LazyFrame
     from narwhals.expr import Expr
     from narwhals.series import Series
 
@@ -196,7 +196,7 @@ Examples:
 
 IntoLazyFrameT = TypeVar("IntoLazyFrameT", bound="IntoLazyFrame")
 
-FrameT = TypeVar("FrameT", DataFrame[Any], LazyFrame[Any])
+FrameT = TypeVar("FrameT", "DataFrame[Any]", "LazyFrame[Any]")
 """TypeVar bound to Narwhals DataFrame or Narwhals LazyFrame.
 
 Use this if your function accepts either `nw.DataFrame` or `nw.LazyFrame` and returns


### PR DESCRIPTION
I think it's better if `_stableify` doesn't accept `Any`, and if we call it (even if redundantly) to fixup some types

one further step towards v2

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
