### PR TITLE
fix: Adjust test error message for 32bit machines

### DIFF
--- a/tests/expr_and_series/map_batches_test.py
+++ b/tests/expr_and_series/map_batches_test.py
@@ -82,7 +82,8 @@ def test_map_batches_exception(
     df = nw.from_native(constructor_eager(data))
     msg = (
         r"`map(?:_batches)?` with `returns_scalar=False` must return a Series; found "
-        "'numpy.int64'.\n\nIf `returns_scalar` is set to `True`, a returned value can be "
+        r"'numpy\.int(?:32|64)'\."
+        "\n\nIf `returns_scalar` is set to `True`, a returned value can be "
         "a scalar value."
     )
 


### PR DESCRIPTION
# Description

To check that this works as expected we should test on a 32bit machine. I think it would be an overkill to run such setting in CI for a single test

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3544