### PR TITLE
tests: fix timezone aware test for Polars>=1.33.0

### DIFF
--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from contextlib import nullcontext as does_not_raise
+from contextlib import AbstractContextManager, nullcontext as does_not_raise
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pyarrow as pa
 import pytest
@@ -214,7 +214,7 @@ def test_to_datetime_tz_aware(
     if "cudf" in str(constructor):
         # cuDF does not yet support timezone-aware datetimes
         request.applymarker(pytest.mark.xfail)
-    context = (
+    context: AbstractContextManager[Any] = (
         pytest.raises(NotImplementedError)
         if any(x in str(constructor) for x in ("duckdb", "ibis")) and format is None
         else does_not_raise()


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

Hi everyone, this should fix CI for `polars>=1.33.0` that now raises an if we have tz-aware string but we don't specify the timezone in the format (i.e. ``narwhals.exceptions.ComputeError: `strptime` / `to_datetime` was called with no format and no time zone, but a time zone is part of the data. This was previously allowed but led to unpredictable and erroneous results. Give a format string, set a time zone or perform the operation eagerly on a Series instead of on an Expr.``)

Bigger questions: should we worry about making this behaviour consistent across backends?  
