### PR TITLE
fix: zfill for old polars and pyarrow versions

### DIFF
--- a/narwhals/_arrow/series_str.py
+++ b/narwhals/_arrow/series_str.py
@@ -67,7 +67,16 @@ class ArrowSeriesStringNamespace(ArrowSeriesNamespace):
         binary_join: Incomplete = pc.binary_join_element_wise
         native = self.native
         hyphen, plus = lit("-"), lit("+")
-        first_char, remaining_chars = self.slice(0, 1).native, self.slice(1, None).native
+
+        _slice_length: int | None = (
+            self.len_chars().max()
+            if self._compliant_series._backend_version < (13, 0)
+            else None
+        )
+        first_char, remaining_chars = (
+            self.slice(0, 1).native,
+            self.slice(1, _slice_length).native,
+        )
 
         # Conditions
         less_than_width = pc.less(pc.utf8_length(native), lit(width))

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -337,9 +337,17 @@ class PolarsExprStringNamespace:
 
     def zfill(self, width: int) -> PolarsExpr:
         native_expr = self._compliant_expr.native
+        backend_version = self._compliant_expr._backend_version
         native_result = native_expr.str.zfill(width)
 
-        if self._compliant_expr._backend_version <= (1, 30, 0):
+        if backend_version < (0, 20, 5):  # pragma: no cover
+            # Reason:
+            # `TypeError: argument 'length': 'Expr' object cannot be interpreted as an integer`
+            # in `native_expr.str.slice(1, length)`
+            msg = "`zfill` is only available in 'polars>=0.20.5', found version '0.20.4'."
+            raise NotImplementedError(msg)
+
+        if backend_version <= (1, 30, 0):
             length = native_expr.str.len_chars()
             less_than_width = length < width
             plus = "+"

--- a/tests/expr_and_series/str/zfill_test.py
+++ b/tests/expr_and_series/str/zfill_test.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import pytest
 
 import narwhals as nw
-from tests.utils import PANDAS_VERSION, Constructor, ConstructorEager, assert_equal_data
+from tests.utils import (
+    PANDAS_VERSION,
+    POLARS_VERSION,
+    Constructor,
+    ConstructorEager,
+    assert_equal_data,
+)
 
 data = {"a": ["-1", "+1", "1", "12", "123", "99999", "+9999", None]}
 expected = {"a": ["-01", "+01", "001", "012", "123", "99999", "+9999", None]}
@@ -16,7 +22,6 @@ def uses_pyarrow_backend(constructor: Constructor | ConstructorEager) -> bool:
     }
 
 
-@pytest.mark.skipif(PANDAS_VERSION < (1, 5), reason="different zfill behavior")
 def test_str_zfill(request: pytest.FixtureRequest, constructor: Constructor) -> None:
     if uses_pyarrow_backend(constructor):
         reason = (
@@ -25,12 +30,22 @@ def test_str_zfill(request: pytest.FixtureRequest, constructor: Constructor) -> 
         )
         request.applymarker(pytest.mark.xfail(reason=reason))
 
+    if "pandas" in str(constructor) and PANDAS_VERSION < (1, 5):
+        reason = "different zfill behavior"
+        pytest.skip(reason=reason)
+
+    if "polars" in str(constructor) and POLARS_VERSION < (0, 20, 5):
+        reason = (
+            "`TypeError: argument 'length': 'Expr' object cannot be interpreted as an integer`"
+            "in `expr.str.slice(1, length)`"
+        )
+        pytest.skip(reason=reason)
+
     df = nw.from_native(constructor(data))
     result = df.select(nw.col("a").str.zfill(3))
     assert_equal_data(result, expected)
 
 
-@pytest.mark.skipif(PANDAS_VERSION < (1, 5), reason="different zfill behavior")
 def test_str_zfill_series(
     request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
@@ -40,6 +55,17 @@ def test_str_zfill_series(
             "https://github.com/pandas-dev/pandas/issues/61485"
         )
         request.applymarker(pytest.mark.xfail(reason=reason))
+
+    if "pandas" in str(constructor_eager) and PANDAS_VERSION < (1, 5):
+        reason = "different zfill behavior"
+        pytest.skip(reason=reason)
+
+    if "polars" in str(constructor_eager) and POLARS_VERSION < (0, 20, 5):
+        reason = (
+            "`TypeError: argument 'length': 'Expr' object cannot be interpreted as an integer`"
+            "in `expr.str.slice(1, length)`"
+        )
+        pytest.skip(reason=reason)
 
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df["a"].str.zfill(3)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #2708

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

- Pyarrow has a workaround, which however requires an extra computation. I tried with `sys.maxsize` to avoid it, but it was resulting in a overflow exception
- Polars has only the new min version which fails, because `expr.str.slice(..., stop=another_expr)` is not valid (it requires an integer). The same workaround as in pyarrow would not work since expressions are lazy, hence even a `.len_chars().max()` results in an expression.
  - Extra bit: I could not use `@requires.backend_version` because of the namespace. I added `self._backend_version` in the `PolarsExprStringNamespace` init, yet this was leading to all kind of typing issues and a very bad formatted message. Thus I chose the simple option