### PR TITLE
chore: Re-sync `_compliant` exports

### DIFF
--- a/narwhals/_arrow/group_by.py
+++ b/narwhals/_arrow/group_by.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
         Aggregation,
         Incomplete,
     )
-    from narwhals._compliant.group_by import NarwhalsAggregation
+    from narwhals._compliant.typing import NarwhalsAggregation
     from narwhals.typing import UniqueKeepStrategy
 
 

--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, cast
 import pyarrow as pa
 import pyarrow.compute as pc
 
-from narwhals._compliant.series import _SeriesNamespace
+from narwhals._compliant import EagerSeriesNamespace
 from narwhals._utils import isinstance_or_issubclass
 
 if TYPE_CHECKING:
@@ -437,6 +437,4 @@ def cast_to_comparable_string_types(
     return (ca.cast(dtype) for ca in chunked_arrays), lit(separator, dtype)
 
 
-class ArrowSeriesNamespace(_SeriesNamespace["ArrowSeries", "ChunkedArrayAny"]):
-    def __init__(self, series: ArrowSeries, /) -> None:
-        self._compliant_series = series
+class ArrowSeriesNamespace(EagerSeriesNamespace["ArrowSeries", "ChunkedArrayAny"]): ...

--- a/narwhals/_compliant/__init__.py
+++ b/narwhals/_compliant/__init__.py
@@ -44,6 +44,7 @@ from narwhals._compliant.when_then import (
     LazyThen,
     LazyWhen,
 )
+from narwhals._compliant.window import WindowInputs
 
 __all__ = [
     "CompliantDataFrame",
@@ -81,4 +82,5 @@ __all__ = [
     "LazyWhen",
     "NativeFrameT_co",
     "NativeSeriesT_co",
+    "WindowInputs",
 ]

--- a/narwhals/_compliant/__init__.py
+++ b/narwhals/_compliant/__init__.py
@@ -5,7 +5,7 @@ from narwhals._compliant.dataframe import (
     CompliantLazyFrame,
     EagerDataFrame,
 )
-from narwhals._compliant.expr import CompliantExpr, EagerExpr, LazyExpr
+from narwhals._compliant.expr import CompliantExpr, DepthTrackingExpr, EagerExpr, LazyExpr
 from narwhals._compliant.group_by import (
     CompliantGroupBy,
     DepthTrackingGroupBy,
@@ -71,6 +71,7 @@ __all__ = [
     "CompliantSeriesT",
     "CompliantThen",
     "CompliantWhen",
+    "DepthTrackingExpr",
     "DepthTrackingGroupBy",
     "DepthTrackingNamespace",
     "EagerDataFrame",

--- a/narwhals/_compliant/__init__.py
+++ b/narwhals/_compliant/__init__.py
@@ -14,6 +14,7 @@ from narwhals._compliant.group_by import (
 )
 from narwhals._compliant.namespace import (
     CompliantNamespace,
+    DepthTrackingNamespace,
     EagerNamespace,
     LazyNamespace,
 )
@@ -62,6 +63,7 @@ __all__ = [
     "CompliantThen",
     "CompliantWhen",
     "DepthTrackingGroupBy",
+    "DepthTrackingNamespace",
     "EagerDataFrame",
     "EagerDataFrameT",
     "EagerExpr",

--- a/narwhals/_compliant/__init__.py
+++ b/narwhals/_compliant/__init__.py
@@ -24,7 +24,16 @@ from narwhals._compliant.selectors import (
     EagerSelectorNamespace,
     LazySelectorNamespace,
 )
-from narwhals._compliant.series import CompliantSeries, EagerSeries
+from narwhals._compliant.series import (
+    CompliantSeries,
+    EagerSeries,
+    EagerSeriesCatNamespace,
+    EagerSeriesDateTimeNamespace,
+    EagerSeriesListNamespace,
+    EagerSeriesNamespace,
+    EagerSeriesStringNamespace,
+    EagerSeriesStructNamespace,
+)
 from narwhals._compliant.typing import (
     CompliantExprT,
     CompliantFrameT,
@@ -71,6 +80,12 @@ __all__ = [
     "EagerNamespace",
     "EagerSelectorNamespace",
     "EagerSeries",
+    "EagerSeriesCatNamespace",
+    "EagerSeriesDateTimeNamespace",
+    "EagerSeriesListNamespace",
+    "EagerSeriesNamespace",
+    "EagerSeriesStringNamespace",
+    "EagerSeriesStructNamespace",
     "EagerSeriesT",
     "EagerWhen",
     "EvalNames",

--- a/narwhals/_compliant/__init__.py
+++ b/narwhals/_compliant/__init__.py
@@ -5,7 +5,13 @@ from narwhals._compliant.dataframe import (
     CompliantLazyFrame,
     EagerDataFrame,
 )
-from narwhals._compliant.expr import CompliantExpr, DepthTrackingExpr, EagerExpr, LazyExpr
+from narwhals._compliant.expr import (
+    CompliantExpr,
+    DepthTrackingExpr,
+    EagerExpr,
+    LazyExpr,
+    LazyExprNamespace,
+)
 from narwhals._compliant.group_by import (
     CompliantGroupBy,
     DepthTrackingGroupBy,
@@ -93,6 +99,7 @@ __all__ = [
     "EvalSeries",
     "IntoCompliantExpr",
     "LazyExpr",
+    "LazyExprNamespace",
     "LazyGroupBy",
     "LazyNamespace",
     "LazySelectorNamespace",

--- a/narwhals/_compliant/expr.py
+++ b/narwhals/_compliant/expr.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
         TimeUnit,
     )
 
-__all__ = ["CompliantExpr", "EagerExpr", "LazyExpr", "NativeExpr"]
+__all__ = ["CompliantExpr", "DepthTrackingExpr", "EagerExpr", "LazyExpr", "NativeExpr"]
 
 
 class NativeExpr(Protocol):

--- a/narwhals/_compliant/group_by.py
+++ b/narwhals/_compliant/group_by.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, TypeVar
 
 from narwhals._compliant.typing import (
     CompliantDataFrameAny,
@@ -14,6 +14,7 @@ from narwhals._compliant.typing import (
     DepthTrackingExprT_contra,
     EagerExprT_contra,
     LazyExprT_contra,
+    NarwhalsAggregation,
     NativeExprT_co,
 )
 from narwhals._typing_compat import Protocol38
@@ -22,25 +23,14 @@ from narwhals._utils import is_sequence_of
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping, Sequence
 
-    from typing_extensions import TypeAlias
-
     _SameFrameT = TypeVar("_SameFrameT", CompliantDataFrameAny, CompliantLazyFrameAny)
 
 
-__all__ = [
-    "CompliantGroupBy",
-    "DepthTrackingGroupBy",
-    "EagerGroupBy",
-    "LazyGroupBy",
-    "NarwhalsAggregation",
-]
+__all__ = ["CompliantGroupBy", "DepthTrackingGroupBy", "EagerGroupBy", "LazyGroupBy"]
 
 NativeAggregationT_co = TypeVar(
     "NativeAggregationT_co", bound="str | Callable[..., Any]", covariant=True
 )
-NarwhalsAggregation: TypeAlias = Literal[
-    "sum", "mean", "median", "max", "min", "std", "var", "len", "n_unique", "count"
-]
 
 
 _RE_LEAF_NAME: re.Pattern[str] = re.compile(r"(\w+->)")

--- a/narwhals/_compliant/namespace.py
+++ b/narwhals/_compliant/namespace.py
@@ -43,7 +43,12 @@ if TYPE_CHECKING:
 
     Incomplete: TypeAlias = Any
 
-__all__ = ["CompliantNamespace", "EagerNamespace"]
+__all__ = [
+    "CompliantNamespace",
+    "DepthTrackingNamespace",
+    "EagerNamespace",
+    "LazyNamespace",
+]
 
 
 class CompliantNamespace(Protocol[CompliantFrameT, CompliantExprT]):

--- a/narwhals/_compliant/series.py
+++ b/narwhals/_compliant/series.py
@@ -56,7 +56,16 @@ if TYPE_CHECKING:
         _SliceIndex,
     )
 
-__all__ = ["CompliantSeries", "EagerSeries"]
+__all__ = [
+    "CompliantSeries",
+    "EagerSeries",
+    "EagerSeriesCatNamespace",
+    "EagerSeriesDateTimeNamespace",
+    "EagerSeriesListNamespace",
+    "EagerSeriesNamespace",
+    "EagerSeriesStringNamespace",
+    "EagerSeriesStructNamespace",
+]
 
 
 class CompliantSeries(

--- a/narwhals/_compliant/typing.py
+++ b/narwhals/_compliant/typing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Callable, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Literal, TypedDict, TypeVar
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
@@ -48,6 +48,7 @@ __all__ = [
     "EvalNames",
     "EvalSeries",
     "IntoCompliantExpr",
+    "NarwhalsAggregation",
     "NativeFrameT_co",
     "NativeSeriesT_co",
 ]
@@ -154,3 +155,16 @@ WindowFunction: TypeAlias = (
     "Callable[[CompliantFrameT, WindowInputs[NativeExprT]], Sequence[NativeExprT]]"
 )
 """A function evaluated with `over(partition_by=..., order_by=...)`."""
+
+NarwhalsAggregation: TypeAlias = Literal[
+    "sum", "mean", "median", "max", "min", "std", "var", "len", "n_unique", "count"
+]
+"""`Expr` methods we aim to support in `DepthTrackingGroupBy`.
+
+Be sure to update me if you're working on one of these:
+- https://github.com/narwhals-dev/narwhals/issues/981
+- https://github.com/narwhals-dev/narwhals/issues/2385
+- https://github.com/narwhals-dev/narwhals/issues/2484
+- https://github.com/narwhals-dev/narwhals/issues/2526
+- https://github.com/narwhals-dev/narwhals/issues/2660
+"""

--- a/narwhals/_compliant/window.py
+++ b/narwhals/_compliant/window.py
@@ -7,6 +7,8 @@ from narwhals._compliant.typing import NativeExprT_co
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+__all__ = ["WindowInputs"]
+
 
 class WindowInputs(Generic[NativeExprT_co]):
     __slots__ = ("order_by", "partition_by")

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
-from narwhals._compliant import LazyExpr
-from narwhals._compliant.expr import DepthTrackingExpr
+from narwhals._compliant import DepthTrackingExpr, LazyExpr
 from narwhals._dask.expr_dt import DaskExprDateTimeNamespace
 from narwhals._dask.expr_str import DaskExprStringNamespace
 from narwhals._dask.utils import (

--- a/narwhals/_dask/expr_dt.py
+++ b/narwhals/_dask/expr_dt.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import DateTimeNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 from narwhals._constants import MS_PER_SECOND, NS_PER_SECOND, US_PER_SECOND
 from narwhals._duration import parse_interval_string
 from narwhals._pandas_like.utils import (

--- a/narwhals/_dask/expr_str.py
+++ b/narwhals/_dask/expr_str.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING
 
 import dask.dataframe as dd
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import StringNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 from narwhals._utils import not_implemented
 
 if TYPE_CHECKING:

--- a/narwhals/_dask/group_by.py
+++ b/narwhals/_dask/group_by.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from pandas.core.groupby import SeriesGroupBy as _PandasSeriesGroupBy
     from typing_extensions import TypeAlias
 
-    from narwhals._compliant.group_by import NarwhalsAggregation
+    from narwhals._compliant.typing import NarwhalsAggregation
     from narwhals._dask.dataframe import DaskLazyFrame
     from narwhals._dask.expr import DaskExpr
 

--- a/narwhals/_dask/namespace.py
+++ b/narwhals/_dask/namespace.py
@@ -7,8 +7,12 @@ from typing import TYPE_CHECKING, cast
 import dask.dataframe as dd
 import pandas as pd
 
-from narwhals._compliant import CompliantThen, CompliantWhen, LazyNamespace
-from narwhals._compliant.namespace import DepthTrackingNamespace
+from narwhals._compliant import (
+    CompliantThen,
+    CompliantWhen,
+    DepthTrackingNamespace,
+    LazyNamespace,
+)
 from narwhals._dask.dataframe import DaskLazyFrame
 from narwhals._dask.expr import DaskExpr
 from narwhals._dask.selectors import DaskSelectorNamespace

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -6,8 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, cast
 from duckdb import CoalesceOperator, StarExpression
 from duckdb.typing import DuckDBPyType
 
-from narwhals._compliant import LazyExpr
-from narwhals._compliant.window import WindowInputs
+from narwhals._compliant import LazyExpr, WindowInputs
 from narwhals._duckdb.expr_dt import DuckDBExprDateTimeNamespace
 from narwhals._duckdb.expr_list import DuckDBExprListNamespace
 from narwhals._duckdb.expr_str import DuckDBExprStringNamespace

--- a/narwhals/_duckdb/expr_dt.py
+++ b/narwhals/_duckdb/expr_dt.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import DateTimeNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 from narwhals._constants import (
     MS_PER_MINUTE,
     MS_PER_SECOND,

--- a/narwhals/_duckdb/expr_list.py
+++ b/narwhals/_duckdb/expr_list.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import ListNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 from narwhals._duckdb.utils import F
 
 if TYPE_CHECKING:

--- a/narwhals/_duckdb/expr_str.py
+++ b/narwhals/_duckdb/expr_str.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import StringNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 from narwhals._duckdb.utils import F, lit, when
 from narwhals._utils import not_implemented
 

--- a/narwhals/_duckdb/expr_struct.py
+++ b/narwhals/_duckdb/expr_struct.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import StructNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 from narwhals._duckdb.utils import F, lit
 
 if TYPE_CHECKING:

--- a/narwhals/_ibis/expr.py
+++ b/narwhals/_ibis/expr.py
@@ -6,8 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, cast
 
 import ibis
 
-from narwhals._compliant import LazyExpr
-from narwhals._compliant.window import WindowInputs
+from narwhals._compliant import LazyExpr, WindowInputs
 from narwhals._expression_parsing import (
     combine_alias_output_names,
     combine_evaluate_output_names,

--- a/narwhals/_ibis/expr_dt.py
+++ b/narwhals/_ibis/expr_dt.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import DateTimeNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 from narwhals._duration import parse_interval_string
 from narwhals._ibis.utils import UNITS_DICT_BUCKET, UNITS_DICT_TRUNCATE
 from narwhals._utils import not_implemented

--- a/narwhals/_ibis/expr_list.py
+++ b/narwhals/_ibis/expr_list.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import ListNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 
 if TYPE_CHECKING:
     from narwhals._ibis.expr import IbisExpr

--- a/narwhals/_ibis/expr_str.py
+++ b/narwhals/_ibis/expr_str.py
@@ -6,8 +6,8 @@ import ibis
 import ibis.expr.types as ir
 from ibis.expr.datatypes import Timestamp
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import StringNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 from narwhals._ibis.utils import lit
 from narwhals._utils import _is_naive_format, not_implemented
 

--- a/narwhals/_ibis/expr_struct.py
+++ b/narwhals/_ibis/expr_struct.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import StructNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 
 if TYPE_CHECKING:
     import ibis.expr.types as ir

--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -12,7 +12,7 @@ from narwhals._utils import find_stacklevel
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
 
-    from narwhals._compliant.group_by import NarwhalsAggregation
+    from narwhals._compliant.typing import NarwhalsAggregation
     from narwhals._pandas_like.dataframe import PandasLikeDataFrame
     from narwhals._pandas_like.expr import PandasLikeExpr
 

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar
 
 import pandas as pd
 
-from narwhals._compliant.series import EagerSeriesNamespace
+from narwhals._compliant import EagerSeriesNamespace
 from narwhals._constants import (
     MS_PER_SECOND,
     NS_PER_MICROSECOND,

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import operator
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, cast
 
-from narwhals._compliant import LazyExpr
-from narwhals._compliant.window import WindowInputs
+from narwhals._compliant import LazyExpr, WindowInputs
 from narwhals._expression_parsing import (
     ExprKind,
     combine_alias_output_names,

--- a/narwhals/_spark_like/expr_dt.py
+++ b/narwhals/_spark_like/expr_dt.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import DateTimeNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 from narwhals._constants import US_PER_SECOND
 from narwhals._duration import parse_interval_string
 from narwhals._spark_like.utils import (

--- a/narwhals/_spark_like/expr_list.py
+++ b/narwhals/_spark_like/expr_list.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import ListNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 
 if TYPE_CHECKING:
     from narwhals._spark_like.expr import SparkLikeExpr

--- a/narwhals/_spark_like/expr_str.py
+++ b/narwhals/_spark_like/expr_str.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from functools import partial
 from typing import TYPE_CHECKING
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import StringNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 from narwhals._spark_like.utils import strptime_to_pyspark_format
 from narwhals._utils import _is_naive_format, not_implemented
 

--- a/narwhals/_spark_like/expr_struct.py
+++ b/narwhals/_spark_like/expr_struct.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from narwhals._compliant import LazyExprNamespace
 from narwhals._compliant.any_namespace import StructNamespace
-from narwhals._compliant.expr import LazyExprNamespace
 
 if TYPE_CHECKING:
     from sqlframe.base.column import Column


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other


## If you have comments or can explain your changes, please do so below
Generally aiming to have all modules outside of the `_compliant` package using imports like

```py
from typing import TYPE_CHECKING

from narwhals._compliant import ...

if TYPE_CHECKING:
    from narwhals._compliant.typing import ...
```

The exception that remains is `any_namespace`.
I thought it was a bit ambiguous when alongside 2 *unrelated* `Namespace` hierarchies and the `EagerSeries*` stuff:

https://github.com/narwhals-dev/narwhals/blob/da0c1c2f39355e6a8aad45f8dc0be0039a976154/narwhals/_compliant/__init__.py#L13-L42


