### PR TITLE
enh: support non-elementwise (but length-preserving) keys in group-by

### DIFF
--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1715,16 +1715,8 @@ class DataFrame(BaseFrame[DataFrameT]):
             k if is_expr else col(k)
             for k, is_expr in zip_strict(flat_keys, key_is_expr_or_series)
         ]
-        expr_flat_keys, kinds = self._flatten_and_extract(*_keys)
-
-        if not all(kind is ExprKind.ELEMENTWISE for kind in kinds):
-            from narwhals.exceptions import ComputeError
-
-            msg = (
-                "Group by is not supported with keys that are not elementwise expressions"
-            )
-            raise ComputeError(msg)
-
+        expr_flat_keys, _kinds = self._flatten_and_extract(*_keys)
+        check_expressions_preserve_length(*_keys, function_name="DataFrame.group_by")
         return GroupBy(self, expr_flat_keys, drop_null_keys=drop_null_keys)
 
     def sort(
@@ -2961,15 +2953,8 @@ class LazyFrame(BaseFrame[LazyFrameT]):
         _keys = [
             k if is_expr else col(k) for k, is_expr in zip_strict(flat_keys, key_is_expr)
         ]
-        expr_flat_keys, kinds = self._flatten_and_extract(*_keys)
-
-        if not all(kind is ExprKind.ELEMENTWISE for kind in kinds):
-            from narwhals.exceptions import ComputeError
-
-            msg = (
-                "Group by is not supported with keys that are not elementwise expressions"
-            )
-            raise ComputeError(msg)
+        expr_flat_keys, _kinds = self._flatten_and_extract(*_keys)
+        check_expressions_preserve_length(*_keys, function_name="LazyFrame.group_by")
 
         return LazyGroupBy(self, expr_flat_keys, drop_null_keys=drop_null_keys)
 

--- a/tests/frame/group_by_test.py
+++ b/tests/frame/group_by_test.py
@@ -11,7 +11,7 @@ import pyarrow as pa
 import pytest
 
 import narwhals as nw
-from narwhals.exceptions import ComputeError, DuplicateError, InvalidOperationError
+from narwhals.exceptions import DuplicateError, InvalidOperationError
 from tests.utils import (
     PANDAS_VERSION,
     POLARS_VERSION,
@@ -511,36 +511,34 @@ def test_group_by_expr(
 
 
 @pytest.mark.parametrize(
-    ("keys", "lazy_context"),
+    "keys",
     [
-        ([nw.col("a").drop_nulls()], pytest.raises(InvalidOperationError)),  # Filtration
-        (
-            [nw.col("a").alias("foo"), nw.col("a").drop_nulls()],
-            pytest.raises(InvalidOperationError),
-        ),  # Transform and Filtration
-        (
-            [nw.col("a").alias("foo"), nw.col("a").max()],
-            pytest.raises(ComputeError),
-        ),  # Transform and Aggregation
-        (
-            [nw.col("a").alias("foo"), nw.col("a").cum_max()],
-            pytest.raises(InvalidOperationError),
-        ),  # Transform and Window
-        ([nw.lit(42)], pytest.raises(ComputeError)),  # Literal
-        ([nw.lit(42).abs()], pytest.raises(ComputeError)),  # Literal
+        [nw.col("a").drop_nulls()],  # Transform and Filtration
+        [nw.col("a").alias("foo"), nw.col("a").drop_nulls()],  # Transform and Filtration
+        [nw.col("a").alias("foo"), nw.col("a").max()],  # Transform and Aggregation
+        [nw.lit(42)],  # Literal
+        [nw.lit(42).abs()],  # Literal
     ],
 )
-def test_group_by_raise_if_not_elementwise(
-    constructor: Constructor, keys: list[nw.Expr], lazy_context: Any
+def test_group_by_raise_if_not_preserves_length(
+    constructor: Constructor, keys: list[nw.Expr]
 ) -> None:
     data = {"a": [1, 2, 2, None], "b": [0, 1, 2, 3], "x": [1, 2, 3, 4]}
     df = nw.from_native(constructor(data))
-
-    context: Any = (
-        lazy_context if isinstance(df, nw.LazyFrame) else pytest.raises(ComputeError)
-    )
-    with context:
+    with pytest.raises(InvalidOperationError):
         df.group_by(keys).agg(nw.col("x").max())
+
+
+def test_group_by_window(constructor: Constructor) -> None:
+    data = {"a": [1, 2, 2, None], "b": [1, 1, 2, 2], "x": [1, 2, 3, 4]}
+    df = nw.from_native(constructor(data))
+    result = (
+        df.group_by(nw.col("a").mean().over("b"))
+        .agg(nw.col("x").max())
+        .sort("a", nulls_last=True)
+    )
+    expected = {"a": [1.5, 2.0], "x": [2, 4]}
+    assert_equal_data(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #3151 

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
