### PR TITLE
chore: remove unnecessary `concat` in stable.v1

### DIFF
--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -32,6 +32,7 @@ from narwhals.functions import (
     _read_parquet_impl,
     _scan_csv_impl,
     _scan_parquet_impl,
+    concat,
     get_level,
     show_versions,
     when as nw_when,
@@ -95,9 +96,7 @@ if TYPE_CHECKING:
     from narwhals._translate import IntoArrowTable
     from narwhals.dataframe import MultiColSelector, MultiIndexSelector
     from narwhals.dtypes import DType
-    from narwhals.stable.v1.typing import FrameT
     from narwhals.typing import (
-        ConcatMethod,
         IntoExpr,
         IntoFrame,
         IntoLazyFrameT,
@@ -1404,29 +1403,6 @@ def max_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
         A new expression.
     """
     return _stableify(nw.max_horizontal(*exprs))
-
-
-def concat(items: Iterable[FrameT], *, how: ConcatMethod = "vertical") -> FrameT:
-    """Concatenate multiple DataFrames, LazyFrames into a single entity.
-
-    Arguments:
-        items: DataFrames, LazyFrames to concatenate.
-        how: concatenating strategy
-
-            - vertical: Concatenate vertically. Column names must match.
-            - horizontal: Concatenate horizontally. If lengths don't match, then
-                missing rows are filled with null values. This is only supported
-                when all inputs are (eager) DataFrames.
-            - diagonal: Finds a union between the column schemas and fills missing column
-                values with null.
-
-    Returns:
-        A new DataFrame or LazyFrame resulting from the concatenation.
-
-    Raises:
-        TypeError: The items to concatenate should either all be eager, or all lazy
-    """
-    return cast("FrameT", _stableify(nw.concat(items, how=how)))
 
 
 def concat_str(

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -1,12 +1,14 @@
 # Test assorted functions which we overwrite in stable.v1
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
 import pytest
-from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from typing_extensions import assert_type
 
 import narwhals as nw
 import narwhals.stable.v1 as nw_v1
@@ -140,7 +142,8 @@ def test_concat(constructor_eager: ConstructorEager) -> None:
     expected = {"a": [1, 2, 3, 1, 2, 3]}
     assert_equal_data(result, expected)
     assert isinstance(result, nw_v1.DataFrame)
-    assert_type(result, nw_v1.DataFrame[Any])
+    if TYPE_CHECKING:
+        assert_type(result, nw_v1.DataFrame[Any])
 
 
 @pytest.mark.filterwarnings(

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -6,6 +6,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pytest
+from typing_extensions import assert_type
 
 import narwhals as nw
 import narwhals.stable.v1 as nw_v1
@@ -139,6 +140,7 @@ def test_concat(constructor_eager: ConstructorEager) -> None:
     expected = {"a": [1, 2, 3, 1, 2, 3]}
     assert_equal_data(result, expected)
     assert isinstance(result, nw_v1.DataFrame)
+    assert_type(result, nw_v1.DataFrame[Any])
 
 
 @pytest.mark.filterwarnings(


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
