### PR TITLE
perf(expr-ir): Optimize `ExpansionFlags.from_ir`

### DIFF
--- a/narwhals/_plan/_expansion.py
+++ b/narwhals/_plan/_expansion.py
@@ -130,16 +130,17 @@ class ExpansionFlags(Immutable):
         has_selector: bool = False
         has_exclude: bool = False
         for e in ir.iter_left():
-            if isinstance(e, (Columns, IndexColumns)):
-                multiple_columns = True
-            elif isinstance(e, Nth):
-                has_nth = True
-            elif isinstance(e, All):
-                has_wildcard = True
-            elif isinstance(e, SelectorIR):
-                has_selector = True
-            elif isinstance(e, Exclude):
-                has_exclude = True
+            if isinstance(e, (_ColumnSelection, SelectorIR)):
+                if isinstance(e, (Columns, IndexColumns)):
+                    multiple_columns = True
+                elif isinstance(e, Nth):
+                    has_nth = True
+                elif isinstance(e, All):
+                    has_wildcard = True
+                elif isinstance(e, SelectorIR):
+                    has_selector = True
+                elif isinstance(e, Exclude):
+                    has_exclude = True
         return ExpansionFlags(
             multiple_columns=multiple_columns,
             has_nth=has_nth,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🔧 Optimization

## Related issues

- Related https://github.com/narwhals-dev/narwhals/pull/2572#discussion_r2426261122
- Child of #2572

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## Description
At least until switching over to (https://github.com/pola-rs/polars/pull/23351), this is a simple optimization that takes advantage of defining a class hierarchy 😄 

The method was originally a port of some upstream code, but skipped the `pl.col(pl.DataType)` and struct/field stuff which we don't use:
- https://github.com/pola-rs/polars/blob/df4d21c30c2b383b651e194f8263244f2afaeda3/crates/polars-plan/src/plans/conversion/expr_expansion.rs#L607-L660

