### PR TITLE
perf: Avoid recursive `union all by name` call for duckdb diagonal concat

### DIFF
--- a/narwhals/_duckdb/namespace.py
+++ b/narwhals/_duckdb/namespace.py
@@ -97,7 +97,7 @@ class DuckDBNamespace(
             temp_table_names = tuple(
                 f"nw_concat_tmp_table_{i}" for i in range(len(native_items))
             )
-            for name, item in zip(temp_table_names, native_items, strict=False):
+            for name, item in zip(temp_table_names, native_items):
                 duckdb.register(name, item)
 
             query = " union all by name ".join(


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

I run a benchmark locally with different configurations (times are average on 3 runs per configuration), and overlap fraction of 50% of the columns:

| n_frames | n_rows | n_cols | time[s] (main) | time[s] (branch) | 
| --------- | ------- | ------- | -------------- | ---------------- |
| 5    |  10000 |      20 |      0.0591 |   0.0504 |
| 5    |  10000 |      50 |      0.0627 |   0.0603 |
| 5    | 100000 |      20 |      0.1759 |   0.1709 |
| 5    | 100000 |      50 |      0.4753 |   0.4462 |
| 10   |   10000 |      20 |      0.0914 |  0.0710 |
| 10   |   10000 |      50 |      0.2312 |  0.1790 |
| 10   |  100000 |      20 |      0.5308 |  0.5432 |
| 10   |  100000 |      50 |      1.3510 |  1.4438 |
| 20   |   10000 |      20 |      0.3652 |  0.2255 |
| 20   |   10000 |      50 |      0.9011 |  0.5725 |
| 20   |  100000 |      20 |      1.9238 |  1.7864 |
| 20   |  100000 |      50 |      4.9235 |  4.4886 |

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related https://github.com/narwhals-dev/narwhals/pull/3398#discussion_r2680061725

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes
