### PR TITLE
fix: ensure generate_temporary_column_name result always starts with character

### DIFF
--- a/narwhals/_utils.py
+++ b/narwhals/_utils.py
@@ -1215,7 +1215,9 @@ def generate_temporary_column_name(n_bytes: int, columns: Sequence[str]) -> str:
     """
     counter = 0
     while True:
-        token = token_hex(n_bytes)
+        # Prepend `'a'` to ensure it always starts with a character
+        # https://github.com/narwhals-dev/narwhals/issues/2510
+        token = f"a{token_hex(n_bytes)[:-1]}"
         if token not in columns:
             return token
 


### PR DESCRIPTION
related to https://github.com/narwhals-dev/narwhals/issues/2510

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
