### PR TITLE
ci: Run pyspark constructors via path

### DIFF
--- a/.github/workflows/pytest-pyspark.yml
+++ b/.github/workflows/pytest-pyspark.yml
@@ -2,7 +2,10 @@ name: PyTest PySpark constructor
 
 on:
   pull_request:
-    types: [opened, labeled, synchronize]  # Triggers on PR creation, updates, and label changes
+    paths:
+      - narwhals/_expression_parsing.py
+      - narwhals/_spark_like/**
+      - narwhals/_sql/**
 
 env:
   PY_COLORS: 1
@@ -11,10 +14,9 @@ env:
 jobs:
 
   pytest-pyspark-constructor:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'pyspark') || contains(github.event.pull_request.labels.*.name, 'spark-like') || contains(github.event.pull_request.labels.*.name, 'release')}}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -39,10 +41,9 @@ jobs:
 
 
   pytest-pyspark-connect-constructor:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'pyspark-connect') || contains(github.event.pull_request.labels.*.name, 'release') }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
         os: [ubuntu-latest]
     env:
       SPARK_VERSION: 3.5.5

--- a/.github/workflows/pytest-pyspark.yml
+++ b/.github/workflows/pytest-pyspark.yml
@@ -6,6 +6,8 @@ on:
       - narwhals/_expression_parsing.py
       - narwhals/_spark_like/**
       - narwhals/_sql/**
+  schedule:
+    - cron: 0 12 * * 0  # Sunday at mid-day
 
 env:
   PY_COLORS: 1

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -1,6 +1,7 @@
 # Utilities for expression parsing
 # Useful for backends which don't have any concept of expressions, such
 # and pandas or PyArrow.
+# ! Any change to this module will trigger the pyspark and pyspark-connect tests in CI
 from __future__ import annotations
 
 from enum import Enum, auto

--- a/narwhals/_spark_like/__init__.py
+++ b/narwhals/_spark_like/__init__.py
@@ -1,0 +1,1 @@
+# ! Any change to this module will trigger the pyspark and pyspark-connect tests in CI

--- a/narwhals/_sql/__init__.py
+++ b/narwhals/_sql/__init__.py
@@ -1,0 +1,1 @@
+# ! Any change to this module will trigger the pyspark and pyspark-connect tests in CI


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- Closes #2909 and closes #2840 

---

I am not sure if we should (and even can) keep the label triggers.
Another idea could be to have a cron once a week