### PR TITLE
feat!: Allow for chaining `.name` expressions, aligning with Polars' new aliasing behaviour

### DIFF
--- a/narwhals/_compliant/expr.py
+++ b/narwhals/_compliant/expr.py
@@ -1097,9 +1097,7 @@ class CompliantExprNameNamespace(  # type: ignore[misc]
 
         return fn
 
-    def _from_callable(
-        self, func: AliasName | None, /, *, alias: bool = True
-    ) -> CompliantExprT_co: ...
+    def _from_callable(self, func: AliasName | None, /) -> CompliantExprT_co: ...
 
 
 class EagerExprNameNamespace(

--- a/narwhals/_compliant/expr.py
+++ b/narwhals/_compliant/expr.py
@@ -939,7 +939,7 @@ class LazyExpr(  # type: ignore[misc]
     CompliantExpr[CompliantLazyFrameT, NativeExprT],
     Protocol[CompliantLazyFrameT, NativeExprT],
 ):
-    def _with_alias_output_names(self, func: AliasNames, /) -> Self: ...
+    def _with_alias_output_names(self, func: AliasNames | None, /) -> Self: ...
     def alias(self, name: str) -> Self:
         def fn(names: Sequence[str]) -> Sequence[str]:
             if len(names) != 1:
@@ -1073,7 +1073,7 @@ class CompliantExprNameNamespace(  # type: ignore[misc]
     Protocol[CompliantExprT_co],
 ):
     def keep(self) -> CompliantExprT_co:
-        return self._from_callable(lambda name: name, alias=False)
+        return self._from_callable(None)
 
     def map(self, function: AliasName) -> CompliantExprT_co:
         return self._from_callable(function)
@@ -1098,7 +1098,7 @@ class CompliantExprNameNamespace(  # type: ignore[misc]
         return fn
 
     def _from_callable(
-        self, func: AliasName, /, *, alias: bool = True
+        self, func: AliasName | None, /, *, alias: bool = True
     ) -> CompliantExprT_co: ...
 
 
@@ -1107,7 +1107,7 @@ class EagerExprNameNamespace(
     CompliantExprNameNamespace[EagerExprT],
     Generic[EagerExprT],
 ):
-    def _from_callable(self, func: AliasName, /, *, alias: bool = True) -> EagerExprT:
+    def _from_callable(self, func: AliasName) -> EagerExprT:
         expr = self.compliant
         return expr._with_alias_output_names(func)
 
@@ -1117,9 +1117,9 @@ class LazyExprNameNamespace(
     CompliantExprNameNamespace[LazyExprT],
     Generic[LazyExprT],
 ):
-    def _from_callable(self, func: AliasName, /, *, alias: bool = True) -> LazyExprT:
+    def _from_callable(self, func: AliasName | None) -> LazyExprT:
         expr = self.compliant
-        output_names = self._alias_output_names(func) if alias else None
+        output_names = self._alias_output_names(func) if func else None
         return expr._with_alias_output_names(output_names)
 
 

--- a/narwhals/_compliant/expr.py
+++ b/narwhals/_compliant/expr.py
@@ -1105,7 +1105,7 @@ class EagerExprNameNamespace(
     CompliantExprNameNamespace[EagerExprT],
     Generic[EagerExprT],
 ):
-    def _from_callable(self, func: AliasName) -> EagerExprT:
+    def _from_callable(self, func: AliasName | None) -> EagerExprT:
         expr = self.compliant
         return expr._with_alias_output_names(func)
 

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -168,12 +168,20 @@ class DaskExpr(
         )
 
     def _with_alias_output_names(self, func: AliasNames | None, /) -> Self:
+        current_alias_output_names = self._alias_output_names
+        alias_output_names = (
+            None
+            if func is None
+            else func
+            if current_alias_output_names is None
+            else lambda output_names: func(current_alias_output_names(output_names))
+        )
         return type(self)(
             call=self._call,
             depth=self._depth,
             function_name=self._function_name,
             evaluate_output_names=self._evaluate_output_names,
-            alias_output_names=func,
+            alias_output_names=alias_output_names,
             version=self._version,
             scalar_kwargs=self._scalar_kwargs,
         )

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -167,7 +167,7 @@ class DaskExpr(
             scalar_kwargs=scalar_kwargs,
         )
 
-    def _with_alias_output_names(self, func: AliasNames | None, /) -> Self:
+    def _with_alias_output_names(self, func: AliasNames, /) -> Self:
         return type(self)(
             call=self._call,
             depth=self._depth,

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -167,7 +167,7 @@ class DaskExpr(
             scalar_kwargs=scalar_kwargs,
         )
 
-    def _with_alias_output_names(self, func: AliasNames, /) -> Self:
+    def _with_alias_output_names(self, func: AliasNames | None, /) -> Self:
         return type(self)(
             call=self._call,
             depth=self._depth,

--- a/narwhals/_sql/expr.py
+++ b/narwhals/_sql/expr.py
@@ -145,10 +145,13 @@ class SQLExpr(LazyExpr[SQLLazyFrameT, NativeExprT], Protocol[SQLLazyFrameT, Nati
         )
 
     def _with_alias_output_names(self, func: AliasNames | None, /) -> Self:
+        current_alias_output_names = self._alias_output_names
         alias_output_names = (
-            func
-            if self._alias_output_names is None
-            else lambda output_names: func(self._alias_output_names(output_names))
+            None
+            if func is None
+            else func
+            if current_alias_output_names is None
+            else lambda output_names: func(current_alias_output_names(output_names))
         )
         return type(self)(
             self._call,

--- a/narwhals/_sql/expr.py
+++ b/narwhals/_sql/expr.py
@@ -145,11 +145,16 @@ class SQLExpr(LazyExpr[SQLLazyFrameT, NativeExprT], Protocol[SQLLazyFrameT, Nati
         )
 
     def _with_alias_output_names(self, func: AliasNames | None, /) -> Self:
+        alias_output_names = (
+            func
+            if self._alias_output_names is None
+            else lambda output_names: func(self._alias_output_names(output_names))
+        )
         return type(self)(
             self._call,
             self._window_function,
             evaluate_output_names=self._evaluate_output_names,
-            alias_output_names=func,
+            alias_output_names=alias_output_names,
             version=self._version,
             implementation=self._implementation,
         )

--- a/narwhals/expr_name.py
+++ b/narwhals/expr_name.py
@@ -19,9 +19,7 @@ class ExprNameNamespace(Generic[ExprT]):
             A new expression.
 
         Notes:
-            This will undo any previous renaming operations on the expression.
-            Due to implementation constraints, this method can only be called as the last
-            expression in a chain. Only one name operation per expression will work.
+            For Polars versions prior to 1.32, this will undo any previous renaming operations on the expression.
 
         Examples:
             >>> import pandas as pd
@@ -45,9 +43,7 @@ class ExprNameNamespace(Generic[ExprT]):
             A new expression.
 
         Notes:
-            This will undo any previous renaming operations on the expression.
-            Due to implementation constraints, this method can only be called as the last
-            expression in a chain. Only one name operation per expression will work.
+            For Polars versions prior to 1.32, this will undo any previous renaming operations on the expression.
 
         Examples:
             >>> import pandas as pd
@@ -72,9 +68,7 @@ class ExprNameNamespace(Generic[ExprT]):
             A new expression.
 
         Notes:
-            This will undo any previous renaming operations on the expression.
-            Due to implementation constraints, this method can only be called as the last
-            expression in a chain. Only one name operation per expression will work.
+            For Polars versions prior to 1.32, this will undo any previous renaming operations on the expression.
 
         Examples:
             >>> import polars as pl
@@ -98,9 +92,7 @@ class ExprNameNamespace(Generic[ExprT]):
             A new expression.
 
         Notes:
-            This will undo any previous renaming operations on the expression.
-            Due to implementation constraints, this method can only be called as the last
-            expression in a chain. Only one name operation per expression will work.
+            For Polars versions prior to 1.32, this will undo any previous renaming operations on the expression.
 
         Examples:
             >>> import polars as pl
@@ -121,9 +113,7 @@ class ExprNameNamespace(Generic[ExprT]):
             A new expression.
 
         Notes:
-            This will undo any previous renaming operations on the expression.
-            Due to implementation constraints, this method can only be called as the last
-            expression in a chain. Only one name operation per expression will work.
+            For Polars versions prior to 1.32, this will undo any previous renaming operations on the expression.
 
         Examples:
             >>> import pyarrow as pa
@@ -144,9 +134,7 @@ class ExprNameNamespace(Generic[ExprT]):
             A new expression.
 
         Notes:
-            This will undo any previous renaming operations on the expression.
-            Due to implementation constraints, this method can only be called as the last
-            expression in a chain. Only one name operation per expression will work.
+            For Polars versions prior to 1.32, this will undo any previous renaming operations on the expression.
 
         Examples:
             >>> import pyarrow as pa

--- a/tests/expr_and_series/name/map_test.py
+++ b/tests/expr_and_series/name/map_test.py
@@ -20,7 +20,7 @@ def test_map(constructor: Constructor) -> None:
 def test_map_after_alias(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.map(function=map_func))
-    expected = {"oof": data["foo"]}
+    expected = {"oof_rof_saila": data["foo"]}
     assert_equal_data(result, expected)
 
 

--- a/tests/expr_and_series/name/map_test.py
+++ b/tests/expr_and_series/name/map_test.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 import narwhals as nw
-from tests.utils import Constructor, assert_equal_data
+from tests.utils import POLARS_VERSION, Constructor, assert_equal_data
 
 data = {"foo": [1, 2, 3], "BAR": [4, 5, 6]}
 
@@ -18,6 +20,8 @@ def test_map(constructor: Constructor) -> None:
 
 
 def test_map_after_alias(constructor: Constructor) -> None:
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 32):
+        pytest.skip(reason="https://github.com/pola-rs/polars/issues/23765")
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.map(function=map_func))
     expected = {"oof_rof_saila": data["foo"]}

--- a/tests/expr_and_series/name/prefix_test.py
+++ b/tests/expr_and_series/name/prefix_test.py
@@ -17,7 +17,7 @@ def test_prefix(constructor: Constructor) -> None:
 def test_suffix_after_alias(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.prefix(prefix))
-    expected = {"with_prefix_foo": [1, 2, 3]}
+    expected = {"with_prefix_alias_for_foo": [1, 2, 3]}
     assert_equal_data(result, expected)
 
 

--- a/tests/expr_and_series/name/prefix_test.py
+++ b/tests/expr_and_series/name/prefix_test.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 import narwhals as nw
-from tests.utils import Constructor, assert_equal_data
+from tests.utils import POLARS_VERSION, Constructor, assert_equal_data
 
 data = {"foo": [1, 2, 3], "BAR": [4, 5, 6]}
 prefix = "with_prefix_"
@@ -15,6 +17,8 @@ def test_prefix(constructor: Constructor) -> None:
 
 
 def test_suffix_after_alias(constructor: Constructor) -> None:
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 32):
+        pytest.skip(reason="https://github.com/pola-rs/polars/issues/23765")
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.prefix(prefix))
     expected = {"with_prefix_alias_for_foo": [1, 2, 3]}

--- a/tests/expr_and_series/name/suffix_test.py
+++ b/tests/expr_and_series/name/suffix_test.py
@@ -17,7 +17,7 @@ def test_suffix(constructor: Constructor) -> None:
 def test_suffix_after_alias(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.suffix(suffix))
-    expected = {"foo_with_suffix": [1, 2, 3]}
+    expected = {"alias_for_foo_with_suffix": [1, 2, 3]}
     assert_equal_data(result, expected)
 
 

--- a/tests/expr_and_series/name/suffix_test.py
+++ b/tests/expr_and_series/name/suffix_test.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 import narwhals as nw
-from tests.utils import Constructor, assert_equal_data
+from tests.utils import POLARS_VERSION, Constructor, assert_equal_data
 
 data = {"foo": [1, 2, 3], "BAR": [4, 5, 6]}
 suffix = "_with_suffix"
@@ -15,6 +17,8 @@ def test_suffix(constructor: Constructor) -> None:
 
 
 def test_suffix_after_alias(constructor: Constructor) -> None:
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 32):
+        pytest.skip(reason="https://github.com/pola-rs/polars/issues/23765")
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.suffix(suffix))
     expected = {"alias_for_foo_with_suffix": [1, 2, 3]}

--- a/tests/expr_and_series/name/to_lowercase_test.py
+++ b/tests/expr_and_series/name/to_lowercase_test.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 import narwhals as nw
-from tests.utils import Constructor, assert_equal_data
+from tests.utils import POLARS_VERSION, Constructor, assert_equal_data
 
 data = {"foo": [1, 2, 3], "BAR": [4, 5, 6]}
 
@@ -14,6 +16,8 @@ def test_to_lowercase(constructor: Constructor) -> None:
 
 
 def test_to_lowercase_after_alias(constructor: Constructor) -> None:
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 32):
+        pytest.skip(reason="https://github.com/pola-rs/polars/issues/23765")
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("BAR")).alias("ALIAS_FOR_BAR").name.to_lowercase())
     expected = {"alias_for_bar": [4, 5, 6]}

--- a/tests/expr_and_series/name/to_lowercase_test.py
+++ b/tests/expr_and_series/name/to_lowercase_test.py
@@ -16,7 +16,7 @@ def test_to_lowercase(constructor: Constructor) -> None:
 def test_to_lowercase_after_alias(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("BAR")).alias("ALIAS_FOR_BAR").name.to_lowercase())
-    expected = {"bar": [4, 5, 6]}
+    expected = {"alias_for_bar": [4, 5, 6]}
     assert_equal_data(result, expected)
 
 

--- a/tests/expr_and_series/name/to_uppercase_test.py
+++ b/tests/expr_and_series/name/to_uppercase_test.py
@@ -16,7 +16,7 @@ def test_to_uppercase(constructor: Constructor) -> None:
 def test_to_uppercase_after_alias(constructor: Constructor) -> None:
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.to_uppercase())
-    expected = {"FOO": [1, 2, 3]}
+    expected = {"ALIAS_FOR_FOO": [1, 2, 3]}
     assert_equal_data(result, expected)
 
 

--- a/tests/expr_and_series/name/to_uppercase_test.py
+++ b/tests/expr_and_series/name/to_uppercase_test.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 import narwhals as nw
-from tests.utils import Constructor, assert_equal_data
+from tests.utils import POLARS_VERSION, Constructor, assert_equal_data
 
 data = {"foo": [1, 2, 3], "BAR": [4, 5, 6]}
 
@@ -14,6 +16,8 @@ def test_to_uppercase(constructor: Constructor) -> None:
 
 
 def test_to_uppercase_after_alias(constructor: Constructor) -> None:
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 32):
+        pytest.skip(reason="https://github.com/pola-rs/polars/issues/23765")
     df = nw.from_native(constructor(data))
     result = df.select((nw.col("foo")).alias("alias_for_foo").name.to_uppercase())
     expected = {"ALIAS_FOR_FOO": [1, 2, 3]}

--- a/tests/selectors_test.py
+++ b/tests/selectors_test.py
@@ -88,6 +88,8 @@ def test_datetime(constructor: Constructor, request: pytest.FixtureRequest) -> N
         or ("pyarrow" in str(constructor) and is_windows())
         or ("pandas" in str(constructor) and PANDAS_VERSION < (2,))
         or "ibis" in str(constructor)
+        or POLARS_VERSION
+        == (1, 32, 0, 1)  # https://github.com/pola-rs/polars/issues/23767
     ):
         request.applymarker(pytest.mark.xfail)
     if "modin" in str(constructor):

--- a/tests/selectors_test.py
+++ b/tests/selectors_test.py
@@ -88,8 +88,8 @@ def test_datetime(constructor: Constructor, request: pytest.FixtureRequest) -> N
         or ("pyarrow" in str(constructor) and is_windows())
         or ("pandas" in str(constructor) and PANDAS_VERSION < (2,))
         or "ibis" in str(constructor)
-        or POLARS_VERSION
-        == (1, 32, 0, 1)  # https://github.com/pola-rs/polars/issues/23767
+        # https://github.com/pola-rs/polars/issues/23767
+        or ("polars" in str(constructor) and POLARS_VERSION == (1, 32, 0, 1))
     ):
         request.applymarker(pytest.mark.xfail)
     if "modin" in str(constructor):

--- a/tests/series_only/is_ordered_categorical_test.py
+++ b/tests/series_only/is_ordered_categorical_test.py
@@ -36,7 +36,7 @@ def test_is_ordered_categorical_polars() -> None:
     s = pl.Series(["a", "b"], dtype=pl.Categorical)
     if POLARS_VERSION < (1, 32):
         assert nw.is_ordered_categorical(nw.from_native(s, series_only=True))
-    else:
+    else:  # pragma: no cover
         # Post 1.32 there's no physical ordering for categoricals anymore.
         assert not nw.is_ordered_categorical(nw.from_native(s, series_only=True))
     s = pl.Series(["a", "b"], dtype=pl.Categorical(ordering="lexical"))

--- a/tests/series_only/is_ordered_categorical_test.py
+++ b/tests/series_only/is_ordered_categorical_test.py
@@ -6,6 +6,7 @@ import pytest
 
 import narwhals as nw
 from narwhals._utils import Version
+from tests.utils import POLARS_VERSION
 
 if TYPE_CHECKING:
     from narwhals.typing import IntoSeries
@@ -33,7 +34,11 @@ def test_is_ordered_categorical_polars() -> None:
 
     s: IntoSeries | Any
     s = pl.Series(["a", "b"], dtype=pl.Categorical)
-    assert nw.is_ordered_categorical(nw.from_native(s, series_only=True))
+    if POLARS_VERSION < (1, 32):
+        assert nw.is_ordered_categorical(nw.from_native(s, series_only=True))
+    else:
+        # Post 1.32 there's no physical ordering for categoricals anymore.
+        assert not nw.is_ordered_categorical(nw.from_native(s, series_only=True))
     s = pl.Series(["a", "b"], dtype=pl.Categorical(ordering="lexical"))
     assert not nw.is_ordered_categorical(nw.from_native(s, series_only=True))
     s = pl.Series(["a", "b"], dtype=pl.Enum(["a", "b"]))


### PR DESCRIPTION
todo:
- [x] xfail for old Polars
- [ ] add explicit test with multiple `.name` operations (will do this as drive-by lateR)

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
