### PR TITLE
feat: Allow `os.PathLike[str]` in `{read,scan}_*` functions

### DIFF
--- a/.github/workflows/pytest-pyspark.yml
+++ b/.github/workflows/pytest-pyspark.yml
@@ -6,6 +6,8 @@ on:
       - narwhals/_expression_parsing.py
       - narwhals/_spark_like/**
       - narwhals/_sql/**
+      - tests/*scan*.py
+      - tests/frame/*sink*.py
   schedule:
     - cron: 0 12 * * 0  # Sunday at mid-day
 

--- a/narwhals/_utils.py
+++ b/narwhals/_utils.py
@@ -2148,3 +2148,11 @@ class _Implementation:
     def __get__(self, instance: LazyFrame[Any], owner: Any) -> _LazyAllowedImpl: ...
     def __get__(self, instance: Narwhals[Any] | None, owner: Any) -> Any:
         return self if instance is None else instance._compliant._implementation
+
+
+def normalize_path(source: str | os.PathLike[str], /) -> str:
+    if isinstance(source, str):
+        return source
+    from pathlib import Path
+
+    return str(Path(source))

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -765,7 +765,7 @@ def read_parquet(
     elif impl is Implementation.PYARROW:
         import pyarrow.parquet as pq  # ignore-banned-import
 
-        native_frame = pq.read_table(source, **kwargs)
+        native_frame = pq.read_table(source, **kwargs)  # type: ignore[arg-type]
     elif impl in {
         Implementation.PYSPARK,
         Implementation.DASK,
@@ -872,7 +872,7 @@ def scan_parquet(
     elif implementation is Implementation.PYARROW:
         import pyarrow.parquet as pq  # ignore-banned-import
 
-        native_frame = pq.read_table(source, **kwargs)
+        native_frame = pq.read_table(source, **kwargs)  # type: ignore[arg-type]
     elif implementation.is_spark_like():
         if (session := kwargs.pop("session", None)) is None:
             msg = "Spark like backends require a session object to be passed in `kwargs`."

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     from narwhals.dataframe import DataFrame, LazyFrame
     from narwhals.typing import (
         ConcatMethod,
+        FileSource,
         FrameT,
         IntoDType,
         IntoExpr,
@@ -564,7 +565,7 @@ def show_versions() -> None:
 
 
 def read_csv(
-    source: str, *, backend: IntoBackend[EagerAllowed], **kwargs: Any
+    source: FileSource, *, backend: IntoBackend[EagerAllowed], **kwargs: Any
 ) -> DataFrame[Any]:
     """Read a CSV file into a DataFrame.
 
@@ -634,7 +635,7 @@ def read_csv(
 
 
 def scan_csv(
-    source: str, *, backend: IntoBackend[Backend], **kwargs: Any
+    source: FileSource, *, backend: IntoBackend[Backend], **kwargs: Any
 ) -> LazyFrame[Any]:
     """Lazily read from a CSV file.
 
@@ -715,7 +716,7 @@ def scan_csv(
 
 
 def read_parquet(
-    source: str, *, backend: IntoBackend[EagerAllowed], **kwargs: Any
+    source: FileSource, *, backend: IntoBackend[EagerAllowed], **kwargs: Any
 ) -> DataFrame[Any]:
     """Read into a DataFrame from a parquet file.
 
@@ -790,7 +791,7 @@ def read_parquet(
 
 
 def scan_parquet(
-    source: str, *, backend: IntoBackend[Backend], **kwargs: Any
+    source: FileSource, *, backend: IntoBackend[Backend], **kwargs: Any
 ) -> LazyFrame[Any]:
     """Lazily read from a parquet file.
 

--- a/narwhals/functions.py
+++ b/narwhals/functions.py
@@ -21,6 +21,7 @@ from narwhals._utils import (
     is_compliant_expr,
     is_eager_allowed,
     is_sequence_but_not_str,
+    normalize_path,
     supports_arrow_c_stream,
     validate_laziness,
 )
@@ -858,6 +859,10 @@ def scan_parquet(
     implementation = Implementation.from_backend(backend)
     native_namespace = implementation.to_native_namespace()
     native_frame: NativeDataFrame | NativeLazyFrame
+
+    # NOTE: Add to this if/when other failures show up
+    if implementation is Implementation.DUCKDB:
+        source = normalize_path(source)
     if implementation is Implementation.POLARS:
         native_frame = native_namespace.scan_parquet(source, **kwargs)
     elif implementation in {

--- a/narwhals/stable/v1/__init__.py
+++ b/narwhals/stable/v1/__init__.py
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
     from narwhals.dataframe import MultiColSelector, MultiIndexSelector
     from narwhals.dtypes import DType
     from narwhals.typing import (
+        FileSource,
         IntoDType,
         IntoExpr,
         IntoFrame,
@@ -1280,7 +1281,7 @@ def from_numpy(
 
 @deprecate_native_namespace(required=True)
 def read_csv(
-    source: str,
+    source: FileSource,
     *,
     backend: IntoBackend[EagerAllowed] | None = None,
     native_namespace: ModuleType | None = None,  # noqa: ARG001
@@ -1298,7 +1299,7 @@ def read_csv(
 
 @deprecate_native_namespace(required=True)
 def scan_csv(
-    source: str,
+    source: FileSource,
     *,
     backend: IntoBackend[Backend] | None = None,
     native_namespace: ModuleType | None = None,  # noqa: ARG001
@@ -1316,7 +1317,7 @@ def scan_csv(
 
 @deprecate_native_namespace(required=True)
 def read_parquet(
-    source: str,
+    source: FileSource,
     *,
     backend: IntoBackend[EagerAllowed] | None = None,
     native_namespace: ModuleType | None = None,  # noqa: ARG001
@@ -1334,7 +1335,7 @@ def read_parquet(
 
 @deprecate_native_namespace(required=True)
 def scan_parquet(
-    source: str,
+    source: FileSource,
     *,
     backend: IntoBackend[Backend] | None = None,
     native_namespace: ModuleType | None = None,  # noqa: ARG001

--- a/narwhals/typing.py
+++ b/narwhals/typing.py
@@ -8,6 +8,7 @@ from narwhals._typing import Backend, EagerAllowed, IntoBackend, LazyAllowed
 
 if TYPE_CHECKING:
     import datetime as dt
+    import os
     from collections.abc import Iterable, Sequence, Sized
     from decimal import Decimal
     from types import ModuleType
@@ -438,6 +439,8 @@ Examples:
 IntoArrowSchema: TypeAlias = "pa.Schema | Mapping[str, pa.DataType]"
 IntoPolarsSchema: TypeAlias = "pl.Schema | Mapping[str, pl.DataType]"
 IntoPandasSchema: TypeAlias = Mapping[str, PandasLikeDType]
+
+FileSource: TypeAlias = "str | os.PathLike[str]"
 
 
 # Annotations for `__getitem__` methods

--- a/tests/read_scan_test.py
+++ b/tests/read_scan_test.py
@@ -26,10 +26,9 @@ if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
     from narwhals._typing import EagerAllowed, _LazyOnly, _SparkLike
+    from narwhals.typing import FileSource
 
 IOSourceKind: TypeAlias = Literal["str", "Path"]
-FileSource: TypeAlias = "str | Path"
-
 
 data: Mapping[str, Any] = {"a": [1, 2, 3], "b": [4.5, 6.7, 8.9], "z": ["x", "y", "w"]}
 skipif_pandas_lt_1_5 = pytest.mark.skipif(
@@ -40,7 +39,8 @@ spark_like_backend = pytest.mark.parametrize("backend", ["pyspark", "sqlframe"])
 
 
 def _into_file_source(source: Path, which: IOSourceKind, /) -> FileSource:
-    return {"str": str(source), "Path": source}[which]
+    mapping: Mapping[IOSourceKind, FileSource] = {"str": str(source), "Path": source}
+    return mapping[which]
 
 
 @pytest.fixture(scope="module", params=["str", "Path"])


### PR DESCRIPTION
Closes #3100

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3100
- Related #3064

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
- WIP
- Tests are passing locally
- Need ci for pyspark