### PR TITLE
ci: remove duplicated `pyright` step

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
+          activate-environment: true
           enable-cache: "true"
           cache-suffix: typing-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
@@ -30,19 +31,12 @@ jobs:
         run: uv venv .venv
       - name: install-reqs
         # TODO: add more dependencies/backends incrementally
-        run: |
-          source .venv/bin/activate
-          uv pip install -e ".[pyspark]" --group core --group typing
+        run: uv pip install -e ".[pyspark]" --group core --group typing
       - name: show-deps
-        run: |
-          source .venv/bin/activate
-          uv pip freeze
+        run: uv pip freeze
       - name: Run mypy and pyright
-        run: |
-          source .venv/bin/activate
-          make typing
+        run: make typing
       - name: Run pyright type completeness
         run: |
-          source .venv/bin/activate
           uv pip install -U pyright-cov
           pyright-cov --verifytypes narwhals --ignoreexternal --fail-under 100


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## If you have comments or can explain your changes, please do so below

I realised we are running `pyright` twice in CI.

`pyright` is already part of `make typing` :)

https://github.com/narwhals-dev/narwhals/blob/7f62eb0097e1aaba50ee433db6fde0d154e1e536/Makefile#L21-L25
