### PR TITLE
fix(deps): `cudf` to `cudf-cu12` in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Repository = "https://github.com/narwhals-dev/narwhals"
 # https://github.com/narwhals-dev/narwhals/issues/817 
 pandas = ["pandas>=1.1.3"]
 modin = ["modin"]
-cudf = ["cudf>=24.10.0"]
+cudf = ["cudf-cu12>=24.10.0"]
 pyarrow = ["pyarrow>=13.0.0"]
 pyspark = ["pyspark>=3.5.0"]
 pyspark-connect = ["pyspark[connect]>=3.5.0"]


### PR DESCRIPTION
cudf changed its naming scheme to include the underlying CUDA version. cudf on pypi only has version 0.6.1.post1 and has not been updated since 2020-01-01.


<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

Attempting to run `uv run pytest`, `uv` fails to resolve the dependency for `cudf` with the below error.

```
❯ uv run python
  × No solution found when resolving dependencies for split (markers: python_full_version >= '3.10'):
  ╰─▶ Because only cudf==0.6.1.post1 is available and narwhals[cudf] depends on cudf>=24.10.0, we can
      conclude that narwhals[cudf]'s requirements are unsatisfiable.
      And because your project requires narwhals[cudf], we can conclude that your project's
      requirements are unsatisfiable.
```

Turns out, cudf changed its naming scheme to include the underlying CUDA version. cudf on pypi only has version `0.6.1.post1` and has not been updated since 2020-01-01. https://pypi.org/project/cudf/

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
