### PR TITLE
feat: when-then broadcasting

### DIFF
--- a/narwhals/_compliant/when_then.py
+++ b/narwhals/_compliant/when_then.py
@@ -154,11 +154,18 @@ class EagerWhen(
         is_expr = self._condition._is_expr
         when: EagerSeriesT = self._condition(df)[0]
         then: EagerSeriesT
+        if (
+            self._condition._metadata is not None
+            and self._condition._metadata.is_scalar_like
+        ):
+            when._broadcast = True
+
         if is_expr(self._then_value):
             then = self._then_value(df)[0]
         else:
             then = when.alias("literal")._from_scalar(self._then_value)
             then._broadcast = True
+
         if is_expr(self._otherwise_value):
             otherwise = self._otherwise_value(df)[0]
         elif self._otherwise_value is not None:

--- a/narwhals/_compliant/when_then.py
+++ b/narwhals/_compliant/when_then.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self, TypeAlias
 
     from narwhals._compliant.typing import EvalSeries, ScalarKwargs
+    from narwhals._compliant.window import WindowInputs
     from narwhals._utils import Implementation, Version, _FullContext
     from narwhals.typing import NonNestedLiteral
 
@@ -50,6 +51,9 @@ class CompliantWhen(Protocol38[FrameT, SeriesT, ExprT]):
     @property
     def _then(self) -> type[CompliantThen[FrameT, SeriesT, ExprT]]: ...
     def __call__(self, compliant_frame: FrameT, /) -> Sequence[SeriesT]: ...
+    def _window_function(
+        self, compliant_frame: FrameT, window_inputs: WindowInputs[Any]
+    ) -> Sequence[SeriesT]: ...
 
     def then(
         self, value: IntoExpr[SeriesT, ExprT], /
@@ -124,9 +128,7 @@ class LazyThen(
         obj = cls.__new__(cls)
         obj._call = when
 
-        # This may require more complicated logic if we want to push down the
-        # `over`: https://github.com/narwhals-dev/narwhals/issues/2652.
-        obj._window_function = None
+        obj._window_function = when._window_function
 
         obj._when_value = when
         obj._depth = 0
@@ -154,11 +156,6 @@ class EagerWhen(
         is_expr = self._condition._is_expr
         when: EagerSeriesT = self._condition(df)[0]
         then: EagerSeriesT
-        if (
-            self._condition._metadata is not None
-            and self._condition._metadata.is_scalar_like
-        ):
-            when._broadcast = True
 
         if is_expr(self._then_value):
             then = self._then_value(df)[0]
@@ -182,7 +179,6 @@ class LazyWhen(
 ):
     when: Callable[..., NativeExprT]
     lit: Callable[..., NativeExprT]
-    _window_function: WindowFunction[CompliantLazyFrameT, NativeExprT] | None
 
     def __call__(self, df: CompliantLazyFrameT) -> Sequence[NativeExprT]:
         is_expr = self._condition._is_expr
@@ -204,13 +200,33 @@ class LazyWhen(
         obj = cls.__new__(cls)
         obj._condition = condition
 
-        # This may require more complicated logic if we want to push down the
-        # `over`: https://github.com/narwhals-dev/narwhals/issues/2652.
-        obj._window_function = None
-
         obj._then_value = None
         obj._otherwise_value = None
         obj._implementation = context._implementation
         obj._backend_version = context._backend_version
         obj._version = context._version
         return obj
+
+    def _window_function(
+        self, df: CompliantLazyFrameT, window_inputs: WindowInputs[NativeExprT]
+    ) -> Sequence[NativeExprT]:
+        is_expr = self._condition._is_expr
+        condition = self._condition.window_function(df, window_inputs)[0]
+        then_ = self._then_value
+        then = (
+            then_.window_function(df, window_inputs)[0]
+            if is_expr(then_)
+            else self.lit(then_)
+        )
+
+        other_ = self._otherwise_value
+        if other_ is None:
+            result = self.when(condition, then)
+        else:
+            other = (
+                other_.window_function(df, window_inputs)[0]
+                if is_expr(other_)
+                else self.lit(other_)
+            )
+            result = self.when(condition, then).otherwise(other)  # type: ignore  # noqa: PGH003
+        return [result]

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -81,7 +81,9 @@ class DaskExpr(
 
     def broadcast(self, kind: Literal[ExprKind.AGGREGATION, ExprKind.LITERAL]) -> Self:
         def func(df: DaskLazyFrame) -> list[dx.Series]:
-            return [result[0] for result in self(df)]
+            # result.loc[0][0] is a workaround for dask~<=2024.10.0/dask_expr~<=1.1.16
+            #   that raised a KeyErrror for result[0] during collection.
+            return [result.loc[0][0] for result in self(df)]
 
         return self.__class__(
             func,

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import operator
 from functools import reduce
-from typing import TYPE_CHECKING, Any, Iterable, Sequence, cast
+from typing import TYPE_CHECKING, Iterable, Sequence, cast
 
 import dask.dataframe as dd
 import pandas as pd
@@ -285,13 +285,6 @@ class DaskWhen(CompliantWhen[DaskLazyFrame, "dx.Series", DaskExpr]):
         return DaskThen
 
     def __call__(self, df: DaskLazyFrame) -> Sequence[dx.Series]:
-        def _aggregates(expr: Any) -> bool:
-            if isinstance(expr, DaskExpr):
-                return expr._metadata is not None and expr._metadata.is_scalar_like
-            elif isinstance(expr, dd.Series):
-                return len(expr) == 1
-            return True
-
         then_value = (
             self._then_value(df)[0]
             if isinstance(self._then_value, DaskExpr)
@@ -307,14 +300,12 @@ class DaskWhen(CompliantWhen[DaskLazyFrame, "dx.Series", DaskExpr]):
             otherwise_value = get_dask_expr()._expr.Where._defaults["other"]
 
         condition = self._condition(df)[0]
-        if (
-            _aggregates(self._condition)
-            and _aggregates(then_value)
-            and _aggregates(otherwise_value)
-        ):
-            df = df._with_native(condition.to_frame())
-        elif _aggregates(self._condition):
+        # re-evaluate DataFrame if the condition aggregates to force
+        #   then/otherwise to be evaluated against the aggregated frame
+        if self._condition._metadata is None or self._condition._metadata.is_scalar_like:
+            new_df = df._with_native(condition.to_frame())
             condition = self._condition.broadcast(ExprKind.AGGREGATION)(df)[0]
+            df = new_df
 
         (condition, then_series, otherwise_series) = align_series_full_broadcast(
             df, condition, then_value, otherwise_value
@@ -322,7 +313,7 @@ class DaskWhen(CompliantWhen[DaskLazyFrame, "dx.Series", DaskExpr]):
 
         validate_comparand(condition, then_series)
         validate_comparand(condition, otherwise_series)
-        return [then_series.where(condition, otherwise_series)]
+        return [then_series.where(condition, otherwise_series)]  # pyright: ignore[reportArgumentType]
 
 
 class DaskThen(CompliantThen[DaskLazyFrame, "dx.Series", DaskExpr], DaskExpr): ...

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -23,6 +23,7 @@ from narwhals._expression_parsing import (
     combine_evaluate_output_names,
 )
 from narwhals._utils import Implementation
+from narwhals.dependencies import get_dask_expr
 
 if TYPE_CHECKING:
     import dask.dataframe.dask_expr as dx
@@ -303,9 +304,7 @@ class DaskWhen(CompliantWhen[DaskLazyFrame, "dx.Series", DaskExpr]):
         )
 
         if self._otherwise_value is None:
-            from dask.dataframe.dask_expr._expr import Where
-
-            otherwise_value = Where._defaults["other"]
+            otherwise_value = get_dask_expr()._expr.Where._defaults["other"]
 
         condition = self._condition(df)[0]
         if (

--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -199,5 +199,12 @@ class DuckDBWhen(LazyWhen["DuckDBLazyFrame", Expression, DuckDBExpr]):
         self.lit = lit
         return super().__call__(df)
 
+    def _window_function(
+        self, df: DuckDBLazyFrame, window_inputs: DuckDBWindowInputs
+    ) -> Sequence[Expression]:
+        self.when = when
+        self.lit = lit
+        return super()._window_function(df, window_inputs)
+
 
 class DuckDBThen(LazyThen["DuckDBLazyFrame", Expression, DuckDBExpr], DuckDBExpr): ...

--- a/narwhals/_spark_like/namespace.py
+++ b/narwhals/_spark_like/namespace.py
@@ -280,6 +280,13 @@ class SparkLikeWhen(LazyWhen[SparkLikeLazyFrame, "Column", SparkLikeExpr]):
         self.lit = df._F.lit
         return super().__call__(df)
 
+    def _window_function(
+        self, df: SparkLikeLazyFrame, window_inputs: SparkWindowInputs
+    ) -> Sequence[Column]:
+        self.when = df._F.when
+        self.lit = df._F.lit
+        return super()._window_function(df, window_inputs)
+
 
 class SparkLikeThen(
     LazyThen[SparkLikeLazyFrame, "Column", SparkLikeExpr], SparkLikeExpr

--- a/narwhals/dependencies.py
+++ b/narwhals/dependencies.py
@@ -100,6 +100,8 @@ def get_ibis() -> Any:
 
 def get_dask_expr() -> Any:  # pragma: no cover
     """Get dask_expr module (if already imported - else return None)."""
+    if (dd := get_dask_dataframe()) is not None and hasattr(dd, "dask_expr"):
+        return dd.dask_expr
     return sys.modules.get("dask_expr", None)
 
 

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -1451,11 +1451,11 @@ class When:
 
     def then(self, value: IntoExpr | NonNestedLiteral | _1DArray) -> Then:
         kind = ExprKind.from_into_expr(value, str_as_lit=False)
-        if (
-            self._predicate._metadata.is_scalar_like is True
-            and kind.is_scalar_like is False
-        ):
-            msg = "When produced a scalar-like result and Then did not"
+        if self._predicate._metadata.is_scalar_like and not kind.is_scalar_like:
+            msg = (
+                "If you pass a scalar-like predicate to `nw.when`, then "
+                "the `then` value must also be scalar-like."
+            )
             raise ShapeError(msg)
 
         return Then(
@@ -1479,8 +1479,11 @@ class When:
 class Then(Expr):
     def otherwise(self, value: IntoExpr | NonNestedLiteral | _1DArray) -> Expr:
         kind = ExprKind.from_into_expr(value, str_as_lit=False)
-        if self._metadata.is_scalar_like is True and is_scalar_like(kind) is False:
-            msg = "When/Then produced a scalar-like result and otherwise did not"
+        if self._metadata.is_scalar_like and not is_scalar_like(kind):
+            msg = (
+                "If you pass a scalar-like predicate to `nw.when`, then "
+                "the `other` value must also be scalar-like."
+            )
             raise ShapeError(msg)
 
         def func(plx: CompliantNamespace[Any, Any]) -> CompliantExpr[Any, Any]:

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -1482,7 +1482,7 @@ class Then(Expr):
         if self._metadata.is_scalar_like and not is_scalar_like(kind):
             msg = (
                 "If you pass a scalar-like predicate to `nw.when`, then "
-                "the `other` value must also be scalar-like."
+                "the `otherwise` value must also be scalar-like."
             )
             raise ShapeError(msg)
 

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -9,7 +9,6 @@ from narwhals._expression_parsing import (
     ExprKind,
     ExprMetadata,
     apply_n_ary_operation,
-    check_expressions_preserve_length,
     combine_metadata,
     extract_compliant,
     is_scalar_like,
@@ -1449,7 +1448,6 @@ def max_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
 class When:
     def __init__(self, *predicates: IntoExpr | Iterable[IntoExpr]) -> None:
         self._predicate = all_horizontal(*flatten(predicates))
-        check_expressions_preserve_length(self._predicate, function_name="when")
 
     def then(self, value: IntoExpr | NonNestedLiteral | _1DArray) -> Then:
         return Then(

--- a/tests/expr_and_series/when_test.py
+++ b/tests/expr_and_series/when_test.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 import narwhals as nw
-from narwhals.exceptions import MultiOutputExpressionError, ShapeError
+from narwhals.exceptions import MultiOutputExpressionError
 from tests.utils import Constructor, ConstructorEager, assert_equal_data
 
 if TYPE_CHECKING:
@@ -115,12 +115,6 @@ def test_when_then_otherwise_into_expr(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
-def test_when_then_invalid(constructor: Constructor) -> None:
-    df = nw.from_native(constructor(data))
-    with pytest.raises(ShapeError):
-        df.select(nw.when(nw.col("a").sum() > 1).then("c"))
-
-
 def test_when_then_otherwise_lit_str(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select(nw.when(nw.col("a") > 1).then(nw.col("b")).otherwise(nw.lit("z")))
@@ -144,3 +138,63 @@ def test_when_then_otherwise_multi_output(constructor: Constructor) -> None:
         df.select(x1=nw.when(nw.all() > 1).then(nw.col("a", "b")))
     with pytest.raises(MultiOutputExpressionError):
         df.select(x1=nw.when(nw.all() > 1).then(nw.lit(1)).otherwise(nw.all()))
+
+
+@pytest.mark.parametrize(
+    ("condition", "then", "otherwise", "expected"),
+    [
+        (nw.col("a").sum() == 6, 100, 200, [100]),
+        (nw.col("a").sum() == 6, nw.col("a"), 200, [1, 2, 3]),
+        (nw.col("a").sum() == 6, nw.col("a"), nw.col("b"), [1, 2, 3]),
+        (nw.col("a").sum() == 6, 100, nw.col("b"), [100, 100, 100]),
+        (nw.col("a").sum() == 5, 100, 200, [200]),
+        (nw.col("a").sum() == 5, nw.col("a"), 200, [200, 200, 200]),
+        (nw.col("a").sum() == 5, nw.col("a"), nw.col("b"), [4, 5, 6]),
+        (nw.col("a").sum() == 5, 100, nw.col("b"), [4, 5, 6]),
+    ],
+)
+def test_when_then_otherwise_broadcast_select(
+    condition: nw.Expr,
+    then: nw.Expr | int,
+    otherwise: nw.Expr | int,
+    expected: list[int],
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+) -> None:
+    # lazy backends needs to be able to pushdown the aggregation for broadcasting to work
+    if any(x in str(constructor) for x in ["duckdb", "sqlframe", "pyspark"]) and not (
+        isinstance(then, int) and isinstance(otherwise, int)
+    ):
+        request.applymarker(pytest.mark.xfail)
+    df = nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]}))
+    result = df.select(a_when=nw.when(condition).then(then).otherwise(otherwise))
+    assert_equal_data(result, {"a_when": expected})
+
+
+@pytest.mark.parametrize(
+    ("condition", "then", "otherwise", "expected"),
+    [
+        (nw.col("a").sum() == 6, 100, 200, [100, 100, 100]),
+        (nw.col("a").sum() == 6, nw.col("a"), 200, [1, 2, 3]),
+        (nw.col("a").sum() == 6, nw.col("a"), nw.col("b"), [1, 2, 3]),
+        (nw.col("a").sum() == 6, 100, nw.col("b"), [100, 100, 100]),
+        (nw.col("a").sum() == 5, 100, 200, [200, 200, 200]),
+        (nw.col("a").sum() == 5, nw.col("a"), 200, [200, 200, 200]),
+        (nw.col("a").sum() == 5, nw.col("a"), nw.col("b"), [4, 5, 6]),
+        (nw.col("a").sum() == 5, 100, nw.col("b"), [4, 5, 6]),
+    ],
+)
+def test_when_then_otherwise_broadcast_with_columns(
+    condition: nw.Expr,
+    then: nw.Expr | int,
+    otherwise: nw.Expr | int,
+    expected: list[int],
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+) -> None:
+    # lazy backends needs to be able to pushdown the aggregation for broadcasting to work
+    if any(x in str(constructor) for x in ["duckdb", "sqlframe", "pyspark"]):
+        request.applymarker(pytest.mark.xfail)
+    df = nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]}))
+    result = df.with_columns(a_when=nw.when(condition).then(then).otherwise(otherwise))
+    assert_equal_data(result.select(nw.col("a_when")), {"a_when": expected})

--- a/tests/expr_and_series/when_test.py
+++ b/tests/expr_and_series/when_test.py
@@ -152,10 +152,12 @@ def test_when_then_otherwise_multi_output(constructor: Constructor) -> None:
 @pytest.mark.parametrize(
     ("condition", "then", "otherwise", "expected"),
     [
+        (nw.col("a").sum() == 6, 100, None, [100]),
         (nw.col("a").sum() == 6, 100, 200, [100]),
         (nw.col("a").sum() == 6, nw.col("a").sum(), 200, [6]),
         (nw.col("a").sum() == 6, 100, nw.col("b").sum(), [100]),
         (nw.col("a").sum() == 6, nw.col("a").sum(), nw.col("b").sum(), [6]),
+        (nw.col("a").sum() == 5, 100, None, [None]),
         (nw.col("a").sum() == 5, 100, 200, [200]),
         (nw.col("a").sum() == 5, nw.col("a").sum(), 200, [200]),
         (nw.col("a").sum() == 5, 100, nw.col("b").sum(), [15]),
@@ -177,10 +179,12 @@ def test_when_then_otherwise_aggregate_select(
 @pytest.mark.parametrize(
     ("condition", "then", "otherwise", "expected"),
     [
+        (nw.col("a").sum() == 6, 100, None, [100, 100, 100]),
         (nw.col("a").sum() == 6, 100, 200, [100, 100, 100]),
         (nw.col("a").sum() == 6, nw.col("a").sum(), 200, [6, 6, 6]),
         (nw.col("a").sum() == 6, 100, nw.col("b").sum(), [100, 100, 100]),
         (nw.col("a").sum() == 6, nw.col("a").sum(), nw.col("b").sum(), [6, 6, 6]),
+        (nw.col("a").sum() == 5, 100, None, [None, None, None]),
         (nw.col("a").sum() == 5, 100, 200, [200, 200, 200]),
         (nw.col("a").sum() == 5, nw.col("a").sum(), 200, [200, 200, 200]),
         (nw.col("a").sum() == 5, 100, nw.col("b").sum(), [15, 15, 15]),


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #2645 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

This adds broadcasting behavior to the `when/then` pattern similar to Polars (see #2645) for our eager backends and dask.
The implementation for the Lazy backends will require #2652 unless we want to introduce some hacky workarounds (e.g. we may be able to do this by joining after an aggregation to "broadcast" results; however I haven't fully thought through how this would look in the codebase).