### PR TITLE
chore: Move `_reuse_series` to complaint level as much as possible

### DIFF
--- a/narwhals/_arrow/expr.py
+++ b/narwhals/_arrow/expr.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from narwhals._compliant.typing import AliasNames, EvalNames, EvalSeries, ScalarKwargs
     from narwhals._expression_parsing import ExprMetadata
     from narwhals._utils import Version, _FullContext
-    from narwhals.typing import RankMethod
 
 
 class ArrowExpr(EagerExpr["ArrowDataFrame", ArrowSeries]):
@@ -122,12 +121,6 @@ class ArrowExpr(EagerExpr["ArrowDataFrame", ArrowSeries]):
     ) -> dict[str, Any]:
         return {"_return_py_scalar": False} if returns_scalar else {}
 
-    def cum_sum(self, *, reverse: bool) -> Self:
-        return self._reuse_series("cum_sum", reverse=reverse)
-
-    def shift(self, n: int) -> Self:
-        return self._reuse_series("shift", n=n)
-
     def over(self, partition_by: Sequence[str], order_by: Sequence[str]) -> Self:
         if (
             partition_by
@@ -185,29 +178,5 @@ class ArrowExpr(EagerExpr["ArrowDataFrame", ArrowSeries]):
             backend_version=self._backend_version,
             version=self._version,
         )
-
-    def cum_count(self, *, reverse: bool) -> Self:
-        return self._reuse_series("cum_count", reverse=reverse)
-
-    def cum_min(self, *, reverse: bool) -> Self:
-        return self._reuse_series("cum_min", reverse=reverse)
-
-    def cum_max(self, *, reverse: bool) -> Self:
-        return self._reuse_series("cum_max", reverse=reverse)
-
-    def cum_prod(self, *, reverse: bool) -> Self:
-        return self._reuse_series("cum_prod", reverse=reverse)
-
-    def rank(self, method: RankMethod, *, descending: bool) -> Self:
-        return self._reuse_series("rank", method=method, descending=descending)
-
-    def log(self, base: float) -> Self:
-        return self._reuse_series("log", base=base)
-
-    def exp(self) -> Self:
-        return self._reuse_series("exp")
-
-    def sqrt(self) -> Self:
-        return self._reuse_series("sqrt")
 
     ewm_mean = not_implemented()

--- a/narwhals/_compliant/expr.py
+++ b/narwhals/_compliant/expr.py
@@ -652,7 +652,7 @@ class EagerExpr(
         limit: int | None,
     ) -> Self:
         return self._reuse_series(
-            "fill_null", value=value, strategy=strategy, limit=limit
+            "fill_null", value=value, scalar_kwargs={"strategy": strategy, "limit": limit}
         )
 
     def is_in(self, other: Any) -> Self:
@@ -677,17 +677,20 @@ class EagerExpr(
         return_dtype: IntoDType | None,
     ) -> Self:
         return self._reuse_series(
-            "replace_strict", old=old, new=new, return_dtype=return_dtype
+            "replace_strict",
+            scalar_kwargs={"old": old, "new": new, "return_dtype": return_dtype},
         )
 
     def sort(self, *, descending: bool, nulls_last: bool) -> Self:
-        return self._reuse_series("sort", descending=descending, nulls_last=nulls_last)
+        return self._reuse_series(
+            "sort", scalar_kwargs={"descending": descending, "nulls_last": nulls_last}
+        )
 
     def abs(self) -> Self:
         return self._reuse_series("abs")
 
     def unique(self) -> Self:
-        return self._reuse_series("unique", maintain_order=False)
+        return self._reuse_series("unique", scalar_kwargs={"maintain_order": False})
 
     def diff(self) -> Self:
         return self._reuse_series("diff")
@@ -701,7 +704,13 @@ class EagerExpr(
         seed: int | None,
     ) -> Self:
         return self._reuse_series(
-            "sample", n=n, fraction=fraction, with_replacement=with_replacement, seed=seed
+            "sample",
+            scalar_kwargs={
+                "n": n,
+                "fraction": fraction,
+                "with_replacement": with_replacement,
+                "seed": seed,
+            },
         )
 
     def alias(self, name: str) -> Self:
@@ -739,25 +748,26 @@ class EagerExpr(
     ) -> Self:
         return self._reuse_series(
             "quantile",
-            quantile=quantile,
-            interpolation=interpolation,
             returns_scalar=True,
+            scalar_kwargs={"quantile": quantile, "interpolation": interpolation},
         )
 
     def head(self, n: int) -> Self:
-        return self._reuse_series("head", n=n)
+        return self._reuse_series("head", scalar_kwargs={"n": n})
 
     def tail(self, n: int) -> Self:
-        return self._reuse_series("tail", n=n)
+        return self._reuse_series("tail", scalar_kwargs={"n": n})
 
     def round(self, decimals: int) -> Self:
-        return self._reuse_series("round", decimals=decimals)
+        return self._reuse_series("round", scalar_kwargs={"decimals": decimals})
 
     def len(self) -> Self:
         return self._reuse_series("len", returns_scalar=True)
 
     def gather_every(self, n: int, offset: int) -> Self:
-        return self._reuse_series("gather_every", n=n, offset=offset)
+        return self._reuse_series(
+            "gather_every", scalar_kwargs={"n": n, "offset": offset}
+        )
 
     def mode(self) -> Self:
         return self._reuse_series("mode")
@@ -768,9 +778,11 @@ class EagerExpr(
     def rolling_mean(self, window_size: int, *, min_samples: int, center: bool) -> Self:
         return self._reuse_series(
             "rolling_mean",
-            window_size=window_size,
-            min_samples=min_samples,
-            center=center,
+            scalar_kwargs={
+                "window_size": window_size,
+                "min_samples": min_samples,
+                "center": center,
+            },
         )
 
     def rolling_std(
@@ -778,15 +790,22 @@ class EagerExpr(
     ) -> Self:
         return self._reuse_series(
             "rolling_std",
-            window_size=window_size,
-            min_samples=min_samples,
-            center=center,
-            ddof=ddof,
+            scalar_kwargs={
+                "window_size": window_size,
+                "min_samples": min_samples,
+                "center": center,
+                "ddof": ddof,
+            },
         )
 
     def rolling_sum(self, window_size: int, *, min_samples: int, center: bool) -> Self:
         return self._reuse_series(
-            "rolling_sum", window_size=window_size, min_samples=min_samples, center=center
+            "rolling_sum",
+            scalar_kwargs={
+                "window_size": window_size,
+                "min_samples": min_samples,
+                "center": center,
+            },
         )
 
     def rolling_var(
@@ -794,10 +813,12 @@ class EagerExpr(
     ) -> Self:
         return self._reuse_series(
             "rolling_var",
-            window_size=window_size,
-            min_samples=min_samples,
-            center=center,
-            ddof=ddof,
+            scalar_kwargs={
+                "window_size": window_size,
+                "min_samples": min_samples,
+                "center": center,
+                "ddof": ddof,
+            },
         )
 
     def map_batches(
@@ -829,6 +850,38 @@ class EagerExpr(
             alias_output_names=self._alias_output_names,
             context=self,
         )
+
+    def shift(self, n: int) -> Self:
+        return self._reuse_series("shift", scalar_kwargs={"n": n})
+
+    def cum_sum(self, *, reverse: bool) -> Self:
+        return self._reuse_series("cum_sum", scalar_kwargs={"reverse": reverse})
+
+    def cum_count(self, *, reverse: bool) -> Self:
+        return self._reuse_series("cum_count", scalar_kwargs={"reverse": reverse})
+
+    def cum_min(self, *, reverse: bool) -> Self:
+        return self._reuse_series("cum_min", scalar_kwargs={"reverse": reverse})
+
+    def cum_max(self, *, reverse: bool) -> Self:
+        return self._reuse_series("cum_max", scalar_kwargs={"reverse": reverse})
+
+    def cum_prod(self, *, reverse: bool) -> Self:
+        return self._reuse_series("cum_prod", scalar_kwargs={"reverse": reverse})
+
+    def rank(self, method: RankMethod, *, descending: bool) -> Self:
+        return self._reuse_series(
+            "rank", scalar_kwargs={"method": method, "descending": descending}
+        )
+
+    def log(self, base: float) -> Self:
+        return self._reuse_series("log", scalar_kwargs={"base": base})
+
+    def exp(self) -> Self:
+        return self._reuse_series("exp")
+
+    def sqrt(self) -> Self:
+        return self._reuse_series("sqrt")
 
     @property
     def cat(self) -> EagerExprCatNamespace[Self]:

--- a/narwhals/_compliant/typing.py
+++ b/narwhals/_compliant/typing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Callable, TypedDict, TypeVar
 
 if TYPE_CHECKING:
@@ -21,21 +21,47 @@ if TYPE_CHECKING:
     from narwhals._compliant.namespace import CompliantNamespace, EagerNamespace
     from narwhals._compliant.series import CompliantSeries, EagerSeries
     from narwhals._compliant.window import WindowInputs
-    from narwhals.typing import FillNullStrategy, NativeFrame, NativeSeries, RankMethod
+    from narwhals.typing import (
+        FillNullStrategy,
+        IntoDType,
+        NativeFrame,
+        NativeSeries,
+        RankMethod,
+        RollingInterpolationMethod,
+    )
 
     class ScalarKwargs(TypedDict, total=False):
         """Non-expressifiable args which we may need to reuse in `agg` or `over`."""
 
+        adjust: bool
+        alpha: float | None
+        base: float
         center: int
+        com: float | None
         ddof: int
+        decimals: int
         descending: bool
+        fraction: float | None
+        half_life: float | None
+        ignore_nulls: bool
+        interpolation: RollingInterpolationMethod
         limit: int | None
+        maintain_order: bool
         method: RankMethod
         min_samples: int
-        n: int
+        n: int | None
+        new: Sequence[Any]
+        nulls_last: bool
+        offset: int
+        old: Sequence[Any] | Mapping[Any, Any]
+        quantile: float
+        return_dtype: IntoDType | None
         reverse: bool
+        seed: int | None
+        span: float | None
         strategy: FillNullStrategy | None
         window_size: int
+        with_replacement: bool
 
 
 __all__ = [

--- a/narwhals/_pandas_like/expr.py
+++ b/narwhals/_pandas_like/expr.py
@@ -18,12 +18,7 @@ if TYPE_CHECKING:
     from narwhals._pandas_like.dataframe import PandasLikeDataFrame
     from narwhals._pandas_like.namespace import PandasLikeNamespace
     from narwhals._utils import Implementation, Version, _FullContext
-    from narwhals.typing import (
-        FillNullStrategy,
-        NonNestedLiteral,
-        PythonLiteral,
-        RankMethod,
-    )
+    from narwhals.typing import PythonLiteral
 
 WINDOW_FUNCTIONS_TO_PANDAS_EQUIVALENT = {
     "cum_sum": "cumsum",
@@ -187,20 +182,16 @@ class PandasLikeExpr(EagerExpr["PandasLikeDataFrame", PandasLikeSeries]):
     ) -> Self:
         return self._reuse_series(
             "ewm_mean",
-            com=com,
-            span=span,
-            half_life=half_life,
-            alpha=alpha,
-            adjust=adjust,
-            min_samples=min_samples,
-            ignore_nulls=ignore_nulls,
+            scalar_kwargs={
+                "com": com,
+                "span": span,
+                "half_life": half_life,
+                "alpha": alpha,
+                "adjust": adjust,
+                "min_samples": min_samples,
+                "ignore_nulls": ignore_nulls,
+            },
         )
-
-    def cum_sum(self, *, reverse: bool) -> Self:
-        return self._reuse_series("cum_sum", scalar_kwargs={"reverse": reverse})
-
-    def shift(self, n: int) -> Self:
-        return self._reuse_series("shift", scalar_kwargs={"n": n})
 
     def over(  # noqa: C901, PLR0915
         self, partition_by: Sequence[str], order_by: Sequence[str]
@@ -323,85 +314,3 @@ class PandasLikeExpr(EagerExpr["PandasLikeDataFrame", PandasLikeSeries]):
             backend_version=self._backend_version,
             version=self._version,
         )
-
-    def cum_count(self, *, reverse: bool) -> Self:
-        return self._reuse_series("cum_count", scalar_kwargs={"reverse": reverse})
-
-    def cum_min(self, *, reverse: bool) -> Self:
-        return self._reuse_series("cum_min", scalar_kwargs={"reverse": reverse})
-
-    def cum_max(self, *, reverse: bool) -> Self:
-        return self._reuse_series("cum_max", scalar_kwargs={"reverse": reverse})
-
-    def cum_prod(self, *, reverse: bool) -> Self:
-        return self._reuse_series("cum_prod", scalar_kwargs={"reverse": reverse})
-
-    def fill_null(
-        self,
-        value: Self | NonNestedLiteral,
-        strategy: FillNullStrategy | None,
-        limit: int | None,
-    ) -> Self:
-        return self._reuse_series(
-            "fill_null", scalar_kwargs={"strategy": strategy, "limit": limit}, value=value
-        )
-
-    def rolling_sum(self, window_size: int, *, min_samples: int, center: bool) -> Self:
-        return self._reuse_series(
-            "rolling_sum",
-            scalar_kwargs={
-                "window_size": window_size,
-                "min_samples": min_samples,
-                "center": center,
-            },
-        )
-
-    def rolling_mean(self, window_size: int, *, min_samples: int, center: bool) -> Self:
-        return self._reuse_series(
-            "rolling_mean",
-            scalar_kwargs={
-                "window_size": window_size,
-                "min_samples": min_samples,
-                "center": center,
-            },
-        )
-
-    def rolling_std(
-        self, window_size: int, *, min_samples: int, center: bool, ddof: int
-    ) -> Self:
-        return self._reuse_series(
-            "rolling_std",
-            scalar_kwargs={
-                "window_size": window_size,
-                "min_samples": min_samples,
-                "center": center,
-                "ddof": ddof,
-            },
-        )
-
-    def rolling_var(
-        self, window_size: int, *, min_samples: int, center: bool, ddof: int
-    ) -> Self:
-        return self._reuse_series(
-            "rolling_var",
-            scalar_kwargs={
-                "window_size": window_size,
-                "min_samples": min_samples,
-                "center": center,
-                "ddof": ddof,
-            },
-        )
-
-    def rank(self, method: RankMethod, *, descending: bool) -> Self:
-        return self._reuse_series(
-            "rank", scalar_kwargs={"method": method, "descending": descending}
-        )
-
-    def log(self, base: float) -> Self:
-        return self._reuse_series("log", base=base)
-
-    def exp(self) -> Self:
-        return self._reuse_series("exp")
-
-    def sqrt(self) -> Self:
-        return self._reuse_series("sqrt")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## If you have comments or can explain your changes, please do so below

While doing something else completely unrelated, I spotted that:

- We are not exploiting `_reuse_series` as much as we could
- We are improperly using or rather not using `scalar_kwargs` when we should. Most likely negligible, but using it properly avoids an extra function call (`df._evaluate_expr(value) if self._is_expr(value) else value`)