### PR TITLE
Refactor descriptives

### DIFF
--- a/narwhals/_duckdb/expr.py
+++ b/narwhals/_duckdb/expr.py
@@ -178,9 +178,6 @@ class DuckDBExpr(SQLExpr["DuckDBLazyFrame", "Expression"]):
 
         return self._with_callable(func)
 
-    def kurtosis(self) -> Self:
-        return self._with_callable(lambda expr: F("kurtosis_pop", expr))
-
     def all(self) -> Self:
         def f(expr: Expression) -> Expression:
             return CoalesceOperator(F("bool_and", expr), lit(True))  # noqa: FBT003

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -428,9 +428,6 @@ class SparkLikeExpr(SQLExpr["SparkLikeLazyFrame", "Column"]):
 
         return self._with_callable(_len)
 
-    def skew(self) -> Self:
-        return self._with_callable(self._F.skewness)
-
     def n_unique(self) -> Self:
         def _n_unique(expr: Column) -> Column:
             return self._F.count_distinct(expr) + self._F.max(

--- a/narwhals/_spark_like/expr.py
+++ b/narwhals/_spark_like/expr.py
@@ -431,9 +431,6 @@ class SparkLikeExpr(SQLExpr["SparkLikeLazyFrame", "Column"]):
     def skew(self) -> Self:
         return self._with_callable(self._F.skewness)
 
-    def kurtosis(self) -> Self:
-        return self._with_callable(self._F.kurtosis)
-
     def n_unique(self) -> Self:
         def _n_unique(expr: Column) -> Column:
             return self._F.count_distinct(expr) + self._F.max(

--- a/narwhals/_sql/expr.py
+++ b/narwhals/_sql/expr.py
@@ -374,6 +374,9 @@ class SQLExpr(
     def min(self) -> Self:
         return self._with_callable(lambda expr: self._function("min", expr))
 
+    def kurtosis(self) -> Self:
+        return self._with_callable(lambda expr: self._function("kurtosis", expr))
+
     # Elementwise
     def abs(self) -> Self:
         return self._with_elementwise(lambda expr: self._function("abs", expr))

--- a/narwhals/_sql/expr.py
+++ b/narwhals/_sql/expr.py
@@ -377,6 +377,9 @@ class SQLExpr(
     def kurtosis(self) -> Self:
         return self._with_callable(lambda expr: self._function("kurtosis", expr))
 
+    def skew(self) -> Self:
+        return self._with_callable(lambda expr: self._function("skewness", expr))
+
     # Elementwise
     def abs(self) -> Self:
         return self._with_elementwise(lambda expr: self._function("abs", expr))


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

I didn't remove the `skew` function from the `DuckDBExpr` class as it has additional logic in it missing from the sparklike class, probably due to implementation differences in the two, I can see it gets the sample skew out. I'm assuming that the sparklike and sql implementations also return sample skew, but is this a dangerous assumption to make? Should I be checking for the population vs sample distinction for all the descriptives in future work?

