### PR TITLE
ci(ruff): Autofix `"utf-8"` encoding for windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,12 +138,14 @@ extend-safe-fixes = [
   "PLR6201", # literal-membership
   "TC",      # flake8-type-checking
   "UP",      # pyupgrade
+  "PLW1514", # unspecified-encoding
 ]
 extend-select = [
   "PLR0914", # too-many-locals
   "PLR0916", # too-many-boolean-expressions
   "PLR1702", # too-many-nested-blocks
   "PLR6201", # literal-membership
+  "PLW1514", # unspecified-encoding
 ]
 select = ["ALL"]
 ignore = [

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -42,7 +42,7 @@ def read_documented_members(source: str | Path) -> list[str]:
     MEMBERS_START = "members:\n"
     MEMBERS_PREFIX = "        - "
     DUNDER_PREFIX = "__"
-    with open(source) as fd:
+    with open(source, encoding="utf-8") as fd:
         lines = deque(fd.readlines())
     head = lines.popleft()
     while not head.endswith(MEMBERS_START):

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -37,7 +37,9 @@ def create_temp_files(examples: list[tuple[Path, str, str]]) -> list[tuple[Path,
     temp_files: list[tuple[Path, str]] = []
 
     for file, name, example in examples:
-        temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False)  # noqa: SIM115
+        temp_file = tempfile.NamedTemporaryFile(  # noqa: SIM115
+            encoding="utf-8", mode="w", suffix=".py", delete=False
+        )
         temp_file.write(example)
         temp_file_path = temp_file.name
         temp_file.close()

--- a/utils/check_for_no_build_errors.py
+++ b/utils/check_for_no_build_errors.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import sys
 
-with open("output.txt") as fd:
+with open("output.txt", encoding="utf-8") as fd:
     content = fd.read()
 
 if "exited with errors" in content:

--- a/utils/generate_random_versions.py
+++ b/utils/generate_random_versions.py
@@ -57,14 +57,14 @@ polars_version = random.choice(POLARS_VERSION)
 pyarrow_version = random.choice(PYARROW_VERSION)
 
 content = f"pandas=={pandas_version}\nnumpy=={numpy_version}\npolars=={polars_version}\npyarrow=={pyarrow_version}\n"
-with open("random-requirements.txt", "w") as fd:
+with open("random-requirements.txt", "w", encoding="utf-8") as fd:
     fd.write(content)
 
-with open("pyproject.toml") as fd:
+with open("pyproject.toml", encoding="utf-8") as fd:
     content = fd.read()
 content = content.replace(
     'filterwarnings = [\n  "error",\n]',
     "filterwarnings = [\n  \"error\",\n  'ignore:distutils Version classes are deprecated:DeprecationWarning',\n]",
 )
-with open("pyproject.toml", "w") as fd:
+with open("pyproject.toml", "w", encoding="utf-8") as fd:
     fd.write(content)

--- a/utils/import_check.py
+++ b/utils/import_check.py
@@ -76,7 +76,7 @@ class ImportPandasChecker(ast.NodeVisitor):
 
 
 def check_import_pandas(filename: str) -> bool:
-    with open(filename) as file:
+    with open(filename, encoding="utf-8") as file:
         content = file.read()
     tree = ast.parse(content, filename=filename)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- https://github.com/narwhals-dev/narwhals/pull/2764/commits/168532205cf491ad1a67de5c511c8d711ba5e269
- https://docs.astral.sh/ruff/rules/unspecified-encoding/

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Was having issues running `pre-commit` on windows

This `ruff` rule autofixes the issue - so we don't have to think about it again 😅 

```py
(narwhals) PS C:\Users\danie\Documents\GitHub\narwhals> pre-commit run -a
ruff format............................................................................Passed
ruff check.............................................................................Passed
check-docstrings.......................................................................Passed
codespell..............................................................................Passed
flake8.................................................................................Passed
check-api-reference....................................................................Passed
import are banned (use `get_pandas` instead of `import pandas`)........................Failed
- hook id: imports-are-banned
- exit code: 1

Traceback (most recent call last):
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 94, in <module>
    ret |= check_import_pandas(filename)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 80, in check_import_pandas
    content = file.read()
  File "C:\Users\danie\AppData\Roaming\uv\python\cpython-3.13.2-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 4148: character maps to <undefined>
Traceback (most recent call last):
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 94, in <module>
    ret |= check_import_pandas(filename)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 80, in check_import_pandas
    content = file.read()
  File "C:\Users\danie\AppData\Roaming\uv\python\cpython-3.13.2-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 3204: character maps to <undefined>
Traceback (most recent call last):
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 94, in <module>
    ret |= check_import_pandas(filename)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 80, in check_import_pandas
    content = file.read()
  File "C:\Users\danie\AppData\Roaming\uv\python\cpython-3.13.2-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 2096: character maps to <undefined>
Traceback (most recent call last):
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 94, in <module>
    ret |= check_import_pandas(filename)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 80, in check_import_pandas
    content = file.read()
  File "C:\Users\danie\AppData\Roaming\uv\python\cpython-3.13.2-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 969: character maps to <undefined>
Traceback (most recent call last):
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 94, in <module>
    ret |= check_import_pandas(filename)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 80, in check_import_pandas
    content = file.read()
  File "C:\Users\danie\AppData\Roaming\uv\python\cpython-3.13.2-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 13630: character maps to <undefined>
Traceback (most recent call last):
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 94, in <module>
    ret |= check_import_pandas(filename)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 80, in check_import_pandas
    content = file.read()
  File "C:\Users\danie\AppData\Roaming\uv\python\cpython-3.13.2-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 49067: character maps to <undefined>
Traceback (most recent call last):
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 94, in <module>
    ret |= check_import_pandas(filename)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 80, in check_import_pandas
    content = file.read()
  File "C:\Users\danie\AppData\Roaming\uv\python\cpython-3.13.2-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 1042: character maps to <undefined>
Traceback (most recent call last):
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 94, in <module>
    ret |= check_import_pandas(filename)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 80, in check_import_pandas
    content = file.read()
  File "C:\Users\danie\AppData\Roaming\uv\python\cpython-3.13.2-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 852: character maps to <undefined>
Traceback (most recent call last):
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 94, in <module>
    ret |= check_import_pandas(filename)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 80, in check_import_pandas
    content = file.read()
  File "C:\Users\danie\AppData\Roaming\uv\python\cpython-3.13.2-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 823: character maps to <undefined>
Traceback (most recent call last):
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 94, in <module>
    ret |= check_import_pandas(filename)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 80, in check_import_pandas
    content = file.read()
  File "C:\Users\danie\AppData\Roaming\uv\python\cpython-3.13.2-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 888: character maps to <undefined>
Traceback (most recent call last):
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 94, in <module>
    ret |= check_import_pandas(filename)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\danie\Documents\GitHub\narwhals\utils\import_check.py", line 80, in check_import_pandas
    content = file.read()
  File "C:\Users\danie\AppData\Roaming\uv\python\cpython-3.13.2-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 21406: character maps to <undefined>

don't annotate `self` argument using `Self`............................................Passed
don't import from narwhals.dtypes (use `Version.dtypes` instead).......................Passed
don't use `pull_request_target`........................................................Passed
blacken-docs...........................................................................Passed
python tests naming....................................................................Passed
don't commit to branch.................................................................Passed
fix end of files.......................................................................Passed
```