### PR TITLE
chore: factor out exp() from SparkLike, DuckDB, and Ibis

### DIFF
--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -390,8 +390,6 @@ class DuckDBExpr(SQLExpr["DuckDBLazyFrame", "Expression"]):
 
         return self._with_elementwise(_log)
 
-        return self._with_elementwise(_exp)
-
     def sqrt(self) -> Self:
         def _sqrt(expr: Expression) -> Expression:
             return when(expr < lit(0), lit(float("nan"))).otherwise(F("sqrt", expr))

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -390,9 +390,9 @@ class DuckDBExpr(SQLExpr["DuckDBLazyFrame", "Expression"]):
 
         return self._with_elementwise(_log)
 
-    def exp(self) -> Self:
-        def _exp(expr: Expression) -> Expression:
-            return F("exp", expr)
+    # def exp(self) -> Self:
+    #     def _exp(expr: Expression) -> Expression:
+    #         return F("exp", expr)
 
         return self._with_elementwise(_exp)
 

--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -390,10 +390,6 @@ class DuckDBExpr(SQLExpr["DuckDBLazyFrame", "Expression"]):
 
         return self._with_elementwise(_log)
 
-    # def exp(self) -> Self:
-    #     def _exp(expr: Expression) -> Expression:
-    #         return F("exp", expr)
-
         return self._with_elementwise(_exp)
 
     def sqrt(self) -> Self:

--- a/narwhals/_ibis/expr.py
+++ b/narwhals/_ibis/expr.py
@@ -361,11 +361,11 @@ class IbisExpr(SQLExpr["IbisLazyFrame", "ir.Value"]):
 
         return self._with_callable(_log)
 
-    def exp(self) -> Self:
-        def _exp(expr: ir.NumericColumn) -> ir.Value:
-            return expr.exp()
+    # def exp(self) -> Self:
+    #     def _exp(expr: ir.NumericColumn) -> ir.Value:
+    #         return expr.exp()
 
-        return self._with_callable(_exp)
+    #     return self._with_callable(_exp)
 
     def sqrt(self) -> Self:
         def _sqrt(expr: ir.NumericColumn) -> ir.Value:

--- a/narwhals/_ibis/expr.py
+++ b/narwhals/_ibis/expr.py
@@ -361,12 +361,6 @@ class IbisExpr(SQLExpr["IbisLazyFrame", "ir.Value"]):
 
         return self._with_callable(_log)
 
-    # def exp(self) -> Self:
-    #     def _exp(expr: ir.NumericColumn) -> ir.Value:
-    #         return expr.exp()
-
-    #     return self._with_callable(_exp)
-
     def sqrt(self) -> Self:
         def _sqrt(expr: ir.NumericColumn) -> ir.Value:
             return ibis.cases((expr < lit(0), lit(float("nan"))), else_=expr.sqrt())

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -491,9 +491,9 @@ class SparkLikeExpr(SQLExpr["SparkLikeLazyFrame", "Column"]):
 
         return self._with_elementwise(_log)
 
-    def exp(self) -> Self:
-        def _exp(expr: Column) -> Column:
-            return self._F.exp(expr)
+    # def exp(self) -> Self:
+    #     def _exp(expr: Column) -> Column:
+    #         return self._F.exp(expr)
 
         return self._with_elementwise(_exp)
 

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -491,12 +491,6 @@ class SparkLikeExpr(SQLExpr["SparkLikeLazyFrame", "Column"]):
 
         return self._with_elementwise(_log)
 
-    # def exp(self) -> Self:
-    #     def _exp(expr: Column) -> Column:
-    #         return self._F.exp(expr)
-
-        return self._with_elementwise(_exp)
-
     def sqrt(self) -> Self:
         def _sqrt(expr: Column) -> Column:
             return self._F.when(expr < 0, self._F.lit(float("nan"))).otherwise(

--- a/narwhals/_sql/expr.py
+++ b/narwhals/_sql/expr.py
@@ -386,7 +386,7 @@ class SQLExpr(
             lambda expr: self._function("round", expr, self._lit(decimals))
         )
 
-    def exp(self):
+    def exp(self) -> Self:
         return self._with_elementwise(lambda expr: self._function("exp", expr))
 
     # Cumulative

--- a/narwhals/_sql/expr.py
+++ b/narwhals/_sql/expr.py
@@ -385,7 +385,7 @@ class SQLExpr(
         return self._with_elementwise(
             lambda expr: self._function("round", expr, self._lit(decimals))
         )
-    
+
     def exp(self):
         return self._with_elementwise(lambda expr: self._function("exp", expr))
 

--- a/narwhals/_sql/expr.py
+++ b/narwhals/_sql/expr.py
@@ -385,6 +385,9 @@ class SQLExpr(
         return self._with_elementwise(
             lambda expr: self._function("round", expr, self._lit(decimals))
         )
+    
+    def exp(self):
+        return self._with_elementwise(lambda expr: self._function("exp", expr))
 
     # Cumulative
     def cum_sum(self, *, reverse: bool) -> Self:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Please let me know if I should additionally do some of the checklist. I ran tests with `pytest tests/expr_and_series/exp_test.py` and the whole suite with `pytest`, both passed for me. Thanks!
