### PR TITLE
fix: Regression in stable.v1.dependencies

### DIFF
--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, cast, overload
 from warnings import warn
 
 import narwhals as nw
-from narwhals import dependencies, exceptions, functions as nw_f, selectors
+from narwhals import exceptions, functions as nw_f, selectors
 from narwhals._typing_compat import TypeVar
 from narwhals._utils import (
     Implementation,
@@ -29,7 +29,7 @@ from narwhals.expr import Expr as NwExpr
 from narwhals.functions import _new_series_impl, concat, show_versions
 from narwhals.schema import Schema as NwSchema
 from narwhals.series import Series as NwSeries
-from narwhals.stable.v1 import dtypes
+from narwhals.stable.v1 import dependencies, dtypes
 from narwhals.stable.v1.dtypes import (
     Array,
     Binary,

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -359,3 +359,10 @@ def test_get_level() -> None:
         )
         == "interchange"
     )
+
+
+def test_regression_dependencies_import() -> None:
+    # See: https://github.com/narwhals-dev/narwhals/pull/2697
+    df = nw_v1.from_native(pd.DataFrame([1, 2, 3, 4]))
+    # Should not raise TypeError
+    assert nw_v1.dependencies.is_pandas_like_dataframe(df) is False


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

This fails on `stable.v1` in v1.43.0 as a result of https://github.com/narwhals-dev/narwhals/pull/1444

``` python
import pandas as pd

# import narwhals as nw
import narwhals.stable.v1 as nw

df = pd.DataFrame([1, 2, 3, 4])
a = nw.from_native(df)
nw.dependencies.is_pandas_like_dataframe(a)
```