### PR TITLE
fix: ensure `fill_null` doesn't silently downcast for pandas per-3.0

### DIFF
--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -597,23 +597,26 @@ class PandasLikeSeries(EagerSeries[Any]):
         limit: int | None,
     ) -> Self:
         ser = self.native
+        kwargs = (
+            {"downcast": False}
+            if self._implementation is Implementation.PANDAS
+            and self._backend_version < (3,)
+            else {}
+        )
         with warnings.catch_warnings():
             warnings.filterwarnings(
-                "ignore",
-                ".*Downcasting object dtype arrays.*is deprecated",
-                category=FutureWarning,
-                module="pandas",
+                "ignore", "The 'downcast' keyword .*is deprecated", category=FutureWarning
             )
             if value is not None:
                 _, native_value = align_and_extract_native(self, value)
                 res_ser = self._with_native(
-                    ser.fillna(value=native_value), preserve_broadcast=True
+                    ser.fillna(value=native_value, **kwargs), preserve_broadcast=True
                 )
             else:
                 res_ser = self._with_native(
-                    ser.ffill(limit=limit)
+                    ser.ffill(limit=limit, **kwargs)
                     if strategy == "forward"
-                    else ser.bfill(limit=limit),
+                    else ser.bfill(limit=limit, **kwargs),
                     preserve_broadcast=True,
                 )
         return res_ser

--- a/narwhals/expr.py
+++ b/narwhals/expr.py
@@ -1375,9 +1375,11 @@ class Expr:
             A new expression.
 
         Notes:
-            pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/)
-            for reference.
+            - pandas handles null values differently from other libraries.
+              See [null_handling](../concepts/null_handling.md/)
+              for reference.
+            - For pandas Series of `object` dtype, `fill_null` will not automatically change the
+              Series' dtype as pandas used to do. Explicitly call `cast` if you want the dtype to change.
 
         Examples:
             >>> import polars as pl

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -1323,9 +1323,11 @@ class Series(Generic[IntoSeriesT]):
             limit: Number of consecutive null values to fill when using the 'forward' or 'backward' strategy.
 
         Notes:
-            pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/)
-            for reference.
+            - pandas handles null values differently from other libraries.
+              See [null_handling](../concepts/null_handling.md/)
+              for reference.
+            - For pandas Series of `object` dtype, `fill_null` will not automatically change the
+              Series' dtype as pandas used to do. Explicitly call `cast` if you want the dtype to change.
 
         Returns:
             A new Series with null values filled according to the specified value or strategy.

--- a/tests/expr_and_series/fill_null_test.py
+++ b/tests/expr_and_series/fill_null_test.py
@@ -33,6 +33,17 @@ def test_fill_null(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
+def test_fill_null_pandas_downcast() -> None:
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df = nw.from_native(pd.DataFrame({"a": [True, None]}))
+    result = df.select(nw.col("a").fill_null(False))  # noqa: FBT003
+    expected = {"a": [True, False]}
+    assert_equal_data(result, expected)
+    assert result["a"].to_native().dtype == "bool"
+
+
 def test_fill_null_series_expression(constructor: Constructor) -> None:
     data = {
         "a": [0.0, None, 2.0, 3.0, 4.0],

--- a/tests/expr_and_series/fill_null_test.py
+++ b/tests/expr_and_series/fill_null_test.py
@@ -41,7 +41,7 @@ def test_fill_null_pandas_downcast() -> None:
     result = df.select(nw.col("a").fill_null(False))  # noqa: FBT003
     expected = {"a": [True, False]}
     assert_equal_data(result, expected)
-    assert result["a"].to_native().dtype == "bool"
+    assert result["a"].to_native().dtype == "object"
 
 
 def test_fill_null_series_expression(constructor: Constructor) -> None:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

closes #2723 

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
