### PR TITLE
docs: Include `DType` methods, properties in API Reference

### DIFF
--- a/docs/api-reference/dtypes.md
+++ b/docs/api-reference/dtypes.md
@@ -40,3 +40,5 @@
       show_root_heading: false
       show_source: false
       show_bases: false
+      filters: ["!^_", "^__eq__$"]
+      inherited_members: true

--- a/docs/api-reference/dtypes.md
+++ b/docs/api-reference/dtypes.md
@@ -4,39 +4,41 @@
     handler: python
     options:
       members:
-        - Array
+        - NumericType
         - Decimal
-        - List
-        - Int128
-        - Int64
-        - Int32
-        - Int16
-        - Int8
-        - IntegerType
-        - UInt128
-        - UInt64
-        - UInt32
-        - UInt16
-        - UInt8
-        - Field
-        - Float64
-        - Float32
         - FloatType
-        - Boolean
-        - Categorical
-        - Enum
-        - NestedType
+        - Float32
+        - Float64
+        - IntegerType
         - SignedIntegerType
-        - String
-        - Struct
+        - Int8
+        - Int16
+        - Int32
+        - Int64
+        - Int128
+        - UnsignedIntegerType
+        - UInt8
+        - UInt16
+        - UInt32
+        - UInt64
+        - UInt128
+        - TemporalType
         - Date
         - Datetime
         - Duration
+        - Time
+        - NestedType
+        - Array
+        - List
+        - Field
+        - Struct
+        - String
+        - Categorical
+        - Enum
+        - Binary
+        - Boolean
         - Object
         - Unknown
-        - UnsignedIntegerType
-        - Time
-        - Binary
       show_root_heading: false
       show_source: false
       show_bases: false

--- a/docs/api-reference/dtypes.md
+++ b/docs/api-reference/dtypes.md
@@ -4,6 +4,7 @@
     handler: python
     options:
       members:
+        - DType
         - NumericType
         - Decimal
         - FloatType
@@ -41,6 +42,6 @@
         - Unknown
       show_root_heading: false
       show_source: false
-      show_bases: false
+      show_bases: true
       filters: ["!^_", "^__eq__$"]
-      inherited_members: true
+      inherited_members: false

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -460,8 +460,26 @@ class Datetime(TemporalType, metaclass=_DatetimeMeta):
             To see valid strings run `import zoneinfo; zoneinfo.available_timezones()` for a full list.
         """
 
-    def __eq__(self, other: object) -> bool:
-        """Check if this DType is equivalent to another DType."""
+    def __eq__(self, other: DType | type[DType]) -> bool:  # type: ignore[override]
+        """Check if this Datetime is equivalent to another DType.
+
+        Examples:
+            >>> import narwhals as nw
+            >>> nw.Datetime("s") == nw.Datetime("s")
+            True
+            >>> nw.Datetime("us") == nw.Datetime()
+            True
+            >>> nw.Datetime("us") == nw.Datetime("ns")
+            False
+            >>> nw.Datetime("us", "UTC") == nw.Datetime(time_unit="us", time_zone="UTC")
+            True
+            >>> nw.Datetime(time_zone="UTC") == nw.Datetime(time_zone="EST")
+            False
+            >>> nw.Datetime() == nw.Duration()
+            False
+            >>> nw.Datetime("ms") == nw.Datetime
+            True
+        """
         if type(other) is _DatetimeMeta:
             return True
         if isinstance(other, self.__class__):

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -615,7 +615,9 @@ class Enum(DType):
             >>> import narwhals as nw
             >>> nw.Enum(["a", "b", "c"]) == nw.Enum(["a", "b", "c"])
             True
-            >>> nw.Enum(["a", "b", "c"]) == nw.Enum(("a", "b", "c"))
+            >>> import polars as pl
+            >>> categories = pl.Series(["a", "b", "c"])
+            >>> nw.Enum(["a", "b", "c"]) == nw.Enum(categories)
             True
             >>> nw.Enum(["a", "b", "c"]) == nw.Enum(["b", "a", "c"])
             False

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -665,6 +665,7 @@ class Field:
     def __eq__(self, other: Field) -> bool:  # type: ignore[override]
         """Check if this Field is equivalent to another Field.
 
+        Two fields are equivalent if they have the same name and the same dtype.
         Examples:
             >>> import narwhals as nw
             >>> nw.Field("a", nw.String) == nw.Field("a", nw.String())

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -615,8 +615,26 @@ class Field:
         self.dtype = dtype
 
     def __eq__(self, other: Field) -> bool:  # type: ignore[override]
-        """Check if this DType is equivalent to another DType."""
-        return (self.name == other.name) & (self.dtype == other.dtype)
+        """Check if this Field is equivalent to another Field.
+
+        Examples:
+            >>> import narwhals as nw
+            >>> nw.Field("a", nw.String) == nw.Field("a", nw.String())
+            True
+            >>> nw.Field("a", nw.String) == nw.Field("a", nw.String)
+            True
+            >>> nw.Field("a", nw.String) == nw.Field("a", nw.Datetime)
+            False
+            >>> nw.Field("a", nw.String) == nw.Field("b", nw.String)
+            False
+            >>> nw.Field("a", nw.String) == nw.String
+            False
+        """
+        return (
+            isinstance(other, Field)
+            and (self.name == other.name)
+            and (self.dtype == other.dtype)
+        )
 
     def __hash__(self) -> int:
         return hash((self.name, self.dtype))

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -467,7 +467,7 @@ class Datetime(TemporalType, metaclass=_DatetimeMeta):
             >>> import narwhals as nw
             >>> nw.Datetime("s") == nw.Datetime("s")
             True
-            >>> nw.Datetime("us") == nw.Datetime()
+            >>> nw.Datetime() == nw.Datetime("us")
             True
             >>> nw.Datetime("us") == nw.Datetime("ns")
             False

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -639,11 +639,24 @@ class Struct(NestedType):
             self.fields = list(fields)
 
     def __eq__(self, other: DType | type[DType]) -> bool:  # type: ignore[override]
-        """Check if this DType is equivalent to another DType."""
-        # The comparison allows comparing objects to classes, and specific
-        # inner types to those without (eg: inner=None). if one of the
-        # arguments is not specific about its inner type we infer it
-        # as being equal. (See the List type for more info).
+        """Check if this Struct is equivalent to another DType.
+
+        Examples:
+            >>> import narwhals as nw
+            >>> nw.Struct({"a": nw.Int64}) == nw.Struct({"a": nw.Int64})
+            True
+            >>> nw.Struct({"a": nw.Int64}) == nw.Struct({"a": nw.Boolean})
+            False
+            >>> nw.Struct({"a": nw.Int64}) == nw.Struct({"b": nw.Int64})
+            False
+            >>> nw.Struct({"a": nw.Int64}) == nw.Struct([nw.Field("a", nw.Int64)])
+            True
+
+            If a parent type is not specific about its inner type, we infer it as equal
+
+            >>> nw.Struct({"a": nw.Int64}) == nw.Struct
+            True
+        """
         if type(other) is type and issubclass(other, self.__class__):
             return True
         if isinstance(other, self.__class__):
@@ -692,12 +705,20 @@ class List(NestedType):
         self.inner = inner
 
     def __eq__(self, other: DType | type[DType]) -> bool:  # type: ignore[override]
-        """Check if this DType is equivalent to another DType."""
-        # This equality check allows comparison of type classes and type instances.
-        # If a parent type is not specific about its inner type, we infer it as equal:
-        # > list[i64] == list[i64] -> True
-        # > list[i64] == list[f32] -> False
-        # > list[i64] == list      -> True
+        """Check if this List is equivalent to another DType.
+
+        Examples:
+            >>> import narwhals as nw
+            >>> nw.List(nw.Int64) == nw.List(nw.Int64)
+            True
+            >>> nw.List(nw.Int64) == nw.List(nw.Float32)
+            False
+
+            If a parent type is not specific about its inner type, we infer it as equal
+
+            >>> nw.List(nw.Int64) == nw.List
+            True
+        """
         if type(other) is type and issubclass(other, self.__class__):
             return True
         if isinstance(other, self.__class__):
@@ -754,14 +775,22 @@ class Array(NestedType):
             raise TypeError(msg)
 
     def __eq__(self, other: DType | type[DType]) -> bool:  # type: ignore[override]
-        """Check if this DType is equivalent to another DType."""
-        # This equality check allows comparison of type classes and type instances.
-        # If a parent type is not specific about its inner type, we infer it as equal:
-        # > array[i64] == array[i64] -> True
-        # > array[i64] == array[f32] -> False
-        # > array[i64] == array      -> True
+        """Check if this Array is equivalent to another DType.
 
-        # allow comparing object instances to class
+        Examples:
+            >>> import narwhals as nw
+            >>> nw.Array(nw.Int64, 2) == nw.Array(nw.Int64, 2)
+            True
+            >>> nw.Array(nw.Int64, 2) == nw.Array(nw.String, 2)
+            False
+            >>> nw.Array(nw.Int64, 2) == nw.Array(nw.Int64, 4)
+            False
+
+            If a parent type is not specific about its inner type, we infer it as equal
+
+            >>> nw.Array(nw.Int64, 2) == nw.Array
+            True
+        """
         if type(other) is type and issubclass(other, self.__class__):
             return True
         if isinstance(other, self.__class__):

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -126,7 +126,21 @@ class DType:
         return issubclass(cls, Boolean)
 
     def __eq__(self, other: DType | type[DType]) -> bool:  # type: ignore[override]
-        """Check if this DType is equivalent to another DType."""
+        """Check if this DType is equivalent to another DType.
+
+        Examples:
+            >>> import narwhals as nw
+            >>> nw.String() == nw.String()
+            True
+            >>> nw.String() == nw.String
+            True
+            >>> nw.Int16() == nw.Int32
+            False
+            >>> nw.Boolean() == nw.Int8
+            False
+            >>> nw.Date() == nw.Datetime
+            False
+        """
         from narwhals._utils import isinstance_or_issubclass
 
         return isinstance_or_issubclass(other, type(self))

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -514,8 +514,22 @@ class Duration(TemporalType, metaclass=_DurationMeta):
         self.time_unit: TimeUnit = time_unit
         """Unit of time."""
 
-    def __eq__(self, other: object) -> bool:
-        """Check if this DType is equivalent to another DType."""
+    def __eq__(self, other: DType | type[DType]) -> bool:  # type: ignore[override]
+        """Check if this Duration is equivalent to another DType.
+
+        Examples:
+            >>> import narwhals as nw
+            >>> nw.Duration("us") == nw.Duration("us")
+            True
+            >>> nw.Duration() == nw.Duration("us")
+            True
+            >>> nw.Duration("us") == nw.Duration("ns")
+            False
+            >>> nw.Duration() == nw.Datetime()
+            False
+            >>> nw.Duration("ms") == nw.Duration
+            True
+        """
         if type(other) is _DurationMeta:
             return True
         if isinstance(other, self.__class__):

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -576,8 +576,24 @@ class Enum(DType):
         msg = f"Internal structure of {type(self).__name__!r} is invalid."  # pragma: no cover
         raise TypeError(msg)  # pragma: no cover
 
-    def __eq__(self, other: object) -> bool:
-        """Check if this DType is equivalent to another DType."""
+    def __eq__(self, other: DType | type[DType]) -> bool:  # type: ignore[override]
+        """Check if this Enum is equivalent to another DType.
+
+        Examples:
+            >>> import narwhals as nw
+            >>> nw.Enum(["a", "b", "c"]) == nw.Enum(["a", "b", "c"])
+            True
+            >>> nw.Enum(["a", "b", "c"]) == nw.Enum(("a", "b", "c"))
+            True
+            >>> nw.Enum(["a", "b", "c"]) == nw.Enum(["b", "a", "c"])
+            False
+            >>> nw.Enum(["a", "b", "c"]) == nw.Enum(["a"])
+            False
+            >>> nw.Enum(["a", "b", "c"]) == nw.Categorical
+            False
+            >>> nw.Enum(["a", "b", "c"]) == nw.Enum
+            True
+        """
         if type(other) is type:
             return other is Enum
         return isinstance(other, type(self)) and self.categories == other.categories

--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -666,6 +666,7 @@ class Field:
         """Check if this Field is equivalent to another Field.
 
         Two fields are equivalent if they have the same name and the same dtype.
+
         Examples:
             >>> import narwhals as nw
             >>> nw.Field("a", nw.String) == nw.Field("a", nw.String())

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -122,6 +122,22 @@ def test_field_repr() -> None:
     assert repr(dtype) == "Field('a', <class 'narwhals.dtypes.Int32'>)"
 
 
+def test_field_eq() -> None:
+    field_1 = nw.Field("a", nw.String)
+    field_2 = nw.Field("a", nw.String())
+    field_3 = nw.Field("b", nw.Datetime())
+    field_4 = nw.Field("b", nw.Datetime("ms"))
+    field_5 = nw.Field("b", nw.Datetime)
+
+    assert field_1 == field_2
+    assert field_2 != field_3
+    # bit of a head-scratcher
+    assert field_3 != field_4
+    assert field_3 == field_5
+    assert field_4 == field_5
+    assert field_1 != field_1.dtype
+
+
 def test_struct_hashes() -> None:
     dtypes = (
         nw.Struct,

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -94,15 +94,7 @@ SERIES_ONLY_METHODS = {
     "__iter__",
     "__contains__",
 }
-BASE_DTYPES = {
-    "NumericType",
-    "DType",
-    "TemporalType",
-    "Literal",
-    "OrderedDict",
-    "Mapping",
-    "Iterable",
-}
+BASE_DTYPES = {"DType", "Literal", "OrderedDict", "Mapping", "Iterable"}
 DIR_API_REF = Path("docs/api-reference")
 
 files = {fp.stem for fp in Path("narwhals").iterdir()}

--- a/utils/check_api_reference.py
+++ b/utils/check_api_reference.py
@@ -8,7 +8,7 @@ import sys
 from collections import deque
 from inspect import isfunction
 from pathlib import Path
-from types import MethodType
+from types import MethodType, ModuleType
 from typing import TYPE_CHECKING, Any
 
 import polars as pl
@@ -37,6 +37,17 @@ else:
 
 def iter_api_reference_names(tp: type[Any]) -> Iterator[str]:
     for name, _ in inspect.getmembers(tp, _is_public_method_or_property):
+        yield name
+
+
+def iter_api_reference_names_dtypes(module: ModuleType) -> Iterator[str]:
+    base = module.DType
+    # NOTE: Special case, only non-dtype
+    field_dtype = module.Field
+    for name, _ in inspect.getmembers(
+        module,
+        lambda x: isinstance(x, type) and (issubclass(x, base) or x is field_dtype),
+    ):
         yield name
 
 
@@ -94,7 +105,6 @@ SERIES_ONLY_METHODS = {
     "__iter__",
     "__contains__",
 }
-BASE_DTYPES = {"DType", "Literal", "OrderedDict", "Mapping", "Iterable"}
 DIR_API_REF = Path("docs/api-reference")
 
 files = {fp.stem for fp in Path("narwhals").iterdir()}
@@ -197,9 +207,9 @@ for namespace in NAMESPACES:
         ret = 1
 
 # DTypes
-dtypes = [i for i in dir(nw.dtypes) if i[0].isupper() and not i.isupper() and i[0] != "_"]
+dtypes = list(iter_api_reference_names_dtypes(nw.dtypes))
 documented = read_documented_members(DIR_API_REF / "dtypes.md")
-if missing := set(dtypes).difference(documented).difference(BASE_DTYPES):
+if missing := set(dtypes).difference(documented):
     print("Dtype: not documented")  # noqa: T201
     print(missing)  # noqa: T201
     ret = 1


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Part of #2965
  - See 97628 links there!

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below
Did some re-aligning with [upstream](https://docs.pola.rs/api/python/version/1/reference/datatypes.html) as well

<details><summary>Outdated</summary>
<p>

What's currently in the PR I'm considering a **starting point** to chisel away at.
I'm happy with the *what*, but the repetition is waaaay too much 😔

So I'm very open to suggestions (even if they're just a link to other docs) on ways we can present it better

</p>
</details> 

Pretty happy with the new `dtypes` page, we've now got the hierarchy documented and examples of how `__eq__` works.

The main changes are shown in (https://github.com/narwhals-dev/narwhals/pull/2999#issuecomment-3193620241)

## Relevant `mkdocs` config
- https://mkdocstrings.github.io/python/usage/configuration/members/
- https://mkdocstrings.github.io/python/usage/configuration/docstrings/
- https://mkdocstrings.github.io/python/usage/configuration/signatures/