### PR TITLE
RFC, feat: Add `assert_series_equal`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,12 +62,12 @@ repos:
       name: don't import from narwhals.dtypes (use `Version.dtypes` instead)
       entry: |
           (?x)
-            import\ narwhals.dtypes|
-            from\ narwhals\ import\ dtypes|
-            from\ narwhals.dtypes\ import\ [^D_]+|
-            import\ narwhals.stable.v1.dtypes|
-            from\ narwhals.stable\.v.\ import\ dtypes|
-            from\ narwhals.stable\.v.\.dtypes\ import
+            import\ narwhals(\.stable\.v\d)?\.dtypes|
+            from\ narwhals(\.stable\.v\d)?\ import\ dtypes|
+            ^from\ narwhals(\.stable\.v\d)?\.dtypes\ import
+              \ (DType,\ )?
+              ((Datetime|Duration|Enum)(,\ )?)+
+              ((,\ )?DType)?
       language: pygrep
       files: ^narwhals/
       exclude: |

--- a/docs/api-reference/testing.md
+++ b/docs/api-reference/testing.md
@@ -1,0 +1,7 @@
+# `narwhals.testing`
+
+::: narwhals.testing
+    handler: python
+    options:
+      members:
+        - assert_series_equal

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
     - api-reference/dtypes.md
     - api-reference/exceptions.md
     - api-reference/selectors.md
+    - api-reference/testing.md
     - api-reference/typing.md
     - api-reference/utils.md
   - This: this.md

--- a/narwhals/testing.py
+++ b/narwhals/testing.py
@@ -90,7 +90,7 @@ def assert_series_equal(  # noqa: C901, PLR0912
             )
         elif l_dtype.is_numeric():
             # Workaround via is_close with 0-tolerances to handle inf and nan values.
-            is_equal_mask = ~left_.is_close(right_, rel_tol=0, abs_tol=0, nans_equal=True)
+            is_equal_mask = left_.is_close(right_, rel_tol=0, abs_tol=0, nans_equal=True)
         else:
             is_equal_mask = l_vals == r_vals
 

--- a/narwhals/testing.py
+++ b/narwhals/testing.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NoReturn
 
-from narwhals.functions import new_series
+from narwhals import from_native, new_series
 
 if TYPE_CHECKING:
-    from narwhals.typing import SeriesT
+    from narwhals.typing import FrameT, SeriesT
 
 
 def _raise_assertion_error(mismatch_type: str, left: Any, right: Any) -> NoReturn:
@@ -18,35 +18,53 @@ def assert_series_equal(
     left: SeriesT,
     right: SeriesT,
     *,
-    check_backend: bool = True,
     check_dtypes: bool = True,
     check_names: bool = True,
-    # check_order: bool = True,  # Don't allow False due to complex types
+    # check_order: bool = True,  # TODO(FBruzzesi): How do we sort complex types?
     check_exact: bool = False,
     rtol: float = 1e-05,
     atol: float = 1e-08,
     # categorical_as_str: bool = False,  # TODO(FBruzzesi): Should we even support this?
 ) -> None:
-    if check_backend and (l_impl := left.implementation) != (
-        r_impl := right.implementation
-    ):
-        _raise_assertion_error("backend mismatch", l_impl, r_impl)
+    """Assert that the left and right Series are equal.
 
-    if (l_len := len(left)) != (r_len := len(right)):
+    Raises a detailed `AssertionError` if the Series differ.
+    This function is intended for use in unit tests.
+
+    Arguments:
+        left: The first Series to compare.
+        right: The second Series to compare.
+        check_dtypes: Requires data types to match.
+        check_names: Requires names to match.
+        check_exact: Requires float values to match exactly. If set to `False`, values are
+            considered equal when within tolerance of each other (see `rtol` and `atol`).
+            Only affects columns with a Float data type.
+        rtol: Relative tolerance for inexact checking, given as a fraction of the values in
+            `right`.
+        atol: Absolute tolerance for inexact checking.
+
+    """
+    left_ = from_native(left, series_only=True)
+    right_ = from_native(right, series_only=True)
+
+    if (l_impl := left_.implementation) != (r_impl := right_.implementation):
+        _raise_assertion_error("implementation mismatch", l_impl, r_impl)
+
+    if (l_len := len(left_)) != (r_len := len(right_)):
         _raise_assertion_error("length mismatch", l_len, r_len)
 
-    if check_dtypes and (l_dtype := left.dtype) != (r_dtype := right.dtype):
+    if check_dtypes and (l_dtype := left_.dtype) != (r_dtype := right_.dtype):
         _raise_assertion_error("dtype mismatch", l_dtype, r_dtype)
 
-    if check_names and (l_name := left.name) != (r_name := right.name):
+    if check_names and (l_name := left_.name) != (r_name := right_.name):
         _raise_assertion_error("name mismatch", l_name, r_name)
 
-    if ((l_null_mask := left.is_null()) != (r_null_mask := right.is_null())).any() or (
-        l_null_count := left.null_count()
-    ) != (r_null_count := right.null_count()):
+    if ((l_null_mask := left_.is_null()) != (r_null_mask := right_.is_null())).any() or (
+        l_null_count := left_.null_count()
+    ) != (r_null_count := right_.null_count()):
         _raise_assertion_error("null value mismatch", l_null_count, r_null_count)
 
-    l_vals, r_vals = left.filter(~l_null_mask), right.filter(~r_null_mask)
+    l_vals, r_vals = left_.filter(~l_null_mask), right_.filter(~r_null_mask)
 
     # TODO(FBruzzesi): Open points:
     #  1. Handle nan's and infinities for numerical
@@ -61,7 +79,7 @@ def assert_series_equal(
         # Namely: abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol).
         l_abs, r_abs = l_vals.abs(), r_vals.abs()
         m1 = l_abs.zip_with(l_abs > r_abs, r_abs) * rtol
-        m2 = new_series(name="tmp", values=[atol] * l_len, backend=l_impl)
+        m2 = new_series(name="tmp", values=[atol] * l_len, backend=left_.implementation)
 
         is_not_close_mask = (l_vals - r_vals).abs() > m1.zip_with(m1 > m2, m2)
 
@@ -71,3 +89,17 @@ def assert_series_equal(
                 l_vals.filter(is_not_close_mask),
                 r_vals.filter(is_not_close_mask),
             )
+
+
+def assert_frame_equal(
+    left: FrameT,
+    right: FrameT,
+    *,
+    check_row_order: bool = True,
+    check_column_order: bool = True,
+    check_dtypes: bool = True,
+    check_exact: bool = False,
+    rtol: float = 1e-05,
+    atol: float = 1e-08,
+    categorical_as_str: bool = False,
+) -> None: ...

--- a/narwhals/testing.py
+++ b/narwhals/testing.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, NoReturn
+
+from narwhals.functions import new_series
+
+if TYPE_CHECKING:
+    from narwhals.typing import SeriesT
+
+
+def _raise_assertion_error(mismatch_type: str, left: Any, right: Any) -> NoReturn:
+    msg = f"Series are different ({mismatch_type})\n[left]: {left}\n[right]: {right}"
+
+    raise AssertionError(msg)
+
+
+def assert_series_equal(
+    left: SeriesT,
+    right: SeriesT,
+    *,
+    check_backend: bool = True,
+    check_dtypes: bool = True,
+    check_names: bool = True,
+    # check_order: bool = True,  # Don't allow False due to complex types
+    check_exact: bool = False,
+    rtol: float = 1e-05,
+    atol: float = 1e-08,
+    # categorical_as_str: bool = False,  # TODO(FBruzzesi): Should we even support this?
+) -> None:
+    if check_backend and (l_impl := left.implementation) != (
+        r_impl := right.implementation
+    ):
+        _raise_assertion_error("backend mismatch", l_impl, r_impl)
+
+    if (l_len := len(left)) != (r_len := len(right)):
+        _raise_assertion_error("length mismatch", l_len, r_len)
+
+    if check_dtypes and (l_dtype := left.dtype) != (r_dtype := right.dtype):
+        _raise_assertion_error("dtype mismatch", l_dtype, r_dtype)
+
+    if check_names and (l_name := left.name) != (r_name := right.name):
+        _raise_assertion_error("name mismatch", l_name, r_name)
+
+    if ((l_null_mask := left.is_null()) != (r_null_mask := right.is_null())).any() or (
+        l_null_count := left.null_count()
+    ) != (r_null_count := right.null_count()):
+        _raise_assertion_error("null value mismatch", l_null_count, r_null_count)
+
+    l_vals, r_vals = left.filter(~l_null_mask), right.filter(~r_null_mask)
+
+    # TODO(FBruzzesi): Open points:
+    #  1. Handle nan's and infinities for numerical
+    #  2. Nested values: do nested values compare "nicely"?
+    #  3. date vs datetime
+    if check_exact or not l_dtype.is_numeric():
+        if not (l_vals == r_vals).all():
+            _raise_assertion_error("exact value mismatch", l_vals, r_vals)
+
+    else:
+        # Based on math.isclosed https://docs.python.org/3/library/math.html#math.isclose
+        # Namely: abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol).
+        l_abs, r_abs = l_vals.abs(), r_vals.abs()
+        m1 = l_abs.zip_with(l_abs > r_abs, r_abs) * rtol
+        m2 = new_series(name="tmp", values=[atol] * l_len, backend=l_impl)
+
+        is_not_close_mask = (l_vals - r_vals).abs() > m1.zip_with(m1 > m2, m2)
+
+        if is_not_close_mask.any():
+            _raise_assertion_error(
+                "values not within tolerance",
+                l_vals.filter(is_not_close_mask),
+                r_vals.filter(is_not_close_mask),
+            )

--- a/narwhals/testing/__init__.py
+++ b/narwhals/testing/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from narwhals.testing.asserts.frame import assert_frame_equal
+from narwhals.testing.asserts.series import assert_series_equal
+
+__all__ = ("assert_frame_equal", "assert_series_equal")

--- a/narwhals/testing/asserts/frame.py
+++ b/narwhals/testing/asserts/frame.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from narwhals.typing import FrameT
+
+
+def assert_frame_equal(
+    left: FrameT,
+    right: FrameT,
+    *,
+    check_row_order: bool = True,
+    check_column_order: bool = True,
+    check_dtypes: bool = True,
+    check_exact: bool = False,
+    rel_tol: float = 1e-05,
+    abs_tol: float = 1e-08,
+    categorical_as_str: bool = False,
+) -> None: ...

--- a/narwhals/testing/asserts/frame.py
+++ b/narwhals/testing/asserts/frame.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from narwhals.typing import FrameT
+    from narwhals.typing import IntoFrameT
 
 
 def assert_frame_equal(
-    left: FrameT,
-    right: FrameT,
+    left: IntoFrameT,
+    right: IntoFrameT,
     *,
     check_row_order: bool = True,
     check_column_order: bool = True,
@@ -17,4 +17,6 @@ def assert_frame_equal(
     rel_tol: float = 1e-05,
     abs_tol: float = 1e-08,
     categorical_as_str: bool = False,
-) -> None: ...
+) -> None:
+    msg = "TODO"  # pragma: no cover
+    raise NotImplementedError(msg)

--- a/narwhals/testing/asserts/series.py
+++ b/narwhals/testing/asserts/series.py
@@ -52,13 +52,14 @@ def assert_series_equal(  # noqa: C901, PLR0912
     if (l_len := len(left_)) != (r_len := len(right_)):
         raise_assertion_error("Series", "length mismatch", l_len, r_len)
 
-    if check_dtypes and (l_dtype := left_.dtype) != (r_dtype := right_.dtype):
+    if (l_dtype := left_.dtype) != (r_dtype := right_.dtype) and check_dtypes:
         raise_assertion_error("Series", "dtype mismatch", l_dtype, r_dtype)
 
-    if check_names and (l_name := left_.name) != (r_name := right_.name):
+    if (l_name := left_.name) != (r_name := right_.name) and check_names:
         raise_assertion_error("Series", "name mismatch", l_name, r_name)
 
-    if isinstance(l_dtype, Categorical) and categorical_as_str:
+    # TODO(FBruzzesi): Add coverage
+    if isinstance(l_dtype, Categorical) and categorical_as_str:  # pragma: no cover
         left_, right_ = left_.cast(String()), right_.cast(String())
 
     if not check_order:
@@ -74,24 +75,29 @@ def assert_series_equal(  # noqa: C901, PLR0912
 
     l_vals, r_vals = left_.filter(~l_null_mask), right_.filter(~r_null_mask)
 
-    # TODO(FBruzzesi): Open points:
-    #  [x] Handle nan's and infinities for numerical
-    #  [ ] Nested values: do nested values compare "nicely"?
-    #  [ ] date vs datetime?
     if check_exact or not l_dtype.is_numeric():
-        if l_dtype.is_nested():
-            is_equal_mask = new_series(
+        if l_dtype.is_numeric():
+            # For numeric dtypes, we can use `is_close` with 0-tolerances to handle inf
+            # and nan values.
+            is_not_equal_mask = ~left_.is_close(
+                right_, rel_tol=0, abs_tol=0, nans_equal=True
+            )
+        elif l_dtype.is_nested():
+            # TODO(FBruzzesi): Handle nested with inner numerical
+            # 1. Polars raises: AssertionError: Series are different (nested value mismatch)
+            # 2. check_exact and tolerances are considered within the inner type as well
+            is_not_equal_mask = new_series(
                 l_vals.name,
-                (l_val == r_val for l_val, r_val in zip(l_vals, r_vals)),
+                (
+                    any(x != y for x, y in zip(l_val, r_val))
+                    for l_val, r_val in zip(l_vals, r_vals)
+                ),
                 backend=l_impl,
             )
-        elif l_dtype.is_numeric():
-            # Workaround via is_close with 0-tolerances to handle inf and nan values.
-            is_equal_mask = left_.is_close(right_, rel_tol=0, abs_tol=0, nans_equal=True)
         else:
-            is_equal_mask = l_vals == r_vals
+            is_not_equal_mask = l_vals != r_vals
 
-        if not is_equal_mask.all():
+        if is_not_equal_mask.any():
             raise_assertion_error("Series", "exact value mismatch", l_vals, r_vals)
 
     else:

--- a/narwhals/testing/asserts/series.py
+++ b/narwhals/testing/asserts/series.py
@@ -47,10 +47,10 @@ def assert_series_equal(  # noqa: C901, PLR0912
         check_names: Requires names to match.
         check_order: Requires elements to appear in the same order.
         check_exact: Requires float values to match exactly. If set to `False`, values are
-            considered equal when within tolerance of each other (see `rel_tol` and `abs_tol`).
-            Only affects columns with a Float data type.
-        rel_tol: Relative tolerance for inexact checking, given as a fraction of the values in
-            `right`.
+            considered equal when within tolerance of each other (see `rel_tol` and
+            `abs_tol`). Only affects columns with a Float data type.
+        rel_tol: Relative tolerance for inexact checking, given as a fraction of the
+            values in `right`.
         abs_tol: Absolute tolerance for inexact checking.
         categorical_as_str: Cast categorical columns to string before comparing.
             Enabling this helps compare columns that do not share the same string cache.
@@ -89,10 +89,10 @@ def assert_series_equal(  # noqa: C901, PLR0912
 
     l_vals, r_vals = left_.filter(~l_null_mask), right_.filter(~r_null_mask)
 
-    if check_exact or not l_dtype.is_numeric():
+    if check_exact or not l_dtype.is_float():
         if l_dtype.is_numeric():
-            # For numeric dtypes, we can use `is_close` with 0-tolerances to handle inf
-            # and nan values out of the box.
+            # For _all_ numeric dtypes, we can use `is_close` with 0-tolerances to handle
+            # inf and nan values out of the box.
             is_not_equal_mask = ~l_vals.is_close(
                 r_vals, rel_tol=0, abs_tol=0, nans_equal=True
             )

--- a/narwhals/testing/asserts/utils.py
+++ b/narwhals/testing/asserts/utils.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any, NoReturn
+
+
+def raise_assertion_error(
+    objects: str, detail: str, left: Any, right: Any, *, cause: Exception | None = None
+) -> NoReturn:
+    """Raise a detailed assertion error."""
+    __tracebackhide__ = True
+    msg = f"{objects} are different ({detail})\n[left]:  {left}\n[right]: {right}"
+    raise AssertionError(msg) from cause

--- a/tests/testing/assert_series_equal_test.py
+++ b/tests/testing/assert_series_equal_test.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+import narwhals as nw
+from narwhals.testing import assert_series_equal
+
+if TYPE_CHECKING:
+    from narwhals.typing import IntoSchema
+    from tests.conftest import Data
+    from tests.utils import ConstructorEager
+
+
+def test_self_equal(
+    constructor_eager: ConstructorEager, data: Data, schema: IntoSchema
+) -> None:
+    """This test exists for validate that nested dtypes are checked correctly, including nulls."""
+    if "pyarrow_table" in str(constructor_eager):
+        # Pyarrow does not support Enum
+        schema = {**schema, "enum": nw.Categorical()}
+
+    df = nw.from_native(constructor_eager(data), eager_only=True).select(
+        nw.col(name).cast(dtype) for name, dtype in schema.items()
+    )
+    for name in schema:
+        assert_series_equal(df[name], df[name])
+
+
+def test_raise_impl_mismatch() -> None:
+    pytest.importorskip("pandas")
+    pytest.importorskip("pyarrow")
+
+    import pandas as pd
+    import pyarrow as pa
+
+    data = [1, 2, 3]
+    left, right = pd.Series(data), pa.chunked_array([data])
+
+    msg = r"Series are different \(implementation mismatch\)"
+    with pytest.raises(AssertionError, match=msg):
+        assert_series_equal(left, right)  # type: ignore[arg-type]
+
+
+def test_raise_length_mismatch(constructor_eager: ConstructorEager) -> None:
+    left = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)["a"]
+    right = left.head(2)
+    msg = r"Series are different \(length mismatch\)"
+    with pytest.raises(AssertionError, match=msg):
+        assert_series_equal(left, right)
+
+
+@pytest.mark.parametrize(
+    ("check_dtypes", "context"),
+    [
+        (False, nullcontext()),
+        (
+            True,
+            pytest.raises(
+                AssertionError, match=r"Series are different \(dtype mismatch\)"
+            ),
+        ),
+    ],
+)
+def test_check_dtypes(
+    constructor_eager: ConstructorEager, *, check_dtypes: bool, context: Any
+) -> None:
+    left = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)["a"]
+    with context:
+        assert_series_equal(
+            left.cast(nw.UInt32()), left.cast(nw.Int64()), check_dtypes=check_dtypes
+        )
+
+
+@pytest.mark.parametrize(
+    ("check_names", "context"),
+    [
+        (False, nullcontext()),
+        (
+            True,
+            pytest.raises(
+                AssertionError, match=r"Series are different \(name mismatch\)"
+            ),
+        ),
+    ],
+)
+def test_check_names(
+    constructor_eager: ConstructorEager, *, check_names: bool, context: Any
+) -> None:
+    left = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)["a"]
+    with context:
+        assert_series_equal(
+            left.rename("foo"), left.rename("bar"), check_names=check_names
+        )
+
+
+@pytest.mark.parametrize(
+    ("check_order", "context"),
+    [(True, nullcontext()), (False, pytest.raises(NotImplementedError))],
+)
+def test_nested_check_order(
+    constructor_eager: ConstructorEager, *, check_order: bool, context: Any
+) -> None:
+    left = nw.from_native(constructor_eager({"a": [[1, 2, 3]]}), eager_only=True)[
+        "a"
+    ].cast(nw.List(nw.Int32()))
+    with context:
+        assert_series_equal(left, left, check_order=check_order)
+
+
+@pytest.mark.parametrize(
+    ("check_order", "context"),
+    [
+        (False, nullcontext()),
+        (
+            True,
+            pytest.raises(
+                AssertionError, match=r"Series are different \(exact value mismatch\)"
+            ),
+        ),
+    ],
+)
+def test_non_nested_check_order(
+    constructor_eager: ConstructorEager, *, check_order: bool, context: Any
+) -> None:
+    data = {"left": ["a", "b", "c"], "right": ["b", "c", "a"]}
+    frame = nw.from_native(constructor_eager(data), eager_only=True)
+    left, right = frame["left"], frame["right"]
+    with context:
+        assert_series_equal(left, right, check_order=check_order, check_names=False)
+
+
+def test_null_mismatch(constructor_eager: ConstructorEager) -> None: ...

--- a/tests/testing/assert_series_equal_test.py
+++ b/tests/testing/assert_series_equal_test.py
@@ -14,6 +14,10 @@ if TYPE_CHECKING:
     from tests.utils import ConstructorEager
 
 
+def _pytest_assertion_error(detail: str) -> Any:
+    return pytest.raises(AssertionError, match=rf"Series are different \({detail}\)")
+
+
 def test_self_equal(
     constructor_eager: ConstructorEager, data: Data, schema: IntoSchema
 ) -> None:
@@ -39,8 +43,7 @@ def test_raise_impl_mismatch() -> None:
     data = [1, 2, 3]
     left, right = pd.Series(data), pa.chunked_array([data])
 
-    msg = r"Series are different \(implementation mismatch\)"
-    with pytest.raises(AssertionError, match=msg):
+    with _pytest_assertion_error("implementation mismatch"):
         assert_series_equal(left, right)  # type: ignore[arg-type]
 
 
@@ -54,15 +57,7 @@ def test_raise_length_mismatch(constructor_eager: ConstructorEager) -> None:
 
 @pytest.mark.parametrize(
     ("check_dtypes", "context"),
-    [
-        (False, nullcontext()),
-        (
-            True,
-            pytest.raises(
-                AssertionError, match=r"Series are different \(dtype mismatch\)"
-            ),
-        ),
-    ],
+    [(False, nullcontext()), (True, _pytest_assertion_error("dtype mismatch"))],
 )
 def test_check_dtypes(
     constructor_eager: ConstructorEager, *, check_dtypes: bool, context: Any
@@ -76,15 +71,7 @@ def test_check_dtypes(
 
 @pytest.mark.parametrize(
     ("check_names", "context"),
-    [
-        (False, nullcontext()),
-        (
-            True,
-            pytest.raises(
-                AssertionError, match=r"Series are different \(name mismatch\)"
-            ),
-        ),
-    ],
+    [(False, nullcontext()), (True, _pytest_assertion_error("name mismatch"))],
 )
 def test_check_names(
     constructor_eager: ConstructorEager, *, check_names: bool, context: Any
@@ -112,15 +99,7 @@ def test_nested_check_order(
 
 @pytest.mark.parametrize(
     ("check_order", "context"),
-    [
-        (False, nullcontext()),
-        (
-            True,
-            pytest.raises(
-                AssertionError, match=r"Series are different \(exact value mismatch\)"
-            ),
-        ),
-    ],
+    [(False, nullcontext()), (True, _pytest_assertion_error("exact value mismatch"))],
 )
 def test_non_nested_check_order(
     constructor_eager: ConstructorEager, *, check_order: bool, context: Any
@@ -132,4 +111,143 @@ def test_non_nested_check_order(
         assert_series_equal(left, right, check_order=check_order, check_names=False)
 
 
-def test_null_mismatch(constructor_eager: ConstructorEager) -> None: ...
+@pytest.mark.parametrize(
+    "_data",
+    [
+        {"left": ["x", None, None], "right": ["x", None, "x"]},
+        {"left": ["x", None, None], "right": [None, None, "x"]},
+    ],
+)
+def test_null_mismatch(constructor_eager: ConstructorEager, _data: Data) -> None:
+    frame = nw.from_native(constructor_eager(_data), eager_only=True)
+    left, right = frame["left"], frame["right"]
+    with _pytest_assertion_error("null value mismatch"):
+        assert_series_equal(left, right, check_names=False)
+
+
+@pytest.mark.parametrize(
+    ("check_exact", "abs_tol", "rel_tol", "context"),
+    [
+        (True, 1e-3, 1e-3, _pytest_assertion_error("exact value mismatch")),
+        (False, 1e-3, 1e-3, _pytest_assertion_error("values not within tolerance")),
+        (False, 2e-1, 2e-1, nullcontext()),
+    ],
+)
+def test_numeric(
+    constructor_eager: ConstructorEager,
+    *,
+    check_exact: bool,
+    abs_tol: float,
+    rel_tol: float,
+    context: Any,
+) -> None:
+    data = {
+        "left": [1.0, float("nan"), float("inf"), None, 1.1],
+        "right": [1.01, float("nan"), float("inf"), None, 1.11],
+    }
+
+    frame = nw.from_native(constructor_eager(data), eager_only=True)
+    left, right = frame["left"], frame["right"]
+    with context:
+        assert_series_equal(
+            left,
+            right,
+            check_names=False,
+            check_exact=check_exact,
+            abs_tol=abs_tol,
+            rel_tol=rel_tol,
+        )
+
+
+@pytest.mark.parametrize(
+    ("l_vals", "r_vals", "check_exact", "context", "dtype"),
+    [
+        (
+            [["foo", "bar"]],
+            [["foo", None]],
+            True,
+            _pytest_assertion_error("nested value mismatch"),
+            nw.List(nw.String()),
+        ),
+        (
+            [["foo", "bar"]],
+            [["foo", None]],
+            True,
+            _pytest_assertion_error("nested value mismatch"),
+            nw.Array(nw.String(), 2),
+        ),
+        (
+            [[0.0, 0.1]],
+            [[0.1, 0.1]],
+            True,
+            _pytest_assertion_error("nested value mismatch"),
+            nw.List(nw.Float32()),
+        ),
+        (
+            [[0.0, 0.1]],
+            [[0.1, 0.1]],
+            True,
+            _pytest_assertion_error("nested value mismatch"),
+            nw.Array(nw.Float32(), 2),
+        ),
+        ([[0.0, 1e-10]], [[1e-10, 0.0]], False, nullcontext(), nw.List(nw.Float64())),
+        ([[0.0, 1e-10]], [[1e-10, 0.0]], False, nullcontext(), nw.Array(nw.Float64(), 2)),
+    ],
+)
+def test_list_like(
+    constructor_eager: ConstructorEager,
+    l_vals: list[list[Any]],
+    r_vals: list[list[Any]],
+    *,
+    check_exact: bool,
+    context: Any,
+    dtype: nw.dtypes.DType,
+) -> None:
+    data = {"left": l_vals, "right": r_vals}
+    frame = nw.from_native(constructor_eager(data), eager_only=True).select(
+        nw.all().cast(dtype)
+    )
+    left, right = frame["left"], frame["right"]
+    with context:
+        assert_series_equal(left, right, check_names=False, check_exact=check_exact)
+
+
+@pytest.mark.parametrize(
+    ("l_vals", "r_vals", "check_exact", "context"),
+    [
+        (
+            [{"a": 0.0, "b": ["orca"]}, None],
+            [{"a": 1e-10, "b": ["orca"]}, None],
+            True,
+            _pytest_assertion_error("exact value mismatch"),
+        ),
+        (
+            [{"a": 0.0, "b": ["beluga"]}, None],
+            [{"a": 0.0, "b": ["orca"]}, None],
+            False,
+            _pytest_assertion_error("exact value mismatch"),
+        ),
+        (
+            [{"a": 0.0, "b": ["orca"]}, None],
+            [{"a": 1e-10, "b": ["orca"]}, None],
+            False,
+            nullcontext(),
+        ),
+    ],
+)
+def test_struct(
+    constructor_eager: ConstructorEager,
+    l_vals: list[dict[str, Any]],
+    r_vals: list[dict[str, Any]],
+    *,
+    check_exact: bool,
+    context: Any,
+) -> None:
+    dtype = nw.Struct({"a": nw.Float32(), "b": nw.List(nw.String())})
+    data = {"left": l_vals, "right": r_vals}
+    frame = nw.from_native(constructor_eager(data), eager_only=True).select(
+        nw.all().cast(dtype)
+    )
+    left, right = frame["left"], frame["right"]
+    with context:
+        assert_series_equal(left, right, check_names=False, check_exact=check_exact)

--- a/tests/testing/conftest.py
+++ b/tests/testing/conftest.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+import narwhals as nw
+
+if TYPE_CHECKING:
+    from narwhals.typing import IntoSchema
+    from tests.conftest import Data
+
+
+@pytest.fixture
+def schema() -> IntoSchema:
+    return {
+        "int": nw.Int32(),
+        "float": nw.Float32(),
+        "str": nw.String(),
+        "categorical": nw.Categorical(),
+        "enum": nw.Enum(["beluga", "narwhal", "orca"]),
+        "bool": nw.Boolean(),
+        "datetime": nw.Datetime(),
+        "date": nw.Date(),
+        "time": nw.Time(),
+        "duration": nw.Duration(),
+        "binary": nw.Binary(),
+        "list": nw.List(nw.Float32()),
+        "array": nw.Array(nw.Int32(), shape=2),
+        "struct": nw.Struct({"a": nw.Int64(), "b": nw.List(nw.String())}),
+    }
+
+
+@pytest.fixture
+def data() -> Data:
+    return {
+        "int": [1, 2, 3, 4],
+        "float": [1.0, float("nan"), float("inf"), None],
+        "str": ["beluga", "narwhal", "orca", None],
+        "categorical": ["beluga", "narwhal", "beluga", None],
+        "enum": ["beluga", "narwhal", "orca", "narwhal"],
+        "bool": [True, False, True, None],
+        "datetime": [
+            datetime(2025, 1, 1, 12),
+            datetime(2025, 1, 2, 12),
+            datetime(2025, 1, 3, 12),
+            None,
+        ],
+        "date": [date(2025, 1, 1), date(2025, 1, 2), date(2025, 1, 3), None],
+        "time": [time(9, 0), time(9, 1, 10), time(9, 2), None],
+        "duration": [
+            timedelta(seconds=1),
+            timedelta(seconds=2),
+            timedelta(seconds=3),
+            None,
+        ],
+        "binary": [b"foo", b"bar", b"baz", None],
+        "list": [[1.0, float("nan")], [], [None], None],
+        "array": [[1, 2], [3, 4], [5, 6], None],
+        "struct": [
+            {"a": 1, "b": ["narwhal", "beluga"]},
+            {"a": 2, "b": ["orca"]},
+            {"a": 3, "b": [None]},
+            None,
+        ],
+    }


### PR DESCRIPTION
# Description

This PR introduces the testing module (mirroring the polars structure) and `assert_series_equal`. It's a step towards: #739 and #2804.

I think it's a good structure to leave space for, let's say, a `constructors` module within it (see #2959 and in particular the discord conversation linked in the issue).

Additional comments:

- One edge case/blocker for nested dtype here is mentioned in #2939 (I am raising a `NotImplementedError`).
- I started with `assert_series_equal` since if this goes through, then `assert_frame_equal` can re-use it for the value checks. However I didn't want to bloat the PR with 1k+ lines changes
- As usual... 600+ lines changes, but in all honesty 50%+ are tests.
- If this and `assert_frame_equal` end up being implemented, I think we can have an issue to track usage for them in the test suite itself

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

