### PR TITLE
fix: Allow `modin[pyarrow]` to use more dtypes

### DIFF
--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -545,7 +545,10 @@ def narwhals_to_native_dtype(  # noqa: C901, PLR0912, PLR0915
     if isinstance_or_issubclass(
         dtype, (dtypes.Struct, dtypes.Array, dtypes.List, dtypes.Time, dtypes.Binary)
     ):
-        if implementation is Implementation.PANDAS and backend_version >= (2, 2):
+        if implementation in {
+            Implementation.PANDAS,
+            Implementation.MODIN,
+        } and Implementation.PANDAS._backend_version() >= (2, 2):
             try:
                 import pandas as pd
                 import pyarrow as pa  # ignore-banned-import  # noqa: F401

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -143,7 +143,7 @@ def test_2d_array(constructor: Constructor, request: pytest.FixtureRequest) -> N
         if condition:
             pytest.skip(reason)
 
-    if any(x in str(constructor) for x in ("dask", "modin", "cudf", "pyspark")):
+    if any(x in str(constructor) for x in ("dask", "cudf", "pyspark")):
         request.applymarker(
             pytest.mark.xfail(
                 reason="2D array operations not supported in these backends"

--- a/tests/expr_and_series/cast_test.py
+++ b/tests/expr_and_series/cast_test.py
@@ -270,9 +270,7 @@ def test_cast_datetime_utc(
 
 
 def test_cast_struct(request: pytest.FixtureRequest, constructor: Constructor) -> None:
-    if any(
-        backend in str(constructor) for backend in ("dask", "modin", "cudf", "sqlframe")
-    ):
+    if any(backend in str(constructor) for backend in ("dask", "cudf", "sqlframe")):
         request.applymarker(pytest.mark.xfail)
 
     if "pandas" in str(constructor) and PANDAS_VERSION < (2, 2):
@@ -328,9 +326,7 @@ def test_cast_time(request: pytest.FixtureRequest, constructor: Constructor) -> 
     if "pandas" in str(constructor) and PANDAS_VERSION < (2, 2):
         pytest.skip()
 
-    if any(
-        backend in str(constructor) for backend in ("dask", "pyspark", "modin", "cudf")
-    ):
+    if any(backend in str(constructor) for backend in ("dask", "pyspark", "cudf")):
         request.applymarker(pytest.mark.xfail)
 
     data = {"a": [time(12, 0, 0), time(12, 0, 5)]}
@@ -343,7 +339,7 @@ def test_cast_binary(request: pytest.FixtureRequest, constructor: Constructor) -
     if "pandas" in str(constructor) and PANDAS_VERSION < (2, 2):
         pytest.skip()
 
-    if any(backend in str(constructor) for backend in ("cudf", "dask", "modin")):
+    if any(backend in str(constructor) for backend in ("cudf", "dask")):
         request.applymarker(pytest.mark.xfail)
 
     data = {"a": ["test1", "test2"]}

--- a/tests/expr_and_series/list/len_test.py
+++ b/tests/expr_and_series/list/len_test.py
@@ -11,7 +11,7 @@ expected = {"a": [2, 3, None, 0, 1]}
 
 
 def test_len_expr(request: pytest.FixtureRequest, constructor: Constructor) -> None:
-    if any(backend in str(constructor) for backend in ("dask", "modin", "cudf")):
+    if any(backend in str(constructor) for backend in ("dask", "cudf")):
         request.applymarker(pytest.mark.xfail)
 
     if "pandas" in str(constructor) and PANDAS_VERSION < (2, 2):
@@ -27,7 +27,7 @@ def test_len_expr(request: pytest.FixtureRequest, constructor: Constructor) -> N
 def test_len_series(
     request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
-    if any(backend in str(constructor_eager) for backend in ("modin", "cudf")):
+    if "cudf" in str(constructor_eager):
         request.applymarker(pytest.mark.xfail)
 
     if "pandas" in str(constructor_eager) and PANDAS_VERSION < (2, 2):

--- a/tests/frame/explode_test.py
+++ b/tests/frame/explode_test.py
@@ -35,10 +35,7 @@ def test_explode_single_col(
     column: str,
     expected_values: list[int | None],
 ) -> None:
-    if any(
-        backend in str(constructor)
-        for backend in ("dask", "modin", "cudf", "pyarrow_table")
-    ):
+    if any(backend in str(constructor) for backend in ("dask", "cudf", "pyarrow_table")):
         request.applymarker(pytest.mark.xfail)
 
     if "pandas" in str(constructor) and PANDAS_VERSION < (2, 2):
@@ -87,15 +84,7 @@ def test_explode_multiple_cols(
 ) -> None:
     if any(
         backend in str(constructor)
-        for backend in (
-            "dask",
-            "modin",
-            "cudf",
-            "pyarrow_table",
-            "duckdb",
-            "pyspark",
-            "ibis",
-        )
+        for backend in ("dask", "cudf", "pyarrow_table", "duckdb", "pyspark", "ibis")
     ):
         request.applymarker(pytest.mark.xfail)
 
@@ -114,10 +103,7 @@ def test_explode_multiple_cols(
 def test_explode_shape_error(
     request: pytest.FixtureRequest, constructor: Constructor
 ) -> None:
-    if any(
-        backend in str(constructor)
-        for backend in ("dask", "modin", "cudf", "pyarrow_table")
-    ):
+    if any(backend in str(constructor) for backend in ("dask", "cudf", "pyarrow_table")):
         request.applymarker(pytest.mark.xfail)
 
     if "pandas" in str(constructor) and PANDAS_VERSION < (2, 2):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Discovered in https://github.com/narwhals-dev/narwhals/commit/0c5b7d5616a6efc6dcfe34143b54181c7a56547d
- `pandas`-only has been enforced (by us) since #2113

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
I was writing a schema conversion test and was confused by the output.

`modin` just re-exports `pd.ArrowDtype` *as-is*, so maybe this was always working? 🤔

- https://github.com/modin-project/modin/blob/e3724b67c60eee972451ca10fee1c7496f7f3861/modin/pandas/__init__.py#L99
- https://modin.readthedocs.io/en/stable/supported_apis/utilities_supported.html#other-objects-structures