### PR TITLE
docs: Fix indentation of coalesce example in doc string

### DIFF
--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -1753,33 +1753,33 @@ def coalesce(
         A new expression.
 
     Examples:
-    >>> import polars as pl
-    >>> import narwhals as nw
-    >>> data = [
-    ...     (1, 5, None),
-    ...     (None, 6, None),
-    ...     (None, None, 9),
-    ...     (4, 8, 10),
-    ...     (None, None, None),
-    ... ]
-    >>> df = pl.DataFrame(data, schema=["a", "b", "c"], orient="row")
-    >>> nw.from_native(df).select(nw.coalesce("a", "b", "c", nw.lit(-1)))
-    ┌──────────────────┐
-    |Narwhals DataFrame|
-    |------------------|
-    |  shape: (5, 1)   |
-    |  ┌─────┐         |
-    |  │ a   │         |
-    |  │ --- │         |
-    |  │ i64 │         |
-    |  ╞═════╡         |
-    |  │ 1   │         |
-    |  │ 6   │         |
-    |  │ 9   │         |
-    |  │ 4   │         |
-    |  │ -1  │         |
-    |  └─────┘         |
-    └──────────────────┘
+        >>> import polars as pl
+        >>> import narwhals as nw
+        >>> data = [
+        ...     (1, 5, None),
+        ...     (None, 6, None),
+        ...     (None, None, 9),
+        ...     (4, 8, 10),
+        ...     (None, None, None),
+        ... ]
+        >>> df = pl.DataFrame(data, schema=["a", "b", "c"], orient="row")
+        >>> nw.from_native(df).select(nw.coalesce("a", "b", "c", nw.lit(-1)))
+        ┌──────────────────┐
+        |Narwhals DataFrame|
+        |------------------|
+        |  shape: (5, 1)   |
+        |  ┌─────┐         |
+        |  │ a   │         |
+        |  │ --- │         |
+        |  │ i64 │         |
+        |  ╞═════╡         |
+        |  │ 1   │         |
+        |  │ 6   │         |
+        |  │ 9   │         |
+        |  │ 4   │         |
+        |  │ -1  │         |
+        |  └─────┘         |
+        └──────────────────┘
     """
     flat_exprs = flatten([*flatten([exprs]), *more_exprs])
 


### PR DESCRIPTION
Prior to this PR, the example of the `coalesce` doc string is not rendered as intended, see here:
https://narwhals-dev.github.io/narwhals/api-reference/narwhals/#narwhals.coalesce
<img width="1742" height="159" alt="Screenshot 2025-08-18 at 18 29 35" src="https://github.com/user-attachments/assets/dd0e68b5-4b11-49b2-8742-bb0d8cc48b16" />

This PR fixed the rendering of the doc string's example by adapting the indentation level of the example content, see:
<img width="721" height="701" alt="Screenshot 2025-08-18 at 18 26 12" src="https://github.com/user-attachments/assets/79bb077c-4c8c-42ec-9dfe-b68823bfc5d1" />


## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
