### PR TITLE
docs: Add python version support to backcompat

### DIFF
--- a/docs/backcompat.md
+++ b/docs/backcompat.md
@@ -98,7 +98,7 @@ Here are exceptions to our backwards compatibility policy:
 - We may consider making some type hints more precise.
 - Anything labelled "unstable".
 - We may sometimes need to bump the minimum versions of supported backends.
-- We will drop support for old python versions, roughly in sync with [devguide](https://devguide.python.org/versions/)
+- We will drop support for old python versions, roughly in sync with [their end of life](https://devguide.python.org/versions/#supported-versions)
 
 In general, decision are driven by use-cases, and we conduct a search of public GitHub repositories
 before making any change.


### PR DESCRIPTION
Closes #2638

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #2638

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below
> [!IMPORTANT]
> `3.9` EOL is in [1 month](https://peps.python.org/pep-0596/) and I forgot about this issue 😬