### PR TITLE
Update marimo downstream CI to use uv instead of hatch

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -104,7 +104,7 @@ jobs:
         if: ${{ matrix.dependencies == 'core,optional' }}
         run: |
           cd marimo
-          uv run --python ${{ matrix.python-version }} -c "import narwhals; print(narwhals.__file__)"
+          uv run --python ${{ matrix.python-version }} python -c "import narwhals; print(narwhals.__file__)"
           scripts/test-narwhals.sh --python=${{ matrix.python-version }}
         timeout-minutes: 15
 


### PR DESCRIPTION
Pending on https://github.com/marimo-team/marimo/pull/8510, which replaces hatch with native uv commands in marimo. Uses `uv add ../ --editable` and a new `scripts/test-narwhals.sh` in marimo instead of the old hatch-based test invocation.
