### PR TITLE
chore: use pandas in `get_categories` to avoid polars categorical flakiness

### DIFF
--- a/narwhals/expr_cat.py
+++ b/narwhals/expr_cat.py
@@ -18,23 +18,16 @@ class ExprCatNamespace(Generic[ExprT]):
         """Get unique categories from column.
 
         Examples:
-            >>> import polars as pl
+            >>> import pandas as pd
             >>> import narwhals as nw
-            >>> df_native = pl.DataFrame(
-            ...     {"fruits": ["apple", "mango", "mango"]},
-            ...     schema={"fruits": pl.Categorical},
+            >>> df_native = pd.DataFrame(
+            ...     {"fruits": ["apple", "mango", "mango"]}, dtype="category"
             ... )
             >>> df = nw.from_native(df_native)
             >>> df.select(nw.col("fruits").cat.get_categories()).to_native()
-            shape: (2, 1)
-            ┌────────┐
-            │ fruits │
-            │ ---    │
-            │ str    │
-            ╞════════╡
-            │ apple  │
-            │ mango  │
-            └────────┘
+              fruits
+            0  apple
+            1  mango
         """
         return self._expr._append_node(
             ExprNode(ExprKind.FILTRATION, "cat.get_categories")


### PR DESCRIPTION
occasionally this fails in ci


<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
