### PR TITLE
test: Modern Polars end-to-end tests

### DIFF
--- a/tests/modern_polars/pivot_test.py
+++ b/tests/modern_polars/pivot_test.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import datetime
 
 import pytest
 
@@ -17,9 +17,9 @@ def test_pivot(
 
     data = {
         "date": [
-            *[date(2020, 1, 2)] * 4,
-            *[date(2020, 1, 1)] * 4,
-            *[date(2020, 1, 3)] * 4,
+            *[datetime(2020, 1, 2)] * 4,
+            *[datetime(2020, 1, 1)] * 4,
+            *[datetime(2020, 1, 3)] * 4,
         ],
         "ticker": [*["AAPL", "TSLA", "MSFT", "NFLX"] * 3],
         "price": [100, 200, 300, 400, 110, 220, 330, 420, 105, 210, 315, 440],
@@ -29,7 +29,7 @@ def test_pivot(
     pivoted = df.pivot(index="date", values="price", on="ticker")
 
     expected = {
-        "date": [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)],
+        "date": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
         "AAPL": [110, 100, 105],
         "TSLA": [220, 200, 210],
         "MSFT": [330, 300, 315],

--- a/tests/modern_polars/pivot_test.py
+++ b/tests/modern_polars/pivot_test.py
@@ -5,9 +5,10 @@ from datetime import date
 import pytest
 
 import narwhals as nw
-from tests.utils import ConstructorEager, assert_equal_data
+from tests.utils import POLARS_VERSION, ConstructorEager, assert_equal_data
 
 
+@pytest.mark.skipif(POLARS_VERSION < (1, 0), reason="requires polars 1.0+")
 def test_pivot(
     constructor_eager: ConstructorEager, request: pytest.FixtureRequest
 ) -> None:

--- a/tests/modern_polars/unpivot_test.py
+++ b/tests/modern_polars/unpivot_test.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from contextlib import nullcontext as does_not_raise
+from datetime import date
+
+import pytest
+
+import narwhals as nw
+from tests.utils import PYARROW_VERSION, Constructor, assert_equal_data
+
+
+def test_unpivot(constructor: Constructor, request: pytest.FixtureRequest) -> None:
+    context = (  # a. sqlframe is expected to be case-insensitive?, b. dask dates are in string-format
+        pytest.raises(AssertionError)
+        if ("sqlframe" in str(constructor) or "dask" in str(constructor))
+        else does_not_raise()
+    )
+
+    with context:
+        if "cudf" in str(constructor) or (
+            "pyarrow_table" in str(constructor) and PYARROW_VERSION < (14, 0, 0)
+        ):
+            request.applymarker(pytest.mark.xfail)
+
+        data = {
+            "date": [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)],
+            "AAPL": [110, 100, 105],
+            "TSLA": [220, 200, 210],
+            "MSFT": [330, 300, 315],
+            "NFLX": [420, 400, 440],
+        }
+
+        df = nw.from_native(constructor(data))
+
+        result = df.unpivot(index="date", value_name="price").sort(
+            by=["date", "variable"]
+        )
+
+        expected = {
+            "date": [
+                *[date(2020, 1, 1)] * 4,
+                *[date(2020, 1, 2)] * 4,
+                *[date(2020, 1, 3)] * 4,
+            ],
+            "variable": [*["AAPL", "MSFT", "NFLX", "TSLA"] * 3],
+            "price": [110, 330, 420, 220, 100, 300, 400, 200, 105, 315, 440, 210],
+        }
+        assert_equal_data(result, expected)

--- a/tests/modern_polars/unpivot_test.py
+++ b/tests/modern_polars/unpivot_test.py
@@ -10,6 +10,11 @@ from tests.utils import PYARROW_VERSION, Constructor, assert_equal_data
 
 
 def test_unpivot(constructor: Constructor, request: pytest.FixtureRequest) -> None:
+    if "cudf" in str(constructor) or (
+        "pyarrow_table" in str(constructor) and PYARROW_VERSION < (13, 0, 0)
+    ):
+        request.applymarker(pytest.mark.xfail)
+
     context = (  # a. sqlframe is expected to be case-insensitive?, b. dask dates are in string-format
         pytest.raises(AssertionError)
         if ("sqlframe" in str(constructor) or "dask" in str(constructor))
@@ -17,11 +22,6 @@ def test_unpivot(constructor: Constructor, request: pytest.FixtureRequest) -> No
     )
 
     with context:
-        if "cudf" in str(constructor) or (
-            "pyarrow_table" in str(constructor) and PYARROW_VERSION < (14, 0, 0)
-        ):
-            request.applymarker(pytest.mark.xfail)
-
         data = {
             "date": [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)],
             "AAPL": [110, 100, 105],

--- a/tests/modern_polars/unpivot_test.py
+++ b/tests/modern_polars/unpivot_test.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from contextlib import nullcontext as does_not_raise
-from datetime import date
+from datetime import datetime
 
 import pytest
 
@@ -15,34 +14,25 @@ def test_unpivot(constructor: Constructor, request: pytest.FixtureRequest) -> No
     ):
         request.applymarker(pytest.mark.xfail)
 
-    context = (  # a. sqlframe is expected to be case-insensitive?, b. dask dates are in string-format
-        pytest.raises(AssertionError)
-        if ("sqlframe" in str(constructor) or "dask" in str(constructor))
-        else does_not_raise()
-    )
+    data = {
+        "date": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
+        "aapl": [110, 100, 105],
+        "tsla": [220, 200, 210],
+        "msft": [330, 300, 315],
+        "nflx": [420, 400, 440],
+    }
 
-    with context:
-        data = {
-            "date": [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)],
-            "AAPL": [110, 100, 105],
-            "TSLA": [220, 200, 210],
-            "MSFT": [330, 300, 315],
-            "NFLX": [420, 400, 440],
-        }
+    df = nw.from_native(constructor(data))
 
-        df = nw.from_native(constructor(data))
+    result = df.unpivot(index="date", value_name="price").sort(by=["date", "variable"])
 
-        result = df.unpivot(index="date", value_name="price").sort(
-            by=["date", "variable"]
-        )
-
-        expected = {
-            "date": [
-                *[date(2020, 1, 1)] * 4,
-                *[date(2020, 1, 2)] * 4,
-                *[date(2020, 1, 3)] * 4,
-            ],
-            "variable": [*["AAPL", "MSFT", "NFLX", "TSLA"] * 3],
-            "price": [110, 330, 420, 220, 100, 300, 400, 200, 105, 315, 440, 210],
-        }
-        assert_equal_data(result, expected)
+    expected = {
+        "date": [
+            *[datetime(2020, 1, 1)] * 4,
+            *[datetime(2020, 1, 2)] * 4,
+            *[datetime(2020, 1, 3)] * 4,
+        ],
+        "variable": [*["aapl", "msft", "nflx", "tsla"] * 3],
+        "price": [110, 330, 420, 220, 100, 300, 400, 200, 105, 315, 440, 210],
+    }
+    assert_equal_data(result, expected)


### PR DESCRIPTION
Continuing work that started in #2177 which appears to have been inactive for a long period of time. The original work addressed `pivot_test`, and I have picked it up to add more end-to-end tests from modern Polars (#1945 ). 

Co-authored-by @tylerriccio33 (contributor of #2177 )

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [X] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #1945 
- Closes #2177 ?

## Checklist

- [X] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes