### PR TITLE
ci(tpch): Pin `"polars==1.37.1"` for tpch queries

### DIFF
--- a/.github/workflows/check_tpch_queries.yml
+++ b/.github/workflows/check_tpch_queries.yml
@@ -26,10 +26,11 @@ jobs:
           cache-suffix: ${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
       - name: local-install
+        # temporary polars pin https://github.com/narwhals-dev/narwhals/issues/3450
         run: |
           uv pip install -U -e ".[dask]" --group core-tests --system
-          uv pip install -U duckdb --system
+          uv pip install -U duckdb "polars==1.37.1" --system
       - name: generate-data
-        run: cd tpch && python generate_data.py
+        run: cd tpch && python generate_data.py --debug
       - name: tpch-tests 
         run: cd tpch && pytest tests


### PR DESCRIPTION
# Description
Lost a lot of time today trying to figure out a good solution to this.

AFAICT, there is no way to write strings anymore 😩

If anyone has any better ideas let me know.
I think `polars` needs to support this, or document how to opt-out of the change:

```py

pl.LazyFrame().sink_parquet(compat_level=pl.CompatLevel.oldest())
```


## Related issues
- [x] https://github.com/pola-rs/polars/pull/26436
- Temp bandage for #3450
- Upstream
  - https://github.com/pola-rs/polars/pull/26236
  - https://github.com/pola-rs/polars/pull/26323
