### PR TITLE
test: Suppress `NotImplementedError` for `cuDF`

### DIFF
--- a/tests/get_dtype_backend_test.py
+++ b/tests/get_dtype_backend_test.py
@@ -119,7 +119,10 @@ def brute_force_construct_dtype(
 ) -> Iterator[ExtensionDtype]:
     """Skips dtypes that are not compatible on the tested version of pandas."""
     for dtype in dtypes:  # pragma: no cover
-        with suppress(TypeError):
+        # NOTE: Slightly different errors between implementations
+        # TypeError: https://github.com/pandas-dev/pandas/blob/2cc37625532045f4ac55b27176454bbbc9baf213/pandas/core/dtypes/base.py#L261-L264
+        # NotImplementedError: https://github.com/rapidsai/cudf/blob/22d1b7c75e892f9136e11e47c09e7913910414ea/python/cudf/cudf/core/dtypes.py#L318-L319
+        with suppress(TypeError, NotImplementedError):
             result = dtype.construct_from_string(alias)
             yield result
             return


### PR DESCRIPTION
Closes #2759

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related #2744
- Closes #2759

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
https://github.com/narwhals-dev/narwhals/issues/2759#issuecomment-3016621477

> Oh right, so the issue is this line
> 
> https://github.com/rapidsai/cudf/blob/22d1b7c75e892f9136e11e47c09e7913910414ea/python/cudf/cudf/core/dtypes.py#L318-L319
> 
> ```py
> class CategoricalDtype(_BaseDtype):
> # ...
>     def construct_from_string(self):
>         raise NotImplementedError()
> ```
> When collecting the `Dtype`s here, I'm only suppressing `TypeError`
> 
> https://github.com/narwhals-dev/narwhals/blob/cd60c428ccb6bccf15d39084a9dba7737696e486/tests/get_dtype_backend_test.py#L117-L125
> 
> I picked `TypeError` because the `pandas` doc was pretty explicit about that error
> 
> 
https://github.com/pandas-dev/pandas/blob/2cc37625532045f4ac55b27176454bbbc9baf213/pandas/core/dtypes/base.py#L238-L292
> 
> But I can change the line to handle this quirk 👍
> 
> ```diff
> -         with suppress(TypeError):
> +         with suppress(TypeError, NotImplementedError):
> ````
