### PR TITLE
ci: Add `# pragma: no cover` for `binary_string_sum_fallback`

### DIFF
--- a/narwhals/_pandas_like/series.py
+++ b/narwhals/_pandas_like/series.py
@@ -404,7 +404,8 @@ class PandasLikeSeries(EagerSeries[Any]):
         preserve_broadcast = self._broadcast and getattr(other, "_broadcast", True)
         try:
             res = op(ser, other_native)
-        except TypeError:
+        except TypeError:  # pragma: no cover
+            # Fixed in pandas 3.0.3
             if (
                 op.__name__ == "add"
                 and self.dtype == String

--- a/narwhals/_pandas_like/utils.py
+++ b/narwhals/_pandas_like/utils.py
@@ -694,7 +694,9 @@ def broadcast_series_to_index(
     return series_class(value, index=index, dtype=native.dtype, name=native.name)
 
 
-def binary_string_sum_fallback(left: pd.Series, right: Any, pdx: Any) -> pd.Series:
+def binary_string_sum_fallback(  # pragma: no cover
+    left: pd.Series, right: Any, pdx: Any
+) -> pd.Series:
     # Workaround some upstream issues:
     # - https://github.com/pandas-dev/pandas/issues/64393
     # - https://github.com/pandas-dev/pandas/issues/65220
@@ -706,7 +708,7 @@ def binary_string_sum_fallback(left: pd.Series, right: Any, pdx: Any) -> pd.Seri
         return left + pa.scalar(right, type=pa.large_string())
     if isinstance(right, pdx.Series):
         right_dtype = right.dtype
-        if left_dtype_str == "object":  # pragma: no cover
+        if left_dtype_str == "object":
             # Only for pandas pre 3.0. Anything is better than `object`, so take RHS.
             return left.astype(right_dtype) + right
         if hasattr(left.values, "__arrow_array__") and hasattr(
@@ -720,8 +722,8 @@ def binary_string_sum_fallback(left: pd.Series, right: Any, pdx: Any) -> pd.Seri
                 # https://github.com/pandas-dev/pandas/blob/b00d4f6710ff6c1c80319196657c31c2cf6c70ff/pandas/core/arrays/arrow/array.py#L1064-L1068
                 pd_pa_large_string = pd.ArrowDtype(pa.large_string())
                 return left.astype(pd_pa_large_string) + right.astype(pd_pa_large_string)
-        else:  # pragma: no cover
+        else:
             pass
         # Give precedence to the left-hand-side dtype.
         return left + right.astype(left_dtype)
-    return left + right  # pragma: no cover
+    return left + right


### PR DESCRIPTION
# Description

Issue was fixed and released on pandas v3.0.3.

Want to get CI green.

Related https://github.com/narwhals-dev/narwhals/actions/runs/25703996739/job/75470094181?pr=3613

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

