### PR TITLE
fix: pandas-like `quantile` in group-by context

### DIFF
--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -66,30 +66,17 @@ _REMAP_ORDERED_INDEX: Mapping[NarwhalsAggregation, Literal[0, -1]] = {
 }
 
 
-def groupby_agg_kwargs_to_pandas_equivalent(
-    function_name: NativeAggregation, kwargs: ScalarKwargs
-) -> dict[str, Any]:
-    if function_name == "quantile":
-        assert "quantile" in kwargs  # noqa: S101
-        assert "interpolation" in kwargs  # noqa: S101
-        pandas_kwargs = {
-            "q": kwargs["quantile"],
-            "interpolation": kwargs["interpolation"],
-        }
-    else:  # sum, len, ...
-        pandas_kwargs = dict(kwargs)
-    return pandas_kwargs
-
-
 @lru_cache(maxsize=32)
 def _native_agg(name: NativeAggregation, /, **kwds: Unpack[ScalarKwargs]) -> _NativeAgg:
     if name == "nunique":
         return methodcaller(name, dropna=False)
+    if name == "quantile":
+        assert "quantile" in kwds  # noqa: S101
+        assert "interpolation" in kwds  # noqa: S101
+        return methodcaller(name, q=kwds["quantile"], interpolation=kwds["interpolation"])
     if not kwds or kwds.get("ddof") == 1:
         return methodcaller(name)
-
-    kwargs = groupby_agg_kwargs_to_pandas_equivalent(name, kwds)
-    return methodcaller(name, **kwargs)
+    return methodcaller(name, **kwds)
 
 
 class AggExpr:

--- a/narwhals/_pandas_like/group_by.py
+++ b/narwhals/_pandas_like/group_by.py
@@ -66,13 +66,30 @@ _REMAP_ORDERED_INDEX: Mapping[NarwhalsAggregation, Literal[0, -1]] = {
 }
 
 
+def groupby_agg_kwargs_to_pandas_equivalent(
+    function_name: NativeAggregation, kwargs: ScalarKwargs
+) -> dict[str, Any]:
+    if function_name == "quantile":
+        assert "quantile" in kwargs  # noqa: S101
+        assert "interpolation" in kwargs  # noqa: S101
+        pandas_kwargs = {
+            "q": kwargs["quantile"],
+            "interpolation": kwargs["interpolation"],
+        }
+    else:  # sum, len, ...
+        pandas_kwargs = dict(kwargs)
+    return pandas_kwargs
+
+
 @lru_cache(maxsize=32)
 def _native_agg(name: NativeAggregation, /, **kwds: Unpack[ScalarKwargs]) -> _NativeAgg:
     if name == "nunique":
         return methodcaller(name, dropna=False)
     if not kwds or kwds.get("ddof") == 1:
         return methodcaller(name)
-    return methodcaller(name, **kwds)
+
+    kwargs = groupby_agg_kwargs_to_pandas_equivalent(name, kwds)
+    return methodcaller(name, **kwargs)
 
 
 class AggExpr:

--- a/tests/expr_and_series/quantile_test.py
+++ b/tests/expr_and_series/quantile_test.py
@@ -58,9 +58,7 @@ def test_quantile_expr(
 def test_quantile_expr_group_by(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
-    if any(
-        x in str(constructor) for x in ("dask", "duckdb", "ibis", "pyspark", "pyarrow")
-    ):
+    if any(x in str(constructor) for x in ("dask", "pyspark", "pyarrow_table")):
         request.applymarker(pytest.mark.xfail)
 
     expected = {"a": [1, 2, 3], "b": [4.0, 6.0, 4.0]}

--- a/tests/expr_and_series/quantile_test.py
+++ b/tests/expr_and_series/quantile_test.py
@@ -58,7 +58,7 @@ def test_quantile_expr(
 def test_quantile_expr_group_by(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
-    if any(x in str(constructor) for x in ("dask", "pyspark", "pyarrow_table")):
+    if any(x in str(constructor) for x in ("dask", "pyarrow_table")):
         request.applymarker(pytest.mark.xfail)
 
     expected = {"a": [1, 2, 3], "b": [4.0, 6.0, 4.0]}

--- a/tests/expr_and_series/quantile_test.py
+++ b/tests/expr_and_series/quantile_test.py
@@ -55,6 +55,26 @@ def test_quantile_expr(
         assert_equal_data(result, expected)
 
 
+def test_quantile_expr_group_by(
+    constructor: Constructor, request: pytest.FixtureRequest
+) -> None:
+    if any(
+        x in str(constructor) for x in ("dask", "duckdb", "ibis", "pyspark", "pyarrow")
+    ):
+        request.applymarker(pytest.mark.xfail)
+
+    expected = {"a": [1, 2, 3], "b": [4.0, 6.0, 4.0]}
+    q = 0.3
+    data = {"a": [1, 2, 3], "b": [4, 6, 4]}
+    df_raw = constructor(data)
+    df = nw.from_native(df_raw)
+
+    result = df.group_by("a").agg(
+        nw.col("b").quantile(quantile=q, interpolation="linear")
+    )
+    assert_equal_data(result.sort("a"), expected)
+
+
 @pytest.mark.parametrize(
     ("interpolation", "expected"),
     [


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

The group_by.quantile expression fails for the pandas backend due to a mismatch in kwargs names.
This fix involves detecting a call to the native pandas quantile within a group_by expression and renaming the kwargs. It's similar to how window function do it. I'm not sure this is the best place to do it, possibly earlier in the call stack would make more sense or be more performant.

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #3582 

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes
