### PR TITLE
fix: pyarrow when/then with nulls

### DIFF
--- a/narwhals/_arrow/namespace.py
+++ b/narwhals/_arrow/namespace.py
@@ -252,4 +252,4 @@ class ArrowNamespace(
         otherwise: ChunkedArrayAny | None = None,
     ) -> ChunkedArrayAny:
         otherwise = pa.nulls(len(when), then.type) if otherwise is None else otherwise
-        return pc.if_else(when, then, otherwise)
+        return pc.if_else(when.fill_null(pa.scalar(False)), then, otherwise)

--- a/tests/expr_and_series/when_test.py
+++ b/tests/expr_and_series/when_test.py
@@ -227,3 +227,13 @@ def test_when_then_empty(constructor: Constructor) -> None:
     result = df.with_columns(nw.when(nw.col("a") == 1).then(nw.lit(1)).alias("new_col"))
     expected: dict[str, Any] = {"a": [], "new_col": []}
     assert_equal_data(result, expected)
+
+
+def test_when_chain_with_nulls(constructor: Constructor) -> None:
+    df = nw.from_native(constructor({"a": [1, None, 3, None, 5]}))
+
+    result = df.select(nw.when(nw.col("a") == 1).then(10).otherwise(99).alias("result"))
+
+    # Null values don't match any condition, so they get otherwise value
+    expected = {"result": [10, 99, 99, 99, 99]}
+    assert_equal_data(result, expected)


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
