### PR TITLE
ci: Add `ruff` to `dev`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ docs = [
 ]
 dev = [
   "pre-commit",
+  "ruff",
   {include-group = "tests"},
   {include-group = "typing"},
 ]


### PR DESCRIPTION
Following (#2803), two (`PD002`) ignores are no longer needed

### Previous
https://github.com/narwhals-dev/narwhals/blob/54bf3d3ec77092d4babc970f245efc2185274e96/narwhals/_pandas_like/group_by.py#L217
https://github.com/narwhals-dev/narwhals/blob/54bf3d3ec77092d4babc970f245efc2185274e96/narwhals/_pandas_like/group_by.py#L264

### `main`
https://github.com/narwhals-dev/narwhals/blob/8afbeec22df2f611d6fb550ac5a345f962d3d314/narwhals/_pandas_like/group_by.py#L217
https://github.com/narwhals-dev/narwhals/blob/8afbeec22df2f611d6fb550ac5a345f962d3d314/narwhals/_pandas_like/group_by.py#L264

## Notes
`pre-commit` autoupdate enforces the latest version of `ruff` in ci, but we don't have anything syncing this with `pyproject.toml`.
A solution for now is just to leave it unpinned, so at least it'll install the latest when updating a local `venv`

Those lines have moved in (#2680), and still require the (`PD002`) ignore - so I think the removal is related to `ruff`'s type inference changing under-the-hood

https://github.com/narwhals-dev/narwhals/blob/46282e8146e60deec5084595d684f54967831c4c/narwhals/_pandas_like/group_by.py#L331