### PR TITLE
test: refactor arithmetic floordiv and mod

### DIFF
--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -157,48 +157,13 @@ def test_truediv_same_dims(
     assert_equal_data({"a": result}, {"a": [2, 1, 1 / 3]})
 
 
-@pytest.mark.slow
 @given(left=st.integers(-100, 100), right=st.integers(-100, 100))
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
-def test_floordiv_pandas(left: int, right: int) -> None:
-    pytest.importorskip("pandas")
-    import pandas as pd
-
-    # hypothesis complains if we add `constructor` as an argument, so this
-    # test is a bit manual unfortunately
-    assume(right != 0)
-    expected = {"a": [left // right]}
-    result: nw.DataFrame[Any] = nw.from_native(
-        pd.DataFrame({"a": [left]}), eager_only=True
-    ).select(nw.col("a") // right)
-    assert_equal_data(result, expected)
-    if PANDAS_VERSION < (2, 2):  # pragma: no cover
-        # Bug in old version of pandas
-        pass
-    else:
-        result = nw.from_native(
-            pd.DataFrame({"a": [left]}).convert_dtypes(dtype_backend="pyarrow"),
-            eager_only=True,
-        ).select(nw.col("a") // right)
-        assert_equal_data(result, expected)
-    result = nw.from_native(
-        pd.DataFrame({"a": [left]}).convert_dtypes(), eager_only=True
-    ).select(nw.col("a") // right)
-    assert_equal_data(result, expected)
-
-
 @pytest.mark.slow
-@given(left=st.integers(-100, 100), right=st.integers(-100, 100))
-@pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
-def test_floordiv_polars(left: int, right: int) -> None:
-    pytest.importorskip("polars")
-    import polars as pl
-
-    # hypothesis complains if we add `constructor` as an argument, so this
-    # test is a bit manual unfortunately
+def test_floordiv(constructor_eager: ConstructorEager, *, left: int, right: int) -> None:
     assume(right != 0)
     expected = {"a": [left // right]}
-    result = nw.from_native(pl.DataFrame({"a": [left]}), eager_only=True).select(
+    result = nw.from_native(constructor_eager({"a": [left]}), eager_only=True).select(
         nw.col("a") // right
     )
     assert_equal_data(result, expected)
@@ -207,70 +172,16 @@ def test_floordiv_polars(left: int, right: int) -> None:
 @pytest.mark.slow
 @given(left=st.integers(-100, 100), right=st.integers(-100, 100))
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
-def test_floordiv_pyarrow(left: int, right: int) -> None:
-    pytest.importorskip("pyarrow")
-    import pyarrow as pa
-
-    # hypothesis complains if we add `constructor` as an argument, so this
-    # test is a bit manual unfortunately
-    assume(right != 0)
-    expected = {"a": [left // right]}
-    result = nw.from_native(pa.table({"a": [left]}), eager_only=True).select(
-        nw.col("a") // right
-    )
-    assert_equal_data(result, expected)
-
-
-@pytest.mark.slow
-@given(left=st.integers(-100, 100), right=st.integers(-100, 100))
-@pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
-def test_mod_pandas(left: int, right: int) -> None:
-    pytest.importorskip("pandas")
-    import pandas as pd
-
-    # hypothesis complains if we add `constructor` as an argument, so this
-    # test is a bit manual unfortunately
+def test_mod(constructor_eager: ConstructorEager, *, left: int, right: int) -> None:
+    if any(
+        x in str(constructor_eager) for x in ["pandas_pyarrow", "modin_pyarrow", "cudf"]
+    ):
+        # pandas[pyarrow] does not implement mod
+        # modin[pyarrow] & cudf are frustratingly slow here
+        pytest.skip()
     assume(right != 0)
     expected = {"a": [left % right]}
-    result: nw.DataFrame[Any] = nw.from_native(
-        pd.DataFrame({"a": [left]}), eager_only=True
-    ).select(nw.col("a") % right)
-    assert_equal_data(result, expected)
-    result = nw.from_native(
-        pd.DataFrame({"a": [left]}).convert_dtypes(), eager_only=True
-    ).select(nw.col("a") % right)
-    assert_equal_data(result, expected)
-
-
-@pytest.mark.slow
-@given(left=st.integers(-100, 100), right=st.integers(-100, 100))
-@pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
-def test_mod_polars(left: int, right: int) -> None:
-    pytest.importorskip("polars")
-    import polars as pl
-
-    # hypothesis complains if we add `constructor` as an argument, so this
-    # test is a bit manual unfortunately
-    assume(right != 0)
-    expected = {"a": [left % right]}
-    result = nw.from_native(pl.DataFrame({"a": [left]}), eager_only=True).select(
-        nw.col("a") % right
-    )
-    assert_equal_data(result, expected)
-
-
-@pytest.mark.slow
-@given(left=st.integers(-100, 100), right=st.integers(-100, 100))
-@pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
-def test_mod_pyarrow(left: int, right: int) -> None:
-    pytest.importorskip("pyarrow")
-    import pyarrow as pa
-
-    # hypothesis complains if we add `constructor` as an argument, so this
-    # test is a bit manual unfortunately
-    assume(right != 0)
-    expected = {"a": [left % right]}
-    result = nw.from_native(pa.table({"a": [left]}), eager_only=True).select(
+    result = nw.from_native(constructor_eager({"a": [left]}), eager_only=True).select(
         nw.col("a") % right
     )
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/arithmetic_test.py
+++ b/tests/expr_and_series/arithmetic_test.py
@@ -161,6 +161,9 @@ def test_truediv_same_dims(
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
 @pytest.mark.slow
 def test_floordiv(constructor_eager: ConstructorEager, *, left: int, right: int) -> None:
+    if any(x in str(constructor_eager) for x in ["modin", "cudf"]):
+        # modin & cudf are too slow here
+        pytest.skip()
     assume(right != 0)
     expected = {"a": [left // right]}
     result = nw.from_native(constructor_eager({"a": [left]}), eager_only=True).select(
@@ -173,11 +176,9 @@ def test_floordiv(constructor_eager: ConstructorEager, *, left: int, right: int)
 @given(left=st.integers(-100, 100), right=st.integers(-100, 100))
 @pytest.mark.skipif(PANDAS_VERSION < (2, 0), reason="convert_dtypes not available")
 def test_mod(constructor_eager: ConstructorEager, *, left: int, right: int) -> None:
-    if any(
-        x in str(constructor_eager) for x in ["pandas_pyarrow", "modin_pyarrow", "cudf"]
-    ):
+    if any(x in str(constructor_eager) for x in ["pandas_pyarrow", "modin", "cudf"]):
         # pandas[pyarrow] does not implement mod
-        # modin[pyarrow] & cudf are frustratingly slow here
+        # modin & cudf are too slow here
         pytest.skip()
     assume(right != 0)
     expected = {"a": [left % right]}


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

A few tests had this comment:
> ```
> # hypothesis complains if we add `constructor` as an argument, so this
> # test is a bit manual unfortunately
> ```

Not sure if I'm missing something but I was able to swap in the constructor_eager argument without an issue.