### PR TITLE
chore: exception `message` attribute annotations

### DIFF
--- a/narwhals/exceptions.py
+++ b/narwhals/exceptions.py
@@ -20,7 +20,7 @@ class FormattedKeyError(KeyError):
     """
 
     message: str
-    
+
     def __init__(self, message: str) -> None:
         self.message = message
 


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

I just added support for detecting untyped instance attributes to [typestats](https://jorenham.github.io/typestats/), and it now reports that narwhals is missing annotations for these three attributes. ~(It's still building at the moment, but you'll be able to see it in 30-45 minutes or so at https://jorenham.github.io/typestats/narwhals/.)~ With these, the type coverage will be 100% (again).

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
