### PR TITLE
docs: Add Support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,9 @@ to this list!
 
 If you'd like to say "thank you", please give us a ⭐ star ⭐.
 
-Please contact [hello_narwhals@proton.me](hello_narwhals@proton.me) if you like to:
+Please contact [hello_narwhals@proton.me](hello_narwhals@proton.me) if you would like to:
 
-- Receive professional support.
+- Receive professional support (e.g., if you're using or would like to use Narwhals at your company).
 - Have any Narwhals fixes / features prioritised.
 - Commission any Narwhals plugins for new backends.
 


### PR DESCRIPTION
Like this, if people want things prioritised beyond what can be done by volunteers, they have an option to speed things up

Note that I would first need to disclose any contacts with my employer (Quansight Labs - they don't own the project in any way, but per my contract with them, I would need to disclose this). Then, if the request was something that they weren't interested in (e.g. if it was too smale-scale) then perhaps one of our regular contributors would be able to take it on independently

Any objections?

<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below
