### PR TITLE
feat: Add `DataFrame.from_dict`

### DIFF
--- a/docs/api-reference/dataframe.md
+++ b/docs/api-reference/dataframe.md
@@ -14,6 +14,7 @@
         - estimated_size
         - explode
         - filter
+        - from_dict
         - gather_every
         - get_column
         - group_by

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -466,6 +466,45 @@ class DataFrame(BaseFrame[DataFrameT]):
         *,
         backend: ModuleType | Implementation | str | None = None,
     ) -> Self:
+        """Instantiate DataFrame from dictionary.
+
+        Indexes (if present, for pandas-like backends) are aligned following
+        the [left-hand-rule](../concepts/pandas_index.md/).
+
+        Notes:
+            For pandas-like dataframes, conversion to schema is applied after dataframe
+            creation.
+
+        Arguments:
+            data: Dictionary to create DataFrame from.
+            schema: The DataFrame schema as Schema or dict of {name: type}. If not
+                specified, the schema will be inferred by the native library.
+            backend: specifies which eager backend instantiate to. Only
+                necessary if inputs are not Narwhals Series.
+
+                `backend` can be specified in various ways
+
+                - As `Implementation.<BACKEND>` with `BACKEND` being `PANDAS`, `PYARROW`,
+                    `POLARS`, `MODIN` or `CUDF`.
+                - As a string: `"pandas"`, `"pyarrow"`, `"polars"`, `"modin"` or `"cudf"`.
+                - Directly as a module `pandas`, `pyarrow`, `polars`, `modin` or `cudf`.
+
+        Returns:
+            A new DataFrame.
+
+        Examples:
+            >>> import pandas as pd
+            >>> import narwhals as nw
+            >>> data = {"c": [5, 2], "d": [1, 4]}
+            >>> nw.DataFrame.from_dict(data, backend="pandas")
+            ┌──────────────────┐
+            |Narwhals DataFrame|
+            |------------------|
+            |        c  d      |
+            |     0  5  1      |
+            |     1  2  4      |
+            └──────────────────┘
+        """
         if backend is None:
             data, backend = _from_dict_no_backend(data)
         implementation = Implementation.from_backend(backend)

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -465,7 +465,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         schema: Mapping[str, DType] | Schema | None = None,
         *,
         backend: ModuleType | Implementation | str | None = None,
-    ) -> Self:
+    ) -> DataFrame[Any]:
         """Instantiate DataFrame from dictionary.
 
         Indexes (if present, for pandas-like backends) are aligned following

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -106,6 +106,17 @@ class DataFrame(NwDataFrame[IntoDataFrameT]):
     # We need to override any method which don't return Self so that type
     # annotations are correct.
 
+    @classmethod
+    def from_dict(
+        cls,
+        data: Mapping[str, Any],
+        schema: Mapping[str, DType] | Schema | None = None,
+        *,
+        backend: ModuleType | Implementation | str | None = None,
+    ) -> DataFrame[Any]:
+        result = super().from_dict(data, schema, backend=backend)
+        return cast("DataFrame[Any]", result)
+
     @property
     def _series(self) -> type[Series[Any]]:
         return cast("type[Series[Any]]", Series)

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -96,6 +96,8 @@ IntoSeriesT = TypeVar("IntoSeriesT", bound="IntoSeries", default=Any)
 
 
 class DataFrame(NwDataFrame[IntoDataFrameT]):
+    _version = Version.V1
+
     @inherit_doc(NwDataFrame)
     def __init__(self, df: Any, *, level: Literal["full", "lazy", "interchange"]) -> None:
         assert df._version is Version.V1  # noqa: S101

--- a/tests/frame/from_dict_test.py
+++ b/tests/frame/from_dict_test.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import narwhals as nw
+from narwhals._utils import Implementation
+from tests.utils import Constructor, assert_equal_data
+
+if TYPE_CHECKING:
+    from narwhals._namespace import EagerAllowed
+
+
+def test_from_dict(eager_backend: EagerAllowed) -> None:
+    result = nw.DataFrame.from_dict({"c": [1, 2], "d": [5, 6]}, backend=eager_backend)
+    expected = {"c": [1, 2], "d": [5, 6]}
+    assert_equal_data(result, expected)
+    assert isinstance(result, nw.DataFrame)
+
+
+def test_from_dict_schema(eager_backend: EagerAllowed) -> None:
+    schema = {"c": nw.Int16(), "d": nw.Float32()}
+    result = nw.DataFrame.from_dict(
+        {"c": [1, 2], "d": [5, 6]}, backend=eager_backend, schema=schema
+    )
+    assert result.collect_schema() == schema
+
+
+@pytest.mark.parametrize("backend", [Implementation.POLARS, "polars"])
+def test_from_dict_without_backend(
+    constructor: Constructor, backend: EagerAllowed
+) -> None:
+    pytest.importorskip("polars")
+
+    df = (
+        nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]}))
+        .lazy()
+        .collect(backend=backend)
+    )
+    result = nw.DataFrame.from_dict({"c": df["a"], "d": df["b"]})
+    assert_equal_data(result, {"c": [1, 2, 3], "d": [4, 5, 6]})
+
+
+def test_from_dict_without_backend_invalid(constructor: Constructor) -> None:
+    df = nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]})).lazy().collect()
+    with pytest.raises(TypeError, match="backend"):
+        nw.DataFrame.from_dict({"c": nw.to_native(df["a"]), "d": nw.to_native(df["b"])})
+
+
+def test_from_dict_with_backend_invalid() -> None:
+    pytest.importorskip("duckdb")
+    with pytest.raises(ValueError, match="lazy-only"):
+        nw.DataFrame.from_dict({"c": [1, 2], "d": [5, 6]}, backend="duckdb")
+
+
+@pytest.mark.parametrize("backend", [Implementation.POLARS, "polars"])
+def test_from_dict_one_native_one_narwhals(
+    constructor: Constructor, backend: EagerAllowed
+) -> None:
+    pytest.importorskip("polars")
+
+    df = (
+        nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]}))
+        .lazy()
+        .collect(backend=backend)
+    )
+    result = nw.DataFrame.from_dict({"c": nw.to_native(df["a"]), "d": df["b"]})
+    expected = {"c": [1, 2, 3], "d": [4, 5, 6]}
+    assert_equal_data(result, expected)
+
+
+def test_from_dict_empty(eager_backend: EagerAllowed) -> None:
+    result = nw.DataFrame.from_dict({}, backend=eager_backend)
+    assert result.shape == (0, 0)
+
+
+def test_from_dict_empty_with_schema(eager_backend: EagerAllowed) -> None:
+    schema = nw.Schema({"a": nw.String(), "b": nw.Int8()})
+    result = nw.DataFrame.from_dict({}, schema, backend=eager_backend)
+    assert result.schema == schema
+
+
+def test_alignment() -> None:
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    # https://github.com/narwhals-dev/narwhals/issues/1474
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    result = nw.DataFrame.from_dict(
+        {"a": df["a"], "b": df["a"].sort_values(ascending=False)}, backend=pd
+    ).to_native()
+    expected = pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]})
+    pd.testing.assert_frame_equal(result, expected)

--- a/tests/frame/from_dict_test.py
+++ b/tests/frame/from_dict_test.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 def test_from_dict(eager_backend: EagerAllowed) -> None:
-    result = nw.DataFrame.from_dict({"c": [1, 2], "d": [5, 6]}, backend=eager_backend)
+    result = nw.DataFrame.from_dict({"c": [1, 2], "d": [5, 6]}, backend=eager_backend)  # type: ignore[var-annotated]
     expected = {"c": [1, 2], "d": [5, 6]}
     assert_equal_data(result, expected)
     assert isinstance(result, nw.DataFrame)
@@ -21,7 +21,7 @@ def test_from_dict(eager_backend: EagerAllowed) -> None:
 
 def test_from_dict_schema(eager_backend: EagerAllowed) -> None:
     schema = {"c": nw.Int16(), "d": nw.Float32()}
-    result = nw.DataFrame.from_dict(
+    result = nw.DataFrame.from_dict(  # type: ignore[var-annotated]
         {"c": [1, 2], "d": [5, 6]}, backend=eager_backend, schema=schema
     )
     assert result.collect_schema() == schema
@@ -38,7 +38,7 @@ def test_from_dict_without_backend(
         .lazy()
         .collect(backend=backend)
     )
-    result = nw.DataFrame.from_dict({"c": df["a"], "d": df["b"]})
+    result = nw.DataFrame.from_dict({"c": df["a"], "d": df["b"]})  # type: ignore[var-annotated]
     assert_equal_data(result, {"c": [1, 2, 3], "d": [4, 5, 6]})
 
 
@@ -65,19 +65,19 @@ def test_from_dict_one_native_one_narwhals(
         .lazy()
         .collect(backend=backend)
     )
-    result = nw.DataFrame.from_dict({"c": nw.to_native(df["a"]), "d": df["b"]})
+    result = nw.DataFrame.from_dict({"c": nw.to_native(df["a"]), "d": df["b"]})  # type: ignore[var-annotated]
     expected = {"c": [1, 2, 3], "d": [4, 5, 6]}
     assert_equal_data(result, expected)
 
 
 def test_from_dict_empty(eager_backend: EagerAllowed) -> None:
-    result = nw.DataFrame.from_dict({}, backend=eager_backend)
+    result = nw.DataFrame.from_dict({}, backend=eager_backend)  # type: ignore[var-annotated]
     assert result.shape == (0, 0)
 
 
 def test_from_dict_empty_with_schema(eager_backend: EagerAllowed) -> None:
     schema = nw.Schema({"a": nw.String(), "b": nw.Int8()})
-    result = nw.DataFrame.from_dict({}, schema, backend=eager_backend)
+    result = nw.DataFrame.from_dict({}, schema, backend=eager_backend)  # type: ignore[var-annotated]
     assert result.schema == schema
 
 
@@ -87,7 +87,7 @@ def test_alignment() -> None:
 
     # https://github.com/narwhals-dev/narwhals/issues/1474
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    result = nw.DataFrame.from_dict(
+    result = nw.DataFrame.from_dict(  # type: ignore[var-annotated]
         {"a": df["a"], "b": df["a"].sort_values(ascending=False)}, backend=pd
     ).to_native()
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]})

--- a/tests/frame/from_dict_test.py
+++ b/tests/frame/from_dict_test.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 def test_from_dict(eager_backend: EagerAllowed) -> None:
-    result = nw.DataFrame.from_dict({"c": [1, 2], "d": [5, 6]}, backend=eager_backend)  # type: ignore[var-annotated]
+    result = nw.DataFrame.from_dict({"c": [1, 2], "d": [5, 6]}, backend=eager_backend)
     expected = {"c": [1, 2], "d": [5, 6]}
     assert_equal_data(result, expected)
     assert isinstance(result, nw.DataFrame)
@@ -21,7 +21,7 @@ def test_from_dict(eager_backend: EagerAllowed) -> None:
 
 def test_from_dict_schema(eager_backend: EagerAllowed) -> None:
     schema = {"c": nw.Int16(), "d": nw.Float32()}
-    result = nw.DataFrame.from_dict(  # type: ignore[var-annotated]
+    result = nw.DataFrame.from_dict(
         {"c": [1, 2], "d": [5, 6]}, backend=eager_backend, schema=schema
     )
     assert result.collect_schema() == schema
@@ -38,7 +38,7 @@ def test_from_dict_without_backend(
         .lazy()
         .collect(backend=backend)
     )
-    result = nw.DataFrame.from_dict({"c": df["a"], "d": df["b"]})  # type: ignore[var-annotated]
+    result = nw.DataFrame.from_dict({"c": df["a"], "d": df["b"]})
     assert_equal_data(result, {"c": [1, 2, 3], "d": [4, 5, 6]})
 
 
@@ -65,19 +65,19 @@ def test_from_dict_one_native_one_narwhals(
         .lazy()
         .collect(backend=backend)
     )
-    result = nw.DataFrame.from_dict({"c": nw.to_native(df["a"]), "d": df["b"]})  # type: ignore[var-annotated]
+    result = nw.DataFrame.from_dict({"c": nw.to_native(df["a"]), "d": df["b"]})
     expected = {"c": [1, 2, 3], "d": [4, 5, 6]}
     assert_equal_data(result, expected)
 
 
 def test_from_dict_empty(eager_backend: EagerAllowed) -> None:
-    result = nw.DataFrame.from_dict({}, backend=eager_backend)  # type: ignore[var-annotated]
+    result = nw.DataFrame.from_dict({}, backend=eager_backend)
     assert result.shape == (0, 0)
 
 
 def test_from_dict_empty_with_schema(eager_backend: EagerAllowed) -> None:
     schema = nw.Schema({"a": nw.String(), "b": nw.Int8()})
-    result = nw.DataFrame.from_dict({}, schema, backend=eager_backend)  # type: ignore[var-annotated]
+    result = nw.DataFrame.from_dict({}, schema, backend=eager_backend)
     assert result.schema == schema
 
 
@@ -87,7 +87,7 @@ def test_alignment() -> None:
 
     # https://github.com/narwhals-dev/narwhals/issues/1474
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    result = nw.DataFrame.from_dict(  # type: ignore[var-annotated]
+    result = nw.DataFrame.from_dict(
         {"a": df["a"], "b": df["a"].sort_values(ascending=False)}, backend=pd
     ).to_native()
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]})

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -35,6 +35,7 @@ from tests.utils import PANDAS_VERSION, Constructor, ConstructorEager, assert_eq
 if TYPE_CHECKING:
     from typing_extensions import assert_type
 
+    from narwhals._namespace import EagerAllowed
     from narwhals.typing import IntoDataFrameT
     from tests.utils import Constructor, ConstructorEager
 
@@ -975,3 +976,13 @@ def test_dask_order_dependent_ops() -> None:
         "i": [True, True, True],
     }
     assert_equal_data(result, expected)
+
+
+def test_dataframe_from_dict(eager_backend: EagerAllowed) -> None:
+    schema = {"c": nw_v1.Int16(), "d": nw_v1.Float32()}
+    result = nw_v1.DataFrame.from_dict(
+        {"c": [1, 2], "d": [5, 6]}, backend=eager_backend, schema=schema
+    )
+    assert result.collect_schema() == schema
+    assert result._version is Version.V1
+    assert isinstance(result, nw_v1.DataFrame)

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -570,7 +570,8 @@ def test_dataframe_recursive_v1() -> None:
 
     pl_frame = pl.DataFrame({"a": [1, 2, 3]})
     nw_frame = nw_v1.from_native(pl_frame)
-    with pytest.raises(AttributeError):
+    # NOTE: (#2629) combined with passing in `nw_v1.DataFrame` (w/ a `_version`) into itself changes the error
+    with pytest.raises(AssertionError):
         nw_v1.DataFrame(nw_frame, level="full")
 
     nw_frame_early_return = nw_v1.from_native(nw_frame)

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -8,6 +8,7 @@ import sys
 from collections import deque
 from inspect import isfunction
 from pathlib import Path
+from types import MethodType
 from typing import TYPE_CHECKING, Any
 
 import polars as pl
@@ -22,15 +23,16 @@ LOWERCASE = tuple(string.ascii_lowercase)
 if sys.version_info >= (3, 13):
 
     def _is_public_method_or_property(obj: Any) -> bool:
-        return (isfunction(obj) or isinstance(obj, property)) and obj.__name__.startswith(
-            LOWERCASE
-        )
+        return (
+            isfunction(obj) or isinstance(obj, (MethodType, property))
+        ) and obj.__name__.startswith(LOWERCASE)
 else:
 
     def _is_public_method_or_property(obj: Any) -> bool:
-        return (isfunction(obj) and obj.__name__.startswith(LOWERCASE)) or (
-            isinstance(obj, property) and obj.fget.__name__.startswith(LOWERCASE)
-        )
+        return (
+            (isfunction(obj) or isinstance(obj, MethodType))
+            and obj.__name__.startswith(LOWERCASE)
+        ) or (isinstance(obj, property) and obj.fget.__name__.startswith(LOWERCASE))
 
 
 def iter_api_reference_names(tp: type[Any]) -> Iterator[str]:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Part of #2116

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below
- [x] Resolve `[var-annotated]` by not using `Self` (https://github.com/narwhals-dev/narwhals/pull/2885/commits/695f9ac4850e56639aa96fe5ae3a67234621e31f)


## Possible Follow-ups
- Figure out how (#2786) fits in
- Add `@overload`s on `backend`
  - Like in `Namespace`
- Defer to `DataFrame.from_dict` in `nw.from_dict`