### PR TITLE
fix: Workaround for `clip` with modin[pyarrow] backend

### DIFF
--- a/tests/expr_and_series/clip_test.py
+++ b/tests/expr_and_series/clip_test.py
@@ -28,8 +28,6 @@ def test_clip_expr(
 def test_clip_expr_expressified(
     request: pytest.FixtureRequest, constructor: Constructor
 ) -> None:
-    if "modin_pyarrow" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
     if "cudf" in str(constructor):
         # https://github.com/rapidsai/cudf/issues/17682
         request.applymarker(pytest.mark.xfail)
@@ -66,8 +64,6 @@ def test_clip_series(
 def test_clip_series_expressified(
     request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
-    if "modin_pyarrow" in str(constructor_eager):
-        request.applymarker(pytest.mark.xfail)
     if "cudf" in str(constructor_eager):
         # https://github.com/rapidsai/cudf/issues/17682
         request.applymarker(pytest.mark.xfail)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related comment: https://github.com/narwhals-dev/narwhals/pull/2983#issuecomment-3185834687

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below
