### PR TITLE
ci: Pin `sqlglot<28.6.0` in `--group typing`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ typing = [  # keep some of these pinned and bump periodically so there's fewer s
   "pyright",
   "pyarrow-stubs==19.2",
   "sqlframe",
+  "sqlglot<28.6.0",
   "polars==1.34.0",
   "uv",
   "narwhals[ibis]",


### PR DESCRIPTION
# Description
#3412 Makes ci quiet, but locally the issues peek out on a reinstall

