### PR TITLE
test: include nulls in `unique` test

### DIFF
--- a/tests/expr_and_series/unique_test.py
+++ b/tests/expr_and_series/unique_test.py
@@ -34,6 +34,9 @@ def test_unique_expr_agg(
     result = df.select(nw.col("a").unique().sum())
     expected = {"a": [3]}
     assert_equal_data(result, expected)
+    result = df.drop_nulls().select(nw.col("a").unique().len())
+    expected = {"a": [2]}
+    assert_equal_data(result, expected)
 
 
 def test_unique_illegal_combination(constructor: Constructor) -> None:
@@ -49,10 +52,16 @@ def test_unique_series(constructor_eager: ConstructorEager) -> None:
     result = series.unique(maintain_order=True)
     expected = {"a": ["x", "y", None]}
     assert_equal_data({"a": result}, expected)
+    result = series.drop_nulls().unique(maintain_order=True)
+    expected = {"a": ["x", "y"]}
+    assert_equal_data({"a": result}, expected)
 
 
 def test_unique_series_numeric(constructor_eager: ConstructorEager) -> None:
     series = nw.from_native(constructor_eager(data), eager_only=True)["a"]
     result = series.unique(maintain_order=True)
     expected = {"a": [1, None, 2]}
+    assert_equal_data({"a": result}, expected)
+    result = series.drop_nulls().unique(maintain_order=True)
+    expected = {"a": [1, 2]}
     assert_equal_data({"a": result}, expected)

--- a/tests/expr_and_series/unique_test.py
+++ b/tests/expr_and_series/unique_test.py
@@ -8,8 +8,8 @@ import narwhals as nw
 from narwhals.exceptions import InvalidOperationError
 from tests.utils import Constructor, ConstructorEager, assert_equal_data
 
-data = {"a": [1, 1, 2]}
-data_str = {"a": ["x", "x", "y"]}
+data = {"a": [1, 1, None, 2]}
+data_str = {"a": ["x", "x", "y", None]}
 
 
 def test_unique_expr(constructor: Constructor) -> None:
@@ -20,8 +20,8 @@ def test_unique_expr(constructor: Constructor) -> None:
         else does_not_raise()
     )
     with context:
-        result = df.select(nw.col("a").unique())
-        expected = {"a": [1, 2]}
+        result = df.select(nw.col("a").unique()).sort("a")
+        expected = {"a": [None, 1, 2]}
         assert_equal_data(result, expected)
 
 
@@ -47,5 +47,12 @@ def test_unique_illegal_combination(constructor: Constructor) -> None:
 def test_unique_series(constructor_eager: ConstructorEager) -> None:
     series = nw.from_native(constructor_eager(data_str), eager_only=True)["a"]
     result = series.unique(maintain_order=True)
-    expected = {"a": ["x", "y"]}
+    expected = {"a": ["x", "y", None]}
+    assert_equal_data({"a": result}, expected)
+
+
+def test_unique_series_numeric(constructor_eager: ConstructorEager) -> None:
+    series = nw.from_native(constructor_eager(data), eager_only=True)["a"]
+    result = series.unique(maintain_order=True)
+    expected = {"a": [1, None, 2]}
     assert_equal_data({"a": result}, expected)


### PR DESCRIPTION
Looks like this is working fine, i'm just concerned that we'd missed nulls out of this test completely

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
