### PR TITLE
tests: fix polars regex in `with_columns`, `filter` and `select` tests

### DIFF
--- a/tests/frame/filter_test.py
+++ b/tests/frame/filter_test.py
@@ -77,7 +77,7 @@ def test_filter_missing_column(
     df = nw.from_native(constructor(data))
 
     if "polars" in str(constructor):
-        msg = r"^unable to find column \"c\"; valid columns: \[\"a\", \"b\"\]"
+        msg = r"unable to find column \"c\"; valid columns: \[\"a\", \"b\"\]"
     elif any(id_ == constructor_id for id_ in ("duckdb", "pyspark")):
         msg = r"\n\nHint: Did you mean one of these columns: \['a', 'b'\]?"
     else:

--- a/tests/frame/select_test.py
+++ b/tests/frame/select_test.py
@@ -100,7 +100,7 @@ def test_missing_columns(
         # and we have no way to recover exactly which columns the user
         # tried selecting. So, we just emit their message (which varies
         # across versions...)
-        msg = r"^e"
+        msg = r"e"
     elif constructor_id == "pyspark[connect]":  # pragma: no cover
         msg = r"^\[UNRESOLVED_COLUMN.WITH_SUGGESTION\]"
     elif any(id_ == constructor_id for id_ in ("duckdb", "pyspark")):
@@ -116,7 +116,7 @@ def test_missing_columns(
 
     # for the next two cases the error message is different in Polars
     if constructor_id == "polars[lazy]":
-        msg = r"^fdfa"
+        msg = r"fdfa"
     elif constructor_id == "polars[eager]":
         msg = r"\n\nHint: Did you mean one of these columns: \['a', 'b', 'z'\]?"
     with pytest.raises(ColumnNotFoundError, match=msg):

--- a/tests/frame/with_columns_test.py
+++ b/tests/frame/with_columns_test.py
@@ -97,7 +97,7 @@ def test_with_columns_missing_column(
     df = nw.from_native(constructor(data))
 
     if "polars" in str(constructor):
-        msg = r"^c"
+        msg = r"c"
     elif any(id_ == constructor_id for id_ in ("duckdb", "pyspark")):
         msg = r"\n\nHint: Did you mean one of these columns: \['a', 'b'\]?"
     elif constructor_id == "pyspark[connect]":  # pragma: no cover


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related comment https://github.com/narwhals-dev/narwhals/pull/2493#issuecomment-3083322667 (thanks @dangotbanned )

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

The regex is a bit too strict and makes the test fail for `polars==0.20.22` in the random version workflow 