### PR TITLE
feat(expr-ir): Add `selectors.decimal`

### DIFF
--- a/narwhals/_plan/expressions/selectors.py
+++ b/narwhals/_plan/expressions/selectors.py
@@ -329,6 +329,9 @@ class Duration(DTypeSelector, dtype=_dtypes.Duration):
 class Enum(DTypeSelector, dtype=_dtypes.Enum): ...
 
 
+class Decimal(DTypeSelector, dtype=_dtypes.Decimal): ...
+
+
 class Float(DTypeSelector, dtype=FloatType): ...
 
 

--- a/narwhals/_plan/selectors.py
+++ b/narwhals/_plan/selectors.py
@@ -33,6 +33,7 @@ __all__ = [
     "by_name",
     "categorical",
     "datetime",
+    "decimal",
     "duration",
     "empty",
     "enum",
@@ -231,6 +232,10 @@ def enum() -> Selector:
     return s_ir.Enum().to_selector_ir().to_narwhals()
 
 
+def decimal() -> Selector:
+    return s_ir.Decimal().to_selector_ir().to_narwhals()
+
+
 def first() -> Selector:
     return s_ir.ByIndex.from_index(0).to_selector_ir().to_narwhals()
 
@@ -284,4 +289,5 @@ _HASH_SENSITIVE_TO_SELECTOR: Mapping[type[DType], Callable[[], Selector]] = {
     _dtypes.Array: array,
     _dtypes.List: list,
     _dtypes.Struct: struct,
+    _dtypes.Decimal: decimal,
 }

--- a/tests/plan/selectors_test.py
+++ b/tests/plan/selectors_test.py
@@ -691,6 +691,17 @@ def test_selector_struct() -> None:
     df.assert_selects(~ncs.struct(), "a", "b", "d", "f", "g")
 
 
+def test_selector_decimal(schema_mixed: nw.Schema) -> None:
+    df = Frame(schema_mixed)
+    df.assert_selects(ncs.decimal())
+    df = df.from_mapping(
+        {"zz0": nw.Float64(), "zz1": nw.Decimal(38, 5), "zz2": nw.Decimal()}
+    )
+    df.assert_selects(ncs.numeric(), "zz0", "zz1", "zz2")
+    df.assert_selects(ncs.decimal(), "zz1", "zz2")
+    df.assert_selects(~ncs.decimal(), "zz0")
+
+
 def test_selector_matches_22816() -> None:
     df = Frame.from_names("ham", "hamburger", "foo", "bar")
     df.assert_selects(ncs.matches(r"^ham.*$"), "ham", "hamburger")


### PR DESCRIPTION
# Description

Wasn't planning this, but following #3377 - one of the [selectors tests](https://github.com/narwhals-dev/narwhals/blob/31aadc4c25a2672982fada53d89d196a44ff1eba/tests/plan/selectors_test.py#L164-L175) started [failing](https://github.com/narwhals-dev/narwhals/actions/runs/21320278433/job/61369125511?pr=2572).

Pretty painless fix, since `polars` [doesn't match by scale/precision](https://github.com/pola-rs/polars/blob/3e39d238b28da3e28501311c247bed8b5568b9fa/py-polars/src/polars/selectors.py#L2009-L2010)

## Related issues

- Related #3377

