### PR TITLE
fix: `.clip` should not treat 0 and None as same

### DIFF
--- a/narwhals/_arrow/series.py
+++ b/narwhals/_arrow/series.py
@@ -831,8 +831,12 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
         lower_bound: Self | NumericLiteral | TemporalLiteral | None,
         upper_bound: Self | NumericLiteral | TemporalLiteral | None,
     ) -> Self:
-        _, lower = extract_native(self, lower_bound) if lower_bound else (None, None)
-        _, upper = extract_native(self, upper_bound) if upper_bound else (None, None)
+        _, lower = (
+            extract_native(self, lower_bound) if lower_bound is not None else (None, None)
+        )
+        _, upper = (
+            extract_native(self, upper_bound) if upper_bound is not None else (None, None)
+        )
 
         if lower is None:
             return self._with_native(pc.min_element_wise(self.native, upper))

--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -816,10 +816,14 @@ class PandasLikeSeries(EagerSeries[Any]):
         upper_bound: Self | NumericLiteral | TemporalLiteral | None,
     ) -> Self:
         _, lower = (
-            align_and_extract_native(self, lower_bound) if lower_bound else (None, None)
+            align_and_extract_native(self, lower_bound)
+            if lower_bound is not None
+            else (None, None)
         )
         _, upper = (
-            align_and_extract_native(self, upper_bound) if upper_bound else (None, None)
+            align_and_extract_native(self, upper_bound)
+            if upper_bound is not None
+            else (None, None)
         )
         kwargs = {"axis": 0} if self._implementation is Implementation.MODIN else {}
         return self._with_native(self.native.clip(lower, upper, **kwargs))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

Spotted while narwhalifying great-tables

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
