### PR TITLE
refactor: Shrink `Polars*Namespace(s)`, but more

### DIFF
--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -334,7 +334,6 @@ class PolarsExpr:
     var: Method[Self]
 
 
-# TODO @dangotbanned: refactor to allow shared `Method[CompliantT_co]`
 class PolarsExprNamespace(PolarsAnyNamespace[PolarsExpr, pl.Expr]):
     def __init__(self, expr: PolarsExpr) -> None:
         self._expr = expr

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -4,9 +4,13 @@ from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import polars as pl
 
-from narwhals._duration import Interval
 from narwhals._polars.utils import (
     PolarsAnyNamespace,
+    PolarsCatNamespace,
+    PolarsDateTimeNamespace,
+    PolarsListNamespace,
+    PolarsStringNamespace,
+    PolarsStructNamespace,
     extract_args_kwargs,
     extract_native,
     narwhals_to_native_dtype,
@@ -344,44 +348,14 @@ class PolarsExprNamespace(PolarsAnyNamespace[PolarsExpr, pl.Expr]):
         return self._expr.native
 
 
-class PolarsExprDateTimeNamespace(PolarsExprNamespace):
-    _accessor = "dt"
-
-    def truncate(self, every: str) -> PolarsExpr:
-        Interval.parse(every)  # Ensure consistent error message is raised.
-        return self.compliant._with_native(self.native.dt.truncate(every))
-
-    def offset_by(self, by: str) -> PolarsExpr:
-        # Ensure consistent error message is raised.
-        Interval.parse_no_constraints(by)
-        return self.compliant._with_native(self.native.dt.offset_by(by))
-
-    to_string: Method[PolarsExpr]
-    replace_time_zone: Method[PolarsExpr]
-    convert_time_zone: Method[PolarsExpr]
-    timestamp: Method[PolarsExpr]
-    date: Method[PolarsExpr]
-    year: Method[PolarsExpr]
-    month: Method[PolarsExpr]
-    day: Method[PolarsExpr]
-    hour: Method[PolarsExpr]
-    minute: Method[PolarsExpr]
-    second: Method[PolarsExpr]
-    millisecond: Method[PolarsExpr]
-    microsecond: Method[PolarsExpr]
-    nanosecond: Method[PolarsExpr]
-    ordinal_day: Method[PolarsExpr]
-    weekday: Method[PolarsExpr]
-    total_minutes: Method[PolarsExpr]
-    total_seconds: Method[PolarsExpr]
-    total_milliseconds: Method[PolarsExpr]
-    total_microseconds: Method[PolarsExpr]
-    total_nanoseconds: Method[PolarsExpr]
+class PolarsExprDateTimeNamespace(
+    PolarsExprNamespace, PolarsDateTimeNamespace[PolarsExpr, pl.Expr]
+): ...
 
 
-class PolarsExprStringNamespace(PolarsExprNamespace):
-    _accessor = "str"
-
+class PolarsExprStringNamespace(
+    PolarsExprNamespace, PolarsStringNamespace[PolarsExpr, pl.Expr]
+):
     def zfill(self, width: int) -> PolarsExpr:
         backend_version = self.compliant._backend_version
         native_result = self.native.str.zfill(width)
@@ -410,24 +384,10 @@ class PolarsExprStringNamespace(PolarsExprNamespace):
 
         return self.compliant._with_native(native_result)
 
-    len_chars: Method[PolarsExpr]
-    replace: Method[PolarsExpr]
-    replace_all: Method[PolarsExpr]
-    strip_chars: Method[PolarsExpr]
-    starts_with: Method[PolarsExpr]
-    ends_with: Method[PolarsExpr]
-    contains: Method[PolarsExpr]
-    slice: Method[PolarsExpr]
-    split: Method[PolarsExpr]
-    to_date: Method[PolarsExpr]
-    to_datetime: Method[PolarsExpr]
-    to_lowercase: Method[PolarsExpr]
-    to_uppercase: Method[PolarsExpr]
 
-
-class PolarsExprCatNamespace(PolarsExprNamespace):
-    _accessor = "cat"
-    get_categories: Method[PolarsExpr]
+class PolarsExprCatNamespace(
+    PolarsExprNamespace, PolarsCatNamespace[PolarsExpr, pl.Expr]
+): ...
 
 
 class PolarsExprNameNamespace(PolarsExprNamespace):
@@ -440,9 +400,9 @@ class PolarsExprNameNamespace(PolarsExprNamespace):
     to_uppercase: Method[PolarsExpr]
 
 
-class PolarsExprListNamespace(PolarsExprNamespace):
-    _accessor = "list"
-
+class PolarsExprListNamespace(
+    PolarsExprNamespace, PolarsListNamespace[PolarsExpr, pl.Expr]
+):
     def len(self) -> PolarsExpr:
         native_expr = self.native
         native_result = native_expr.list.len()
@@ -457,6 +417,6 @@ class PolarsExprListNamespace(PolarsExprNamespace):
         return self.compliant._with_native(native_result)
 
 
-class PolarsExprStructNamespace(PolarsExprNamespace):
-    _accessor = "struct"
-    field: Method[PolarsExpr]
+class PolarsExprStructNamespace(
+    PolarsExprNamespace, PolarsStructNamespace[PolarsExpr, pl.Expr]
+): ...

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -330,6 +330,7 @@ class PolarsExpr:
     var: Method[Self]
 
 
+# TODO @dangotbanned: refactor to allow shared `Method[CompliantT_co]`
 class PolarsExprNamespace(PolarsAnyNamespace[PolarsExpr, pl.Expr]):
     def __init__(self, expr: PolarsExpr) -> None:
         self._expr = expr

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -687,7 +687,6 @@ class PolarsSeries:
         return PolarsSeriesListNamespace(self)
 
 
-# TODO @dangotbanned: refactor to allow shared `Method[CompliantT_co]`
 class PolarsSeriesNamespace(PolarsAnyNamespace[PolarsSeries, pl.Series]):
     def __init__(self, series: PolarsSeries) -> None:
         self._series = series

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -7,6 +7,11 @@ import polars as pl
 from narwhals._polars.utils import (
     BACKEND_VERSION,
     PolarsAnyNamespace,
+    PolarsCatNamespace,
+    PolarsDateTimeNamespace,
+    PolarsListNamespace,
+    PolarsStringNamespace,
+    PolarsStructNamespace,
     catch_polars_exception,
     extract_args_kwargs,
     extract_native,
@@ -696,66 +701,29 @@ class PolarsSeriesNamespace(PolarsAnyNamespace[PolarsSeries, pl.Series]):
         return self._series.native
 
 
-class PolarsSeriesDateTimeNamespace(PolarsSeriesNamespace):
-    _accessor = "dt"
-
-    truncate: Method[PolarsSeries]
-    offset_by: Method[PolarsSeries]
-    to_string: Method[PolarsSeries]
-    replace_time_zone: Method[PolarsSeries]
-    convert_time_zone: Method[PolarsSeries]
-    timestamp: Method[PolarsSeries]
-    date: Method[PolarsSeries]
-    year: Method[PolarsSeries]
-    month: Method[PolarsSeries]
-    day: Method[PolarsSeries]
-    hour: Method[PolarsSeries]
-    minute: Method[PolarsSeries]
-    second: Method[PolarsSeries]
-    millisecond: Method[PolarsSeries]
-    microsecond: Method[PolarsSeries]
-    nanosecond: Method[PolarsSeries]
-    ordinal_day: Method[PolarsSeries]
-    weekday: Method[PolarsSeries]
-    total_minutes: Method[PolarsSeries]
-    total_seconds: Method[PolarsSeries]
-    total_milliseconds: Method[PolarsSeries]
-    total_microseconds: Method[PolarsSeries]
-    total_nanoseconds: Method[PolarsSeries]
+class PolarsSeriesDateTimeNamespace(
+    PolarsSeriesNamespace, PolarsDateTimeNamespace[PolarsSeries, pl.Series]
+): ...
 
 
-class PolarsSeriesStringNamespace(PolarsSeriesNamespace):
-    _accessor = "str"
-
+class PolarsSeriesStringNamespace(
+    PolarsSeriesNamespace, PolarsStringNamespace[PolarsSeries, pl.Series]
+):
     def zfill(self, width: int) -> PolarsSeries:
         series = self.compliant
         name = series.name
         ns = series.__narwhals_namespace__()
         return series.to_frame().select(ns.col(name).str.zfill(width)).get_column(name)
 
-    len_chars: Method[PolarsSeries]
-    replace: Method[PolarsSeries]
-    replace_all: Method[PolarsSeries]
-    strip_chars: Method[PolarsSeries]
-    starts_with: Method[PolarsSeries]
-    ends_with: Method[PolarsSeries]
-    contains: Method[PolarsSeries]
-    slice: Method[PolarsSeries]
-    split: Method[PolarsSeries]
-    to_date: Method[PolarsSeries]
-    to_datetime: Method[PolarsSeries]
-    to_lowercase: Method[PolarsSeries]
-    to_uppercase: Method[PolarsSeries]
+
+class PolarsSeriesCatNamespace(
+    PolarsSeriesNamespace, PolarsCatNamespace[PolarsSeries, pl.Series]
+): ...
 
 
-class PolarsSeriesCatNamespace(PolarsSeriesNamespace):
-    _accessor = "cat"
-    get_categories: Method[PolarsSeries]
-
-
-class PolarsSeriesListNamespace(PolarsSeriesNamespace):
-    _accessor = "list"
-
+class PolarsSeriesListNamespace(
+    PolarsSeriesNamespace, PolarsListNamespace[PolarsSeries, pl.Series]
+):
     def len(self) -> PolarsSeries:
         native_result = self.native.list.len()
         if self.compliant._backend_version < (1, 16):  # pragma: no cover
@@ -770,6 +738,6 @@ class PolarsSeriesListNamespace(PolarsSeriesNamespace):
         return self.compliant._with_native(native_result)
 
 
-class PolarsSeriesStructNamespace(PolarsSeriesNamespace):
-    _accessor = "struct"
-    field: Method[PolarsSeries]
+class PolarsSeriesStructNamespace(
+    PolarsSeriesNamespace, PolarsStructNamespace[PolarsSeries, pl.Series]
+): ...

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -682,6 +682,7 @@ class PolarsSeries:
         return PolarsSeriesListNamespace(self)
 
 
+# TODO @dangotbanned: refactor to allow shared `Method[CompliantT_co]`
 class PolarsSeriesNamespace(PolarsAnyNamespace[PolarsSeries, pl.Series]):
     def __init__(self, series: PolarsSeries) -> None:
         self._series = series


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues
Building on these two
- (1) #2897
- (2) #2918

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
Going to be setting the groundwork for #2474

Basic idea is at the end of (https://github.com/narwhals-dev/narwhals/pull/2451#discussion_r2070128922)

Trying out with the `Expr|Series` namespaces, since they can can use a `TypeVar` in any case like this:

https://github.com/narwhals-dev/narwhals/blob/0052ca5c646b0f5f396e7f5efd682caaac2e45f6/narwhals/_polars/series.py#L735

https://github.com/narwhals-dev/narwhals/blob/0052ca5c646b0f5f396e7f5efd682caaac2e45f6/narwhals/_polars/expr.py#L412