### PR TITLE
feat: Support `DataFrame().lazy("ibis")`

### DIFF
--- a/narwhals/_arrow/dataframe.py
+++ b/narwhals/_arrow/dataframe.py
@@ -561,6 +561,16 @@ class ArrowDataFrame(
                 backend_version=parse_version(dask),
                 version=self._version,
             )
+        elif backend.is_ibis():
+            import ibis  # ignore-banned-import
+
+            from narwhals._ibis.dataframe import IbisLazyFrame
+
+            return IbisLazyFrame(
+                ibis.memtable(self.native, columns=self.columns),
+                backend_version=parse_version(ibis),
+                version=self._version,
+            )
         raise AssertionError  # pragma: no cover
 
     def collect(

--- a/narwhals/_pandas_like/dataframe.py
+++ b/narwhals/_pandas_like/dataframe.py
@@ -819,6 +819,16 @@ class PandasLikeDataFrame(
                 backend_version=parse_version(dask),
                 version=self._version,
             )
+        elif backend.is_ibis():
+            import ibis  # ignore-banned-import
+
+            from narwhals._ibis.dataframe import IbisLazyFrame
+
+            return IbisLazyFrame(
+                ibis.memtable(pandas_df, columns=self.columns),
+                backend_version=parse_version(ibis),
+                version=self._version,
+            )
         raise AssertionError  # pragma: no cover
 
     @property

--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -477,6 +477,16 @@ class PolarsDataFrame(PolarsBaseFrame[pl.DataFrame]):
                 backend_version=parse_version(dask),
                 version=self._version,
             )
+        elif backend.is_ibis():
+            import ibis  # ignore-banned-import
+
+            from narwhals._ibis.dataframe import IbisLazyFrame
+
+            return IbisLazyFrame(
+                ibis.memtable(self.native, columns=self.columns),
+                backend_version=parse_version(ibis),
+                version=self._version,
+            )
         raise AssertionError  # pragma: no cover
 
     @overload

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -534,10 +534,10 @@ class DataFrame(BaseFrame[DataFrameT]):
 
                 `backend` can be specified in various ways
 
-                - As `Implementation.<BACKEND>` with `BACKEND` being `DASK`, `DUCKDB`
-                    or `POLARS`.
-                - As a string: `"dask"`, `"duckdb"` or `"polars"`
-                - Directly as a module `dask.dataframe`, `duckdb` or `polars`.
+                - As `Implementation.<BACKEND>` with `BACKEND` being `DASK`, `DUCKDB`,
+                    `IBIS` or `POLARS`.
+                - As a string: `"dask"`, `"duckdb"`, `"ibis"` or `"polars"`
+                - Directly as a module `dask.dataframe`, `duckdb`, `ibis` or `polars`.
 
         Returns:
             A new LazyFrame.

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -580,6 +580,7 @@ class DataFrame(BaseFrame[DataFrameT]):
             Implementation.DASK,
             Implementation.DUCKDB,
             Implementation.POLARS,
+            Implementation.IBIS,
         )
         if lazy_backend is not None and lazy_backend not in supported_lazy_backends:
             msg = (

--- a/tests/frame/lazy_test.py
+++ b/tests/frame/lazy_test.py
@@ -52,9 +52,11 @@ def test_lazy_to_default(constructor_eager: ConstructorEager) -> None:
         Implementation.POLARS,
         Implementation.DUCKDB,
         Implementation.DASK,
+        Implementation.IBIS,
         "polars",
         "duckdb",
         "dask",
+        "ibis",
     ],
 )
 def test_lazy_backend(


### PR DESCRIPTION
Was missing coverage in (https://github.com/narwhals-dev/narwhals/pull/2764/commits/4d78e212764b56398e507a2859aa7f4eaecc69c1)
https://ibis-project.org/reference/expression-tables#ibis.memtable


<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Discovered missing in (https://github.com/narwhals-dev/narwhals/pull/2764/commits/4d78e212764b56398e507a2859aa7f4eaecc69c1)
- Seems we missed it in (#2000)

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below
