### PR TITLE
test: skip pandas only if in constructor

### DIFF
--- a/tests/frame/sink_parquet_test.py
+++ b/tests/frame/sink_parquet_test.py
@@ -15,9 +15,10 @@ pytest.importorskip("pyarrow")
 data = {"a": [1, 2, 3]}
 
 
-@pytest.mark.skipif(PANDAS_VERSION < (2, 0, 0), reason="too old for pyarrow")
 @pytest.mark.filterwarnings("ignore:.*is_sparse is deprecated:DeprecationWarning")
 def test_sink_parquet(constructor: Constructor, tmpdir: pytest.TempdirFactory) -> None:
+    if "pandas" in str(constructor) and PANDAS_VERSION < (2, 0, 0):
+        pytest.skip(reason="too old for pyarrow")
     path = tmpdir / "foo.parquet"  # type: ignore[operator]
     df = nw.from_native(constructor(data))
     df.lazy().sink_parquet(str(path))


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description
While working on a Narwhals Daft plugin, this test was skipped. Changed it skip only if pandas is in constructor.
<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
