### PR TITLE
[Enh]: Fix bug in ibis where log base is not set to e by default

### DIFF
--- a/narwhals/_ibis/expr.py
+++ b/narwhals/_ibis/expr.py
@@ -214,6 +214,17 @@ class IbisExpr(SQLExpr["IbisLazyFrame", "ir.Value"]):
             raise NotImplementedError(msg)
         return self._with_callable(lambda expr: expr.quantile(quantile))
 
+    def log(self, base: float) -> Self:
+        def _log(expr: ir.Value) -> ir.Value:
+            numeric_expr = cast("ir.NumericValue", expr)
+            return ibis.cases(
+                (expr < lit(0), lit(float("nan"))),
+                (expr == lit(0), lit(float("-inf"))),
+                else_=numeric_expr.log(lit(base)),
+            )
+
+        return self._with_elementwise(_log)
+
     def n_unique(self) -> Self:
         return self._with_callable(
             lambda expr: expr.nunique() + expr.isnull().any().cast("int8")

--- a/narwhals/_ibis/expr.py
+++ b/narwhals/_ibis/expr.py
@@ -214,7 +214,7 @@ class IbisExpr(SQLExpr["IbisLazyFrame", "ir.Value"]):
             raise NotImplementedError(msg)
         return self._with_callable(lambda expr: expr.quantile(quantile))
 
-    def log(self, base: float) -> Self:
+    def log(self, base: float) -> Self:  # pragma: no cover
         def _log(expr: ir.Value) -> ir.Value:
             numeric_expr = cast("ir.NumericValue", expr)
             return ibis.cases(

--- a/narwhals/_ibis/expr.py
+++ b/narwhals/_ibis/expr.py
@@ -214,7 +214,7 @@ class IbisExpr(SQLExpr["IbisLazyFrame", "ir.Value"]):
             raise NotImplementedError(msg)
         return self._with_callable(lambda expr: expr.quantile(quantile))
 
-    def log(self, base: float) -> Self:  # pragma: no cover
+    def log(self, base: float) -> Self:
         def _log(expr: ir.Value) -> ir.Value:
             numeric_expr = cast("ir.NumericValue", expr)
             return ibis.cases(

--- a/tests/expr_and_series/log_test.py
+++ b/tests/expr_and_series/log_test.py
@@ -24,6 +24,24 @@ def test_log_expr(constructor: Constructor, base: float) -> None:
     assert_equal_data(result, {"a": expected[base]})
 
 
+def test_log_default_base_polars_ibis() -> None:
+    pytest.importorskip("ibis")
+    pytest.importorskip("polars")
+    import ibis
+    import polars as pl
+
+    con = ibis.polars.connect()
+
+    ibis_table = con.create_table("t", pl.LazyFrame(data))
+
+    df = nw.from_native(ibis_table)
+    result_default = df.select(nw.col("a").log())
+    result_e = df.select(nw.col("a").log(base=math.e))
+
+    assert_equal_data(result_default, {"a": expected[math.e]})
+    assert_equal_data(result_e, {"a": expected[math.e]})
+
+
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("base", [2, 10, math.e])
 def test_log_series(constructor_eager: ConstructorEager, base: float) -> None:

--- a/tests/expr_and_series/log_test.py
+++ b/tests/expr_and_series/log_test.py
@@ -24,7 +24,7 @@ def test_log_expr(constructor: Constructor, base: float) -> None:
     assert_equal_data(result, {"a": expected[base]})
 
 
-def test_log_default_base_polars_ibis() -> None:
+def test_log_default_base_polars_ibis() -> None:  # pragma: no cover
     pytest.importorskip("ibis")
     pytest.importorskip("polars")
     import ibis


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

Ibis doesn't actually set the base of the log to `e` by default for some backends (test in polars and snowflake). This PR adds a log expression for ibis that always passes it.
The ibis bug is https://github.com/ibis-project/ibis/issues/11997

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes
