### PR TITLE
docs: Add note on return type of columns property

### DIFF
--- a/docs/concepts/column_names.md
+++ b/docs/concepts/column_names.md
@@ -1,6 +1,7 @@
 # Column names
 
-Polars and PyArrow only allow for string column names. What about pandas?
+The majority of backends, as Polars, PyArrow, duckdb and PySpark for example,
+only allow for string column names. What about pandas-like and Dask backends?
 
 ```python exec="yes" source="above" result="python" session="col_names"
 import pandas as pd

--- a/narwhals/dataframe.py
+++ b/narwhals/dataframe.py
@@ -1353,6 +1353,13 @@ class DataFrame(BaseFrame[DataFrameT]):
     def columns(self) -> list[str]:
         """Get column names.
 
+        Note:
+            The pandas-like and dask backends allow non-string column names
+            (e.g. integers or booleans). While discouraged, this is supported,
+            so the return type is not guaranteed to be `list[str]`.
+
+            See [concepts - column names](../concepts/column_names.md) for details.
+
         Examples:
             >>> import pyarrow as pa
             >>> import narwhals as nw
@@ -2637,6 +2644,13 @@ class LazyFrame(BaseFrame[LazyFrameT]):
     @property
     def columns(self) -> list[str]:
         r"""Get column names.
+
+        Note:
+            The pandas-like and dask backends allow non-string column names
+            (e.g. integers or booleans). While discouraged, this is supported,
+            so the return type is not guaranteed to be `list[str]`.
+
+            See [concepts - column names](../concepts/column_names.md) for details.
 
         Examples:
             >>> import duckdb

--- a/narwhals/schema.py
+++ b/narwhals/schema.py
@@ -45,6 +45,13 @@ __all__ = ["Schema"]
 class Schema(OrderedDict[str, "DType"]):
     """Ordered mapping of column names to their data type.
 
+    Note:
+        The pandas-like and dask backends allow non-string column names
+        (e.g. integers or booleans). While discouraged, this is supported,
+        so we cannot guarantee that the keys are strictly strings.
+
+        See [concepts - column names](../concepts/column_names.md) for details.
+
     Arguments:
         schema: The schema definition given by column names and their associated
             *instantiated* Narwhals data type. Accepts a mapping or an iterable of tuples.
@@ -81,7 +88,15 @@ class Schema(OrderedDict[str, "DType"]):
         super().__init__(schema)
 
     def names(self) -> list[str]:
-        """Get the column names of the schema."""
+        """Get the column names of the schema.
+
+        Note:
+            The pandas-like and dask backends allow non-string column names
+            (e.g. integers or booleans). While discouraged, this is supported,
+            so the return type is not guaranteed to be `list[str]`.
+
+            See [concepts - column names](../concepts/column_names.md) for details.
+        """
         return list(self.keys())
 
     def dtypes(self) -> list[DType]:


### PR DESCRIPTION
# Description

1. Do you like the phrasing?
2. Should we add the same note for the `Schema` spec? For the same reason we cannot guarantee it to be a Mapping from str to DType.


## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3571

