### PR TITLE
refactor: _duckdb runtime type checks to front end

### DIFF
--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -15,7 +15,6 @@ from narwhals._duckdb.expr_str import DuckDBExprStringNamespace
 from narwhals._duckdb.expr_struct import DuckDBExprStructNamespace
 from narwhals._duckdb.utils import (
     col,
-    ensure_type,
     generate_order_by_sql,
     generate_partition_by_sql,
     lit,
@@ -546,8 +545,6 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "Expression"]):
 
     @requires.backend_version((1, 3))
     def shift(self, n: int) -> Self:
-        ensure_type(n, int)
-
         def func(inputs: DuckDBWindowInputs) -> Expression:
             order_by_sql = generate_order_by_sql(*inputs.order_by, ascending=True)
             partition_by_sql = generate_partition_by_sql(*inputs.partition_by)

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -125,8 +125,6 @@ class DuckDBExpr(LazyExpr["DuckDBLazyFrame", "Expression"]):
         min_samples: int,
         ddof: int | None = None,
     ) -> DuckDBWindowFunction:
-        ensure_type(window_size, int, type(None))
-        ensure_type(min_samples, int)
         supported_funcs = ["sum", "mean", "std", "var"]
         if center:
             half = (window_size - 1) // 2

--- a/narwhals/_duckdb/utils.py
+++ b/narwhals/_duckdb/utils.py
@@ -284,12 +284,3 @@ def generate_order_by_sql(*order_by: str, ascending: bool) -> str:
     else:
         by_sql = ", ".join([f"{col(x)} desc nulls last" for x in order_by])
     return f"order by {by_sql}"
-
-
-def ensure_type(obj: Any, *valid_types: type[Any]) -> None:
-    # Use this for extra (possibly redundant) validation in places where we
-    # use SQLExpression, as an extra guard against unsafe inputs.
-    if not isinstance(obj, valid_types):  # pragma: no cover
-        tp_names = " | ".join(tp.__name__ for tp in valid_types)
-        msg = f"Expected {tp_names!r}, got: {type(obj).__name__!r}"
-        raise TypeError(msg)

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -993,6 +993,10 @@ class Expr:
             |└─────┴─────────┘ |
             └──────────────────┘
         """
+        if not isinstance(n, int):
+            msg = f"argument `n` must be of type {int!r}, got type {type(n)!r}"
+            raise TypeError(msg)
+
         return self._with_orderable_window(
             lambda plx: self._to_compliant_expr(plx).shift(n)
         )

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -1017,6 +1017,10 @@ class Series(Generic[IntoSeriesT]):
             2    4.0
             dtype: float64
         """
+        if not isinstance(n, int):
+            msg = f"argument `n` must be of type {int!r}, got type {type(n)!r}"
+            raise TypeError(msg)
+
         return self._with_compliant(self._compliant_series.shift(n))
 
     def sample(

--- a/tests/expr_and_series/shift_test.py
+++ b/tests/expr_and_series/shift_test.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
+from typing import Any
+
 import pyarrow as pa
 import pytest
 
@@ -65,3 +68,36 @@ def test_shift_multi_chunk_pyarrow() -> None:
     result = df.select(nw.col("a").shift(0))
     expected = {"a": [1, 2, 3, 1, 2, 3, 1, 2, 3]}
     assert_equal_data(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("n", "context"),
+    [
+        (1.0, pytest.raises(TypeError, match="argument `n` must be of type")),
+        ("1", pytest.raises(TypeError, match="argument `n` must be of type")),
+        (None, pytest.raises(TypeError, match="argument `n` must be of type")),
+        (1, nullcontext()),
+        (0, nullcontext()),
+    ],
+)
+def test_shift_expr_invalid_params(n: Any, context: Any) -> None:
+    with context:
+        nw.col("a").shift(n)
+
+
+@pytest.mark.parametrize(
+    ("n", "context"),
+    [
+        (1.0, pytest.raises(TypeError, match="argument `n` must be of type")),
+        ("1", pytest.raises(TypeError, match="argument `n` must be of type")),
+        (None, pytest.raises(TypeError, match="argument `n` must be of type")),
+        (1, nullcontext()),
+        (0, nullcontext()),
+    ],
+)
+def test_shift_series_invalid_params(
+    constructor_eager: ConstructorEager, n: Any, context: Any
+) -> None:
+    df = nw.from_native(constructor_eager(data), eager_only=True)
+    with context:
+        df["a"].shift(n)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #2583 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

If runtime type checks are required, they should be handled at the superficial most level. Note that this was already being done for the various `Expr.rolling_*` and `Series.rolling_*` methods via `narwhals.utils._validate_rolling_arguments`, so the check at the `_duckdb` level was redundant.

This PR:
- removes `narwhals._duckdb.utils.ensure_type`
- adds runtime type checking to the `Expr.shift` and `Series.shift` (and tests for these)