### PR TITLE
docs: Remove `utils.Version` from API Reference

### DIFF
--- a/docs/api-reference/utils.md
+++ b/docs/api-reference/utils.md
@@ -6,7 +6,6 @@
       members:
         - parse_version
         - Implementation
-        - Version
       show_root_heading: false
       show_source: false
       show_bases: false


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

Follow-up to https://discord.com/channels/1235257048170762310/1272835535190364283/1393547598568099881

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
> @dangotbanned 
> Was the inclusion of `Version` in the API docs intentional?
> 
> https://narwhals-dev.github.io/narwhals/api-reference/utils/#narwhals.utils.Version
> 
> I could see someone mistaking it's properties, and by extension *everything as deep as this* as public.
> 
> <img width="940" height="560" alt="image" src="https://github.com/user-attachments/assets/4c86f598-399b-4ed1-afc2-269928ce8bed" />
> 
> 
> But AFAIK, there isn't a user-facing need for `Version` being exposed :thinking:

> @marcogorelli
> i can't remember, but it probably doesn't need to be public


