### PR TITLE
ci: Use py-shiny composite actions for Docker Playwright

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -166,39 +166,33 @@ jobs:
         run: |
           git clone https://github.com/posit-dev/py-shiny.git
           cd py-shiny
-          uv venv -p ${{ matrix.python-version }}
           git log
-      - name: install-basics
-        run: |
-          cd py-shiny
-          . .venv/bin/activate
-          uv pip install --upgrade tox virtualenv setuptools
-      - name: install-shiny-dev
-        run: |
-          cd py-shiny
-          . .venv/bin/activate
-          # temporary pin to get CI green
-          uv pip install "flake8-bugbear<25.10.21"
-          make narwhals-install-shiny
+
+      # TODO: Change to @main after posit-dev/py-shiny#2218 is merged
+      - name: Narwhals integration setup
+        uses: posit-dev/py-shiny/.github/py-shiny/narwhals-setup@schloerke/narwhals-ci-docker
+        with:
+          shiny-dir: py-shiny
+
       - name: install-narwhals-dev
+        env:
+          UV_SYSTEM_PYTHON: "1"
         run: |
           cd py-shiny
-          . .venv/bin/activate
           uv pip uninstall narwhals
           uv pip install -e ./..
       - name: show-deps
+        env:
+          UV_SYSTEM_PYTHON: "1"
         run: |
           cd py-shiny
-          . .venv/bin/activate
           uv pip freeze
-      - name: Run `make narwhals-test-integration`
-        run: |
-          cd py-shiny
-          . .venv/bin/activate
-          # Isort seems to behave slightly differently in CI
-          # so we ignore its output
-          make format -s
-          make narwhals-test-integration
+
+      # TODO: Change to @main after posit-dev/py-shiny#2218 is merged
+      - name: Narwhals integration test
+        uses: posit-dev/py-shiny/.github/py-shiny/narwhals-test@schloerke/narwhals-ci-docker
+        with:
+          shiny-dir: py-shiny
 
   tea-tasting:
     strategy:

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -168,9 +168,8 @@ jobs:
           cd py-shiny
           git log
 
-      # TODO: Change to @main after posit-dev/py-shiny#2218 is merged
       - name: Narwhals integration setup
-        uses: posit-dev/py-shiny/.github/py-shiny/narwhals-setup@schloerke/narwhals-ci-docker
+        uses: posit-dev/py-shiny/.github/py-shiny/narwhals-setup@main
         with:
           shiny-dir: py-shiny
 
@@ -188,9 +187,8 @@ jobs:
           cd py-shiny
           uv pip freeze
 
-      # TODO: Change to @main after posit-dev/py-shiny#2218 is merged
       - name: Narwhals integration test
-        uses: posit-dev/py-shiny/.github/py-shiny/narwhals-test@schloerke/narwhals-ci-docker
+        uses: posit-dev/py-shiny/.github/py-shiny/narwhals-test@main
         with:
           shiny-dir: py-shiny
 


### PR DESCRIPTION
## Motivation

The `shiny` downstream test job installs Playwright browsers from scratch (`playwright install --with-deps chromium`), which can sometimes take 30min+. py-shiny now provides reusable composite actions that start a Docker container with pre-baked browsers.

## Summary
- Replace manual venv setup, browser installation, and test execution with two composite actions from py-shiny:
  - `narwhals-setup`: installs py-shiny deps + starts Docker Playwright server
  - `narwhals-test`: runs the integration test suite
- The narwhals dev install is sandwiched between the two actions

## Test plan
- [x] `shiny` job passes in CI with Docker Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)