### PR TITLE
fix: Support passing `nw.Object` to pandas-like

### DIFF
--- a/narwhals/_arrow/utils.py
+++ b/narwhals/_arrow/utils.py
@@ -224,7 +224,9 @@ def narwhals_to_native_dtype(dtype: IntoDType, version: Version) -> pa.DataType:
         return pa.time64("ns")
     if isinstance_or_issubclass(dtype, dtypes.Binary):
         return pa.binary()
-
+    if isinstance_or_issubclass(dtype, dtypes.Object):
+        msg = f"Converting to {dtype} dtype is not supported for pyarrow."
+        raise NotImplementedError(msg)
     msg = f"Unknown dtype: {dtype}"  # pragma: no cover
     raise AssertionError(msg)
 

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -562,6 +562,8 @@ def narwhals_to_native_dtype(  # noqa: C901, PLR0912, PLR0915
             f"{implementation} and version {version}."
         )
         raise NotImplementedError(msg)
+    if isinstance_or_issubclass(dtype, dtypes.Object):
+        return "object"
     msg = f"Unknown dtype: {dtype}"  # pragma: no cover
     raise AssertionError(msg)
 

--- a/tests/frame/from_dict_test.py
+++ b/tests/frame/from_dict_test.py
@@ -92,3 +92,19 @@ def test_alignment() -> None:
     ).to_native()
     expected = pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]})
     pd.testing.assert_frame_equal(result, expected)
+
+
+def test_from_dict_object_2851(
+    eager_backend: EagerAllowed, request: pytest.FixtureRequest
+) -> None:
+    data = {"Var1": [3, "a"], "Var2": ["a", "b"]}
+    schema = {"Var1": nw.Object(), "Var2": nw.String()}
+    request.applymarker(
+        pytest.mark.xfail(
+            "pyarrow" in str(eager_backend),
+            reason="Object DType not supported in pyarrow",
+            raises=NotImplementedError,
+        )
+    )
+    df = nw.DataFrame.from_dict(data, backend=eager_backend, schema=schema)
+    assert df.schema == schema


### PR DESCRIPTION
Closes #2851

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #2851

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
- `polars` always supported it
- `pyarrow` never will