### PR TITLE
feat: being able to read daft dataframes

### DIFF
--- a/daft-plugin/setup.py
+++ b/daft-plugin/setup.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import setuptools
+
+setuptools.setup(
+    name="daft-plugin",
+    entry_points={
+        "daft.extension": [
+            "X1 = daft-plugin:ExampleOne"
+            # "X2 = daft-plugin:ExampleTwo",
+        ]
+    },
+)

--- a/daft-plugin/src/__init__.py
+++ b/daft-plugin/src/__init__.py
@@ -1,0 +1,11 @@
+"""Module for an example Flake8 plugin."""
+
+from __future__ import annotations
+
+# from .off_by_default import ExampleTwo
+from .on_by_default import ExampleOne
+
+__all__ = (
+    "ExampleOne",
+    # "ExampleTwo",
+)

--- a/daft-plugin/src/on_by_default.py
+++ b/daft-plugin/src/on_by_default.py
@@ -1,0 +1,19 @@
+"""Our first example plugin."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+class ExampleOne:
+    """First Example Plugin."""
+
+    def __init__(self, tree: Any) -> None:
+        self.tree = tree
+
+    def run(self) -> Generator[Any, Any, None]:
+        """Do nothing."""
+        yield from []


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

started trying to adapt `nw` so that it can read daft dataframes, but I might be barking up the wrong tree: I installed daft in the repo so that it would be available to nw. I have a feeling we want to avoid that, and I'm working as if I were adding an actual `_daft` module rather than prep for a plugin. 

note to self: if installing daft was correct, need to add this to an install file, think it's pyproject.toml
