### PR TITLE
feat: Add `prefix` argument to `generate_temporary_column_name`

### DIFF
--- a/narwhals/_dask/dataframe.py
+++ b/narwhals/_dask/dataframe.py
@@ -247,7 +247,9 @@ class DaskLazyFrame(
             raise error
         if keep == "none":
             subset = subset or self.columns
-            token = generate_temporary_column_name(n_bytes=8, columns=subset)
+            token = generate_temporary_column_name(
+                n_bytes=8, columns=subset, prefix="count_"
+            )
             ser = self.native.groupby(subset).size().rename(token)
             ser = ser[ser == 1]
             unique = ser.reset_index().drop(columns=token)
@@ -335,7 +337,7 @@ class DaskLazyFrame(
 
     def _join_cross(self, other: Self, *, suffix: str) -> dd.DataFrame:
         key_token = generate_temporary_column_name(
-            n_bytes=8, columns=(*self.columns, *other.columns)
+            n_bytes=8, columns=(*self.columns, *other.columns), prefix="cross_join_key_"
         )
         return (
             self.native.assign(**{key_token: 0})
@@ -365,7 +367,7 @@ class DaskLazyFrame(
         self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str]
     ) -> dd.DataFrame:
         indicator_token = generate_temporary_column_name(
-            n_bytes=8, columns=(*self.columns, *other.columns)
+            n_bytes=8, columns=(*self.columns, *other.columns), prefix="join_indicator_"
         )
         other_native = self._join_filter_rename(
             other=other,
@@ -477,7 +479,9 @@ class DaskLazyFrame(
         raise NotImplementedError(msg)
 
     def gather_every(self, n: int, offset: int) -> Self:
-        row_index_token = generate_temporary_column_name(n_bytes=8, columns=self.columns)
+        row_index_token = generate_temporary_column_name(
+            n_bytes=8, columns=self.columns, prefix="row_index_"
+        )
         plx = self.__narwhals_namespace__()
         return (
             self.with_row_index(row_index_token, order_by=None)

--- a/narwhals/_dask/expr.py
+++ b/narwhals/_dask/expr.py
@@ -529,7 +529,9 @@ class DaskExpr(
     def is_first_distinct(self) -> Self:
         def func(expr: dx.Series) -> dx.Series:
             _name = expr.name
-            col_token = generate_temporary_column_name(n_bytes=8, columns=[_name])
+            col_token = generate_temporary_column_name(
+                n_bytes=8, columns=[_name], prefix="row_index_"
+            )
             frame = add_row_index(expr.to_frame(), col_token)
             first_distinct_index = frame.groupby(_name).agg({col_token: "min"})[col_token]
             return frame[col_token].isin(first_distinct_index)
@@ -539,7 +541,9 @@ class DaskExpr(
     def is_last_distinct(self) -> Self:
         def func(expr: dx.Series) -> dx.Series:
             _name = expr.name
-            col_token = generate_temporary_column_name(n_bytes=8, columns=[_name])
+            col_token = generate_temporary_column_name(
+                n_bytes=8, columns=[_name], prefix="row_index_"
+            )
             frame = add_row_index(expr.to_frame(), col_token)
             last_distinct_index = frame.groupby(_name).agg({col_token: "max"})[col_token]
             return frame[col_token].isin(last_distinct_index)

--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -389,7 +389,7 @@ class DuckDBLazyFrame(
         subset_ = subset or self.columns
         if error := self._check_columns_exist(subset_):
             raise error
-        tmp_name = generate_temporary_column_name(8, self.columns)
+        tmp_name = generate_temporary_column_name(8, self.columns, prefix="row_index_")
         if order_by and keep == "last":
             descending = [True] * len(order_by)
             nulls_last = [True] * len(order_by)

--- a/narwhals/_ibis/dataframe.py
+++ b/narwhals/_ibis/dataframe.py
@@ -330,7 +330,7 @@ class IbisLazyFrame(
         subset_ = subset or self.columns
         if error := self._check_columns_exist(subset_):
             raise error
-        tmp_name = generate_temporary_column_name(8, self.columns)
+        tmp_name = generate_temporary_column_name(8, self.columns, prefix="row_index_")
         if order_by and keep == "last":
             order_by_ = IbisExpr._sort(*order_by, descending=True, nulls_last=True)
         elif order_by:

--- a/narwhals/_polars/dataframe.py
+++ b/narwhals/_polars/dataframe.py
@@ -184,7 +184,7 @@ class PolarsBaseFrame(Generic[NativePolarsFrame]):
         order_by: Sequence[str] | None = None,
     ) -> Self:
         if order_by and maintain_order:
-            token = generate_temporary_column_name(8, self.columns)
+            token = generate_temporary_column_name(8, self.columns, prefix="row_index_")
             res = (
                 self.native.with_row_index(token)
                 .sort(order_by, nulls_last=False)

--- a/narwhals/_spark_like/dataframe.py
+++ b/narwhals/_spark_like/dataframe.py
@@ -376,7 +376,7 @@ class SparkLikeLazyFrame(
         subset_ = subset or self.columns
         if error := self._check_columns_exist(subset_):
             raise error
-        tmp_name = generate_temporary_column_name(8, self.columns)
+        tmp_name = generate_temporary_column_name(8, self.columns, prefix="row_index_")
         window = self._Window.partitionBy(subset_)
         if order_by and keep == "last":
             window = window.orderBy(*[self._F.desc_nulls_last(x) for x in order_by])

--- a/narwhals/_utils.py
+++ b/narwhals/_utils.py
@@ -1248,17 +1248,19 @@ def is_ordered_categorical(series: Series[Any]) -> bool:
 
 
 def generate_unique_token(
-    n_bytes: int, columns: Container[str]
+    n_bytes: int, columns: Container[str], prefix: str = "nw"
 ) -> str:  # pragma: no cover
     msg = (
         "Use `generate_temporary_column_name` instead. `generate_unique_token` is "
         "deprecated and it will be removed in future versions"
     )
     issue_deprecation_warning(msg, _version="1.13.0")
-    return generate_temporary_column_name(n_bytes=n_bytes, columns=columns)
+    return generate_temporary_column_name(n_bytes=n_bytes, columns=columns, prefix=prefix)
 
 
-def generate_temporary_column_name(n_bytes: int, columns: Container[str]) -> str:
+def generate_temporary_column_name(
+    n_bytes: int, columns: Container[str], prefix: str = "nw"
+) -> str:
     """Generates a unique column name that is not present in the given list of columns.
 
     It relies on [python secrets token_hex](https://docs.python.org/3/library/secrets.html#secrets.token_hex)
@@ -1267,6 +1269,7 @@ def generate_temporary_column_name(n_bytes: int, columns: Container[str]) -> str
     Arguments:
         n_bytes: The number of bytes to generate for the token.
         columns: The list of columns to check for uniqueness.
+        prefix: prefix with which the temporary column name should start with.
 
     Returns:
         A unique token that is not present in the given list of columns.
@@ -1279,12 +1282,15 @@ def generate_temporary_column_name(n_bytes: int, columns: Container[str]) -> str
         >>> columns = ["abc", "xyz"]
         >>> nw.generate_temporary_column_name(n_bytes=8, columns=columns) not in columns
         True
+        >>> temp_name = nw.generate_temporary_column_name(
+        ...     n_bytes=8, columns=columns, prefix="foo"
+        ... )
+        >>> temp_name not in columns and temp_name.startswith("foo")
+        True
     """
     counter = 0
     while True:
-        # Prepend `'nw'` to ensure it always starts with a character
-        # https://github.com/narwhals-dev/narwhals/issues/2510
-        token = f"nw{token_hex(n_bytes - 1)}"
+        token = f"{prefix}{token_hex(n_bytes - 1)}"
         if token not in columns:
             return token
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -314,8 +314,6 @@ def test_generate_temporary_column_name_pr_3118_example() -> None:
     pytest.importorskip("duckdb")
     import duckdb
 
-    import narwhals as nw
-
     conn = duckdb.connect()
     conn.sql("""CREATE TABLE df (a int64, b int64);""")
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -312,10 +312,10 @@ def test_generate_temporary_column_name_raise() -> None:
 
 def test_generate_temporary_column_name_pr_3118_example() -> None:
     from tests.utils import DUCKDB_VERSION
-    
+
     if DUCKDB_VERSION < (1, 3, 0):
         pytest.skip()
-    
+
     import duckdb
 
     conn = duckdb.connect()

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -311,7 +311,11 @@ def test_generate_temporary_column_name_raise() -> None:
 
 
 def test_generate_temporary_column_name_pr_3118_example() -> None:
-    pytest.importorskip("duckdb")
+    from tests.utils import DUCKDB_VERSION
+    
+    if DUCKDB_VERSION < (1, 3, 0):
+        pytest.skip()
+    
     import duckdb
 
     conn = duckdb.connect()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3121

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

Added explicit prefix only on lazy backends operations since these are the ones that a user might be able to investigate in various way. Not really applicable in the eager case