### PR TITLE
ci: Remove `sqlglot` pin in `--group typing`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ typing = [  # keep some of these pinned and bump periodically so there's fewer s
   "pyright",
   "pyarrow-stubs==19.2",
   "sqlframe",
-  "sqlglot<28.6.0",
   "polars",
   "uv",
   "narwhals[ibis]",


### PR DESCRIPTION
## Description
Resolves all of these

```py
======================================================================================== short test summary info =========================================================================================
FAILED tests/expr_and_series/list/sum_test.py::test_sum_expr[sqlframe] - AttributeError: module 'sqlglot.expressions' has no attribute 'ArrayCompact'
FAILED tests/expr_and_series/list/mean_test.py::test_mean_expr[sqlframe] - AttributeError: module 'sqlglot.expressions' has no attribute 'ArrayCompact'
FAILED tests/expr_and_series/list/median_test.py::test_median_expr[sqlframe] - AttributeError: module 'sqlglot.expressions' has no attribute 'ArrayCompact'
FAILED tests/expr_and_series/list/max_test.py::test_max_expr[sqlframe] - AttributeError: module 'sqlglot.expressions' has no attribute 'ArrayCompact'
FAILED tests/expr_and_series/list/unique_test.py::test_unique_expr[sqlframe] - AttributeError: module 'sqlglot.expressions' has no attribute 'ArrayAppend'
```


## Related issues
- Pin added #3432
- Original issue resolved https://github.com/eakmanrq/sqlframe/issues/577
- Current pin blocking https://github.com/tobymao/sqlglot/pull/6735
- Pin complained about https://github.com/narwhals-dev/narwhals/issues/3445#issuecomment-3841382309

