### PR TITLE
chore: invert version.V1 conditions 

### DIFF
--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -92,12 +92,11 @@ class DuckDBLazyFrame(
     def to_narwhals(
         self, *args: Any, **kwds: Any
     ) -> LazyFrame[duckdb.DuckDBPyRelation] | DataFrameV1[duckdb.DuckDBPyRelation]:
-        if self._version is Version.MAIN:
-            return self._version.lazyframe(self, level="lazy")
+        if self._version is Version.V1:
+            from narwhals.stable.v1 import DataFrame as DataFrameV1
 
-        from narwhals.stable.v1 import DataFrame as DataFrameV1
-
-        return DataFrameV1(self, level="interchange")  # type: ignore[no-any-return]
+            return DataFrameV1(self, level="interchange")  # type: ignore[no-any-return]
+        return self._version.lazyframe(self, level="lazy")
 
     def __narwhals_dataframe__(self) -> Self:  # pragma: no cover
         # Keep around for backcompat.

--- a/narwhals/_ibis/dataframe.py
+++ b/narwhals/_ibis/dataframe.py
@@ -67,12 +67,11 @@ class IbisLazyFrame(
         return cls(data, version=context._version)
 
     def to_narwhals(self) -> LazyFrame[ir.Table] | DataFrameV1[ir.Table]:
-        if self._version is Version.MAIN:
-            return self._version.lazyframe(self, level="lazy")
+        if self._version is Version.V1:
+            from narwhals.stable.v1 import DataFrame
 
-        from narwhals.stable.v1 import DataFrame as DataFrameV1
-
-        return DataFrameV1(self, level="interchange")
+            return DataFrame(self, level="interchange")
+        return self._version.lazyframe(self, level="lazy")
 
     def __narwhals_dataframe__(self) -> Self:  # pragma: no cover
         # Keep around for backcompat.

--- a/narwhals/_utils.py
+++ b/narwhals/_utils.py
@@ -216,53 +216,53 @@ class Version(Enum):
 
     @property
     def namespace(self) -> type[Namespace[Any]]:
-        if self is Version.MAIN:
-            from narwhals._namespace import Namespace
+        if self is Version.V1:
+            from narwhals.stable.v1._namespace import Namespace as NamespaceV1
 
-            return Namespace
-        from narwhals.stable.v1._namespace import Namespace
+            return NamespaceV1
+        from narwhals._namespace import Namespace
 
         return Namespace
 
     @property
     def dtypes(self) -> DTypes:
-        if self is Version.MAIN:
-            from narwhals import dtypes
+        if self is Version.V1:
+            from narwhals.stable.v1 import dtypes as dtypes_v1
 
-            return dtypes
-        from narwhals.stable.v1 import dtypes as v1_dtypes
+            return dtypes_v1
+        from narwhals import dtypes
 
-        return v1_dtypes
+        return dtypes
 
     @property
     def dataframe(self) -> type[DataFrame[Any]]:
-        if self is Version.MAIN:
-            from narwhals.dataframe import DataFrame
+        if self is Version.V1:
+            from narwhals.stable.v1 import DataFrame as DataFrameV1
 
-            return DataFrame
-        from narwhals.stable.v1 import DataFrame as DataFrameV1
+            return DataFrameV1
+        from narwhals.dataframe import DataFrame
 
-        return DataFrameV1
+        return DataFrame
 
     @property
     def lazyframe(self) -> type[LazyFrame[Any]]:
-        if self is Version.MAIN:
-            from narwhals.dataframe import LazyFrame
+        if self is Version.V1:
+            from narwhals.stable.v1 import LazyFrame as LazyFrameV1
 
-            return LazyFrame
-        from narwhals.stable.v1 import LazyFrame as LazyFrameV1
+            return LazyFrameV1
+        from narwhals.dataframe import LazyFrame
 
-        return LazyFrameV1
+        return LazyFrame
 
     @property
     def series(self) -> type[Series[Any]]:
-        if self is Version.MAIN:
-            from narwhals.series import Series
+        if self is Version.V1:
+            from narwhals.stable.v1 import Series as SeriesV1
 
-            return Series
-        from narwhals.stable.v1 import Series as SeriesV1
+            return SeriesV1
+        from narwhals.series import Series
 
-        return SeriesV1
+        return Series
 
 
 class Implementation(NoAutoEnum):


### PR DESCRIPTION
this just makes it a bit easier to get v2 started. we should generally assume MAIN behaviour, and make verison-based exceptions when necessary, rather than the other way round