### PR TITLE
Revert "ci: pin scipy"

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -371,8 +371,6 @@ jobs:
         run: |
           uv pip uninstall narwhals --system
           uv pip install -e . --system
-          # Temporary pin to get CI green
-          uv pip install "scipy<1.16.0" --system
       - name: show-deps
         run: uv pip freeze
       - name: Run tests
@@ -416,8 +414,6 @@ jobs:
           cd formulaic
           hatch run uv pip uninstall narwhals
           hatch run uv pip install -e ./..
-          # temporary pin to get CI green
-          hatch run uv pip install "scipy<1.16.0"
       - name: show-deps
         run: hatch run uv pip freeze
       - name: run test


### PR DESCRIPTION
Reverts narwhals-dev/narwhals#2725

Both libraries have addressed the issue.

Closes #2726