### PR TITLE
fix: Pass/Retrieve empty categories from nw.Enum

### DIFF
--- a/narwhals/dtypes.py
+++ b/narwhals/dtypes.py
@@ -633,9 +633,9 @@ class Enum(DType):
     @property
     def categories(self) -> tuple[str, ...]:
         """The categories in the dataset."""
-        if cached := self._cached_categories:
+        if (cached := self._cached_categories) is not None:
             return cached
-        if delayed := self._delayed_categories:
+        if (delayed := self._delayed_categories) is not None:
             self._cached_categories = delayed.to_tuple()
             return self._cached_categories
         msg = f"Internal structure of {type(self).__name__!r} is invalid."  # pragma: no cover

--- a/tests/dtypes/dtypes_test.py
+++ b/tests/dtypes/dtypes_test.py
@@ -441,7 +441,9 @@ def test_cast_decimal_to_native() -> None:
             )
 
 
-@pytest.mark.parametrize("categories", [["a", "b"], enum.Enum("Test", "a b"), [1, 2, 3]])
+@pytest.mark.parametrize(
+    "categories", [["a", "b"], enum.Enum("Test", "a b"), [1, 2, 3], []]
+)
 def test_enum_valid(categories: Iterable[Any] | type[enum.Enum]) -> None:
     dtype = nw.Enum(categories)
     assert dtype == nw.Enum


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3235 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes
    - This was expected, but untested behavior.

## If you have comments or can explain your changes, please do so below

```python
>>> import narwhals as nw
>>> dtype = nw.Enum([])
>>> dtype.categories # old behavior: TypeError: Internal structure of 'Enum' is invalid.
()                   # new behavior: returns correctly
```