### PR TITLE
chore(typing): Ignore inferred type in `dask_expr.Series.mask`

### DIFF
--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -448,7 +448,7 @@ class DaskExpr(
                 if get_dtype_backend(expr.dtype, self._implementation)
                 else value_numpy
             )
-            return expr.mask(mask, fill)
+            return expr.mask(mask, fill)  # pyright: ignore[reportArgumentType]
 
         return self._with_callable(func, "fill_nan")
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- Added in #3030
- https://github.com/narwhals-dev/narwhals/actions/runs/17204513065/job/48802070870?pr=3016

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
We don't have `dask` installed for typing CI, so this slipped through

Started getting this locally and in (#3016), where I needed `dask` (and `modin`) to verify the new fancy overloads 😅

```py
Success: no issues found in 429 source files
/narwhals/_dask/expr.py
  /narwhals/_dask/expr.py:451:36 - error: Argument of type "NAType | float" cannot be assigned to parameter "other" of type "float" in function "mask"
    Type "NAType | float" is not assignable to type "float"
      "NAType" is not assignable to "float" (reportArgumentType)
1 error, 0 warnings, 0 informations
```