### PR TITLE
feat: Use `_repr_html_` when native supports it

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -22,9 +22,11 @@ from narwhals._expression_parsing import (
 )
 from narwhals._utils import (
     Implementation,
+    _hasattr_static,
     find_stacklevel,
     flatten,
     generate_repr,
+    generate_repr_html,
     is_compliant_dataframe,
     is_compliant_lazyframe,
     is_index_selector,
@@ -489,6 +491,12 @@ class DataFrame(BaseFrame[DataFrameT]):
 
     def __repr__(self) -> str:  # pragma: no cover
         return generate_repr("Narwhals DataFrame", self.to_native().__repr__())
+
+    def _repr_html_(self) -> str | None:  # pragma: no cover
+        native: Any = self.to_native()
+        if _hasattr_static(native, "_repr_html_") and (html := native._repr_html_()):
+            return generate_repr_html("Narwhals DataFrame", html)
+        return None
 
     def __arrow_c_stream__(self, requested_schema: object | None = None) -> object:
         """Export a DataFrame via the Arrow PyCapsule Interface.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [X] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related #1702
- https://ipython.readthedocs.io/en/stable/config/integrating.html#rich-display
- https://github.com/pandas-dev/pandas/blob/22f12fc5d3f7fda3f198760204e7c13150c78581/pandas/core/frame.py#L1189-L1232
- https://github.com/pola-rs/polars/blob/8011fa34e0c5f1270ef52e2d3b0b2946bb2faa72/py-polars/polars/dataframe/frame.py#L1580-L1605

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
I discovered this method in (#2572), when I was trying to work out why `polars.Expr` looked so much better that what I had 😅

Thinking we can get more immediate benefits *now* by allowing this option when a backend supports it for `DataFrame`, `LazyFrame`, `Series`.


(screenshot)
