### PR TITLE
ci: Replace workflow-level `$PY_COLORS`

### DIFF
--- a/.github/workflows/check_tpch_queries.yml
+++ b/.github/workflows/check_tpch_queries.yml
@@ -3,9 +3,6 @@ name: Tests for TPCH Queries
 on:
   pull_request:
 
-env:
-  PY_COLORS: 1
-
 jobs:
   validate-queries:
     strategy:

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -3,9 +3,6 @@ name: Test Downstream Libraries - Fast
 on:
   pull_request:
 
-env:
-  PY_COLORS: 1
-
 jobs:
   altair:
     strategy:

--- a/.github/workflows/downstream_tests_slow.yml
+++ b/.github/workflows/downstream_tests_slow.yml
@@ -4,9 +4,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-env:
-  PY_COLORS: 1
-
 jobs:
   vegafusion:
      env:

--- a/.github/workflows/extremes.yml
+++ b/.github/workflows/extremes.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
 
 env:
-  PY_COLORS: 1
   PYTEST_ADDOPTS: "--numprocesses=logical"
   
 jobs:

--- a/.github/workflows/pytest-ibis.yml
+++ b/.github/workflows/pytest-ibis.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
 
 env:
-  PY_COLORS: 1
   PYTEST_ADDOPTS: "--numprocesses=logical"
 
 jobs:

--- a/.github/workflows/pytest-modin.yml
+++ b/.github/workflows/pytest-modin.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
 
 env:
-  PY_COLORS: 1
   PYTEST_ADDOPTS: "--numprocesses=logical"
 
 jobs:

--- a/.github/workflows/pytest-pyspark.yml
+++ b/.github/workflows/pytest-pyspark.yml
@@ -12,7 +12,6 @@ on:
     - cron: 0 12 * * 0  # Sunday at mid-day
 
 env:
-  PY_COLORS: 1
   PYTEST_ADDOPTS: "--numprocesses=logical"
 
 jobs:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
 
 env:
-  PY_COLORS: 1
   PYTEST_ADDOPTS: "--numprocesses=logical"
 
 jobs:

--- a/.github/workflows/random_ci_pytest.yml
+++ b/.github/workflows/random_ci_pytest.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
 
 env:
-  PY_COLORS: 1
   PYTEST_ADDOPTS: "--numprocesses=logical"
 
 jobs:

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -3,9 +3,6 @@ name: Type checking
 on:
   pull_request:
 
-env:
-  PY_COLORS: 1
-
 jobs:
   typing:
     strategy:


### PR DESCRIPTION
# Description

Following ([Defining configuration variables for multiple workflows](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#defining-configuration-variables-for-multiple-workflows)), I've added `PY_COLORS` to the repo level variables.

FWIW, I'd never heard of that one - but do have [`FORCE_COLOR`](https://force-color.org/) so I added both.
Maybe we'll see more pretty colors?

<img width="787" alt="image" src="https://github.com/user-attachments/assets/d7cda0ff-fb38-49b0-859b-142b64d52658" />



## Related issues

- Review this one first :pray: #3455

