### PR TITLE
fix(docs): Keep table filter only in api-completeness page

### DIFF
--- a/docs/javascripts/table.js
+++ b/docs/javascripts/table.js
@@ -1,4 +1,10 @@
 document$.subscribe(function() {
+  // Only run on api-completeness pages
+  var currentPath = window.location.pathname
+  if (!currentPath.includes('/api-completeness/')) {
+    return
+  }
+  
   var tables = document.querySelectorAll("article table:not([class])")
   tables.forEach(function(table) {
     new Tablesort(table)

--- a/utils/generate_backend_completeness.py
+++ b/utils/generate_backend_completeness.py
@@ -301,9 +301,9 @@ def get_backend_methods(
 
     methods = set(ALWAYS_IMPLEMENTED)
     if compliant_class is not None:
-        methods = get_implemented_methods_from_class(compliant_class)
+        methods.update(get_implemented_methods_from_class(compliant_class))
 
-    if backend.name not in SERIES_REUSING_BACKENDS or not module_name.startswith("expr"):
+    if backend.name in SERIES_REUSING_BACKENDS and module_name.startswith("expr"):
         methods = _add_series_reusing_methods(
             methods, module_name, backend, target_class_name
         )


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

Related https://github.com/narwhals-dev/narwhals/pull/3285#issuecomment-3682111318

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes


<details><summary>Screenshots</summary>
<p>

filter is gone for api-reference

<img width="1196" height="389" alt="image" src="https://github.com/user-attachments/assets/0f0c3d0f-9b54-48c7-abe5-6edd214af4e9" />

while it's still there for api-completeness

<img width="650" height="631" alt="image" src="https://github.com/user-attachments/assets/9b0154be-f10b-4384-9e62-8d713ff8a528" />



</p>
</details> 