### PR TITLE
fix: `scatter` was raising unnecessarily for pyarrow

### DIFF
--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -467,9 +467,7 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
         # - Missing `replacements` type
         # - Missing return type
         pc_replace_with_mask: Incomplete = pc.replace_with_mask
-        return self._with_native(
-            pc_replace_with_mask(self.native, mask, values_native.take(indices_native))
-        )
+        return self._with_native(pc_replace_with_mask(self.native, mask, values_native))
 
     def to_list(self) -> list[Any]:
         return self.native.to_pylist()

--- a/tests/series_only/scatter_test.py
+++ b/tests/series_only/scatter_test.py
@@ -61,3 +61,19 @@ def test_scatter_unordered_indices(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data))
     result = df["a"].scatter(indices, df["a"])
     assert_equal_data({"a": result}, {"a": [10, 12, 5, 6, 2, 9, 16]})
+
+
+def test_scatter_2862(constructor_eager: ConstructorEager) -> None:
+    df = nw.from_native(
+        constructor_eager({"a": [1, 2, 3], "b": [142, 124, 132]}), eager_only=True
+    )
+    ser = df["a"]
+    result = ser.scatter(1, 999)
+    expected = {"a": [1, 999, 3]}
+    assert_equal_data({"a": result}, expected)
+    result = ser.scatter([0, 2], [999, 888])
+    expected = {"a": [999, 2, 888]}
+    assert_equal_data({"a": result}, expected)
+    result = ser.scatter([2, 0], [999, 888])
+    expected = {"a": [888, 2, 999]}
+    assert_equal_data({"a": result}, expected)


### PR DESCRIPTION
closes #2862

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
