### PR TITLE
ci: Remove `duckdb` nightly from cov

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -84,8 +84,6 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: install-reqs
         run: uv pip install -e ".[dask, modin, ibis]" --group core-tests --group extra --system
-      - name: install duckdb nightly
-        run: uv pip install -U --pre duckdb --system
       - name: show-deps
         run: uv pip freeze
       - name: Run pytest

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -27,7 +27,7 @@ from narwhals._utils import (
 from narwhals.exceptions import InvalidOperationError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Mapping, Sequence
+    from collections.abc import Iterator, Mapping, Sequence
     from io import BytesIO
     from pathlib import Path
     from types import ModuleType
@@ -163,34 +163,27 @@ class SparkLikeLazyFrame(
                 schema.append((key, native_dtype))
         return pa.schema(schema)
 
-    def _to_arrow_from_batches(self, batches: Iterable[pa.RecordBatch]) -> pa.Table:
-        import pyarrow as pa  # ignore-banned-import
-
-        try:
-            return pa.Table.from_batches(batches)
-        except ValueError as exc:
-            if "at least one RecordBatch" in str(exc):
-                # Empty dataframe
-                data: dict[str, list[Any]] = {k: [] for k in self.columns}
-                return pa.Table.from_pydict(data, schema=self._to_arrow_schema())
-            raise  # pragma: no cover
-
     def _collect_to_arrow(self) -> pa.Table:
-        import pyarrow as pa  # ignore-banned-import
-
         if self._implementation.is_pyspark() and self._backend_version < (4,):
-            return self._to_arrow_from_batches(self.native._collect_as_arrow())
-        if self._implementation.is_pyspark_connect() and self._backend_version < (4,):
+            import pyarrow as pa  # ignore-banned-import
+
+            try:
+                return pa.Table.from_batches(self.native._collect_as_arrow())
+            except ValueError as exc:
+                if "at least one RecordBatch" in str(exc):
+                    # Empty dataframe
+
+                    data: dict[str, list[Any]] = {k: [] for k in self.columns}
+                    pa_schema = self._to_arrow_schema()
+                    return pa.Table.from_pydict(data, schema=pa_schema)
+                raise  # pragma: no cover
+        elif self._implementation.is_pyspark_connect() and self._backend_version < (4,):
+            import pyarrow as pa  # ignore-banned-import
+
             pa_schema = self._to_arrow_schema()
             return pa.Table.from_pandas(self.native.toPandas(), schema=pa_schema)
-        # NOTE: Returns `pa.RecordBatchReader` since https://github.com/duckdb/duckdb/pull/18642
-        to_arrow: Incomplete = self.native.toArrow
-        pa_native: pa.Table | pa.RecordBatchReader = to_arrow()
-        return (
-            pa_native
-            if isinstance(pa_native, pa.Table)
-            else self._to_arrow_from_batches(pa_native)
-        )
+        else:
+            return self.native.toArrow()
 
     def _iter_columns(self) -> Iterator[Column]:
         for col in self.columns:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- https://github.com/duckdb/duckdb/pull/18642
- https://github.com/narwhals-dev/narwhals/actions/runs/17096107509/job/48483947375
- https://discord.com/channels/1235257048170762310/1272835922924273694/1407676349925036052

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

> [!IMPORTANT]
> Originally named *fix: Handle `pa.RecordBatchReader` in `SparkLikeLazyFrame.collect`*