### PR TITLE
doc: fix incorrect narwhals daft url

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -62,4 +62,4 @@ handle plugins. For this integration to work, any plugin architecture must conta
   
 ## Can I see an example?
 
-Yes! For a reference plugin, please check out [narwhals-daft](https://github.com/narwhals-daft/narwhals-daft).
+Yes! For a reference plugin, please check out [narwhals-daft](https://github.com/narwhals-dev/narwhals-daft).


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request! 
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes

## If you have comments or can explain your changes, please do so below

Just noticed the url link to narwhals-daft has a typo.
