### PR TITLE
chore: rename narwhals.utils to narwhals._utils

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
       exclude: |
         (?x)
           ^(
-            narwhals/utils\.py|
+            narwhals/_utils\.py|
             narwhals/stable/v1/_dtypes.py|
             narwhals/.*__init__.py|
             narwhals/.*typing\.py

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -25,3 +25,4 @@
 - [narwhals.exceptions](exceptions.md)
 - [narwhals.selectors](selectors.md)
 - [narwhals.typing](typing.md)
+- [narwhals.utils](utils.md)

--- a/docs/api-reference/utils.md
+++ b/docs/api-reference/utils.md
@@ -5,6 +5,7 @@
     options:
       members:
         - parse_version
+        - Implementation
         - Version
       show_root_heading: false
       show_source: false

--- a/docs/api-reference/utils.md
+++ b/docs/api-reference/utils.md
@@ -1,0 +1,11 @@
+# `narwhals.utils`
+
+::: narwhals.utils
+    handler: python
+    options:
+      members:
+        - parse_version
+        - Version
+      show_root_heading: false
+      show_source: false
+      show_bases: false

--- a/docs/how_it_works.md
+++ b/docs/how_it_works.md
@@ -70,7 +70,7 @@ import pandas as pd
 import narwhals as nw
 from narwhals._pandas_like.namespace import PandasLikeNamespace
 from narwhals._pandas_like.utils import Implementation
-from narwhals.utils import parse_version, Version
+from narwhals._utils import parse_version, Version
 
 pn = PandasLikeNamespace(
     implementation=Implementation.PANDAS,
@@ -96,7 +96,7 @@ import narwhals as nw
 from narwhals._pandas_like.namespace import PandasLikeNamespace
 from narwhals._pandas_like.utils import Implementation
 from narwhals._pandas_like.dataframe import PandasLikeDataFrame
-from narwhals.utils import parse_version, Version
+from narwhals._utils import parse_version, Version
 import pandas as pd
 
 pn = PandasLikeNamespace(
@@ -194,7 +194,7 @@ import narwhals as nw
 from narwhals._pandas_like.namespace import PandasLikeNamespace
 from narwhals._pandas_like.utils import Implementation
 from narwhals._pandas_like.dataframe import PandasLikeDataFrame
-from narwhals.utils import parse_version, Version
+from narwhals._utils import parse_version, Version
 import pandas as pd
 
 pn = PandasLikeNamespace(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
     - api-reference/exceptions.md
     - api-reference/selectors.md
     - api-reference/typing.md
+    - api-reference/utils.md
   - This: this.md
 theme:
   name: material

--- a/narwhals/__init__.py
+++ b/narwhals/__init__.py
@@ -3,6 +3,16 @@ from __future__ import annotations
 import typing as _t
 
 from narwhals import dependencies, dtypes, exceptions, selectors
+from narwhals._utils import (
+    Implementation,
+    generate_temporary_column_name,
+    is_ordered_categorical,
+    maybe_align_index,
+    maybe_convert_dtypes,
+    maybe_get_index,
+    maybe_reset_index,
+    maybe_set_index,
+)
 from narwhals.dataframe import DataFrame, LazyFrame
 from narwhals.dtypes import (
     Array,
@@ -75,16 +85,6 @@ from narwhals.translate import (
     narwhalify,
     to_native,
     to_py_scalar,
-)
-from narwhals.utils import (
-    Implementation,
-    generate_temporary_column_name,
-    is_ordered_categorical,
-    maybe_align_index,
-    maybe_convert_dtypes,
-    maybe_get_index,
-    maybe_reset_index,
-    maybe_set_index,
 )
 
 __version__: str

--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -20,9 +20,7 @@ from narwhals._arrow.series import ArrowSeries
 from narwhals._arrow.utils import align_series_full_broadcast, native_to_narwhals_dtype
 from narwhals._compliant import EagerDataFrame
 from narwhals._expression_parsing import ExprKind
-from narwhals.dependencies import is_numpy_array_1d
-from narwhals.exceptions import ShapeError
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     Version,
     check_column_names_are_unique,
@@ -35,6 +33,8 @@ from narwhals.utils import (
     supports_arrow_c_stream,
     validate_backend_version,
 )
+from narwhals.dependencies import is_numpy_array_1d
+from narwhals.exceptions import ShapeError
 
 if TYPE_CHECKING:
     from io import BytesIO
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     )
     from narwhals._compliant.typing import CompliantDataFrameAny, CompliantLazyFrameAny
     from narwhals._translate import IntoArrowTable
+    from narwhals._utils import Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.schema import Schema
     from narwhals.typing import (
@@ -68,7 +69,6 @@ if TYPE_CHECKING:
         _SliceIndex,
         _SliceName,
     )
-    from narwhals.utils import Version, _FullContext
 
     JoinType: TypeAlias = Literal[
         "left semi",

--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -7,7 +7,11 @@ import pyarrow.compute as pc
 from narwhals._arrow.series import ArrowSeries
 from narwhals._compliant import EagerExpr
 from narwhals._expression_parsing import evaluate_output_names_and_aliases
-from narwhals.utils import Implementation, generate_temporary_column_name, not_implemented
+from narwhals._utils import (
+    Implementation,
+    generate_temporary_column_name,
+    not_implemented,
+)
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -16,8 +20,8 @@ if TYPE_CHECKING:
     from narwhals._arrow.namespace import ArrowNamespace
     from narwhals._compliant.typing import AliasNames, EvalNames, EvalSeries, ScalarKwargs
     from narwhals._expression_parsing import ExprMetadata
+    from narwhals._utils import Version, _FullContext
     from narwhals.typing import RankMethod
-    from narwhals.utils import Version, _FullContext
 
 
 class ArrowExpr(EagerExpr["ArrowDataFrame", ArrowSeries]):

--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -9,7 +9,7 @@ import pyarrow.compute as pc
 from narwhals._arrow.utils import cast_to_comparable_string_types, extract_py_scalar
 from narwhals._compliant import EagerGroupBy
 from narwhals._expression_parsing import evaluate_output_names_and_aliases
-from narwhals.utils import generate_temporary_column_name
+from narwhals._utils import generate_temporary_column_name
 
 if TYPE_CHECKING:
     from narwhals._arrow.dataframe import ArrowDataFrame

--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -21,13 +21,13 @@ from narwhals._expression_parsing import (
     combine_alias_output_names,
     combine_evaluate_output_names,
 )
-from narwhals.utils import Implementation
+from narwhals._utils import Implementation
 
 if TYPE_CHECKING:
     from narwhals._arrow.typing import ArrayOrScalar, ChunkedArrayAny, Incomplete
+    from narwhals._utils import Version
     from narwhals.dtypes import DType
     from narwhals.typing import NonNestedLiteral
-    from narwhals.utils import Version
 
 
 class ArrowNamespace(

--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -32,9 +32,7 @@ from narwhals._arrow.utils import (
 )
 from narwhals._compliant import EagerSeries
 from narwhals._expression_parsing import ExprKind
-from narwhals.dependencies import is_numpy_array_1d
-from narwhals.exceptions import InvalidOperationError
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     generate_temporary_column_name,
     is_list_of,
@@ -42,6 +40,8 @@ from narwhals.utils import (
     requires,
     validate_backend_version,
 )
+from narwhals.dependencies import is_numpy_array_1d
+from narwhals.exceptions import InvalidOperationError
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
         _AsPyType,
         _BasicDataType,
     )
+    from narwhals._utils import Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.typing import (
         ClosedInterval,
@@ -80,7 +81,6 @@ if TYPE_CHECKING:
         _2DArray,
         _SliceIndex,
     )
-    from narwhals.utils import Version, _FullContext
 
 
 # TODO @dangotbanned: move into `_arrow.utils`

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -7,8 +7,8 @@ import pyarrow as pa
 import pyarrow.compute as pc
 
 from narwhals._compliant.series import _SeriesNamespace
+from narwhals._utils import isinstance_or_issubclass
 from narwhals.exceptions import ShapeError
-from narwhals.utils import isinstance_or_issubclass
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias, TypeIs
@@ -24,9 +24,9 @@ if TYPE_CHECKING:
         ScalarAny,
     )
     from narwhals._duration import IntervalUnit
+    from narwhals._utils import Version
     from narwhals.dtypes import DType
     from narwhals.typing import PythonLiteral
-    from narwhals.utils import Version
 
     # NOTE: stubs don't allow for `ChunkedArray[StructArray]`
     # Intended to represent the `.chunks` property storing `list[pa.StructArray]`

--- a/narwhals/_compliant/any_namespace.py
+++ b/narwhals/_compliant/any_namespace.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol
 
-from narwhals.utils import CompliantT_co, _StoresCompliant
+from narwhals._utils import CompliantT_co, _StoresCompliant
 
 if TYPE_CHECKING:
     from typing import Callable

--- a/narwhals/_compliant/dataframe.py
+++ b/narwhals/_compliant/dataframe.py
@@ -33,7 +33,7 @@ from narwhals._translate import (
     ToNarwhalsT_co,
 )
 from narwhals._typing_compat import deprecated
-from narwhals.utils import (
+from narwhals._utils import (
     Version,
     _StoresNative,
     check_columns_exist,
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     from narwhals._compliant.group_by import CompliantGroupBy, DataFrameGroupBy
     from narwhals._compliant.namespace import EagerNamespace
     from narwhals._translate import IntoArrowTable
+    from narwhals._utils import Implementation, _FullContext
     from narwhals.dataframe import DataFrame
     from narwhals.dtypes import DType
     from narwhals.exceptions import ColumnNotFoundError
@@ -78,7 +79,6 @@ if TYPE_CHECKING:
         _SliceIndex,
         _SliceName,
     )
-    from narwhals.utils import Implementation, _FullContext
 
     Incomplete: TypeAlias = Any
 

--- a/narwhals/_compliant/expr.py
+++ b/narwhals/_compliant/expr.py
@@ -36,9 +36,9 @@ from narwhals._compliant.typing import (
     NativeExprT,
 )
 from narwhals._typing_compat import Protocol38, deprecated
+from narwhals._utils import _StoresCompliant, not_implemented
 from narwhals.dependencies import get_numpy, is_numpy_array
 from narwhals.dtypes import DType
-from narwhals.utils import _StoresCompliant, not_implemented
 
 if TYPE_CHECKING:
     from typing import Mapping
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     from narwhals._compliant.series import CompliantSeries
     from narwhals._compliant.typing import AliasNames, EvalNames, EvalSeries, ScalarKwargs
     from narwhals._expression_parsing import ExprKind, ExprMetadata
+    from narwhals._utils import Implementation, Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.typing import (
         FillNullStrategy,
@@ -59,7 +60,6 @@ if TYPE_CHECKING:
         TemporalLiteral,
         TimeUnit,
     )
-    from narwhals.utils import Implementation, Version, _FullContext
 
 __all__ = ["CompliantExpr", "EagerExpr", "LazyExpr", "NativeExpr"]
 

--- a/narwhals/_compliant/group_by.py
+++ b/narwhals/_compliant/group_by.py
@@ -30,7 +30,7 @@ from narwhals._compliant.typing import (
     NativeExprT_co,
 )
 from narwhals._typing_compat import Protocol38
-from narwhals.utils import is_sequence_of
+from narwhals._utils import is_sequence_of
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias

--- a/narwhals/_compliant/namespace.py
+++ b/narwhals/_compliant/namespace.py
@@ -25,22 +25,22 @@ from narwhals._compliant.typing import (
     NativeFrameT_co,
     NativeSeriesT,
 )
-from narwhals.dependencies import is_numpy_array_2d
-from narwhals.utils import (
+from narwhals._utils import (
     exclude_column_names,
     get_column_names,
     passthrough_column_names,
 )
+from narwhals.dependencies import is_numpy_array_2d
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
     from narwhals._compliant.selectors import CompliantSelectorNamespace
     from narwhals._compliant.when_then import CompliantWhen, EagerWhen
+    from narwhals._utils import Implementation, Version
     from narwhals.dtypes import DType
     from narwhals.schema import Schema
     from narwhals.typing import ConcatMethod, Into1DArray, NonNestedLiteral, _2DArray
-    from narwhals.utils import Implementation, Version
 
     Incomplete: TypeAlias = Any
 

--- a/narwhals/_compliant/selectors.py
+++ b/narwhals/_compliant/selectors.py
@@ -17,7 +17,7 @@ from typing import (
 
 from narwhals._compliant.expr import CompliantExpr
 from narwhals._typing_compat import Protocol38
-from narwhals.utils import (
+from narwhals._utils import (
     _parse_time_unit_and_time_zone,
     dtype_matches_time_unit_and_time_zone,
     get_column_names,
@@ -41,9 +41,9 @@ if TYPE_CHECKING:
         EvalSeries,
         ScalarKwargs,
     )
+    from narwhals._utils import Implementation, Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.typing import TimeUnit
-    from narwhals.utils import Implementation, Version, _FullContext
 
 __all__ = [
     "CompliantSelector",

--- a/narwhals/_compliant/series.py
+++ b/narwhals/_compliant/series.py
@@ -25,7 +25,7 @@ from narwhals._compliant.typing import (
     NativeSeriesT_co,
 )
 from narwhals._translate import FromIterable, FromNative, NumpyConvertible, ToNarwhals
-from narwhals.utils import (
+from narwhals._utils import (
     _StoresCompliant,
     _StoresNative,
     is_compliant_series,
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from narwhals._compliant.dataframe import CompliantDataFrame
     from narwhals._compliant.expr import CompliantExpr, EagerExpr
     from narwhals._compliant.namespace import CompliantNamespace, EagerNamespace
+    from narwhals._utils import Implementation, Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.series import Series
     from narwhals.typing import (
@@ -60,7 +61,6 @@ if TYPE_CHECKING:
         _1DArray,
         _SliceIndex,
     )
-    from narwhals.utils import Implementation, Version, _FullContext
 
 __all__ = ["CompliantSeries", "EagerSeries"]
 

--- a/narwhals/_compliant/when_then.py
+++ b/narwhals/_compliant/when_then.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
     from typing_extensions import Self, TypeAlias
 
     from narwhals._compliant.typing import EvalSeries, ScalarKwargs
+    from narwhals._utils import Implementation, Version, _FullContext
     from narwhals.typing import NonNestedLiteral
-    from narwhals.utils import Implementation, Version, _FullContext
 
 
 __all__ = ["CompliantThen", "CompliantWhen", "EagerWhen", "LazyWhen"]

--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -5,10 +5,9 @@ from typing import TYPE_CHECKING, Any, Iterator, Mapping, Sequence
 import dask.dataframe as dd
 import pandas as pd
 
-from narwhals._dask.utils import add_row_index, evaluate_exprs
+from narwhals._dask._utils import add_row_index, evaluate_exprs
 from narwhals._pandas_like.utils import native_to_narwhals_dtype, select_columns_by_name
-from narwhals.typing import CompliantLazyFrame
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     _remap_full_join_keys,
     check_column_names_are_unique,
@@ -18,6 +17,7 @@ from narwhals.utils import (
     parse_version,
     validate_backend_version,
 )
+from narwhals.typing import CompliantLazyFrame
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -29,10 +29,10 @@ if TYPE_CHECKING:
     from narwhals._dask.expr import DaskExpr
     from narwhals._dask.group_by import DaskLazyGroupBy
     from narwhals._dask.namespace import DaskNamespace
+    from narwhals._utils import Version, _FullContext
     from narwhals.dataframe import LazyFrame
     from narwhals.dtypes import DType
     from narwhals.typing import AsofJoinStrategy, JoinStrategy, LazyUniqueKeepStrategy
-    from narwhals.utils import Version, _FullContext
 
 
 class DaskLazyFrame(

--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Iterator, Mapping, Sequence
 import dask.dataframe as dd
 import pandas as pd
 
-from narwhals._dask._utils import add_row_index, evaluate_exprs
+from narwhals._dask.utils import add_row_index, evaluate_exprs
 from narwhals._pandas_like.utils import native_to_narwhals_dtype, select_columns_by_name
 from narwhals._utils import (
     Implementation,

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -5,13 +5,13 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence
 
 from narwhals._compliant import LazyExpr
 from narwhals._compliant.expr import DepthTrackingExpr
-from narwhals._dask._utils import (
+from narwhals._dask.expr_dt import DaskExprDateTimeNamespace
+from narwhals._dask.expr_str import DaskExprStringNamespace
+from narwhals._dask.utils import (
     add_row_index,
     maybe_evaluate_expr,
     narwhals_to_native_dtype,
 )
-from narwhals._dask.expr_dt import DaskExprDateTimeNamespace
-from narwhals._dask.expr_str import DaskExprStringNamespace
 from narwhals._expression_parsing import ExprKind, evaluate_output_names_and_aliases
 from narwhals._pandas_like.utils import native_to_narwhals_dtype
 from narwhals._utils import (

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -5,17 +5,21 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence
 
 from narwhals._compliant import LazyExpr
 from narwhals._compliant.expr import DepthTrackingExpr
-from narwhals._dask.expr_dt import DaskExprDateTimeNamespace
-from narwhals._dask.expr_str import DaskExprStringNamespace
-from narwhals._dask.utils import (
+from narwhals._dask._utils import (
     add_row_index,
     maybe_evaluate_expr,
     narwhals_to_native_dtype,
 )
+from narwhals._dask.expr_dt import DaskExprDateTimeNamespace
+from narwhals._dask.expr_str import DaskExprStringNamespace
 from narwhals._expression_parsing import ExprKind, evaluate_output_names_and_aliases
 from narwhals._pandas_like.utils import native_to_narwhals_dtype
+from narwhals._utils import (
+    Implementation,
+    generate_temporary_column_name,
+    not_implemented,
+)
 from narwhals.exceptions import InvalidOperationError
-from narwhals.utils import Implementation, generate_temporary_column_name, not_implemented
 
 if TYPE_CHECKING:
     import dask.dataframe.dask_expr as dx
@@ -25,6 +29,7 @@ if TYPE_CHECKING:
     from narwhals._dask.dataframe import DaskLazyFrame
     from narwhals._dask.namespace import DaskNamespace
     from narwhals._expression_parsing import ExprKind, ExprMetadata
+    from narwhals._utils import Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.typing import (
         FillNullStrategy,
@@ -33,7 +38,6 @@ if TYPE_CHECKING:
         RollingInterpolationMethod,
         TemporalLiteral,
     )
-    from narwhals.utils import Version, _FullContext
 
 
 class DaskExpr(

--- a/narwhals/_dask/expr_dt.py
+++ b/narwhals/_dask/expr_dt.py
@@ -9,7 +9,7 @@ from narwhals._pandas_like.utils import (
     calculate_timestamp_datetime,
     native_to_narwhals_dtype,
 )
-from narwhals.utils import Implementation
+from narwhals._utils import Implementation
 
 if TYPE_CHECKING:
     import dask.dataframe.dask_expr as dx

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -9,26 +9,26 @@ import pandas as pd
 
 from narwhals._compliant import CompliantThen, CompliantWhen, LazyNamespace
 from narwhals._compliant.namespace import DepthTrackingNamespace
-from narwhals._dask.dataframe import DaskLazyFrame
-from narwhals._dask.expr import DaskExpr
-from narwhals._dask.selectors import DaskSelectorNamespace
-from narwhals._dask.utils import (
+from narwhals._dask._utils import (
     align_series_full_broadcast,
     narwhals_to_native_dtype,
     validate_comparand,
 )
+from narwhals._dask.dataframe import DaskLazyFrame
+from narwhals._dask.expr import DaskExpr
+from narwhals._dask.selectors import DaskSelectorNamespace
 from narwhals._expression_parsing import (
     combine_alias_output_names,
     combine_evaluate_output_names,
 )
-from narwhals.utils import Implementation
+from narwhals._utils import Implementation
 
 if TYPE_CHECKING:
     import dask.dataframe.dask_expr as dx
 
+    from narwhals._utils import Version
     from narwhals.dtypes import DType
     from narwhals.typing import ConcatMethod, NonNestedLiteral
-    from narwhals.utils import Version
 
 
 class DaskNamespace(

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -9,14 +9,14 @@ import pandas as pd
 
 from narwhals._compliant import CompliantThen, CompliantWhen, LazyNamespace
 from narwhals._compliant.namespace import DepthTrackingNamespace
-from narwhals._dask._utils import (
+from narwhals._dask.dataframe import DaskLazyFrame
+from narwhals._dask.expr import DaskExpr
+from narwhals._dask.selectors import DaskSelectorNamespace
+from narwhals._dask.utils import (
     align_series_full_broadcast,
     narwhals_to_native_dtype,
     validate_comparand,
 )
-from narwhals._dask.dataframe import DaskLazyFrame
-from narwhals._dask.expr import DaskExpr
-from narwhals._dask.selectors import DaskSelectorNamespace
 from narwhals._expression_parsing import (
     combine_alias_output_names,
     combine_evaluate_output_names,

--- a/narwhals/_dask/utils.py
+++ b/narwhals/_dask/utils.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Sequence
 
 from narwhals._pandas_like.utils import select_columns_by_name
-from narwhals.dependencies import get_pandas, get_pyarrow
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     Version,
     isinstance_or_issubclass,
     parse_version,
 )
+from narwhals.dependencies import get_pandas, get_pyarrow
 
 if TYPE_CHECKING:
     import dask.dataframe as dd

--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -16,10 +16,7 @@ from narwhals._duckdb.utils import (
     lit,
     native_to_narwhals_dtype,
 )
-from narwhals.dependencies import get_duckdb
-from narwhals.exceptions import InvalidOperationError
-from narwhals.typing import CompliantLazyFrame
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     Version,
     generate_temporary_column_name,
@@ -28,6 +25,9 @@ from narwhals.utils import (
     parse_version,
     validate_backend_version,
 )
+from narwhals.dependencies import get_duckdb
+from narwhals.exceptions import InvalidOperationError
+from narwhals.typing import CompliantLazyFrame
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -43,11 +43,11 @@ if TYPE_CHECKING:
     from narwhals._duckdb.group_by import DuckDBGroupBy
     from narwhals._duckdb.namespace import DuckDBNamespace
     from narwhals._duckdb.series import DuckDBInterchangeSeries
+    from narwhals._utils import _FullContext
     from narwhals.dataframe import LazyFrame
     from narwhals.dtypes import DType
     from narwhals.stable.v1 import DataFrame as DataFrameV1
     from narwhals.typing import AsofJoinStrategy, JoinStrategy, LazyUniqueKeepStrategy
-    from narwhals.utils import _FullContext
 
 with contextlib.suppress(ImportError):  # requires duckdb>=1.3.0
     from duckdb import SQLExpression

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -22,7 +22,7 @@ from narwhals._duckdb.utils import (
     when,
 )
 from narwhals._expression_parsing import ExprKind
-from narwhals.utils import Implementation, not_implemented, requires
+from narwhals._utils import Implementation, not_implemented, requires
 
 if TYPE_CHECKING:
     from duckdb import Expression
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from narwhals._duckdb.dataframe import DuckDBLazyFrame
     from narwhals._duckdb.namespace import DuckDBNamespace
     from narwhals._expression_parsing import ExprMetadata
+    from narwhals._utils import Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.typing import (
         FillNullStrategy,
@@ -47,7 +48,6 @@ if TYPE_CHECKING:
         RollingInterpolationMethod,
         TemporalLiteral,
     )
-    from narwhals.utils import Version, _FullContext
 
     DuckDBWindowInputs = WindowInputs[Expression]
     DuckDBUnorderableWindowInputs = UnorderableWindowInputs[Expression]

--- a/narwhals/_duckdb/expr_dt.py
+++ b/narwhals/_duckdb/expr_dt.py
@@ -6,7 +6,7 @@ from duckdb import FunctionExpression
 
 from narwhals._duckdb.utils import UNITS_DICT, fetch_rel_time_zone, lit
 from narwhals._duration import parse_interval_string
-from narwhals.utils import not_implemented
+from narwhals._utils import not_implemented
 
 if TYPE_CHECKING:
     from duckdb import Expression

--- a/narwhals/_duckdb/expr_str.py
+++ b/narwhals/_duckdb/expr_str.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from duckdb import FunctionExpression
 
 from narwhals._duckdb.utils import lit
-from narwhals.utils import not_implemented
+from narwhals._utils import not_implemented
 
 if TYPE_CHECKING:
     from duckdb import Expression

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -18,12 +18,12 @@ from narwhals._expression_parsing import (
     combine_alias_output_names,
     combine_evaluate_output_names,
 )
-from narwhals.utils import Implementation
+from narwhals._utils import Implementation
 
 if TYPE_CHECKING:
+    from narwhals._utils import Version
     from narwhals.dtypes import DType
     from narwhals.typing import ConcatMethod, NonNestedLiteral
-    from narwhals.utils import Version
 
 
 class DuckDBNamespace(

--- a/narwhals/_duckdb/series.py
+++ b/narwhals/_duckdb/series.py
@@ -11,8 +11,8 @@ if TYPE_CHECKING:
     import duckdb
     from typing_extensions import Never, Self
 
+    from narwhals._utils import Version
     from narwhals.dtypes import DType
-    from narwhals.utils import Version
 
 
 class DuckDBInterchangeSeries:

--- a/narwhals/_duckdb/utils.py
+++ b/narwhals/_duckdb/utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 import duckdb
 
-from narwhals.utils import Version, isinstance_or_issubclass
+from narwhals._utils import Version, isinstance_or_issubclass
 
 if TYPE_CHECKING:
     from duckdb import DuckDBPyRelation, Expression

--- a/narwhals/_duckdb/utils.py
+++ b/narwhals/_duckdb/utils.py
@@ -159,7 +159,7 @@ def fetch_rel_time_zone(rel: duckdb.DuckDBPyRelation) -> str:
         "duckdb_settings()", "select value from duckdb_settings() where name = 'TimeZone'"
     ).fetchone()
     assert result is not None  # noqa: S101
-    return result[0]
+    return result[0]  # type: ignore[no-any-return]
 
 
 @lru_cache(maxsize=16)

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -7,6 +7,7 @@ from enum import Enum, auto
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Literal, Sequence, TypeVar, cast
 
+from narwhals._utils import is_compliant_expr
 from narwhals.dependencies import is_narwhals_series, is_numpy_array
 from narwhals.exceptions import (
     InvalidOperationError,
@@ -14,7 +15,6 @@ from narwhals.exceptions import (
     MultiOutputExpressionError,
     ShapeError,
 )
-from narwhals.utils import is_compliant_expr
 
 if TYPE_CHECKING:
     from typing_extensions import Never, TypeIs

--- a/narwhals/_ibis/dataframe.py
+++ b/narwhals/_ibis/dataframe.py
@@ -16,9 +16,7 @@ import ibis
 import ibis.expr.types as ir
 
 from narwhals._ibis.utils import evaluate_exprs, native_to_narwhals_dtype
-from narwhals.exceptions import ColumnNotFoundError, InvalidOperationError
-from narwhals.typing import CompliantLazyFrame
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     Version,
     not_implemented,
@@ -26,6 +24,8 @@ from narwhals.utils import (
     parse_version,
     validate_backend_version,
 )
+from narwhals.exceptions import ColumnNotFoundError, InvalidOperationError
+from narwhals.typing import CompliantLazyFrame
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -40,11 +40,11 @@ if TYPE_CHECKING:
     from narwhals._ibis.group_by import IbisGroupBy
     from narwhals._ibis.namespace import IbisNamespace
     from narwhals._ibis.series import IbisInterchangeSeries
+    from narwhals._utils import _FullContext
     from narwhals.dataframe import LazyFrame
     from narwhals.dtypes import DType
     from narwhals.stable.v1 import DataFrame as DataFrameV1
     from narwhals.typing import AsofJoinStrategy, JoinStrategy, LazyUniqueKeepStrategy
-    from narwhals.utils import _FullContext
 
     JoinPredicates: TypeAlias = "Sequence[ir.BooleanColumn] | Sequence[str]"
 

--- a/narwhals/_ibis/expr.py
+++ b/narwhals/_ibis/expr.py
@@ -13,7 +13,7 @@ from narwhals._ibis.expr_list import IbisExprListNamespace
 from narwhals._ibis.expr_str import IbisExprStringNamespace
 from narwhals._ibis.expr_struct import IbisExprStructNamespace
 from narwhals._ibis.utils import is_floating, lit, narwhals_to_native_dtype
-from narwhals.utils import Implementation, not_implemented
+from narwhals._utils import Implementation, not_implemented
 
 if TYPE_CHECKING:
     import ibis.expr.types as ir
@@ -29,9 +29,9 @@ if TYPE_CHECKING:
     from narwhals._expression_parsing import ExprKind, ExprMetadata
     from narwhals._ibis.dataframe import IbisLazyFrame
     from narwhals._ibis.namespace import IbisNamespace
+    from narwhals._utils import Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.typing import RankMethod, RollingInterpolationMethod
-    from narwhals.utils import Version, _FullContext
 
     ExprT = TypeVar("ExprT", bound=ir.Value)
     IbisWindowFunction = WindowFunction[ir.Value]

--- a/narwhals/_ibis/expr_dt.py
+++ b/narwhals/_ibis/expr_dt.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from narwhals._duration import parse_interval_string
 from narwhals._ibis.utils import UNITS_DICT_BUCKET, UNITS_DICT_TRUNCATE
-from narwhals.utils import not_implemented
+from narwhals._utils import not_implemented
 
 if TYPE_CHECKING:
     import ibis.expr.types as ir

--- a/narwhals/_ibis/expr_str.py
+++ b/narwhals/_ibis/expr_str.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from ibis.expr.datatypes import Timestamp
 
-from narwhals.utils import _is_naive_format, not_implemented
+from narwhals._utils import _is_naive_format, not_implemented
 
 if TYPE_CHECKING:
     import ibis.expr.types as ir

--- a/narwhals/_ibis/namespace.py
+++ b/narwhals/_ibis/namespace.py
@@ -17,12 +17,12 @@ from narwhals._ibis.dataframe import IbisLazyFrame
 from narwhals._ibis.expr import IbisExpr
 from narwhals._ibis.selectors import IbisSelectorNamespace
 from narwhals._ibis.utils import lit, narwhals_to_native_dtype
-from narwhals.utils import Implementation, requires
+from narwhals._utils import Implementation, requires
 
 if TYPE_CHECKING:
+    from narwhals._utils import Version
     from narwhals.dtypes import DType
     from narwhals.typing import ConcatMethod
-    from narwhals.utils import Version
 
 
 class IbisNamespace(LazyNamespace[IbisLazyFrame, IbisExpr, "ir.Table"]):

--- a/narwhals/_ibis/series.py
+++ b/narwhals/_ibis/series.py
@@ -10,8 +10,8 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
+    from narwhals._utils import Version
     from narwhals.dtypes import DType
-    from narwhals.utils import Version
 
 
 class IbisInterchangeSeries:

--- a/narwhals/_ibis/utils.py
+++ b/narwhals/_ibis/utils.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal, Mapping
 import ibis
 import ibis.expr.datatypes as ibis_dtypes
 
-from narwhals.utils import isinstance_or_issubclass
+from narwhals._utils import isinstance_or_issubclass
 
 if TYPE_CHECKING:
     import ibis.expr.types as ir
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
     from narwhals._duration import IntervalUnit
     from narwhals._ibis.dataframe import IbisLazyFrame
     from narwhals._ibis.expr import IbisExpr
+    from narwhals._utils import Version
     from narwhals.dtypes import DType
-    from narwhals.utils import Version
 
 lit = ibis.literal
 """Alias for `ibis.literal`."""

--- a/narwhals/_interchange/dataframe.py
+++ b/narwhals/_interchange/dataframe.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 from typing import TYPE_CHECKING, Any, NoReturn
 
-from narwhals.utils import Version, parse_version
+from narwhals._utils import Version, parse_version
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/narwhals/_interchange/series.py
+++ b/narwhals/_interchange/series.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, NoReturn
 
 from narwhals._interchange.dataframe import map_interchange_dtype_to_narwhals_dtype
-from narwhals.utils import Version
+from narwhals._utils import Version
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/narwhals/_namespace.py
+++ b/narwhals/_namespace.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 from narwhals._compliant.typing import CompliantNamespaceAny, CompliantNamespaceT_co
+from narwhals._utils import Implementation, Version
 from narwhals.dependencies import (
     get_cudf,
     get_modin,
@@ -27,7 +28,6 @@ from narwhals.dependencies import (
     is_pyspark_dataframe,
     is_sqlframe_dataframe,
 )
-from narwhals.utils import Implementation, Version
 
 if TYPE_CHECKING:
     from types import ModuleType

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -759,7 +759,7 @@ class PandasLikeDataFrame(
 
     # --- lazy-only ---
     def lazy(self, *, backend: Implementation | None = None) -> CompliantLazyFrameAny:
-        from narwhals._utils import parse_version
+        from narwhals.utils import parse_version
 
         pandas_df = self.to_pandas()
         if backend is None:

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -29,9 +29,7 @@ from narwhals._pandas_like.utils import (
     select_columns_by_name,
     set_index,
 )
-from narwhals.dependencies import is_pandas_like_dataframe
-from narwhals.exceptions import InvalidOperationError, ShapeError
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     _into_arrow_table,
     _remap_full_join_keys,
@@ -42,6 +40,8 @@ from narwhals.utils import (
     scale_bytes,
     validate_backend_version,
 )
+from narwhals.dependencies import is_pandas_like_dataframe
+from narwhals.exceptions import InvalidOperationError, ShapeError
 
 if TYPE_CHECKING:
     from io import BytesIO
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from narwhals._pandas_like.group_by import PandasLikeGroupBy
     from narwhals._pandas_like.namespace import PandasLikeNamespace
     from narwhals._translate import IntoArrowTable
+    from narwhals._utils import Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.schema import Schema
     from narwhals.typing import (
@@ -72,7 +73,6 @@ if TYPE_CHECKING:
         _SliceIndex,
         _SliceName,
     )
-    from narwhals.utils import Version, _FullContext
 
     Constructor: TypeAlias = Callable[..., pd.DataFrame]
 
@@ -759,7 +759,7 @@ class PandasLikeDataFrame(
 
     # --- lazy-only ---
     def lazy(self, *, backend: Implementation | None = None) -> CompliantLazyFrameAny:
-        from narwhals.utils import parse_version
+        from narwhals._utils import parse_version
 
         pandas_df = self.to_pandas()
         if backend is None:

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -6,7 +6,7 @@ from narwhals._compliant import EagerExpr
 from narwhals._expression_parsing import evaluate_output_names_and_aliases
 from narwhals._pandas_like.group_by import PandasLikeGroupBy
 from narwhals._pandas_like.series import PandasLikeSeries
-from narwhals.utils import generate_temporary_column_name
+from narwhals._utils import generate_temporary_column_name
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -15,13 +15,13 @@ if TYPE_CHECKING:
     from narwhals._expression_parsing import ExprMetadata
     from narwhals._pandas_like.dataframe import PandasLikeDataFrame
     from narwhals._pandas_like.namespace import PandasLikeNamespace
+    from narwhals._utils import Implementation, Version, _FullContext
     from narwhals.typing import (
         FillNullStrategy,
         NonNestedLiteral,
         PythonLiteral,
         RankMethod,
     )
-    from narwhals.utils import Implementation, Version, _FullContext
 
 WINDOW_FUNCTIONS_TO_PANDAS_EQUIVALENT = {
     "cum_sum": "cumsum",

--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Iterator, Mapping, Sequence
 from narwhals._compliant import EagerGroupBy
 from narwhals._expression_parsing import evaluate_output_names_and_aliases
 from narwhals._pandas_like.utils import select_columns_by_name
-from narwhals.utils import find_stacklevel
+from narwhals._utils import find_stacklevel
 
 if TYPE_CHECKING:
     from narwhals._compliant.group_by import NarwhalsAggregation

--- a/narwhals/_pandas_like/namespace.py
+++ b/narwhals/_pandas_like/namespace.py
@@ -20,9 +20,9 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from narwhals._pandas_like.typing import NDFrameT
+    from narwhals._utils import Implementation, Version
     from narwhals.dtypes import DType
     from narwhals.typing import NonNestedLiteral
-    from narwhals.utils import Implementation, Version
 
 VERTICAL: Literal[0] = 0
 HORIZONTAL: Literal[1] = 1

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -20,14 +20,14 @@ from narwhals._pandas_like.utils import (
     select_columns_by_name,
     set_index,
 )
-from narwhals.dependencies import is_numpy_array_1d, is_pandas_like_series
-from narwhals.exceptions import InvalidOperationError
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     is_list_of,
     parse_version,
     validate_backend_version,
 )
+from narwhals.dependencies import is_numpy_array_1d, is_pandas_like_series
+from narwhals.exceptions import InvalidOperationError
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from narwhals._arrow.typing import ChunkedArrayAny
     from narwhals._pandas_like.dataframe import PandasLikeDataFrame
     from narwhals._pandas_like.namespace import PandasLikeNamespace
+    from narwhals._utils import Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.typing import (
         ClosedInterval,
@@ -56,7 +57,6 @@ if TYPE_CHECKING:
         _AnyDArray,
         _SliceIndex,
     )
-    from narwhals.utils import Version, _FullContext
 
 PANDAS_TO_NUMPY_DTYPE_NO_MISSING = {
     "Int64": "int64",

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -8,14 +8,14 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Sized, TypeVar
 import pandas as pd
 
 from narwhals._compliant.series import EagerSeriesNamespace
-from narwhals.exceptions import DuplicateError, ShapeError
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     Version,
     _DeferredIterable,
     check_columns_exist,
     isinstance_or_issubclass,
 )
+from narwhals.exceptions import DuplicateError, ShapeError
 
 T = TypeVar("T", bound=Sized)
 

--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -21,9 +21,7 @@ from narwhals._polars.utils import (
     extract_args_kwargs,
     native_to_narwhals_dtype,
 )
-from narwhals.dependencies import is_numpy_array_1d
-from narwhals.exceptions import ColumnNotFoundError
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     _into_arrow_table,
     check_columns_exist,
@@ -39,6 +37,8 @@ from narwhals.utils import (
     requires,
     validate_backend_version,
 )
+from narwhals.dependencies import is_numpy_array_1d
+from narwhals.exceptions import ColumnNotFoundError
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from narwhals._polars.expr import PolarsExpr
     from narwhals._polars.group_by import PolarsGroupBy, PolarsLazyGroupBy
     from narwhals._translate import IntoArrowTable
+    from narwhals._utils import Version, _FullContext
     from narwhals.dataframe import DataFrame, LazyFrame
     from narwhals.dtypes import DType
     from narwhals.schema import Schema
@@ -63,7 +64,6 @@ if TYPE_CHECKING:
         SingleIndexSelector,
         _2DArray,
     )
-    from narwhals.utils import Version, _FullContext
 
     T = TypeVar("T")
     R = TypeVar("R")

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -10,7 +10,7 @@ from narwhals._polars.utils import (
     extract_native,
     narwhals_to_native_dtype,
 )
-from narwhals.utils import Implementation, requires
+from narwhals._utils import Implementation, requires
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
     from narwhals._expression_parsing import ExprKind, ExprMetadata
     from narwhals._polars.dataframe import Method
     from narwhals._polars.namespace import PolarsNamespace
+    from narwhals._utils import Version
     from narwhals.dtypes import DType
-    from narwhals.utils import Version
 
 
 class PolarsExpr:

--- a/narwhals/_polars/group_by.py
+++ b/narwhals/_polars/group_by.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterator, Sequence, cast
 
-from narwhals.utils import is_sequence_of
+from narwhals._utils import is_sequence_of
 
 if TYPE_CHECKING:
     from polars.dataframe.group_by import GroupBy as NativeGroupBy

--- a/narwhals/_polars/namespace.py
+++ b/narwhals/_polars/namespace.py
@@ -17,9 +17,9 @@ import polars as pl
 from narwhals._polars.expr import PolarsExpr
 from narwhals._polars.series import PolarsSeries
 from narwhals._polars.utils import extract_args_kwargs, narwhals_to_native_dtype
+from narwhals._utils import Implementation, requires
 from narwhals.dependencies import is_numpy_array_2d
 from narwhals.dtypes import DType
-from narwhals.utils import Implementation, requires
 
 if TYPE_CHECKING:
     from datetime import timezone
@@ -27,9 +27,9 @@ if TYPE_CHECKING:
     from narwhals._compliant import CompliantSelectorNamespace, CompliantWhen
     from narwhals._polars.dataframe import Method, PolarsDataFrame, PolarsLazyFrame
     from narwhals._polars.typing import FrameT
+    from narwhals._utils import Version, _FullContext
     from narwhals.schema import Schema
     from narwhals.typing import Into1DArray, TimeUnit, _2DArray
-    from narwhals.utils import Version, _FullContext
 
 
 class PolarsNamespace:

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -20,8 +20,8 @@ from narwhals._polars.utils import (
     narwhals_to_native_dtype,
     native_to_narwhals_dtype,
 )
+from narwhals._utils import Implementation, requires, validate_backend_version
 from narwhals.dependencies import is_numpy_array_1d
-from narwhals.utils import Implementation, requires, validate_backend_version
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -34,10 +34,10 @@ if TYPE_CHECKING:
     from narwhals._polars.dataframe import Method, PolarsDataFrame
     from narwhals._polars.expr import PolarsExpr
     from narwhals._polars.namespace import PolarsNamespace
+    from narwhals._utils import Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.series import Series
     from narwhals.typing import Into1DArray, MultiIndexSelector, _1DArray
-    from narwhals.utils import Version, _FullContext
 
     T = TypeVar("T")
 

--- a/narwhals/_polars/utils.py
+++ b/narwhals/_polars/utils.py
@@ -14,6 +14,7 @@ from typing import (
 
 import polars as pl
 
+from narwhals._utils import Version, _DeferredIterable, isinstance_or_issubclass
 from narwhals.exceptions import (
     ColumnNotFoundError,
     ComputeError,
@@ -22,13 +23,12 @@ from narwhals.exceptions import (
     NarwhalsError,
     ShapeError,
 )
-from narwhals.utils import Version, _DeferredIterable, isinstance_or_issubclass
 
 if TYPE_CHECKING:
     from typing_extensions import TypeIs
 
+    from narwhals._utils import _StoresNative
     from narwhals.dtypes import DType
-    from narwhals.utils import _StoresNative
 
     T = TypeVar("T")
     NativeT = TypeVar(

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -13,9 +13,7 @@ from narwhals._spark_like.utils import (
     import_window,
     native_to_narwhals_dtype,
 )
-from narwhals.exceptions import InvalidOperationError
-from narwhals.typing import CompliantLazyFrame
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     find_stacklevel,
     generate_temporary_column_name,
@@ -24,6 +22,8 @@ from narwhals.utils import (
     parse_version,
     validate_backend_version,
 )
+from narwhals.exceptions import InvalidOperationError
+from narwhals.typing import CompliantLazyFrame
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -38,10 +38,10 @@ if TYPE_CHECKING:
     from narwhals._spark_like.expr import SparkLikeExpr
     from narwhals._spark_like.group_by import SparkLikeLazyGroupBy
     from narwhals._spark_like.namespace import SparkLikeNamespace
+    from narwhals._utils import Version, _FullContext
     from narwhals.dataframe import LazyFrame
     from narwhals.dtypes import DType
     from narwhals.typing import JoinStrategy, LazyUniqueKeepStrategy
-    from narwhals.utils import Version, _FullContext
 
     SQLFrameDataFrame = BaseDataFrame[Any, Any, Any, Any, Any]
 

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from narwhals._expression_parsing import ExprMetadata
     from narwhals._spark_like.dataframe import SparkLikeLazyFrame
     from narwhals._spark_like.namespace import SparkLikeNamespace
+    from narwhals._utils import Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.typing import (
         FillNullStrategy,
@@ -51,7 +52,6 @@ if TYPE_CHECKING:
         RankMethod,
         TemporalLiteral,
     )
-    from narwhals.utils import Version, _FullContext
 
     NativeRankMethod: TypeAlias = Literal["rank", "dense_rank", "row_number"]
     Asc: TypeAlias = Literal[False]

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -28,7 +28,6 @@ from narwhals._spark_like.utils import (
 )
 from narwhals._utils import Implementation, not_implemented, parse_version
 from narwhals.dependencies import get_pyspark
-from narwhals.exceptions import InvalidOperationError
 from narwhals.utils import Implementation, not_implemented, parse_version
 
 if TYPE_CHECKING:

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -26,9 +26,9 @@ from narwhals._spark_like.utils import (
     import_window,
     narwhals_to_native_dtype,
 )
+from narwhals._utils import Implementation, not_implemented, parse_version
 from narwhals.dependencies import get_pyspark
 from narwhals.exceptions import InvalidOperationError
-from narwhals.utils import Implementation, not_implemented, parse_version
 
 if TYPE_CHECKING:
     from sqlframe.base.column import Column
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from narwhals._expression_parsing import ExprMetadata
     from narwhals._spark_like.dataframe import SparkLikeLazyFrame
     from narwhals._spark_like.namespace import SparkLikeNamespace
+    from narwhals._utils import Version, _FullContext
     from narwhals.dtypes import DType
     from narwhals.typing import (
         FillNullStrategy,
@@ -53,7 +54,6 @@ if TYPE_CHECKING:
         RankMethod,
         TemporalLiteral,
     )
-    from narwhals.utils import Version, _FullContext
 
     NativeRankMethod: TypeAlias = Literal["rank", "dense_rank", "row_number"]
     Asc: TypeAlias = Literal[False]

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -60,7 +60,6 @@ if TYPE_CHECKING:
     NullsLast: TypeAlias = Literal[True]
 
     SparkWindowFunction = WindowFunction[SparkLikeLazyFrame, Column]
-    SparkWindowInputs = WindowInputs[Column]
 
 ASC_NULLS_FIRST: tuple[Asc, NullsFirst] = False, False
 ASC_NULLS_LAST: tuple[Asc, NullsLast] = False, True
@@ -100,7 +99,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
     @property
     def window_function(self) -> SparkWindowFunction:
         def default_window_func(
-            df: SparkLikeLazyFrame, window_inputs: SparkWindowInputs
+            df: SparkLikeLazyFrame, window_inputs: WindowInputs
         ) -> list[Column]:
             assert not window_inputs.order_by  # noqa: S101
             return [
@@ -116,7 +115,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
     def broadcast(self, kind: Literal[ExprKind.AGGREGATION, ExprKind.LITERAL]) -> Self:
         if kind is ExprKind.LITERAL:
             return self
-        return self.over([self._F.lit(1)], [])
+        return self._with_callable(lambda expr: expr.over(self.partition_by()))
 
     @property
     def _F(self):  # type: ignore[no-untyped-def] # noqa: ANN202, N802
@@ -205,7 +204,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         reverse: bool,
         func_name: Literal["sum", "max", "min", "count", "product"],
     ) -> SparkWindowFunction:
-        def func(df: SparkLikeLazyFrame, inputs: SparkWindowInputs) -> Sequence[Column]:
+        def func(df: SparkLikeLazyFrame, inputs: WindowInputs) -> Sequence[Column]:
             window = (
                 self.partition_by(*inputs.partition_by)
                 .orderBy(
@@ -238,7 +237,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
             start = self._Window.currentRow - window_size + 1
             end = self._Window.currentRow
 
-        def func(df: SparkLikeLazyFrame, inputs: SparkWindowInputs) -> Sequence[Column]:
+        def func(df: SparkLikeLazyFrame, inputs: WindowInputs) -> Sequence[Column]:
             window = (
                 self.partition_by(*inputs.partition_by)
                 .orderBy(*self._sort(*inputs.order_by))
@@ -331,8 +330,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
 
     def _with_alias_output_names(self, func: AliasNames | None, /) -> Self:
         return type(self)(
-            self._call,
-            self._window_function,
+            call=self._call,
             evaluate_output_names=self._evaluate_output_names,
             alias_output_names=func,
             backend_version=self._backend_version,
@@ -424,42 +422,10 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         return self._with_callable(self._F.abs)
 
     def all(self) -> Self:
-        def f(expr: Column) -> Column:
-            return self._F.coalesce(self._F.bool_and(expr), self._F.lit(True))  # noqa: FBT003
-
-        def window_f(
-            df: SparkLikeLazyFrame, window_inputs: SparkWindowInputs
-        ) -> Sequence[Column]:
-            return [
-                self._F.coalesce(
-                    self._F.bool_and(expr).over(
-                        self.partition_by(*window_inputs.partition_by)
-                    ),
-                    self._F.lit(True),  # noqa: FBT003
-                )
-                for expr in self(df)
-            ]
-
-        return self._with_callable(f)._with_window_function(window_f)
+        return self._with_callable(self._F.bool_and)
 
     def any(self) -> Self:
-        def f(expr: Column) -> Column:
-            return self._F.coalesce(self._F.bool_or(expr), self._F.lit(False))  # noqa: FBT003
-
-        def window_f(
-            df: SparkLikeLazyFrame, window_inputs: SparkWindowInputs
-        ) -> Sequence[Column]:
-            return [
-                self._F.coalesce(
-                    self._F.bool_or(expr).over(
-                        self.partition_by(*window_inputs.partition_by)
-                    ),
-                    self._F.lit(False),  # noqa: FBT003
-                )
-                for expr in self(df)
-            ]
-
-        return self._with_callable(f)._with_window_function(window_f)
+        return self._with_callable(self._F.bool_or)
 
     def cast(self, dtype: DType | type[DType]) -> Self:
         def _cast(expr: Column) -> Column:
@@ -504,23 +470,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         return self._with_callable(_null_count)
 
     def sum(self) -> Self:
-        def f(expr: Column) -> Column:
-            return self._F.coalesce(self._F.sum(expr), self._F.lit(0))
-
-        def window_f(
-            df: SparkLikeLazyFrame, window_inputs: SparkWindowInputs
-        ) -> Sequence[Column]:
-            return [
-                self._F.coalesce(
-                    self._F.sum(expr).over(
-                        self.partition_by(*window_inputs.partition_by)
-                    ),
-                    self._F.lit(0),
-                )
-                for expr in self(df)
-            ]
-
-        return self._with_callable(f)._with_window_function(window_f)
+        return self._with_callable(self._F.sum)
 
     def std(self, ddof: int) -> Self:
         F = self._F  # noqa: N806
@@ -628,7 +578,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
 
         return self._with_callable(_n_unique)
 
-    def over(self, partition_by: Sequence[str | Column], order_by: Sequence[str]) -> Self:
+    def over(self, partition_by: Sequence[str], order_by: Sequence[str]) -> Self:
         def func(df: SparkLikeLazyFrame) -> Sequence[Column]:
             return self.window_function(df, WindowInputs(partition_by, order_by))
 
@@ -651,7 +601,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         return self._with_callable(_is_nan)
 
     def shift(self, n: int) -> Self:
-        def func(df: SparkLikeLazyFrame, inputs: SparkWindowInputs) -> Sequence[Column]:
+        def func(df: SparkLikeLazyFrame, inputs: WindowInputs) -> Sequence[Column]:
             window = self.partition_by(*inputs.partition_by).orderBy(
                 *self._sort(*inputs.order_by)
             )
@@ -660,7 +610,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         return self._with_window_function(func)
 
     def is_first_distinct(self) -> Self:
-        def func(df: SparkLikeLazyFrame, inputs: SparkWindowInputs) -> Sequence[Column]:
+        def func(df: SparkLikeLazyFrame, inputs: WindowInputs) -> Sequence[Column]:
             return [
                 self._F.row_number().over(
                     self.partition_by(*inputs.partition_by, expr).orderBy(
@@ -674,7 +624,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         return self._with_window_function(func)
 
     def is_last_distinct(self) -> Self:
-        def func(df: SparkLikeLazyFrame, inputs: SparkWindowInputs) -> Sequence[Column]:
+        def func(df: SparkLikeLazyFrame, inputs: WindowInputs) -> Sequence[Column]:
             return [
                 self._F.row_number().over(
                     self.partition_by(*inputs.partition_by, expr).orderBy(
@@ -688,7 +638,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         return self._with_window_function(func)
 
     def diff(self) -> Self:
-        def func(df: SparkLikeLazyFrame, inputs: SparkWindowInputs) -> Sequence[Column]:
+        def func(df: SparkLikeLazyFrame, inputs: WindowInputs) -> Sequence[Column]:
             window = self.partition_by(*inputs.partition_by).orderBy(
                 *self._sort(*inputs.order_by)
             )
@@ -730,7 +680,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
         if strategy is not None:
 
             def _fill_with_strategy(
-                df: SparkLikeLazyFrame, inputs: SparkWindowInputs
+                df: SparkLikeLazyFrame, inputs: WindowInputs
             ) -> Sequence[Column]:
                 fn = self._F.last_value if strategy == "forward" else self._F.first_value
                 if strategy == "forward":
@@ -838,7 +788,7 @@ class SparkLikeExpr(LazyExpr["SparkLikeLazyFrame", "Column"]):
             return _rank(expr, descending=descending)
 
         def _partitioned_rank(
-            df: SparkLikeLazyFrame, inputs: SparkWindowInputs
+            df: SparkLikeLazyFrame, inputs: WindowInputs
         ) -> Sequence[Column]:
             assert not inputs.order_by  # noqa: S101
             return [

--- a/narwhals/_spark_like/expr_str.py
+++ b/narwhals/_spark_like/expr_str.py
@@ -4,7 +4,7 @@ from functools import partial
 from typing import TYPE_CHECKING
 
 from narwhals._spark_like.utils import strptime_to_pyspark_format
-from narwhals.utils import _is_naive_format
+from narwhals._utils import _is_naive_format
 
 if TYPE_CHECKING:
     from sqlframe.base.column import Column

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -18,9 +18,9 @@ if TYPE_CHECKING:
     from sqlframe.base.column import Column
 
     from narwhals._spark_like.dataframe import SQLFrameDataFrame  # noqa: F401
+    from narwhals._utils import Implementation, Version
     from narwhals.dtypes import DType
     from narwhals.typing import ConcatMethod, NonNestedLiteral
-    from narwhals.utils import Implementation, Version
 
 
 class SparkLikeNamespace(

--- a/narwhals/_spark_like/utils.py
+++ b/narwhals/_spark_like/utils.py
@@ -4,8 +4,8 @@ from functools import lru_cache
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, overload
 
+from narwhals._utils import Implementation, isinstance_or_issubclass
 from narwhals.exceptions import UnsupportedDTypeError
-from narwhals.utils import Implementation, isinstance_or_issubclass
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
 
     from narwhals._spark_like.dataframe import SparkLikeLazyFrame
     from narwhals._spark_like.expr import SparkLikeExpr
+    from narwhals._utils import Version
     from narwhals.dtypes import DType
-    from narwhals.utils import Version
 
     _NativeDType: TypeAlias = sqlframe_types.DataType
     SparkSession = Session[Any, Any, Any, Any, Any, Any, Any]

--- a/narwhals/_utils.py
+++ b/narwhals/_utils.py
@@ -1711,7 +1711,7 @@ def unstable(fn: _Fn, /) -> _Fn:
         Decorated function (unchanged).
 
     Examples:
-        >>> from narwhals.utils import unstable
+        >>> from narwhals._utils import unstable
         >>> @unstable
         ... def a_work_in_progress_feature(*args):
         ...     return args
@@ -1757,7 +1757,7 @@ class not_implemented:  # noqa: N801
         - Allows us to use `isinstance(...)` instead of monkeypatching an attribute to the function
 
     Examples:
-        >>> from narwhals.utils import not_implemented
+        >>> from narwhals._utils import not_implemented
         >>> class Thing:
         ...     def totally_ready(self) -> str:
         ...         return "I'm ready!"
@@ -1843,7 +1843,7 @@ class requires:  # noqa: N801
         _hint: Optional suggested alternative.
 
     Examples:
-        >>> from narwhals.utils import requires, Implementation
+        >>> from narwhals._utils import requires, Implementation
         >>> class SomeBackend:
         ...     _implementation = Implementation.PYARROW
         ...     _backend_version = 20, 0, 0
@@ -1961,7 +1961,7 @@ def ensure_type(obj: Any, /, *valid_types: type[Any], param_name: str = "") -> N
         TypeError: If `obj` is not an instance of any of the provided `valid_types`.
 
     Examples:
-        >>> from narwhals.utils import ensure_type
+        >>> from narwhals._utils import ensure_type
         >>> ensure_type(42, int, float)
         >>> ensure_type("hello", str)
 

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -23,16 +23,7 @@ from narwhals._expression_parsing import (
     check_expressions_preserve_length,
     is_scalar_like,
 )
-from narwhals.dependencies import get_polars, is_numpy_array
-from narwhals.exceptions import (
-    InvalidIntoExprError,
-    LengthChangingExprError,
-    OrderDependentExprError,
-)
-from narwhals.schema import Schema
-from narwhals.series import Series
-from narwhals.translate import to_native
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     find_stacklevel,
     flatten,
@@ -47,6 +38,15 @@ from narwhals.utils import (
     parse_version,
     supports_arrow_c_stream,
 )
+from narwhals.dependencies import get_polars, is_numpy_array
+from narwhals.exceptions import (
+    InvalidIntoExprError,
+    LengthChangingExprError,
+    OrderDependentExprError,
+)
+from narwhals.schema import Schema
+from narwhals.series import Series
+from narwhals.translate import to_native
 
 if TYPE_CHECKING:
     from io import BytesIO

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -6,7 +6,7 @@ from datetime import timezone
 from itertools import starmap
 from typing import TYPE_CHECKING, Iterable, Mapping
 
-from narwhals.utils import _DeferredIterable, isinstance_or_issubclass
+from narwhals._utils import _DeferredIterable, isinstance_or_issubclass
 
 if TYPE_CHECKING:
     from typing import Iterator, Sequence
@@ -62,7 +62,7 @@ class DType:
         return issubclass(cls, NestedType)
 
     def __eq__(self, other: DType | type[DType]) -> bool:  # type: ignore[override]
-        from narwhals.utils import isinstance_or_issubclass
+        from narwhals._utils import isinstance_or_issubclass
 
         return isinstance_or_issubclass(other, type(self))
 

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -9,6 +9,12 @@ from narwhals._expression_parsing import (
     combine_metadata,
     extract_compliant,
 )
+from narwhals._utils import (
+    _validate_rolling_arguments,
+    ensure_type,
+    flatten,
+    issue_deprecation_warning,
+)
 from narwhals.dtypes import _validate_dtype
 from narwhals.exceptions import InvalidOperationError
 from narwhals.expr_cat import ExprCatNamespace
@@ -18,12 +24,6 @@ from narwhals.expr_name import ExprNameNamespace
 from narwhals.expr_str import ExprStringNamespace
 from narwhals.expr_struct import ExprStructNamespace
 from narwhals.translate import to_native
-from narwhals.utils import (
-    _validate_rolling_arguments,
-    ensure_type,
-    flatten,
-    issue_deprecation_warning,
-)
 
 if TYPE_CHECKING:
     from typing import TypeVar

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -14,16 +14,7 @@ from narwhals._expression_parsing import (
     extract_compliant,
     is_scalar_like,
 )
-from narwhals.dependencies import (
-    is_narwhals_series,
-    is_numpy_array,
-    is_numpy_array_2d,
-    is_pyarrow_table,
-)
-from narwhals.exceptions import InvalidOperationError
-from narwhals.expr import Expr
-from narwhals.translate import from_native, to_native
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     Version,
     deprecate_native_namespace,
@@ -35,6 +26,15 @@ from narwhals.utils import (
     supports_arrow_c_stream,
     validate_laziness,
 )
+from narwhals.dependencies import (
+    is_narwhals_series,
+    is_numpy_array,
+    is_numpy_array_2d,
+    is_pyarrow_table,
+)
+from narwhals.exceptions import InvalidOperationError
+from narwhals.expr import Expr
+from narwhals.translate import from_native, to_native
 
 if TYPE_CHECKING:
     from types import ModuleType

--- a/narwhals/group_by.py
+++ b/narwhals/group_by.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Generic, Iterable, Iterator, Sequence, TypeVar
 
 from narwhals._expression_parsing import all_exprs_are_scalar_like
+from narwhals._utils import flatten, tupleify
 from narwhals.exceptions import InvalidOperationError
 from narwhals.typing import DataFrameT
-from narwhals.utils import flatten, tupleify
 
 if TYPE_CHECKING:
     from narwhals._compliant.typing import CompliantExprAny

--- a/narwhals/schema.py
+++ b/narwhals/schema.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 from functools import partial
 from typing import TYPE_CHECKING, Iterable, Mapping, cast
 
-from narwhals.utils import Implementation, Version, parse_version
+from narwhals._utils import Implementation, Version, parse_version
 
 if TYPE_CHECKING:
     from typing import Any, ClassVar

--- a/narwhals/selectors.py
+++ b/narwhals/selectors.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Iterable, NoReturn
 
 from narwhals._expression_parsing import ExprMetadata, combine_metadata
+from narwhals._utils import flatten
 from narwhals.expr import Expr
-from narwhals.utils import flatten
 
 if TYPE_CHECKING:
     from datetime import timezone

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -13,6 +13,15 @@ from typing import (
     overload,
 )
 
+from narwhals._utils import (
+    _validate_rolling_arguments,
+    ensure_type,
+    generate_repr,
+    is_compliant_series,
+    is_index_selector,
+    parse_version,
+    supports_arrow_c_stream,
+)
 from narwhals.dependencies import is_numpy_scalar
 from narwhals.dtypes import _validate_dtype
 from narwhals.exceptions import ComputeError
@@ -23,15 +32,6 @@ from narwhals.series_str import SeriesStringNamespace
 from narwhals.series_struct import SeriesStructNamespace
 from narwhals.translate import to_native
 from narwhals.typing import IntoSeriesT
-from narwhals.utils import (
-    _validate_rolling_arguments,
-    ensure_type,
-    generate_repr,
-    is_compliant_series,
-    is_index_selector,
-    parse_version,
-    supports_arrow_c_stream,
-)
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from narwhals._compliant import CompliantSeries
+    from narwhals._utils import Implementation
     from narwhals.dataframe import DataFrame, MultiIndexSelector
     from narwhals.dtypes import DType
     from narwhals.typing import (
@@ -55,7 +56,6 @@ if TYPE_CHECKING:
         TemporalLiteral,
         _1DArray,
     )
-    from narwhals.utils import Implementation
 
 
 class Series(Generic[IntoSeriesT]):

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -17,6 +17,21 @@ from warnings import warn
 import narwhals as nw
 from narwhals import dependencies, exceptions, functions as nw_f, selectors
 from narwhals._typing_compat import TypeVar
+from narwhals._utils import (
+    Implementation,
+    Version,
+    deprecate_native_namespace,
+    find_stacklevel,
+    generate_temporary_column_name,
+    inherit_doc,
+    is_ordered_categorical,
+    maybe_align_index,
+    maybe_convert_dtypes,
+    maybe_get_index,
+    maybe_reset_index,
+    maybe_set_index,
+    validate_strict_and_pass_though,
+)
 from narwhals.dataframe import DataFrame as NwDataFrame, LazyFrame as NwLazyFrame
 from narwhals.dependencies import get_polars
 from narwhals.exceptions import InvalidIntoExprError
@@ -57,21 +72,6 @@ from narwhals.stable.v1.dtypes import (
 )
 from narwhals.translate import _from_native_impl, get_native_namespace, to_py_scalar
 from narwhals.typing import IntoDataFrameT, IntoFrameT
-from narwhals.utils import (
-    Implementation,
-    Version,
-    deprecate_native_namespace,
-    find_stacklevel,
-    generate_temporary_column_name,
-    inherit_doc,
-    is_ordered_categorical,
-    maybe_align_index,
-    maybe_convert_dtypes,
-    maybe_get_index,
-    maybe_reset_index,
-    maybe_set_index,
-    validate_strict_and_pass_though,
-)
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -305,8 +305,8 @@ class Series(NwSeries[IntoSeriesT]):
         bin_count: int | None = None,
         include_breakpoint: bool = True,
     ) -> DataFrame[Any]:
+        from narwhals._utils import find_stacklevel
         from narwhals.exceptions import NarwhalsUnstableWarning
-        from narwhals.utils import find_stacklevel
 
         msg = (
             "`Series.hist` is being called from the stable API although considered "
@@ -1023,9 +1023,9 @@ def to_native(
     Returns:
         Object of class that user started with.
     """
+    from narwhals._utils import validate_strict_and_pass_though
     from narwhals.dataframe import BaseFrame
     from narwhals.series import Series
-    from narwhals.utils import validate_strict_and_pass_though
 
     pass_through = validate_strict_and_pass_though(
         strict, pass_through, pass_through_default=False, emit_deprecation_warning=False

--- a/narwhals/stable/v1/_dtypes.py
+++ b/narwhals/stable/v1/_dtypes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from narwhals._utils import inherit_doc
 from narwhals.dtypes import (
     Array,
     Binary,
@@ -39,7 +40,6 @@ from narwhals.dtypes import (
     Unknown,
     UnsignedIntegerType,
 )
-from narwhals.utils import inherit_doc
 
 if TYPE_CHECKING:
     from datetime import timezone

--- a/narwhals/stable/v1/_namespace.py
+++ b/narwhals/stable/v1/_namespace.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from narwhals._compliant.typing import CompliantNamespaceT_co
 from narwhals._namespace import Namespace as NwNamespace
-from narwhals.utils import Version
+from narwhals._utils import Version
 
 __all__ = ["Namespace"]
 

--- a/narwhals/translate.py
+++ b/narwhals/translate.py
@@ -11,6 +11,7 @@ from narwhals._namespace import (
     is_native_polars,
     is_native_spark_like,
 )
+from narwhals._utils import Version
 from narwhals.dependencies import (
     get_dask,
     get_dask_expr,
@@ -27,7 +28,6 @@ from narwhals.dependencies import (
     is_pyarrow_scalar,
     is_pyarrow_table,
 )
-from narwhals.utils import Version
 
 if TYPE_CHECKING:
     from narwhals.dataframe import DataFrame, LazyFrame
@@ -96,9 +96,9 @@ def to_native(
     Returns:
         Object of class that user started with.
     """
+    from narwhals._utils import validate_strict_and_pass_though
     from narwhals.dataframe import BaseFrame
     from narwhals.series import Series
-    from narwhals.utils import validate_strict_and_pass_though
 
     pass_through = validate_strict_and_pass_though(
         strict, pass_through, pass_through_default=False, emit_deprecation_warning=True
@@ -324,7 +324,7 @@ def from_native(  # noqa: D417
         DataFrame, LazyFrame, Series, or original object, depending
             on which combination of parameters was passed.
     """
-    from narwhals.utils import validate_strict_and_pass_though
+    from narwhals._utils import validate_strict_and_pass_though
 
     pass_through = validate_strict_and_pass_though(
         strict, pass_through, pass_through_default=False, emit_deprecation_warning=True
@@ -355,15 +355,15 @@ def _from_native_impl(  # noqa: C901, PLR0911, PLR0912, PLR0915
     allow_series: bool | None = None,
     version: Version,
 ) -> Any:
-    from narwhals.dataframe import DataFrame, LazyFrame
-    from narwhals.series import Series
-    from narwhals.utils import (
+    from narwhals._utils import (
         _supports_dataframe_interchange,
         is_compliant_dataframe,
         is_compliant_lazyframe,
         is_compliant_series,
         parse_version,
     )
+    from narwhals.dataframe import DataFrame, LazyFrame
+    from narwhals.series import Series
 
     # Early returns
     if isinstance(native_object, (DataFrame, LazyFrame)) and not series_only:
@@ -610,7 +610,7 @@ def _get_native_namespace_single_obj(
 ) -> Any:
     from contextlib import suppress
 
-    from narwhals.utils import has_native_namespace
+    from narwhals._utils import has_native_namespace
 
     with suppress(TypeError, AssertionError):
         return Version.MAIN.namespace.from_native_object(
@@ -689,7 +689,7 @@ def narwhalify(
         ... def agnostic_group_by_sum(df):
         ...     return df.group_by("a").agg(nw.col("b").sum())
     """
-    from narwhals.utils import validate_strict_and_pass_though
+    from narwhals._utils import validate_strict_and_pass_though
 
     pass_through = validate_strict_and_pass_though(
         strict, pass_through, pass_through_default=True, emit_deprecation_warning=True

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -1,0 +1,6 @@
+# Re-export some functions from `_utils` to make them public.
+from __future__ import annotations
+
+from narwhals._utils import Version, parse_version
+
+__all__ = ["Version", "parse_version"]

--- a/narwhals/utils.py
+++ b/narwhals/utils.py
@@ -1,6 +1,6 @@
 # Re-export some functions from `_utils` to make them public.
 from __future__ import annotations
 
-from narwhals._utils import Version, parse_version
+from narwhals._utils import Implementation, Version, parse_version
 
-__all__ = ["Version", "parse_version"]
+__all__ = ["Implementation", "Version", "parse_version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,13 +313,13 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [
-  "*._expression_parsing",
-  "*.utils",
-  "*._pandas_like.*",
-  "*._ibis.*",
-  "*._arrow.*",
-  "*._dask.*",
-  "*._spark_like.*",
+  "narwhals._expression_parsing",
+  "narwhals._utils",
+  "narwhals._pandas_like.*",
+  "narwhals._ibis.*",
+  "narwhals._arrow.*",
+  "narwhals._dask.*",
+  "narwhals._spark_like.*",
 ]
 warn_return_any = false
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence, cast
 
 import pytest
 
-from narwhals.utils import generate_temporary_column_name
+from narwhals._utils import generate_temporary_column_name
 from tests.utils import PANDAS_VERSION
 
 if TYPE_CHECKING:

--- a/tests/frame/collect_test.py
+++ b/tests/frame/collect_test.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import narwhals as nw
+from narwhals._utils import Implementation
 from narwhals.dependencies import get_cudf, get_modin, get_polars
-from narwhals.utils import Implementation
 from tests.utils import PANDAS_VERSION, POLARS_VERSION, Constructor, assert_equal_data
 
 if TYPE_CHECKING:

--- a/tests/frame/lazy_test.py
+++ b/tests/frame/lazy_test.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import narwhals as nw
+from narwhals._utils import Implementation
 from narwhals.dependencies import get_cudf, get_modin
-from narwhals.utils import Implementation
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager

--- a/tests/from_dict_test.py
+++ b/tests/from_dict_test.py
@@ -8,7 +8,7 @@ import pytest
 
 import narwhals as nw
 import narwhals.stable.v1 as nw_v1
-from narwhals.utils import Implementation
+from narwhals._utils import Implementation
 from tests.utils import Constructor, assert_equal_data
 
 TEST_EAGER_BACKENDS: list[Implementation | str] = []

--- a/tests/from_pycapsule_test.py
+++ b/tests/from_pycapsule_test.py
@@ -13,7 +13,7 @@ from tests.utils import PYARROW_VERSION, assert_equal_data
 pytest.importorskip("pyarrow")
 import pyarrow as pa
 
-from narwhals.utils import Implementation, Version
+from narwhals._utils import Implementation, Version
 
 
 @dataclass

--- a/tests/namespace_test.py
+++ b/tests/namespace_test.py
@@ -8,7 +8,7 @@ import pytest
 
 import narwhals as nw
 from narwhals._namespace import Namespace
-from narwhals.utils import Version
+from narwhals._utils import Version
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias, assert_type

--- a/tests/read_scan_test.py
+++ b/tests/read_scan_test.py
@@ -8,7 +8,7 @@ import pytest
 
 import narwhals as nw
 import narwhals.stable.v1 as nw_v1
-from narwhals.utils import Implementation
+from narwhals._utils import Implementation
 from tests.utils import PANDAS_VERSION, Constructor, ConstructorEager, assert_equal_data
 
 pytest.importorskip("polars")

--- a/tests/series_only/is_ordered_categorical_test.py
+++ b/tests/series_only/is_ordered_categorical_test.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import narwhals as nw
-from narwhals.utils import Version
+from narwhals._utils import Version
 
 if TYPE_CHECKING:
     from narwhals.typing import IntoSeries

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -31,7 +31,7 @@ import pytest
 
 import narwhals as nw
 import narwhals.stable.v1 as nw_v1
-from narwhals.utils import Version
+from narwhals._utils import Version
 from tests.utils import Constructor, maybe_get_modin_df
 
 if TYPE_CHECKING:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,8 +12,8 @@ import pandas as pd
 import pyarrow as pa
 
 import narwhals as nw
+from narwhals._utils import Implementation, parse_version
 from narwhals.translate import from_native
-from narwhals.utils import Implementation, parse_version
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -15,7 +15,7 @@ from pandas.testing import assert_frame_equal, assert_index_equal, assert_series
 
 import narwhals as nw
 import narwhals.stable.v1 as nw_v1
-from narwhals.utils import (
+from narwhals._utils import (
     Implementation,
     Version,
     _DeferredIterable,
@@ -31,9 +31,9 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
+    from narwhals._utils import _SupportsVersion
     from narwhals.series import Series
     from narwhals.typing import IntoSeries
-    from narwhals.utils import _SupportsVersion
 
 
 @dataclass
@@ -336,7 +336,7 @@ def test_not_implemented() -> None:
 
     from narwhals._arrow.expr import ArrowExpr
     from narwhals._polars.expr import PolarsExpr, PolarsExprStringNamespace
-    from narwhals.utils import not_implemented
+    from narwhals._utils import not_implemented
 
     data: dict[str, Any] = {"foo": [1, 2], "bar": [6.0, 7.0]}
     df = pa.table(data)
@@ -351,7 +351,7 @@ def test_not_implemented() -> None:
     assert isinstance(ArrowExpr.ewm_mean, not_implemented)
 
     if TYPE_CHECKING:
-        from narwhals.utils import _SupportsGet
+        from narwhals._utils import _SupportsGet
 
     class DummyCompliant(Protocol):
         _implementation: nw_v1.Implementation

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -10,7 +10,7 @@ from typing import Any, Iterator
 import polars as pl
 
 import narwhals as nw
-from narwhals.utils import remove_prefix
+from narwhals._utils import remove_prefix
 
 LOWERCASE = tuple(string.ascii_lowercase)
 

--- a/utils/generate_backend_completeness.py
+++ b/utils/generate_backend_completeness.py
@@ -11,7 +11,7 @@ from typing import Any, Final, Iterator, NamedTuple
 import polars as pl
 from jinja2 import Template
 
-from narwhals.utils import not_implemented
+from narwhals._utils import not_implemented
 
 TEMPLATE_PATH: Final[Path] = Path("utils") / "api-completeness.md.jinja"
 DESTINATION_PATH: Final[Path] = Path("docs") / "api-completeness"


### PR DESCRIPTION
`narwhals.utils` isn't technically public (at least, it's not documented), but in practice there's cases when people are using it

For backwards compatibility i think we can keep what people are already using public, and move the rest to `_utils`

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
