### PR TITLE
chore: simplify parsing expressions in group-by

### DIFF
--- a/narwhals/_compliant/series.py
+++ b/narwhals/_compliant/series.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from typing_extensions import NotRequired, Self, TypedDict
 
     from narwhals._compliant.dataframe import CompliantDataFrame
+    from narwhals._compliant.expr import CompliantExpr, EagerExpr
     from narwhals._compliant.namespace import EagerNamespace
     from narwhals._utils import Implementation, Version, _LimitedContext
     from narwhals.dtypes import DType
@@ -95,6 +96,8 @@ class CompliantSeries(
 
     def _with_native(self, series: Any) -> Self: ...
     def _with_version(self, version: Version) -> Self: ...
+
+    def _to_expr(self) -> CompliantExpr[Any, Self]: ...
 
     # NOTE: `polars`
     @property
@@ -242,6 +245,9 @@ class EagerSeries(CompliantSeries[NativeSeriesT], Protocol[NativeSeriesT]):
     def __narwhals_namespace__(
         self,
     ) -> EagerNamespace[Any, Self, Any, Any, NativeSeriesT]: ...
+
+    def _to_expr(self) -> EagerExpr[Any, Any]:
+        return self.__narwhals_namespace__()._expr._from_series(self)  # type: ignore[no-any-return]
 
     def _gather(self, rows: SizedMultiIndexSelector[NativeSeriesT]) -> Self: ...
     def _gather_slice(self, rows: _SliceIndex | range) -> Self: ...

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -601,7 +601,10 @@ def apply_n_ary_operation(
 ) -> CompliantExprAny:
     parse = plx.parse_into_expr
     compliant_exprs = (parse(into, str_as_lit=str_as_lit) for into in comparands)
-    kinds = [ExprKind.from_into_expr(x, str_as_lit=str_as_lit) for x in compliant_exprs]
+    kinds = [
+        ExprKind.from_into_expr(comparand, str_as_lit=str_as_lit)
+        for comparand in comparands
+    ]
 
     broadcast = any(not kind.is_scalar_like for kind in kinds)
     compliant_exprs = (

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -5,11 +5,10 @@
 from __future__ import annotations
 
 from enum import Enum, auto
-from itertools import chain
 from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar
 
 from narwhals._utils import is_compliant_expr, zip_strict
-from narwhals.dependencies import is_narwhals_series, is_numpy_array, is_numpy_array_1d
+from narwhals.dependencies import is_narwhals_series, is_numpy_array
 from narwhals.exceptions import InvalidOperationError, MultiOutputExpressionError
 
 if TYPE_CHECKING:
@@ -44,13 +43,6 @@ def is_series(obj: Any) -> TypeIs[Series[Any]]:
     from narwhals.series import Series
 
     return isinstance(obj, Series)
-
-
-def is_into_expr_eager(obj: Any) -> TypeIs[Expr | Series[Any] | str | _1DArray]:
-    from narwhals.expr import Expr
-    from narwhals.series import Series
-
-    return isinstance(obj, (Series, Expr, str)) or is_numpy_array_1d(obj)
 
 
 def combine_evaluate_output_names(
@@ -582,14 +574,6 @@ def check_expressions_preserve_length(*args: IntoExpr, function_name: str) -> No
     ):
         msg = f"Expressions which aggregate or change length cannot be passed to '{function_name}'."
         raise InvalidOperationError(msg)
-
-
-def all_exprs_are_scalar_like(*args: IntoExpr, **kwargs: IntoExpr) -> bool:
-    # Raise if any argument in `args` isn't an aggregation or literal.
-    # For Series input, we don't raise (yet), we let such checks happen later,
-    # as this function works lazily and so can't evaluate lengths.
-    exprs = chain(args, kwargs.values())
-    return all(is_expr(x) and x._metadata.is_scalar_like for x in exprs)
 
 
 def apply_n_ary_operation(

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -144,7 +144,7 @@ class ExprKind(Enum):
         return self in {ExprKind.ORDERABLE_WINDOW, ExprKind.ORDERABLE_AGGREGATION}
 
     @classmethod
-    def from_compliant_expr(cls, obj: CompliantExprAny) -> ExprKind:
+    def from_expr(cls, obj: Expr) -> ExprKind:
         meta = obj._metadata
         assert meta is not None  # noqa: S101
         if meta.is_literal:
@@ -160,7 +160,7 @@ class ExprKind(Enum):
         cls, obj: IntoExpr | NonNestedLiteral | _1DArray, *, str_as_lit: bool
     ) -> ExprKind:
         if is_expr(obj):
-            return cls.from_compliant_expr(obj)
+            return cls.from_expr(obj)
         if (
             is_narwhals_series(obj)
             or is_numpy_array(obj)
@@ -601,10 +601,7 @@ def apply_n_ary_operation(
 ) -> CompliantExprAny:
     parse = plx.parse_into_expr
     compliant_exprs = (parse(into, str_as_lit=str_as_lit) for into in comparands)
-    kinds = [
-        ExprKind.from_into_expr(comparand, str_as_lit=str_as_lit)
-        for comparand in comparands
-    ]
+    kinds = [ExprKind.from_into_expr(x, str_as_lit=str_as_lit) for x in compliant_exprs]
 
     broadcast = any(not kind.is_scalar_like for kind in kinds)
     compliant_exprs = (

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -144,8 +144,9 @@ class ExprKind(Enum):
         return self in {ExprKind.ORDERABLE_WINDOW, ExprKind.ORDERABLE_AGGREGATION}
 
     @classmethod
-    def from_expr(cls, obj: Expr) -> ExprKind:
+    def from_compliant_expr(cls, obj: CompliantExprAny) -> ExprKind:
         meta = obj._metadata
+        assert meta is not None  # noqa: S101
         if meta.is_literal:
             return ExprKind.LITERAL
         if meta.is_scalar_like:
@@ -159,7 +160,7 @@ class ExprKind(Enum):
         cls, obj: IntoExpr | NonNestedLiteral | _1DArray, *, str_as_lit: bool
     ) -> ExprKind:
         if is_expr(obj):
-            return cls.from_expr(obj)
+            return cls.from_compliant_expr(obj)
         if (
             is_narwhals_series(obj)
             or is_numpy_array(obj)

--- a/narwhals/_expression_parsing.py
+++ b/narwhals/_expression_parsing.py
@@ -146,7 +146,6 @@ class ExprKind(Enum):
     @classmethod
     def from_expr(cls, obj: Expr) -> ExprKind:
         meta = obj._metadata
-        assert meta is not None  # noqa: S101
         if meta.is_literal:
             return ExprKind.LITERAL
         if meta.is_scalar_like:

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from narwhals._expression_parsing import ExprKind, ExprMetadata
     from narwhals._polars.dataframe import Method
     from narwhals._polars.namespace import PolarsNamespace
+    from narwhals._polars.series import PolarsSeries
     from narwhals._utils import Version
     from narwhals.typing import IntoDType, ModeKeepStrategy, NumericLiteral
 
@@ -60,6 +61,10 @@ class PolarsExpr:
     def __init__(self, expr: pl.Expr, version: Version) -> None:
         self._native_expr = expr
         self._version = version
+
+    @classmethod
+    def _from_series(cls, series: PolarsSeries) -> Self:
+        return series._to_expr()
 
     @property
     def _backend_version(self) -> tuple[int, ...]:

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from narwhals._expression_parsing import ExprKind, ExprMetadata
     from narwhals._polars.dataframe import Method
     from narwhals._polars.namespace import PolarsNamespace
-    from narwhals._polars.series import PolarsSeries
     from narwhals._utils import Version
     from narwhals.typing import IntoDType, ModeKeepStrategy, NumericLiteral
 
@@ -61,11 +60,6 @@ class PolarsExpr:
     def __init__(self, expr: pl.Expr, version: Version) -> None:
         self._native_expr = expr
         self._version = version
-
-    @classmethod
-    def _from_series(cls, series: PolarsSeries) -> PolarsExpr:
-        # Polars can treat Series as Expr, so just pass down `series.native`.
-        return PolarsExpr(series.native, version=series._version)  # type: ignore[arg-type]
 
     @property
     def _backend_version(self) -> tuple[int, ...]:

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -64,7 +64,8 @@ class PolarsExpr:
 
     @classmethod
     def _from_series(cls, series: PolarsSeries) -> PolarsExpr:
-        return series._to_expr()
+        # Polars can treat Series as Expr, so just pass down `series.native`.
+        return PolarsExpr(series.native, version=series._version)  # type: ignore[arg-type]
 
     @property
     def _backend_version(self) -> tuple[int, ...]:

--- a/narwhals/_polars/expr.py
+++ b/narwhals/_polars/expr.py
@@ -63,7 +63,7 @@ class PolarsExpr:
         self._version = version
 
     @classmethod
-    def _from_series(cls, series: PolarsSeries) -> Self:
+    def _from_series(cls, series: PolarsSeries) -> PolarsExpr:
         return series._to_expr()
 
     @property

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast, overload
 
 import polars as pl
 
-from narwhals._polars.expr import PolarsExpr
 from narwhals._polars.utils import (
     BACKEND_VERSION,
     SERIES_ACCEPTS_PD_INDEX,
@@ -150,10 +149,6 @@ class PolarsSeries:
     def __init__(self, series: pl.Series, *, version: Version) -> None:
         self._native_series = series
         self._version = version
-
-    def _to_expr(self) -> PolarsExpr:
-        # Polars can treat Series as Expr, so just pass down `self.native`.
-        return PolarsExpr(self.native, version=self._version)  # type: ignore[arg-type]
 
     @property
     def _backend_version(self) -> tuple[int, ...]:

--- a/narwhals/_polars/series.py
+++ b/narwhals/_polars/series.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast, overload
 
 import polars as pl
 
+from narwhals._polars.expr import PolarsExpr
 from narwhals._polars.utils import (
     BACKEND_VERSION,
     SERIES_ACCEPTS_PD_INDEX,
@@ -149,6 +150,10 @@ class PolarsSeries:
     def __init__(self, series: pl.Series, *, version: Version) -> None:
         self._native_series = series
         self._version = version
+
+    def _to_expr(self) -> PolarsExpr:
+        # Polars can treat Series as Expr, so just pass down `self.native`.
+        return PolarsExpr(self.native, version=self._version)  # type: ignore[arg-type]
 
     @property
     def _backend_version(self) -> tuple[int, ...]:

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -19,8 +19,9 @@ from narwhals._exceptions import issue_warning
 from narwhals._expression_parsing import (
     ExprKind,
     check_expressions_preserve_length,
-    is_into_expr_eager,
+    is_expr,
     is_scalar_like,
+    is_series,
 )
 from narwhals._typing import Arrow, Pandas, _LazyAllowedImpl, _LazyFrameCollectImpl
 from narwhals._utils import (
@@ -43,14 +44,14 @@ from narwhals._utils import (
     supports_arrow_c_stream,
     zip_strict,
 )
-from narwhals.dependencies import is_numpy_array_2d, is_pyarrow_table
+from narwhals.dependencies import is_numpy_array_1d, is_numpy_array_2d, is_pyarrow_table
 from narwhals.exceptions import (
     ColumnNotFoundError,
     InvalidIntoExprError,
     InvalidOperationError,
     PerformanceWarning,
 )
-from narwhals.functions import _from_dict_no_backend, _is_into_schema
+from narwhals.functions import _from_dict_no_backend, _is_into_schema, col, new_series
 from narwhals.schema import Schema
 from narwhals.series import Series
 from narwhals.translate import to_native
@@ -67,9 +68,10 @@ if TYPE_CHECKING:
     from typing_extensions import Concatenate, ParamSpec, Self, TypeAlias
 
     from narwhals._compliant import CompliantDataFrame, CompliantLazyFrame
-    from narwhals._compliant.typing import CompliantExprAny, EagerNamespaceAny
+    from narwhals._compliant.typing import CompliantExprAny
     from narwhals._translate import IntoArrowTable
     from narwhals._typing import EagerAllowed, IntoBackend, LazyAllowed, Polars
+    from narwhals.expr import Expr
     from narwhals.group_by import GroupBy, LazyGroupBy
     from narwhals.typing import (
         AsofJoinStrategy,
@@ -87,6 +89,7 @@ if TYPE_CHECKING:
         SingleIndexSelector,
         SizeUnit,
         UniqueKeepStrategy,
+        _1DArray,
         _2DArray,
     )
 
@@ -148,18 +151,21 @@ class BaseFrame(Generic[_FrameT]):
         # NOTE: Strings are interpreted as column names.
         out_exprs = []
         out_kinds = []
+        ns = self.__narwhals_namespace__()
         for expr in flatten(exprs):
-            compliant_expr = self._extract_compliant(expr)
+            compliant_expr = self._parse_into_expr(expr)._to_compliant_expr(ns)
             out_exprs.append(compliant_expr)
-            out_kinds.append(ExprKind.from_into_expr(expr, str_as_lit=False))
+            out_kinds.append(ExprKind.from_compliant_expr(compliant_expr))
         for alias, expr in named_exprs.items():
-            compliant_expr = self._extract_compliant(expr).alias(alias)
+            compliant_expr = (
+                self._parse_into_expr(expr).alias(alias)._to_compliant_expr(ns)
+            )
             out_exprs.append(compliant_expr)
-            out_kinds.append(ExprKind.from_into_expr(expr, str_as_lit=False))
+            out_kinds.append(ExprKind.from_compliant_expr(compliant_expr))
         return out_exprs, out_kinds
 
     @abstractmethod
-    def _extract_compliant(self, arg: Any) -> Any:
+    def _parse_into_expr(self, arg: Any) -> Expr:
         raise NotImplementedError
 
     def _extract_compliant_frame(self, other: Self | Any, /) -> Any:
@@ -476,10 +482,15 @@ class DataFrame(BaseFrame[DataFrameT]):
     def _compliant(self) -> CompliantDataFrame[Any, Any, DataFrameT, Self]:
         return self._compliant_frame
 
-    def _extract_compliant(self, arg: Any) -> Any:
-        if is_into_expr_eager(arg):
-            plx: EagerNamespaceAny = self.__narwhals_namespace__()
-            return plx.parse_into_expr(arg, str_as_lit=False)
+    def _parse_into_expr(self, arg: Expr | Series[Any] | _1DArray | str) -> Expr:
+        if isinstance(arg, str):
+            return col(arg)
+        if is_numpy_array_1d(arg):
+            return new_series("", arg, backend=self.implementation)._to_expr()
+        if is_series(arg):
+            return arg._to_expr()
+        if is_expr(arg):
+            return arg
         raise InvalidIntoExprError.from_invalid_type(type(arg))
 
     @property
@@ -2287,39 +2298,34 @@ class LazyFrame(BaseFrame[LazyFrameT]):
     def _compliant(self) -> CompliantLazyFrame[Any, LazyFrameT, Self]:
         return self._compliant_frame
 
-    def _extract_compliant(self, arg: Any) -> Any:
-        from narwhals.expr import Expr
-        from narwhals.series import Series
-
-        if isinstance(arg, Series):  # pragma: no cover
-            msg = "Binary operations between Series and LazyFrame are not supported."
-            raise TypeError(msg)
-        if isinstance(arg, (Expr, str)):
-            if isinstance(arg, Expr):
-                if arg._metadata.n_orderable_ops:
-                    msg = (
-                        "Order-dependent expressions are not supported for use in LazyFrame.\n\n"
-                        "Hint: To make the expression valid, use `.over` with `order_by` specified.\n\n"
-                        "For example, if you wrote `nw.col('price').cum_sum()` and you have a column\n"
-                        "`'date'` which orders your data, then replace:\n\n"
-                        "   nw.col('price').cum_sum()\n\n"
-                        " with:\n\n"
-                        "   nw.col('price').cum_sum().over(order_by='date')\n"
-                        "                            ^^^^^^^^^^^^^^^^^^^^^^\n\n"
-                        "See https://narwhals-dev.github.io/narwhals/concepts/order_dependence/."
-                    )
-                    raise InvalidOperationError(msg)
-                if arg._metadata.is_filtration:
-                    msg = (
-                        "Length-changing expressions are not supported for use in LazyFrame, unless\n"
-                        "followed by an aggregation.\n\n"
-                        "Hints:\n"
-                        "- Instead of `lf.select(nw.col('a').head())`, use `lf.select('a').head()\n"
-                        "- Instead of `lf.select(nw.col('a').drop_nulls()).select(nw.sum('a'))`,\n"
-                        "  use `lf.select(nw.col('a').drop_nulls().sum())\n"
-                    )
-                    raise InvalidOperationError(msg)
-            return self.__narwhals_namespace__().parse_into_expr(arg, str_as_lit=False)
+    def _parse_into_expr(self, arg: Expr | str) -> Expr:
+        if isinstance(arg, str):
+            return col(arg)
+        if is_expr(arg):
+            if arg._metadata.n_orderable_ops:
+                msg = (
+                    "Order-dependent expressions are not supported for use in LazyFrame.\n\n"
+                    "Hint: To make the expression valid, use `.over` with `order_by` specified.\n\n"
+                    "For example, if you wrote `nw.col('price').cum_sum()` and you have a column\n"
+                    "`'date'` which orders your data, then replace:\n\n"
+                    "   nw.col('price').cum_sum()\n\n"
+                    " with:\n\n"
+                    "   nw.col('price').cum_sum().over(order_by='date')\n"
+                    "                            ^^^^^^^^^^^^^^^^^^^^^^\n\n"
+                    "See https://narwhals-dev.github.io/narwhals/concepts/order_dependence/."
+                )
+                raise InvalidOperationError(msg)
+            if arg._metadata.is_filtration:
+                msg = (
+                    "Length-changing expressions are not supported for use in LazyFrame, unless\n"
+                    "followed by an aggregation.\n\n"
+                    "Hints:\n"
+                    "- Instead of `lf.select(nw.col('a').head())`, use `lf.select('a').head()\n"
+                    "- Instead of `lf.select(nw.col('a').drop_nulls()).select(nw.sum('a'))`,\n"
+                    "  use `lf.select(nw.col('a').drop_nulls().sum())\n"
+                )
+                raise InvalidOperationError(msg)
+            return arg
         raise InvalidIntoExprError.from_invalid_type(type(arg))
 
     @property

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -152,14 +152,16 @@ class BaseFrame(Generic[_FrameT]):
         out_exprs = []
         out_kinds = []
         ns = self.__narwhals_namespace__()
-        for expr in flatten(exprs):
-            parsed_expr = self._parse_into_expr(expr)
-            out_exprs.append(parsed_expr._to_compliant_expr(ns))
-            out_kinds.append(ExprKind.from_expr(parsed_expr))
-        for alias, expr in named_exprs.items():
-            parsed_expr = self._parse_into_expr(expr).alias(alias)
-            out_exprs.append(parsed_expr._to_compliant_expr(ns))
-            out_kinds.append(ExprKind.from_expr(parsed_expr))
+        all_exprs = chain(
+            (self._parse_into_expr(x) for x in flatten(exprs)),
+            (
+                self._parse_into_expr(expr).alias(alias)
+                for alias, expr in named_exprs.items()
+            ),
+        )
+        for expr in all_exprs:
+            out_exprs.append(expr._to_compliant_expr(ns))
+            out_kinds.append(ExprKind.from_expr(expr))
         return out_exprs, out_kinds
 
     @abstractmethod

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -153,15 +153,13 @@ class BaseFrame(Generic[_FrameT]):
         out_kinds = []
         ns = self.__narwhals_namespace__()
         for expr in flatten(exprs):
-            compliant_expr = self._parse_into_expr(expr)._to_compliant_expr(ns)
-            out_exprs.append(compliant_expr)
-            out_kinds.append(ExprKind.from_compliant_expr(compliant_expr))
+            parsed_expr = self._parse_into_expr(expr)
+            out_exprs.append(parsed_expr._to_compliant_expr(ns))
+            out_kinds.append(ExprKind.from_expr(parsed_expr))
         for alias, expr in named_exprs.items():
-            compliant_expr = (
-                self._parse_into_expr(expr).alias(alias)._to_compliant_expr(ns)
-            )
-            out_exprs.append(compliant_expr)
-            out_kinds.append(ExprKind.from_compliant_expr(compliant_expr))
+            parsed_expr = self._parse_into_expr(expr).alias(alias)
+            out_exprs.append(parsed_expr._to_compliant_expr(ns))
+            out_kinds.append(ExprKind.from_expr(parsed_expr))
         return out_exprs, out_kinds
 
     @abstractmethod

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -160,7 +160,7 @@ class BaseFrame(Generic[_FrameT]):
             ),
         )
         for expr in all_exprs:
-            out_exprs.append(expr._to_compliant_expr(ns))
+            out_exprs.append(ns.parse_into_expr(expr, str_as_lit=False))
             out_kinds.append(ExprKind.from_expr(expr))
         return out_exprs, out_kinds
 

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -160,7 +160,7 @@ class BaseFrame(Generic[_FrameT]):
             ),
         )
         for expr in all_exprs:
-            out_exprs.append(ns.parse_into_expr(expr, str_as_lit=False))
+            out_exprs.append(expr._to_compliant_expr(ns))
             out_kinds.append(ExprKind.from_expr(expr))
         return out_exprs, out_kinds
 

--- a/narwhals/group_by.py
+++ b/narwhals/group_by.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from narwhals._expression_parsing import all_exprs_are_scalar_like
-from narwhals._utils import flatten, tupleify
+from narwhals._utils import tupleify
 from narwhals.exceptions import InvalidOperationError
 from narwhals.typing import DataFrameT
 
@@ -72,8 +71,8 @@ class GroupBy(Generic[DataFrameT]):
             2  b  3  2
             3  c  3  1
         """
-        flat_aggs = tuple(flatten(aggs))
-        if not all_exprs_are_scalar_like(*flat_aggs, **named_aggs):
+        compliant_aggs, kinds = self._df._flatten_and_extract(*aggs, **named_aggs)
+        if not all(x.is_scalar_like for x in kinds):
             msg = (
                 "Found expression which does not aggregate.\n\n"
                 "All expressions passed to GroupBy.agg must aggregate.\n"
@@ -81,14 +80,6 @@ class GroupBy(Generic[DataFrameT]):
                 "but `df.group_by('a').agg(nw.col('b'))` is not."
             )
             raise InvalidOperationError(msg)
-        plx = self._df.__narwhals_namespace__()
-        compliant_aggs = (
-            *(x._to_compliant_expr(plx) for x in flat_aggs),
-            *(
-                value.alias(key)._to_compliant_expr(plx)
-                for key, value in named_aggs.items()
-            ),
-        )
         return self._df._with_compliant(self._grouped.agg(*compliant_aggs))
 
     def __iter__(self) -> Iterator[tuple[Any, DataFrameT]]:
@@ -166,8 +157,8 @@ class LazyGroupBy(Generic[LazyFrameT]):
             |└─────┴─────┴─────┘|
             └───────────────────┘
         """
-        flat_aggs = tuple(flatten(aggs))
-        if not all_exprs_are_scalar_like(*flat_aggs, **named_aggs):
+        compliant_aggs, kinds = self._df._flatten_and_extract(*aggs, **named_aggs)
+        if not all(x.is_scalar_like for x in kinds):
             msg = (
                 "Found expression which does not aggregate.\n\n"
                 "All expressions passed to GroupBy.agg must aggregate.\n"
@@ -175,12 +166,4 @@ class LazyGroupBy(Generic[LazyFrameT]):
                 "but `df.group_by('a').agg(nw.col('b'))` is not."
             )
             raise InvalidOperationError(msg)
-        plx = self._df.__narwhals_namespace__()
-        compliant_aggs = (
-            *(x._to_compliant_expr(plx) for x in flat_aggs),
-            *(
-                value.alias(key)._to_compliant_expr(plx)
-                for key, value in named_aggs.items()
-            ),
-        )
         return self._df._with_compliant(self._grouped.agg(*compliant_aggs))

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -4,6 +4,7 @@ import math
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, Literal, overload
 
+from narwhals._expression_parsing import ExprMetadata
 from narwhals._utils import (
     Implementation,
     Version,
@@ -20,6 +21,7 @@ from narwhals._utils import (
 from narwhals.dependencies import is_numpy_array, is_numpy_array_1d, is_numpy_scalar
 from narwhals.dtypes import _validate_dtype, _validate_into_dtype
 from narwhals.exceptions import ComputeError, InvalidOperationError
+from narwhals.expr import Expr
 from narwhals.series_cat import SeriesCatNamespace
 from narwhals.series_dt import SeriesDateTimeNamespace
 from narwhals.series_list import SeriesListNamespace
@@ -88,6 +90,10 @@ class Series(Generic[IntoSeriesT]):
         from narwhals.dataframe import DataFrame
 
         return DataFrame
+
+    def _to_expr(self) -> Expr:
+        md = ExprMetadata.selector_single()
+        return Expr(lambda plx: plx._expr._from_series(self._compliant), md)
 
     def __init__(
         self, series: Any, *, level: Literal["full", "lazy", "interchange"]

--- a/narwhals/series.py
+++ b/narwhals/series.py
@@ -93,7 +93,7 @@ class Series(Generic[IntoSeriesT]):
 
     def _to_expr(self) -> Expr:
         md = ExprMetadata.selector_single()
-        return Expr(lambda plx: plx._expr._from_series(self._compliant), md)
+        return Expr(lambda _plx: self._compliant._to_expr(), md)
 
     def __init__(
         self, series: Any, *, level: Literal["full", "lazy", "interchange"]

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -234,7 +234,7 @@ class LazyFrame(NwLazyFrame[IntoLazyFrameT]):
     def _dataframe(self) -> type[DataFrame[Any]]:
         return DataFrame
 
-    def _parse_into_expr(self, arg: Expr | str) -> Expr:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def _parse_into_expr(self, arg: Expr | str) -> Expr:  # type: ignore[override]
         # After v1, we raise when passing order-dependent, length-changing,
         # or filtration expressions to LazyFrame
         if isinstance(arg, str):

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, cast, overload
 import narwhals as nw
 from narwhals import exceptions, functions as nw_f
 from narwhals._exceptions import issue_warning
+from narwhals._expression_parsing import is_expr
 from narwhals._typing_compat import TypeVar, assert_never
 from narwhals._utils import (
     Implementation,
@@ -233,17 +234,13 @@ class LazyFrame(NwLazyFrame[IntoLazyFrameT]):
     def _dataframe(self) -> type[DataFrame[Any]]:
         return DataFrame
 
-    def _extract_compliant(self, arg: Any) -> Any:
+    def _parse_into_expr(self, arg: Expr | str) -> Expr:  # pyright: ignore[reportIncompatibleMethodOverride]
         # After v1, we raise when passing order-dependent, length-changing,
         # or filtration expressions to LazyFrame
-        from narwhals.expr import Expr
-        from narwhals.series import Series
-
-        if isinstance(arg, Series):  # pragma: no cover
-            msg = "Mixing Series with LazyFrame is not supported."
-            raise TypeError(msg)
-        if isinstance(arg, (Expr, str)):
-            return self.__narwhals_namespace__().parse_into_expr(arg, str_as_lit=False)
+        if isinstance(arg, str):
+            return col(arg)
+        if is_expr(arg):
+            return arg
         raise InvalidIntoExprError.from_invalid_type(type(arg))
 
     def collect(

--- a/tests/frame/group_by_test.py
+++ b/tests/frame/group_by_test.py
@@ -364,7 +364,7 @@ def test_group_by_shift_raises(constructor: Constructor) -> None:
     df_native = {"a": [1, 2, 3], "b": [1, 1, 2]}
     df = nw.from_native(constructor(df_native))
     with pytest.raises(InvalidOperationError, match="does not aggregate"):
-        df.group_by("b").agg(nw.col("a").shift(1))
+        df.group_by("b").agg(nw.col("a").abs())
 
 
 def test_double_same_aggregation(


### PR DESCRIPTION
This had been annoying me for a while

We're using `CompliantNamespace.parse_into_expr`, which accepts Python scalars, in `{DataFrame,LazyFrame}.{select,with_columns}`, even though there we don't accept Python scalars

I think this simplifies things a little, and means we can do `.alias` within `flatten_and_extract` before going to the compliant level (which I think is not a bad thing, given that there we're still at the Narwhals level. this will also help in some follow-up / skunkworks)