### PR TITLE
chore: take `reset_index(inplace=True)` out of `_select_results`

### DIFF
--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -219,6 +219,9 @@ class PandasLikeGroupBy(
             raise empty_results_error()
         else:
             result = self._apply_aggs(exprs)
+        # NOTE: Keep `inplace=True` to avoid making a redundant copy.
+        # This may need updating, depending on https://github.com/pandas-dev/pandas/pull/51466/files
+        result.reset_index(inplace=True)  # noqa: PD002
         return self._select_results(result, agg_exprs)
 
     def _select_results(
@@ -228,9 +231,6 @@ class PandasLikeGroupBy(
 
         See `ParseKeysGroupBy`.
         """
-        # NOTE: Keep `inplace=True` to avoid making a redundant copy.
-        # This may need updating, depending on https://github.com/pandas-dev/pandas/pull/51466/files
-        df.reset_index(inplace=True)  # noqa: PD002
         new_names = chain.from_iterable(e.aliases for e in agg_exprs)
         return (
             self.compliant._with_native(df, validate_column_names=False)

--- a/tests/frame/group_by_test.py
+++ b/tests/frame/group_by_test.py
@@ -604,7 +604,7 @@ def test_group_by_no_preserve_dtype(
     if (
         "polars" in str(constructor_eager)
         and isinstance(low, Decimal)
-        and POLARS_VERSION < (1, 0, 0)
+        and POLARS_VERSION < (1, 21, 0)
     ):
         pytest.skip("Decimal support in group_by for polars didn't stabilize until 1.0.0")
     data = {


### PR DESCRIPTION
i'm not super-keen on how `_select_results` has side-effects

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
