### PR TITLE
fix(dependencies): update import check for modin.pandas module

### DIFF
--- a/narwhals/dependencies.py
+++ b/narwhals/dependencies.py
@@ -56,7 +56,7 @@ def get_pandas() -> Any:
 
 def get_modin() -> Any:  # pragma: no cover
     """Get modin.pandas module (if already imported - else return None)."""
-   return sys.modules.get("modin.pandas", None)
+    return sys.modules.get("modin.pandas", None)
 
 
 def get_cudf() -> Any:


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- https://github.com/snowflakedb/snowpark-python/pull/3907

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
The dependencies function `get_modin` currently checks whether the entire modin library is available, then tries to import the pandas module specifically. Instead, check if the module is available before importing. 

Please see related issue in the snowpark-python repo [here](https://github.com/snowflakedb/snowpark-python/pull/3907) for more details about the case where this was discovered. 
