### PR TITLE
fix: add `--upgrade` flag to `uv sync --dev`

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -79,7 +79,9 @@ jobs:
           uv venv -p 3.12
           git log
       - name: install-basics
-        run: uv pip install --upgrade tox virtualenv setuptools hatch "click!=8.3.0" --system
+        run:
+          uv pip install --upgrade tox virtualenv setuptools hatch
+          "click!=8.3.0" --system
       - name: install-marimo-dev
         run: |
           cd marimo
@@ -240,7 +242,7 @@ jobs:
           cd tea-tasting
           uv pip uninstall narwhals
           uv pip install -e ./..
-      - name: temporary pin duckdb  # TODO(FBruzzesi): Unpin duckdb
+      - name: temporary pin duckdb # TODO(FBruzzesi): Unpin duckdb
         run: |
           cd tea-tasting
           uv pip uninstall duckdb
@@ -280,7 +282,8 @@ jobs:
           cd tubular
           git log
       - name: install-basics
-        run: uv pip install --upgrade tox virtualenv setuptools pytest-env --system
+        run:
+          uv pip install --upgrade tox virtualenv setuptools pytest-env --system
       - name: install-tubular-dev
         run: |
           cd tubular
@@ -502,7 +505,7 @@ jobs:
       - name: install-validoopsie-dev
         run: |
           cd validoopsie
-          uv sync --dev
+          uv sync --dev --upgrade
       - name: install-narwhals-dev
         run: |
           cd validoopsie
@@ -523,7 +526,7 @@ jobs:
           # Keep `--no-sync` in case Narwhals is re-synced with PyPI version
           uv run --no-sync pytest tests
         timeout-minutes: 15
-  
+
   darts:
     strategy:
       matrix:

--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -27,7 +27,6 @@ from narwhals._utils import (
     not_implemented,
     parse_columns_to_drop,
     requires,
-    to_pyarrow_table,
     zip_strict,
 )
 from narwhals.dependencies import get_duckdb
@@ -138,8 +137,12 @@ class DuckDBLazyFrame(
         if backend is None or backend is Implementation.PYARROW:
             from narwhals._arrow.dataframe import ArrowDataFrame
 
+            if self._backend_version < (1, 4):
+                ret = self.native.arrow()
+            else:
+                ret = self.native.fetch_arrow_table()
             return ArrowDataFrame(
-                to_pyarrow_table(self.native.arrow()),
+                ret,
                 validate_backend_version=True,
                 version=self._version,
                 validate_column_names=True,

--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -139,7 +139,7 @@ class DuckDBLazyFrame(
 
             if self._backend_version < (1, 4):
                 ret = self.native.arrow()
-            else:
+            else:  # pragma: no cover
                 ret = self.native.fetch_arrow_table()
             return ArrowDataFrame(
                 ret,

--- a/tests/frame/collect_test.py
+++ b/tests/frame/collect_test.py
@@ -7,7 +7,7 @@ import pytest
 import narwhals as nw
 from narwhals._utils import Implementation
 from narwhals.dependencies import get_cudf, get_modin, get_polars
-from tests.utils import DUCKDB_VERSION, POLARS_VERSION, Constructor, assert_equal_data
+from tests.utils import POLARS_VERSION, Constructor, assert_equal_data
 
 if TYPE_CHECKING:
     from narwhals._typing import Arrow, Dask, IntoBackend, Modin, Pandas, Polars
@@ -164,9 +164,7 @@ def test_collect_with_kwargs(constructor: Constructor) -> None:
 
 
 def test_collect_empty(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if any(
-        x in str(constructor) for x in ("duckdb", "sqlframe", "ibis")
-    ) and DUCKDB_VERSION >= (1, 4):
+    if any(x in str(constructor) for x in ("sqlframe", "ibis")):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor({"a": [1, 2, 3]}))
     lf = df.filter(nw.col("a").is_null()).with_columns(b=nw.lit(None)).lazy()

--- a/tests/frame/collect_test.py
+++ b/tests/frame/collect_test.py
@@ -7,7 +7,7 @@ import pytest
 import narwhals as nw
 from narwhals._utils import Implementation
 from narwhals.dependencies import get_cudf, get_modin, get_polars
-from tests.utils import POLARS_VERSION, Constructor, assert_equal_data
+from tests.utils import DUCKDB_VERSION, POLARS_VERSION, Constructor, assert_equal_data
 
 if TYPE_CHECKING:
     from narwhals._typing import Arrow, Dask, IntoBackend, Modin, Pandas, Polars
@@ -164,7 +164,10 @@ def test_collect_with_kwargs(constructor: Constructor) -> None:
 
 
 def test_collect_empty(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if any(x in str(constructor) for x in ("sqlframe", "ibis")):
+    if any(x in str(constructor) for x in ("sqlframe", "ibis")) and DUCKDB_VERSION >= (
+        1,
+        4,
+    ):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor({"a": [1, 2, 3]}))
     lf = df.filter(nw.col("a").is_null()).with_columns(b=nw.lit(None)).lazy()


### PR DESCRIPTION
The `uv sync` command was using pinned dependency versions from `uv.lock` instead of fetching the latest versions. This caused a hidden issue where tests were running against outdated dependencies - notably discovered with duckdb failing locally while CI tests passed.

Adding the `--upgrade` flag forces `uv sync` to fetch the latest versions of dependencies, ignoring the pinned versions in the lock file.


<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [X] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [X] ✅ Test
- [ ] 🐳 Other

