### PR TITLE
api: remove support for dataframe interchange protocol from main namespace (but keep supported in `narwhals.stable.v1`

### DIFF
--- a/narwhals/_duckdb/series.py
+++ b/narwhals/_duckdb/series.py
@@ -36,7 +36,7 @@ class DuckDBInterchangeSeries:
 
     def __getattr__(self, attr: str) -> Never:
         msg = (  # pragma: no cover
-            f"Attribute {attr} is not supported for metadata-only dataframes.\n\n"
+            f"Attribute {attr} is not supported for interchange-level dataframes.\n\n"
             "If you would like to see this kind of object better supported in "
             "Narwhals, please open a feature request "
             "at https://github.com/narwhals-dev/narwhals/issues."

--- a/narwhals/_ibis/series.py
+++ b/narwhals/_ibis/series.py
@@ -33,7 +33,7 @@ class IbisInterchangeSeries:
 
     def __getattr__(self, attr: str) -> NoReturn:
         msg = (
-            f"Attribute {attr} is not supported for metadata-only dataframes.\n\n"
+            f"Attribute {attr} is not supported for interchange-level dataframes.\n\n"
             "If you would like to see this kind of object better supported in "
             "Narwhals, please open a feature request "
             "at https://github.com/narwhals-dev/narwhals/issues."

--- a/narwhals/_interchange/series.py
+++ b/narwhals/_interchange/series.py
@@ -3,25 +3,26 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, NoReturn
 
 from narwhals._interchange.dataframe import map_interchange_dtype_to_narwhals_dtype
+from narwhals.utils import Version
 
 if TYPE_CHECKING:
     from typing_extensions import Self
 
     from narwhals.dtypes import DType
-    from narwhals.utils import Version
 
 
 class InterchangeSeries:
-    def __init__(self, df: Any, version: Version) -> None:
+    _version = Version.V1
+
+    def __init__(self, df: Any) -> None:
         self._native_series = df
-        self._version = version
 
     def __narwhals_series__(self) -> Self:
         return self
 
     def __native_namespace__(self) -> NoReturn:
         msg = (
-            "Cannot access native namespace for metadata-only series with unknown backend. "
+            "Cannot access native namespace for interchange-level series with unknown backend. "
             "If you would like to see this kind of object supported in Narwhals, please "
             "open a feature request at https://github.com/narwhals-dev/narwhals/issues."
         )
@@ -29,9 +30,7 @@ class InterchangeSeries:
 
     @property
     def dtype(self) -> DType:
-        return map_interchange_dtype_to_narwhals_dtype(
-            self._native_series.dtype, version=self._version
-        )
+        return map_interchange_dtype_to_narwhals_dtype(self._native_series.dtype)
 
     @property
     def native(self) -> Any:
@@ -39,7 +38,7 @@ class InterchangeSeries:
 
     def __getattr__(self, attr: str) -> NoReturn:
         msg = (  # pragma: no cover
-            f"Attribute {attr} is not supported for metadata-only dataframes.\n\n"
+            f"Attribute {attr} is not supported for interchange-level dataframes.\n\n"
             "Hint: you probably called `nw.from_native` on an object which isn't fully "
             "supported by Narwhals, yet implements `__dataframe__`. If you would like to "
             "see this kind of object supported in Narwhals, please open a feature request "

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -552,9 +552,17 @@ def _from_native_impl(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 )
                 raise TypeError(msg)
             return native_object
-        return version.dataframe(
-            InterchangeFrame(native_object, version=version), level="interchange"
-        )
+        if version is not Version.V1:
+            if pass_through:
+                return native_object
+            msg = (
+                "The Dataframe Interchange Protocol is no longer supported in Narwhals.\n\n"
+                "You may want to:\n"
+                " - Use `narwhals.stable.v1`, where it is still supported.\n"
+                " - Use `pass_through=True` to pass the object through without raising."
+            )
+            raise TypeError(msg)
+        return Version.V1.dataframe(InterchangeFrame(native_object), level="interchange")
 
     elif not pass_through:
         msg = f"Expected pandas-like dataframe, Polars dataframe, or Polars lazyframe, got: {type(native_object)}"

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -556,9 +556,10 @@ def _from_native_impl(  # noqa: C901, PLR0911, PLR0912, PLR0915
             if pass_through:
                 return native_object
             msg = (
-                "The Dataframe Interchange Protocol is no longer supported in Narwhals.\n\n"
+                "The Dataframe Interchange Protocol is no longer supported in the main `narwhals` namespace.\n\n"
                 "You may want to:\n"
                 " - Use `narwhals.stable.v1`, where it is still supported.\n"
+                "    - See https://narwhals-dev.github.io/narwhals/backcompat\n"
                 " - Use `pass_through=True` to pass the object through without raising."
             )
             raise TypeError(msg)

--- a/tests/frame/interchange_native_namespace_test.py
+++ b/tests/frame/interchange_native_namespace_test.py
@@ -19,13 +19,13 @@ def test_interchange() -> None:
 
     with pytest.raises(
         NotImplementedError,
-        match="Cannot access native namespace for metadata-only dataframes with unknown backend",
+        match="Cannot access native namespace for interchange-level dataframes with unknown backend",
     ):
         df.__native_namespace__()
 
     with pytest.raises(
         NotImplementedError,
-        match="Cannot access native namespace for metadata-only series with unknown backend",
+        match="Cannot access native namespace for interchange-level series with unknown backend",
     ):
         series.__native_namespace__()
 

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -236,7 +236,7 @@ def test_interchange_schema_duckdb() -> None:
 def test_invalid() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]}).__dataframe__()
     with pytest.raises(
-        NotImplementedError, match="is not supported for metadata-only dataframes"
+        NotImplementedError, match="is not supported for interchange-level dataframes"
     ):
         nw_v1.from_native(df, eager_or_interchange_only=True).filter([True, False, True])
     with pytest.raises(TypeError, match="Cannot only use `series_only=True`"):

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -343,6 +343,18 @@ def test_from_mock_interchange_protocol_non_strict() -> None:
     assert result is mockdf
 
 
+def test_interchange_protocol_non_v1() -> None:
+    class MockDf:
+        def __dataframe__(self) -> None:  # pragma: no cover
+            pass
+
+    mockdf = MockDf()
+    result = nw.from_native(mockdf, pass_through=True)
+    assert result is mockdf
+    with pytest.raises(TypeError):
+        nw.from_native(mockdf)
+
+
 def test_from_native_strict_native_series() -> None:
     obj: list[int] = [1, 2, 3, 4]
     array_like = cast("Iterable[Any]", obj)


### PR DESCRIPTION
closes #2635

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
