### PR TITLE
RFC, patch: Preserves dtype_backend in `str.to_datetime`

### DIFF
--- a/narwhals/_pandas_like/series_str.py
+++ b/narwhals/_pandas_like/series_str.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 from narwhals._compliant.any_namespace import StringNamespace
 from narwhals._pandas_like.utils import (
     PandasLikeSeriesNamespace,
+    get_dtype_backend,
     is_pyarrow_dtype_backend,
 )
 
@@ -68,8 +69,14 @@ class PandasLikeSeriesStringNamespace(
         return result
 
     def _to_datetime(self, format: str | None, *, utc: bool) -> Any:
-        return self.implementation.to_native_namespace().to_datetime(
+        dtype_backend = get_dtype_backend(self.native.dtype, self.implementation)
+        result = self.implementation.to_native_namespace().to_datetime(
             self.native, format=format, utc=utc
+        )
+        return (
+            result.convert_dtypes(dtype_backend=dtype_backend)
+            if dtype_backend is not None
+            else result
         )
 
     def to_uppercase(self) -> PandasLikeSeries:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

So I was looking at how to implement `str.to_date` and for pandas I was falling back to `.str.to_datetime().dt.date()`, and then noticed that we are not preserving the dtype backend.

This is an issue upstream: [pandas#58220](https://github.com/pandas-dev/pandas/issues/58220)
But in the meanwhile we can convert it back (not sure this is the best way of achieving it)

---

Disclaimer: the test I added is failing for `numpy_nullable`, I will comment down below in the codebase