### PR TITLE
fix: Address DuckDB 1.5 `fetch_arrow_table` deprecation

### DIFF
--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -137,8 +137,13 @@ class DuckDBLazyFrame(
         if backend is None or backend is Implementation.PYARROW:
             from narwhals._arrow.dataframe import ArrowDataFrame
 
+            res_native = (
+                self.native.to_arrow_table()
+                if self._backend_version >= (1, 5)
+                else self.native.fetch_arrow_table()
+            )
             return ArrowDataFrame(
-                self.native.fetch_arrow_table(),
+                res_native,
                 validate_backend_version=True,
                 version=self._version,
                 validate_column_names=True,


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- https://github.com/duckdb/duckdb-python/pull/287

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
