### PR TITLE
fix: Ibis backend was not respecting `over` params for `shift` and `diff`

### DIFF
--- a/narwhals/_ibis/expr.py
+++ b/narwhals/_ibis/expr.py
@@ -452,8 +452,12 @@ class IbisExpr(LazyExpr["IbisLazyFrame", "ir.Column"]):
         return self._with_callable(lambda expr: expr.round(decimals))
 
     def shift(self, n: int) -> Self:
-        def _func(inputs: IbisWindowInputs) -> ir.Column:
-            return cast("ir.Column", inputs.expr).lag(n)
+        def _func(inputs: IbisWindowInputs) -> ir.Value:
+            return (
+                cast("ir.Column", inputs.expr)
+                .lag(n)
+                .over(ibis.window(group_by=inputs.partition_by, order_by=inputs.order_by))
+            )
 
         return self._with_window_function(_func)
 

--- a/narwhals/_ibis/expr.py
+++ b/narwhals/_ibis/expr.py
@@ -485,7 +485,14 @@ class IbisExpr(LazyExpr["IbisLazyFrame", "ir.Column"]):
         def _func(inputs: IbisWindowInputs) -> ir.NumericValue:
             expr = cast("ir.NumericColumn", inputs.expr)
             return expr - cast(
-                "ir.NumericColumn", expr.lag().over(ibis.window(following=0))
+                "ir.NumericColumn",
+                expr.lag().over(
+                    ibis.window(
+                        order_by=inputs.order_by,
+                        group_by=inputs.partition_by,
+                        following=0,
+                    )
+                ),
             )
 
         return self._with_window_function(_func)

--- a/tests/expr_and_series/shift_test.py
+++ b/tests/expr_and_series/shift_test.py
@@ -43,6 +43,26 @@ def test_shift_lazy(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
+def test_shift_lazy_grouped(
+    constructor: Constructor, request: pytest.FixtureRequest
+) -> None:
+    if "pyarrow_table" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 10):
+        pytest.skip()
+    if "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3):
+        pytest.skip()
+    df = nw.from_native(constructor(data))
+    result = df.with_columns(nw.col("a").shift(1).over("b", order_by="i")).sort("i")
+    expected = {
+        "i": [0, 1, 2, 3, 4],
+        "a": [None, None, None, None, 2],
+        "b": [1, 2, 3, 5, 3],
+        "c": [5, 4, 3, 2, 1],
+    }
+    assert_equal_data(result, expected)
+
+
 def test_shift_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.with_columns(df["a"].shift(2), df["b"].shift(2), df["c"].shift(2)).filter(


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
