### PR TITLE
fix(expr-ir): Add compat for old polars

### DIFF
--- a/narwhals/_plan/_dispatch.py
+++ b/narwhals/_plan/_dispatch.py
@@ -339,7 +339,8 @@ def _dispatch_debug(
             f"Hint: Try adding `{self.name_full}()`"
         )
         raise NotImplementedError(msg) from err
-    return method(node, frame, name)
+    # NOTE: Coverage is flaky on the last line only?
+    return method(node, frame, name)  # pragma: no cover
 
 
 _DISPATCHER_CALL: Final = (

--- a/narwhals/_plan/options.py
+++ b/narwhals/_plan/options.py
@@ -80,6 +80,8 @@ class SortMultipleOptions(Immutable):
         nulls_last = self._ensure_single_nulls_last("pyarrow")
         return sort(*by, descending=self.descending, nulls_last=nulls_last)
 
+    # TODO @dangotbanned: Use `_ensure_single_nulls_last` for old `polars` (found at polars==0.20.19)
+    # https://github.com/narwhals-dev/narwhals/actions/runs/25729399118/job/75550427567?pr=2572#step:9:9427
     def to_polars(self, by: Sequence[str]) -> _SortOptions:
         """[`extend_bool`] doesn't broadcast length 1 sequences, so we do it here.
 

--- a/narwhals/_plan/options.py
+++ b/narwhals/_plan/options.py
@@ -11,19 +11,12 @@ from narwhals.typing import AsofJoinStrategy, JoinStrategy, UniqueKeepStrategy
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import TypedDict
 
     import pyarrow.compute as pc
 
     from narwhals._plan.typing import NonCrossJoinStrategy, OneOrIterable, Seq
     from narwhals._typing import Backend
     from narwhals.typing import AsofJoinStrategy as JoinAsofStrategy, RankMethod
-
-    # TODO @dangotbanned: Replace with `dict[Literal["descending", "nulls_last"], Seq[bool]]` after bumping mypy
-    # to include https://github.com/python/mypy/pull/20416
-    class _SortOptions(TypedDict):
-        descending: bool | Seq[bool]
-        nulls_last: bool | Seq[bool]
 
 
 class SortOptions(Immutable):
@@ -79,20 +72,6 @@ class SortMultipleOptions(Immutable):
 
         nulls_last = self._ensure_single_nulls_last("pyarrow")
         return sort(*by, descending=self.descending, nulls_last=nulls_last)
-
-    # TODO @dangotbanned: Use `_ensure_single_nulls_last` for old `polars` (found at polars==0.20.19)
-    # https://github.com/narwhals-dev/narwhals/actions/runs/25729399118/job/75550427567?pr=2572#step:9:9427
-    def to_polars(self, by: Sequence[str]) -> _SortOptions:
-        """[`extend_bool`] doesn't broadcast length 1 sequences, so we do it here.
-
-        [`extend_bool`]: https://github.com/pola-rs/polars/blob/b8bfb07a4a37a8d449d6d1841e345817431142df/py-polars/polars/_utils/various.py#L580-L594
-        """
-        len_by = len(by)
-        desc, nulls = self.descending, self.nulls_last
-        if len_by != 1:
-            desc = desc if len(desc) != 1 else desc * len_by
-            nulls = nulls if len(nulls) != 1 else nulls * len_by
-        return {"descending": desc, "nulls_last": nulls}
 
 
 class RankOptions(Immutable):

--- a/narwhals/_plan/plugins/_manager.py
+++ b/narwhals/_plan/plugins/_manager.py
@@ -146,7 +146,7 @@ class PluginManager:
             return self._plugin_load(name, entry_point)
         raise _unsupported_error(name, name)
 
-    def _iter_plugins(self) -> Iterator[PluginAny | BuiltinAny]:
+    def iter_plugins(self) -> Iterator[PluginAny | BuiltinAny]:
         yield from self._loaded.values()
         while self._discovered:  # pragma: no cover
             name, ep = self._discovered.popitem()
@@ -277,20 +277,6 @@ class PluginManager:
                 raise _unavailable_error(plugin)  # pragma: no cover
             for module in plugin.requirements:
                 import_module(module)
-
-    def importable(self) -> Iterator[BackendName | PluginName]:
-        """Yield the names of all importable plugins."""
-        for plugin in self._iter_plugins():
-            if plugin.can_import():
-                yield plugin.name
-            else:  # pragma: no cover
-                continue
-
-    def imported(self) -> Iterator[BackendName | PluginName]:
-        """Yield the names of all imported plugins."""
-        for plugin in self._iter_plugins():
-            if plugin.is_imported():
-                yield plugin.name
 
     def known(self) -> Iterator[BackendName | PluginName | str]:
         """Yield the names of all known plugins."""

--- a/narwhals/_plan/polars/compat.py
+++ b/narwhals/_plan/polars/compat.py
@@ -37,6 +37,9 @@ DUNDER_ARRAY_SUPPORTS_COPY: Final = BACKEND_VERSION >= (0, 20, 29)
 JOIN_OUTER_RENAMED_TO_FULL: Final = BACKEND_VERSION >= (0, 20, 29)
 """https://github.com/pola-rs/polars/pull/16417"""
 
+SERIES_HAS_HAS_NULLS: Final = BACKEND_VERSION >= (0, 20, 30)
+"""https://github.com/pola-rs/polars/pull/16488"""
+
 MELT_RENAMED_TO_UNPIVOT: Final = BACKEND_VERSION >= (1, 0)
 """https://github.com/pola-rs/polars/pull/17095"""
 

--- a/narwhals/_plan/polars/compat.py
+++ b/narwhals/_plan/polars/compat.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Final
+from typing import TYPE_CHECKING, Final, Literal, TypeAlias
 
 from narwhals._polars.utils import (
     SERIES_ACCEPTS_PD_INDEX as SERIES_ACCEPTS_PD_INDEX,  # noqa: PLC0414
     SERIES_RESPECTS_DTYPE as SERIES_RESPECTS_DTYPE,  # noqa: PLC0414
 )
 from narwhals._utils import Implementation
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 BACKEND_VERSION: Final = Implementation.POLARS._backend_version()
 """Static backend version for `polars`."""
@@ -59,3 +62,65 @@ MIN_PERIODS_RENAMED_TO_MIN_SAMPLES: Final = BACKEND_VERSION >= (1, 21)
 
 PIVOT_SUPPORTS_ON_COLUMNS: Final = BACKEND_VERSION >= (1, 36)
 """https://github.com/pola-rs/polars/pull/25016"""
+
+
+OVER_SUPPORTS_ORDER_BY: Final = BACKEND_VERSION >= (1, 0)
+"""https://github.com/pola-rs/polars/pull/16743
+
+Supports:
+
+    pl.col("a").first().over("b", order_by="c")
+"""
+
+OVER_ORDER_BY_GROUP_BY_FIX: Final = BACKEND_VERSION >= (1, 9)
+"""https://github.com/MarcoGorelli/narwhals/commit/5f35d22857f231bc0fba6ace6389cb58d742923c
+
+- The condition checks for `< 1.9`
+- The message says         `<= 1.9`
+- Only thing for `over` in that release is https://github.com/pola-rs/polars/pull/18947
+"""
+
+OVER_SUPPORTS_DESCENDING: Final = BACKEND_VERSION >= (1, 22)
+"""[#20919], [#20952]
+
+Supports:
+
+    pl.col("a").first().over("b", order_by="c", descending=True)
+    pl.col("a").first().over("b", order_by="c", descending=True, nulls_last=False)
+
+[#20919]: https://github.com/pola-rs/polars/pull/20919
+[#20952]: https://github.com/pola-rs/polars/pull/20952
+"""
+
+OVER_WITHOUT_PARTITION_BY: Final = BACKEND_VERSION >= (1, 30)
+"""https://github.com/pola-rs/polars/pull/22712
+
+Supports:
+
+    pl.col("a").first().over(order_by="c", descending=True, nulls_last=False)
+"""
+
+OVER_RESPECTS_NULLS_LAST: Final = BACKEND_VERSION >= (1, 39)
+"""https://github.com/pola-rs/polars/pull/26718
+
+Supports:
+
+    pl.col("a").first().over(order_by="c", descending=True, nulls_last=True)
+"""
+
+_OverFeature: TypeAlias = Literal[
+    "order_by_any", "descending", "order_by_only", "nulls_last"
+]
+
+_OVER_ERRORS: Final[Mapping[_OverFeature, tuple[str, str]]] = {
+    "order_by_any": ("..., order_by=...", "1.0.0"),
+    "descending": ("..., order_by=..., descending=True", "1.22.0"),
+    "order_by_only": ("order_by=...", "1.30.0"),
+    "nulls_last": ("order_by=..., nulls_last=True", "1.39.0"),
+}
+
+
+def over_error(feature: _OverFeature, /) -> NotImplementedError:
+    args, version = _OVER_ERRORS[feature]
+    msg = f"`over({args})` requires `polars>={version}`"
+    return NotImplementedError(msg)

--- a/narwhals/_plan/polars/compat.py
+++ b/narwhals/_plan/polars/compat.py
@@ -120,6 +120,8 @@ Supports:
 OVER_WITHOUT_PARTITION_BY: Final = BACKEND_VERSION >= (1, 30)
 """https://github.com/pola-rs/polars/pull/22712
 
+**Use `over(pl.lit(1), order_by=...)` on older versions!**
+
 Supports:
 
     pl.col("a").first().over(order_by="c", descending=True, nulls_last=False)
@@ -133,14 +135,11 @@ Supports:
     pl.col("a").first().over(order_by="c", descending=True, nulls_last=True)
 """
 
-_OverFeature: TypeAlias = Literal[
-    "order_by_any", "descending", "order_by_only", "nulls_last"
-]
+_OverFeature: TypeAlias = Literal["order_by_any", "descending", "nulls_last"]
 
 _OVER_ERRORS: Final[Mapping[_OverFeature, tuple[str, str]]] = {
     "order_by_any": ("..., order_by=...", "1.0.0"),
     "descending": ("..., order_by=..., descending=True", "1.22.0"),
-    "order_by_only": ("order_by=...", "1.30.0"),
     "nulls_last": ("order_by=..., nulls_last=True", "1.39.0"),
 }
 

--- a/narwhals/_plan/polars/compat.py
+++ b/narwhals/_plan/polars/compat.py
@@ -74,7 +74,7 @@ Note:
 SERIES_RPOW_PRESERVES_NAME: Final = BACKEND_VERSION >= (1, 16, 1)
 """https://github.com/pola-rs/polars/pull/20072"""
 
-IS_NAN_NUMERIC_PROPAGATES_NULLS: Final = BACKEND_VERSION >= (1, 18)
+IS_NAN_NUMERIC_PRESERVES_NULLS: Final = BACKEND_VERSION >= (1, 18)
 """https://github.com/pola-rs/polars/pull/20386"""
 
 MIN_PERIODS_RENAMED_TO_MIN_SAMPLES: Final = BACKEND_VERSION >= (1, 21)

--- a/narwhals/_plan/polars/compat.py
+++ b/narwhals/_plan/polars/compat.py
@@ -97,14 +97,6 @@ Supports:
     pl.col("a").first().over("b", order_by="c")
 """
 
-OVER_ORDER_BY_GROUP_BY_FIX: Final = BACKEND_VERSION >= (1, 9)
-"""https://github.com/MarcoGorelli/narwhals/commit/5f35d22857f231bc0fba6ace6389cb58d742923c
-
-- The condition checks for `< 1.9`
-- The message says         `<= 1.9`
-- Only thing for `over` in that release is https://github.com/pola-rs/polars/pull/18947
-"""
-
 OVER_SUPPORTS_DESCENDING: Final = BACKEND_VERSION >= (1, 22)
 """[#20919], [#20952]
 

--- a/narwhals/_plan/polars/compat.py
+++ b/narwhals/_plan/polars/compat.py
@@ -40,6 +40,8 @@ JOIN_OUTER_RENAMED_TO_FULL: Final = BACKEND_VERSION >= (0, 20, 29)
 MELT_RENAMED_TO_UNPIVOT: Final = BACKEND_VERSION >= (1, 0)
 """https://github.com/pola-rs/polars/pull/17095"""
 
+LAZYFRAME_HAS_COLLECT_SCHEMA: Final = BACKEND_VERSION >= (1, 0)
+
 CONSTRUCTOR_ACCEPTS_PYCAPSULE: Final = BACKEND_VERSION >= (1, 3)
 """https://github.com/pola-rs/polars/pull/17693"""
 

--- a/narwhals/_plan/polars/compat.py
+++ b/narwhals/_plan/polars/compat.py
@@ -163,7 +163,7 @@ def too_old(code: LiteralString, version: LiteralString, /) -> NotImplementedErr
 if NULLS_LAST_ACCEPTS_MULTIPLE:
 
     def sort(self: SortMultipleOptions, by: Sequence[str], /) -> _SortOptions:
-        """Try to convert `self` into something the current version of polars suppurts.
+        """Try to convert `self` into something the current version of polars supports.
 
         [`extend_bool`] doesn't broadcast length 1 sequences, so we do it here.
 

--- a/narwhals/_plan/polars/compat.py
+++ b/narwhals/_plan/polars/compat.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final, Literal, TypeAlias
+from typing import TYPE_CHECKING, Final, Literal, TypeAlias, TypedDict
 
 from narwhals._polars.utils import (
     SERIES_ACCEPTS_PD_INDEX as SERIES_ACCEPTS_PD_INDEX,  # noqa: PLC0414
@@ -11,9 +11,19 @@ from narwhals._polars.utils import (
 from narwhals._utils import Implementation
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
     from typing_extensions import LiteralString
+
+    from narwhals._plan.options import SortMultipleOptions
+    from narwhals._plan.typing import Seq
+
+    # TODO @dangotbanned: Replace with `dict[Literal["descending", "nulls_last"], Seq[bool]]` after bumping mypy
+    # to include https://github.com/python/mypy/pull/20416
+    class _SortOptions(TypedDict):
+        descending: bool | Seq[bool]
+        nulls_last: bool | Seq[bool]
+
 
 BACKEND_VERSION: Final = Implementation.POLARS._backend_version()
 """Static backend version for `polars`."""
@@ -39,6 +49,9 @@ JOIN_OUTER_RENAMED_TO_FULL: Final = BACKEND_VERSION >= (0, 20, 29)
 
 SERIES_HAS_HAS_NULLS: Final = BACKEND_VERSION >= (0, 20, 30)
 """https://github.com/pola-rs/polars/pull/16488"""
+
+NULLS_LAST_ACCEPTS_MULTIPLE: Final = BACKEND_VERSION >= (0, 20, 31)
+"""https://github.com/pola-rs/polars/pull/16639"""
 
 MELT_RENAMED_TO_UNPIVOT: Final = BACKEND_VERSION >= (1, 0)
 """https://github.com/pola-rs/polars/pull/17095"""
@@ -145,3 +158,30 @@ def too_old(code: LiteralString, version: LiteralString, /) -> NotImplementedErr
         Consider adding a layer above this for anything with complexity (see `over_error`)
     """
     return NotImplementedError(f"`{code}` requires `polars>={version}`")
+
+
+if NULLS_LAST_ACCEPTS_MULTIPLE:
+
+    def sort(self: SortMultipleOptions, by: Sequence[str], /) -> _SortOptions:
+        """Try to convert `self` into something the current version of polars suppurts.
+
+        [`extend_bool`] doesn't broadcast length 1 sequences, so we do it here.
+
+        [`extend_bool`]: https://github.com/pola-rs/polars/blob/b8bfb07a4a37a8d449d6d1841e345817431142df/py-polars/polars/_utils/various.py#L580-L594
+        """
+        desc, nulls = self.descending, self.nulls_last
+        len_by = len(by)
+        if len_by != 1:
+            desc = desc if len(desc) != 1 else desc * len_by
+            nulls = nulls if len(nulls) != 1 else nulls * len_by
+        return {"descending": desc, "nulls_last": nulls}
+else:
+
+    def sort(self: SortMultipleOptions, by: Sequence[str], /) -> _SortOptions:
+        desc, nulls = self.descending, self.nulls_last
+        desc = desc if len(desc) != 1 else desc * len(by)
+        first = nulls[0]
+        if len(nulls) != 1 and any(x != first for x in nulls[1:]):
+            msg = "nulls_last=(..., )"
+            raise too_old(msg, "0.20.31")
+        return {"descending": desc, "nulls_last": first}

--- a/narwhals/_plan/polars/compat.py
+++ b/narwhals/_plan/polars/compat.py
@@ -13,6 +13,8 @@ from narwhals._utils import Implementation
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from typing_extensions import LiteralString
+
 BACKEND_VERSION: Final = Implementation.POLARS._backend_version()
 """Static backend version for `polars`."""
 
@@ -59,6 +61,9 @@ IS_NAN_NUMERIC_PROPAGATES_NULLS: Final = BACKEND_VERSION >= (1, 18)
 
 MIN_PERIODS_RENAMED_TO_MIN_SAMPLES: Final = BACKEND_VERSION >= (1, 21)
 """https://github.com/pola-rs/polars/pull/20850"""
+
+HAS_LINEAR_SPACE: Final = BACKEND_VERSION >= (1, 21)
+"""https://github.com/pola-rs/polars/pull/20678"""
 
 PIVOT_SUPPORTS_ON_COLUMNS: Final = BACKEND_VERSION >= (1, 36)
 """https://github.com/pola-rs/polars/pull/25016"""
@@ -122,5 +127,16 @@ _OVER_ERRORS: Final[Mapping[_OverFeature, tuple[str, str]]] = {
 
 def over_error(feature: _OverFeature, /) -> NotImplementedError:
     args, version = _OVER_ERRORS[feature]
-    msg = f"`over({args})` requires `polars>={version}`"
-    return NotImplementedError(msg)
+    return too_old(f"over({args})", version)
+
+
+def too_old(code: LiteralString, version: LiteralString, /) -> NotImplementedError:
+    """Create an error for a version of polars that's `too_old`.
+
+    >>> too_old("DataFrame.pivot(...)", "1.0.0")
+    NotImplementedError('`DataFrame.pivot(...)` requires `polars>=1.0.0`')
+
+    Tip:
+        Consider adding a layer above this for anything with complexity (see `over_error`)
+    """
+    return NotImplementedError(f"`{code}` requires `polars>={version}`")

--- a/narwhals/_plan/polars/compat.py
+++ b/narwhals/_plan/polars/compat.py
@@ -41,6 +41,8 @@ Prior this this version, `nulls_last` was [only available on `*Frame` and `Expr`
 [only available on `*Frame` and `Expr`]: https://github.com/pola-rs/polars/issues/13788
 """
 
+HAS_LEN: Final = BACKEND_VERSION >= (0, 20, 6)
+
 DUNDER_ARRAY_SUPPORTS_COPY: Final = BACKEND_VERSION >= (0, 20, 29)
 """https://github.com/pola-rs/polars/pull/16401"""
 

--- a/narwhals/_plan/polars/dataframe.py
+++ b/narwhals/_plan/polars/dataframe.py
@@ -259,7 +259,7 @@ class PolarsDataFrame(PolarsFrame, CompliantDataFrame[pl.DataFrame, pl.Series]):
         return self.from_native(self.native.slice(offset, length))
 
     def sort(self, by: Sequence[str], options: SortMultipleOptions) -> Self:
-        return self.from_native(self.native.sort(by, **options.to_polars(by)))
+        return self.from_native(self.native.sort(by, **compat.sort(options, by)))
 
     @overload
     def to_dict(self, *, as_series: Literal[True]) -> Mapping[str, Series]: ...

--- a/narwhals/_plan/polars/dataframe.py
+++ b/narwhals/_plan/polars/dataframe.py
@@ -11,7 +11,7 @@ from narwhals._plan.common import temp
 from narwhals._plan.compliant import CompliantDataFrame
 from narwhals._plan.polars import compat
 from narwhals._plan.polars.classes import PolarsClasses
-from narwhals._plan.polars.expr import over
+from narwhals._plan.polars.expr import row_index
 from narwhals._plan.polars.frame import PolarsFrame
 from narwhals._plan.polars.namespace import dtype_to_native, explode_todo
 from narwhals._utils import Implementation, Version, not_implemented, requires
@@ -391,14 +391,11 @@ class PolarsDataFrame(PolarsFrame, CompliantDataFrame[pl.DataFrame, pl.Series]):
     def with_row_index(self, name: str) -> Self:
         return self.from_native(self.native.with_row_index(name))
 
-    # TODO @dangotbanned: Support using `Expr.sort_by` or `DataFrame.sort` for back-compat
     def with_row_index_by(
         self, name: str, order_by: Sequence[str], *, nulls_last: bool = False
     ) -> Self:
-        int_range = over(
-            pl.int_range(pl.len()), order_by=order_by, nulls_last=nulls_last
-        ).alias(name)
-        return self.from_native(self.native.select(int_range, pl.all()))
+        expr = row_index(name, order_by=order_by, nulls_last=nulls_last)
+        return self.from_native(self.native.select(expr, pl.all()))
 
     _group_by = not_implemented()  # pyright: ignore[reportAssignmentType, reportIncompatibleMethodOverride]
     lazy = not_implemented()

--- a/narwhals/_plan/polars/dataframe.py
+++ b/narwhals/_plan/polars/dataframe.py
@@ -11,6 +11,7 @@ from narwhals._plan.common import temp
 from narwhals._plan.compliant import CompliantDataFrame
 from narwhals._plan.polars import compat
 from narwhals._plan.polars.classes import PolarsClasses
+from narwhals._plan.polars.expr import over
 from narwhals._plan.polars.frame import PolarsFrame
 from narwhals._plan.polars.namespace import dtype_to_native, explode_todo
 from narwhals._utils import Implementation, Version, not_implemented, requires
@@ -91,7 +92,6 @@ class remap_exceptions:  # noqa: N801
         return False
 
 
-# TODO @dangotbanned: Add slots after making sure every protocol has empty one's
 class PolarsDataFrame(PolarsFrame, CompliantDataFrame[pl.DataFrame, pl.Series]):
     __slots__ = ("_native",)
     _native: pl.DataFrame
@@ -391,14 +391,13 @@ class PolarsDataFrame(PolarsFrame, CompliantDataFrame[pl.DataFrame, pl.Series]):
     def with_row_index(self, name: str) -> Self:
         return self.from_native(self.native.with_row_index(name))
 
+    # TODO @dangotbanned: Support using `Expr.sort_by` or `DataFrame.sort` for back-compat
     def with_row_index_by(
         self, name: str, order_by: Sequence[str], *, nulls_last: bool = False
     ) -> Self:
-        int_range = (
-            pl.int_range(pl.len())
-            .over(order_by=order_by, nulls_last=nulls_last)
-            .alias(name)
-        )
+        int_range = over(
+            pl.int_range(pl.len()), order_by=order_by, nulls_last=nulls_last
+        ).alias(name)
         return self.from_native(self.native.select(int_range, pl.all()))
 
     _group_by = not_implemented()  # pyright: ignore[reportAssignmentType, reportIncompatibleMethodOverride]

--- a/narwhals/_plan/polars/dataframe.py
+++ b/narwhals/_plan/polars/dataframe.py
@@ -14,14 +14,13 @@ from narwhals._plan.polars.classes import PolarsClasses
 from narwhals._plan.polars.expr import row_index
 from narwhals._plan.polars.frame import PolarsFrame
 from narwhals._plan.polars.namespace import dtype_to_native, explode_todo
-from narwhals._utils import Implementation, Version, not_implemented, requires
+from narwhals._utils import Implementation, not_implemented, requires
 from narwhals.exceptions import NarwhalsError
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping, Sequence
     from io import BytesIO
     from pathlib import Path
-    from typing import TypeAlias
 
     import pandas as pd
     import pyarrow as pa
@@ -43,10 +42,6 @@ if TYPE_CHECKING:
         PivotAgg,
         UniqueKeepStrategy,
     )
-
-
-Incomplete: TypeAlias = Any
-MAIN = Version.MAIN
 
 
 class remap_exceptions:  # noqa: N801
@@ -313,7 +308,7 @@ class PolarsDataFrame(PolarsFrame, CompliantDataFrame[pl.DataFrame, pl.Series]):
         separator: str = "_",
         sort_columns: bool = False,
     ) -> Self:
-        kwds: dict[str, Incomplete] = (
+        kwds: dict[str, Any] = (
             {"on_columns": on_columns.native}
             if compat.PIVOT_SUPPORTS_ON_COLUMNS
             else {"sort_columns": sort_columns}

--- a/narwhals/_plan/polars/expr.py
+++ b/narwhals/_plan/polars/expr.py
@@ -72,6 +72,17 @@ else:
         raise compat.too_old("linear_space", "1.21.0")
 
 
+# TODO @dangotbanned: (low-priority) Support without triggering
+# `over(..., order_by=...)` requires `polars>=1.0.0`
+def row_index(
+    name: str = "index", order_by: Sequence[str] = (), *, nulls_last: bool = False
+) -> pl.Expr:
+    expr = pl.int_range(pl.len())
+    if order_by:
+        expr = over(expr, order_by=order_by, nulls_last=nulls_last)
+    return expr.alias(name)
+
+
 class PolarsExpr(CompliantExpr["DataFrame", pl.Expr, pl.Expr]):
     __slots__ = ("_native",)
     _native: pl.Expr

--- a/narwhals/_plan/polars/expr.py
+++ b/narwhals/_plan/polars/expr.py
@@ -59,7 +59,7 @@ else:
                     raise compat.over_error("descending")
                 options["descending"] = descending
             if not partition_by and compat.OVER_WITHOUT_PARTITION_BY:
-                raise compat.over_error("order_by_only")
+                partition_by = (pl.lit(1),)
         return self.over(*partition_by, **options)
 
 

--- a/narwhals/_plan/polars/expr.py
+++ b/narwhals/_plan/polars/expr.py
@@ -72,12 +72,20 @@ else:
         raise compat.too_old("linear_space", "1.21.0")
 
 
+if compat.HAS_LEN or TYPE_CHECKING:
+    len = pl.len
+else:
+
+    def len() -> pl.Expr:
+        return pl.count().alias("len")
+
+
 # TODO @dangotbanned: (low-priority) Support without triggering
 # `over(..., order_by=...)` requires `polars>=1.0.0`
 def row_index(
     name: str = "index", order_by: Sequence[str] = (), *, nulls_last: bool = False
 ) -> pl.Expr:
-    expr = pl.int_range(pl.len())
+    expr = pl.int_range(len())
     if order_by:
         expr = over(expr, order_by=order_by, nulls_last=nulls_last)
     return expr.alias(name)
@@ -145,7 +153,7 @@ class PolarsExpr(CompliantExpr["DataFrame", pl.Expr, pl.Expr]):
 
     @classmethod
     def len_star(cls, _: ir.Len, __: Incomplete, name: str, /) -> Self:
-        return cls.from_native(pl.len(), name)
+        return cls.from_native(len(), name)
 
     abs = todo()
     all = todo()

--- a/narwhals/_plan/polars/expr.py
+++ b/narwhals/_plan/polars/expr.py
@@ -63,6 +63,15 @@ else:
         return self.over(*partition_by, **options)
 
 
+if compat.HAS_LINEAR_SPACE or TYPE_CHECKING:
+    # NOTE: Has some pretty intricate `@overload`s that can be preserved this way
+    linear_space = pl.linear_space
+else:
+
+    def linear_space(*_: Any, **__: Any) -> Any:
+        raise compat.too_old("linear_space", "1.21.0")
+
+
 class PolarsExpr(CompliantExpr["DataFrame", pl.Expr, pl.Expr]):
     __slots__ = ("_native",)
     _native: pl.Expr

--- a/narwhals/_plan/polars/expr.py
+++ b/narwhals/_plan/polars/expr.py
@@ -6,11 +6,13 @@ import polars as pl
 
 from narwhals._plan.common import todo
 from narwhals._plan.compliant.expr import CompliantExpr
+from narwhals._plan.polars import compat
 from narwhals._plan.polars.classes import PolarsClasses
 from narwhals._plan.polars.namespace import dtype_to_native, dtype_to_native_fast
 from narwhals._utils import Version
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from typing import TypeAlias
 
     from typing_extensions import Self
@@ -23,6 +25,42 @@ if TYPE_CHECKING:
 
 
 Incomplete: TypeAlias = Any
+
+if compat.OVER_RESPECTS_NULLS_LAST:
+    # NOTE: Allows all features, so no need to branch in any calls
+    def over(
+        self: pl.Expr,
+        *partition_by: pl.Expr | str,
+        order_by: Sequence[str] | None = None,
+        descending: bool = False,
+        nulls_last: bool = False,
+    ) -> pl.Expr:
+        return self.over(
+            *partition_by, order_by=order_by, descending=descending, nulls_last=nulls_last
+        )
+else:
+
+    def over(
+        self: pl.Expr,
+        *partition_by: pl.Expr | str,
+        order_by: Sequence[str] | None = None,
+        descending: bool = False,
+        nulls_last: bool = False,
+    ) -> pl.Expr:
+        if nulls_last:
+            raise compat.over_error("nulls_last")
+        options: dict[str, Any] = {}
+        if order_by:
+            if not compat.OVER_SUPPORTS_ORDER_BY:
+                raise compat.over_error("order_by_any")
+            options["order_by"] = order_by
+            if descending:
+                if not compat.OVER_SUPPORTS_DESCENDING:
+                    raise compat.over_error("descending")
+                options["descending"] = descending
+            if not partition_by and compat.OVER_WITHOUT_PARTITION_BY:
+                raise compat.over_error("order_by_only")
+        return self.over(*partition_by, **options)
 
 
 class PolarsExpr(CompliantExpr["DataFrame", pl.Expr, pl.Expr]):

--- a/narwhals/_plan/polars/lazyframe.py
+++ b/narwhals/_plan/polars/lazyframe.py
@@ -8,10 +8,9 @@ from narwhals._plan._version import into_version
 from narwhals._plan.common import temp, todo
 from narwhals._plan.compliant.lazyframe import CompliantLazyFrame
 from narwhals._plan.plans.visitors import ResolvedToCompliant
-from narwhals._plan.polars import compat
 from narwhals._plan.polars.expr import over
 from narwhals._plan.polars.frame import PolarsFrame
-from narwhals._plan.polars.namespace import explode_todo
+from narwhals._plan.polars.namespace import collect_schema, explode_todo
 from narwhals._utils import Implementation, Version
 
 if TYPE_CHECKING:
@@ -28,13 +27,6 @@ if TYPE_CHECKING:
     from narwhals._typing import IntoBackend
     from narwhals.schema import Schema
     from narwhals.typing import EagerAllowed
-
-if compat.LAZYFRAME_HAS_COLLECT_SCHEMA or TYPE_CHECKING:
-    collect_schema = pl.LazyFrame.collect_schema
-else:
-
-    def collect_schema(self: pl.LazyFrame) -> pl.Schema:
-        return self.schema
 
 
 class PolarsLazyFrame(PolarsFrame, CompliantLazyFrame[pl.LazyFrame]):

--- a/narwhals/_plan/polars/lazyframe.py
+++ b/narwhals/_plan/polars/lazyframe.py
@@ -8,6 +8,7 @@ from narwhals._plan._version import into_version
 from narwhals._plan.common import temp, todo
 from narwhals._plan.compliant.lazyframe import CompliantLazyFrame
 from narwhals._plan.plans.visitors import ResolvedToCompliant
+from narwhals._plan.polars.expr import over
 from narwhals._plan.polars.frame import PolarsFrame
 from narwhals._plan.polars.namespace import explode_todo
 from narwhals._utils import Implementation, Version
@@ -250,7 +251,7 @@ class PolarsEvaluator(ResolvedToCompliant[pl.LazyFrame]):
     def with_row_index_by(self, plan: rp.MapFunction[rp.RowIndexBy]) -> PolarsLazyFrame:
         f = plan.function
         native = plan.input.evaluate(self).native
-        int_range = pl.int_range(pl.len()).over(order_by=f.order_by).alias(f.name)
+        int_range = over(pl.int_range(pl.len()), order_by=f.order_by).alias(f.name)
         return self._into_compliant(native.select(int_range, pl.all()))
 
     # TODO @dangotbanned: All require adding an `Expr` layer

--- a/narwhals/_plan/polars/lazyframe.py
+++ b/narwhals/_plan/polars/lazyframe.py
@@ -8,6 +8,7 @@ from narwhals._plan._version import into_version
 from narwhals._plan.common import temp, todo
 from narwhals._plan.compliant.lazyframe import CompliantLazyFrame
 from narwhals._plan.plans.visitors import ResolvedToCompliant
+from narwhals._plan.polars import compat
 from narwhals._plan.polars.expr import over
 from narwhals._plan.polars.frame import PolarsFrame
 from narwhals._plan.polars.namespace import collect_schema, explode_todo
@@ -192,7 +193,7 @@ class PolarsEvaluator(ResolvedToCompliant[pl.LazyFrame]):
     def sort(self, plan: rp.Sort, /) -> PolarsLazyFrame:
         by = plan.by
         return self._into_compliant(
-            plan.input.evaluate(self).native.sort(by, **plan.options.to_polars(by))
+            plan.input.evaluate(self).native.sort(by, **compat.sort(plan.options, by))
         )
 
     def unique(self, plan: rp.Unique) -> PolarsLazyFrame:

--- a/narwhals/_plan/polars/lazyframe.py
+++ b/narwhals/_plan/polars/lazyframe.py
@@ -9,7 +9,7 @@ from narwhals._plan.common import temp, todo
 from narwhals._plan.compliant.lazyframe import CompliantLazyFrame
 from narwhals._plan.plans.visitors import ResolvedToCompliant
 from narwhals._plan.polars import compat
-from narwhals._plan.polars.expr import over
+from narwhals._plan.polars.expr import row_index
 from narwhals._plan.polars.frame import PolarsFrame
 from narwhals._plan.polars.namespace import collect_schema, explode_todo
 from narwhals._utils import Implementation, Version
@@ -252,8 +252,8 @@ class PolarsEvaluator(ResolvedToCompliant[pl.LazyFrame]):
     def with_row_index_by(self, plan: rp.MapFunction[rp.RowIndexBy]) -> PolarsLazyFrame:
         f = plan.function
         native = plan.input.evaluate(self).native
-        int_range = over(pl.int_range(pl.len()), order_by=f.order_by).alias(f.name)
-        return self._into_compliant(native.select(int_range, pl.all()))
+        expr = row_index(f.name, f.order_by)
+        return self._into_compliant(native.select(expr, pl.all()))
 
     # TODO @dangotbanned: All require adding an `Expr` layer
     # Revisit after getting coverage for everything else

--- a/narwhals/_plan/polars/lazyframe.py
+++ b/narwhals/_plan/polars/lazyframe.py
@@ -8,6 +8,7 @@ from narwhals._plan._version import into_version
 from narwhals._plan.common import temp, todo
 from narwhals._plan.compliant.lazyframe import CompliantLazyFrame
 from narwhals._plan.plans.visitors import ResolvedToCompliant
+from narwhals._plan.polars import compat
 from narwhals._plan.polars.expr import over
 from narwhals._plan.polars.frame import PolarsFrame
 from narwhals._plan.polars.namespace import explode_todo
@@ -27,6 +28,13 @@ if TYPE_CHECKING:
     from narwhals._typing import IntoBackend
     from narwhals.schema import Schema
     from narwhals.typing import EagerAllowed
+
+if compat.LAZYFRAME_HAS_COLLECT_SCHEMA or TYPE_CHECKING:
+    collect_schema = pl.LazyFrame.collect_schema
+else:
+
+    def collect_schema(self: pl.LazyFrame) -> pl.Schema:
+        return self.schema
 
 
 class PolarsLazyFrame(PolarsFrame, CompliantLazyFrame[pl.LazyFrame]):
@@ -66,7 +74,7 @@ class PolarsLazyFrame(PolarsFrame, CompliantLazyFrame[pl.LazyFrame]):
     def input_schema(self) -> Schema:
         if self._input_schema is None:
             self._input_schema = into_version(self.version).schema.from_polars(
-                self.native.collect_schema()
+                collect_schema(self.native)
             )
         return self._input_schema
 

--- a/narwhals/_plan/polars/namespace.py
+++ b/narwhals/_plan/polars/namespace.py
@@ -7,6 +7,7 @@ import polars as pl
 from narwhals._plan._version import into_version
 from narwhals._plan.common import todo
 from narwhals._plan.compliant.namespace import CompliantNamespace
+from narwhals._plan.polars import compat
 from narwhals._polars.utils import (
     narwhals_to_native_dtype as _dtype_native,
     native_to_narwhals_dtype as _dtype_from_native,
@@ -68,6 +69,14 @@ def explode_todo(
     return True, True
 
 
+if compat.LAZYFRAME_HAS_COLLECT_SCHEMA or TYPE_CHECKING:
+    collect_schema = pl.LazyFrame.collect_schema
+else:
+
+    def collect_schema(self: pl.LazyFrame) -> pl.Schema:
+        return self.schema
+
+
 class PolarsNamespace(CompliantNamespace["Expr", "Expr"]):
     __slots__ = ()
     version: ClassVar[Version] = MAIN
@@ -110,7 +119,7 @@ class PolarsNamespace(CompliantNamespace["Expr", "Expr"]):
         return PolarsEvaluator
 
     def read_csv_schema(self, source: str, /, **kwds: Any) -> Schema:
-        schema = pl.scan_csv(source, **kwds).collect_schema()
+        schema = collect_schema(pl.scan_csv(source, **kwds))
         return into_version(self.version).schema.from_polars(schema)
 
     def read_parquet_schema(self, source: str, /, **kwds: Any) -> Schema:

--- a/narwhals/_plan/polars/series.py
+++ b/narwhals/_plan/polars/series.py
@@ -191,22 +191,29 @@ class PolarsSeries(CompliantSeries[pl.Series]):
     def is_in(self, other: Self) -> Self:
         return self._with_native(self.native.is_in(other.native))
 
-    def is_nan(self) -> Self:
-        result = self.native.is_nan()
-        if not compat.IS_NAN_NUMERIC_PROPAGATES_NULLS:  # pragma: no cover
-            s = self.native
-            result = (
-                s.to_frame()
-                .select(pl.when(pl.col(s.name).is_not_null()).then(result))
-                .to_series()
-            )
-        return self._with_native(result)
+    def _preserve_nulls(self, after: pl.Expr | pl.Series, /) -> Self:  # pragma: no cover
+        """Propagate nulls positionally from `self.native` to `after`."""
+        s = self.native
+        expr = pl.when(pl.col(s.name).is_not_null()).then(after)
+        return self._with_native(s.to_frame().select(expr).to_series())
+
+    if compat.IS_NAN_NUMERIC_PRESERVES_NULLS:
+
+        def is_nan(self) -> Self:
+            return self._with_native(self.native.is_nan())
+
+        def is_not_nan(self) -> Self:
+            return self._with_native(self.native.is_not_nan())
+    else:  # pragma: no cover
+
+        def is_nan(self) -> Self:
+            return self._preserve_nulls(self.native.is_nan())
+
+        def is_not_nan(self) -> Self:
+            return self._preserve_nulls(self.native.is_not_nan())
 
     def is_null(self) -> Self:
         return self._with_native(self.native.is_null())
-
-    def is_not_nan(self) -> Self:
-        return self._with_native(self.native.is_not_nan())
 
     def is_not_null(self) -> Self:
         return self._with_native(self.native.is_not_null())

--- a/narwhals/_plan/polars/series.py
+++ b/narwhals/_plan/polars/series.py
@@ -184,9 +184,9 @@ class PolarsSeries(CompliantSeries[pl.Series]):
         result = self.native.cast(dtype_to_native(dtype, self.version))
         return self._with_native(result)
 
-    # TODO @dangotbanned: `Series.has_nulls` compat (found at polars==0.20.19)
     def has_nulls(self) -> bool:
-        return self.native.has_nulls()
+        s = self.native
+        return s.has_nulls() if compat.SERIES_HAS_HAS_NULLS else s.has_validity()
 
     def is_in(self, other: Self) -> Self:
         return self._with_native(self.native.is_in(other.native))

--- a/narwhals/_plan/polars/series.py
+++ b/narwhals/_plan/polars/series.py
@@ -192,6 +192,7 @@ class PolarsSeries(CompliantSeries[pl.Series]):
         return self._with_native(self.native.is_in(other.native))
 
     # NOTE: Needs compat
+    # https://github.com/narwhals-dev/narwhals/actions/runs/25753098308/job/75634350024?pr=3617#step:9:1393
     # https://github.com/narwhals-dev/narwhals/blob/c207fc096263ce174470240748e0c568f38f93e2/narwhals/_polars/series.py#L364-L372
     def is_nan(self) -> Self:
         if compat.IS_NAN_NUMERIC_PROPAGATES_NULLS:

--- a/narwhals/_plan/polars/series.py
+++ b/narwhals/_plan/polars/series.py
@@ -184,6 +184,7 @@ class PolarsSeries(CompliantSeries[pl.Series]):
         result = self.native.cast(dtype_to_native(dtype, self.version))
         return self._with_native(result)
 
+    # TODO @dangotbanned: `Series.has_nulls` compat (found at polars==0.20.19)
     def has_nulls(self) -> bool:
         return self.native.has_nulls()
 

--- a/narwhals/_plan/polars/series.py
+++ b/narwhals/_plan/polars/series.py
@@ -191,14 +191,16 @@ class PolarsSeries(CompliantSeries[pl.Series]):
     def is_in(self, other: Self) -> Self:
         return self._with_native(self.native.is_in(other.native))
 
-    # NOTE: Needs compat
-    # https://github.com/narwhals-dev/narwhals/actions/runs/25753098308/job/75634350024?pr=3617#step:9:1393
-    # https://github.com/narwhals-dev/narwhals/blob/c207fc096263ce174470240748e0c568f38f93e2/narwhals/_polars/series.py#L364-L372
     def is_nan(self) -> Self:
-        if compat.IS_NAN_NUMERIC_PROPAGATES_NULLS:
-            return self._with_native(self.native.is_nan())
-        msg = "TODO @dangotbanned: `is_nan` backcompat\nSee https://github.com/narwhals-dev/narwhals/pull/1625#issuecomment-2565591385"
-        raise NotImplementedError(msg)
+        result = self.native.is_nan()
+        if not compat.IS_NAN_NUMERIC_PROPAGATES_NULLS:  # pragma: no cover
+            s = self.native
+            result = (
+                s.to_frame()
+                .select(pl.when(pl.col(s.name).is_not_null()).then(result))
+                .to_series()
+            )
+        return self._with_native(result)
 
     def is_null(self) -> Self:
         return self._with_native(self.native.is_null())

--- a/narwhals/_plan/polars/series.py
+++ b/narwhals/_plan/polars/series.py
@@ -10,6 +10,7 @@ from narwhals._plan.compliant import CompliantSeries, typing as ct
 from narwhals._plan.compliant.accessors import SeriesStructNamespace as StructNamespace
 from narwhals._plan.polars import compat
 from narwhals._plan.polars.classes import PolarsClasses
+from narwhals._plan.polars.expr import linear_space
 from narwhals._plan.polars.namespace import (
     dtype_from_native,
     dtype_to_native,
@@ -443,7 +444,7 @@ class PolarsSeries(CompliantSeries[pl.Series]):
         closed: ClosedInterval = "both",
         name: str = "literal",
     ) -> Self:
-        native = pl.linear_space(start, end, num_samples, closed=closed, eager=True)
+        native = linear_space(start, end, num_samples, closed=closed, eager=True)
         return cls.from_native(native, name)
 
     @property

--- a/narwhals/_plan/translate.py
+++ b/narwhals/_plan/translate.py
@@ -83,7 +83,7 @@ class _FromNative(Generic[P, R_co]):
         native_kind = cls._name
         query = (
             p
-            for p in manager._iter_plugins()
+            for p in manager.iter_plugins()
             if p.is_imported()
             and parse(p.name).has(native_kind)
             and cls.is_native(native, p)

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -106,6 +106,7 @@ def test_pyarrow_string_type(
     assert expected_function(result.field("store_item").type)
 
 
+# https://github.com/narwhals-dev/narwhals/actions/runs/25753098308/job/75634350024?pr=3617#step:9:1395
 @pytest.mark.skipif(
     PANDAS_VERSION < (2, 2), reason='"add" was not implemented yet for large-string'
 )

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -106,7 +106,6 @@ def test_pyarrow_string_type(
     assert expected_function(result.field("store_item").type)
 
 
-# https://github.com/narwhals-dev/narwhals/actions/runs/25753098308/job/75634350024?pr=3617#step:9:1395
 @pytest.mark.skipif(
     PANDAS_VERSION < (2, 2), reason='"add" was not implemented yet for large-string'
 )

--- a/tests/plan/compliant_test.py
+++ b/tests/plan/compliant_test.py
@@ -16,6 +16,7 @@ from narwhals.exceptions import (
 )
 from tests.plan.utils import (
     DataFrame,
+    Eager,
     Series,
     assert_equal_data,
     assert_equal_series,
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
     from _pytest.fixtures import TopRequest  # `pytest.FixtureRequest.node` returns `Any`
 
     from narwhals._plan.typing import ColumnNameOrSelector, IntoExpr, OneOrIterable
-    from narwhals.typing import EagerAllowed, PythonLiteral
+    from narwhals.typing import PythonLiteral
     from tests.conftest import Data
 
 
@@ -761,7 +762,7 @@ def test_dataframe_iter_columns(data_small: Data, dataframe: DataFrame) -> None:
     assert_equal_data(df, result)
 
 
-def test_dataframe_from_dict_misc(data_small: Data, eager: EagerAllowed) -> None:
+def test_dataframe_from_dict_misc(data_small: Data, eager: Eager) -> None:
     items = iter(data_small.items())
     name, values = next(items)
     mapping: dict[str, Any] = {
@@ -835,7 +836,7 @@ def test_dataframe_to_struct(data_small_af: Data, dataframe: DataFrame) -> None:
 
 
 # TODO @dangotbanned: Split this up
-def test_series_misc(eager: EagerAllowed) -> None:
+def test_series_misc(eager: Eager) -> None:
     values = [1.0, None, 7.1, float("nan"), 4.9, 12.0, 1.1, float("nan"), 0.2, None]
     name = "ser"
     ser = nwp.Series.from_iterable(values, name=name, dtype=nw.Float64, backend=eager)
@@ -867,7 +868,7 @@ def test_series_misc(eager: EagerAllowed) -> None:
     assert len(list(ser)) == len(values)
 
 
-def test_series_sort(eager: EagerAllowed) -> None:
+def test_series_sort(eager: Eager) -> None:
     ser = nwp.Series.from_iterable([1.0, 7.1, None, 4.9], backend=eager)
     assert_equal_series(ser.sort(), [None, 1.0, 4.9, 7.1], "")
     assert_equal_series(ser.sort(nulls_last=True), [1.0, 4.9, 7.1, None], "")
@@ -877,7 +878,7 @@ def test_series_sort(eager: EagerAllowed) -> None:
     )
 
 
-def test_series_cast(eager: EagerAllowed) -> None:
+def test_series_cast(eager: Eager) -> None:
     ser = nwp.int_range(10, step=2, eager=eager, dtype=nw.Int64)
     assert ser.dtype == nw.Int64
     ser_float = ser.cast(nw.Float64)

--- a/tests/plan/compliant_test.py
+++ b/tests/plan/compliant_test.py
@@ -409,7 +409,10 @@ def test_select_positional_iterable(
     dataframe: DataFrame, into_exprs: Iterable[IntoExpr], expected: Data
 ) -> None:
     data = {"one": ["A", "B", "A"], "two": [1, 2, 3], "three": [4, 5, 6]}
-    result = dataframe(data).select(*into_exprs)
+    result = dataframe(
+        data,
+        schema=nw.Schema({"one": nw.String(), "two": nw.Int64(), "three": nw.Int32()}),
+    ).select(*into_exprs)
     assert_equal_data(result, expected)
 
 
@@ -836,10 +839,10 @@ def test_dataframe_to_struct(data_small_af: Data, dataframe: DataFrame) -> None:
 
 
 # TODO @dangotbanned: Split this up
-def test_series_misc(eager: Eager) -> None:
+def test_series_misc(series: Series) -> None:
     values = [1.0, None, 7.1, float("nan"), 4.9, 12.0, 1.1, float("nan"), 0.2, None]
     name = "ser"
-    ser = nwp.Series.from_iterable(values, name=name, dtype=nw.Float64, backend=eager)
+    ser = series(values, name=name, dtype=nw.Float64)
     assert ser.is_empty() is False
     assert ser.has_nulls()
     assert ser.null_count() == 2

--- a/tests/plan/conftest.py
+++ b/tests/plan/conftest.py
@@ -10,11 +10,13 @@ if TYPE_CHECKING:
 
     from typing_extensions import LiteralString
 
-    from narwhals.typing import EagerAllowed, LazyAllowed
     from tests.plan.utils import (
         ConstructorFixtureName,
         DataFrame,
+        Eager,
+        EagerOrFalse,
         Identifier,
+        Lazy,
         LazyFrame,
         Series,
         TestBackendAny,
@@ -27,11 +29,11 @@ if TYPE_CHECKING:
     @pytest.fixture
     def series() -> Series: ...
     @pytest.fixture
-    def eager() -> EagerAllowed: ...
+    def eager() -> Eager: ...
     @pytest.fixture
-    def eager_or_false() -> EagerAllowed | Literal[False]: ...
+    def eager_or_false() -> EagerOrFalse: ...
     @pytest.fixture
-    def lazy() -> LazyAllowed: ...
+    def lazy() -> Lazy: ...
 
 
 _MAIN_DEFAULT_CONSTRUCTORS = (

--- a/tests/plan/conftest.py
+++ b/tests/plan/conftest.py
@@ -60,7 +60,9 @@ _option = cast("Callable[[pytest.Config, str], Any]", pytest.Config.getoption)
 
 def _resolve_options(
     config: pytest.Config,
-) -> tuple[Collection[Identifier] | Literal["ALL"], Collection[Identifier] | None]:
+) -> tuple[
+    Collection[Identifier] | Literal["ALL"], Collection[Identifier] | None
+]:  # pragma: no cover
     """Convert command line options into `include` and `exclude` sets.
 
     Piggybacks off of `--constructors`, if that was used instead of `--plan-include` or `--plan-exclude`.
@@ -92,7 +94,7 @@ def _resolve_options(
 get_identifier: Callable[[Any], str] = attrgetter("identifier")
 
 
-def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:  # pragma: no cover
     from tests.plan.utils import TestBackend
 
     include, exclude = _resolve_options(metafunc.config)

--- a/tests/plan/frame_scan_read_test.py
+++ b/tests/plan/frame_scan_read_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import narwhals as nw
 import narwhals._plan as nwp
-from tests.plan.utils import assert_equal_data
+from tests.plan.utils import Eager, Lazy, assert_equal_data
 from tests.utils import PANDAS_VERSION
 
 pytest.importorskip("polars")
@@ -19,9 +19,10 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
     from typing import TypeAlias
 
-    from narwhals._typing import BackendName, EagerAllowed, _LazyOnly
+    from narwhals._typing import BackendName
     from narwhals.typing import FileSource
     from tests.conftest import Data
+
 
 IOSourceKind: TypeAlias = Literal["str", "Path", "PathLike"]
 IntoKwds: TypeAlias = "dict[str, Any] | Callable[[], dict[str, Any]]"
@@ -112,7 +113,7 @@ def assert_equal_eager(result: nwp.DataFrame[Any], expected: Data) -> None:
     assert isinstance(result, nwp.DataFrame)
 
 
-def test_read_csv(data: Data, csv_path: FileSource, eager: EagerAllowed) -> None:
+def test_read_csv(data: Data, csv_path: FileSource, eager: Eager) -> None:
     assert_equal_eager(nwp.read_csv(csv_path, backend=eager), data)
 
 
@@ -120,20 +121,20 @@ def test_read_csv(data: Data, csv_path: FileSource, eager: EagerAllowed) -> None
     ("backend", "into_kwds"), [param_pandas_import, ("pyarrow", pyarrow_read_csv_kwds)]
 )
 def test_read_csv_kwargs(
-    data: Data, csv_path: FileSource, backend: EagerAllowed, into_kwds: IntoKwds
+    data: Data, csv_path: FileSource, backend: Eager, into_kwds: IntoKwds
 ) -> None:
     kwds = _into_kwds(into_kwds)
     assert_equal_eager(nwp.read_csv(csv_path, backend=backend, **kwds), data)
 
 
 @lazy_core_backend
-def test_read_csv_raise_with_lazy(backend: _LazyOnly) -> None:
+def test_read_csv_raise_with_lazy(backend: Lazy) -> None:
     pytest.importorskip(backend)
     with pytest.raises(ValueError, match="support in Narwhals is lazy-only"):
-        nwp.read_csv("unused.csv", backend=backend)  # type: ignore[call-overload]
+        nwp.read_csv("unused.csv", backend=backend)  # type: ignore[arg-type]
 
 
-def test_read_parquet(data: Data, parquet_path: FileSource, eager: EagerAllowed) -> None:
+def test_read_parquet(data: Data, parquet_path: FileSource, eager: Eager) -> None:
     assert_equal_eager(nwp.read_parquet(parquet_path, backend=eager), data)
 
 
@@ -145,17 +146,17 @@ def test_read_parquet(data: Data, parquet_path: FileSource, eager: EagerAllowed)
     ],
 )
 def test_read_parquet_kwargs(
-    data: Data, parquet_path: FileSource, backend: EagerAllowed, into_kwds: IntoKwds
+    data: Data, parquet_path: FileSource, backend: Eager, into_kwds: IntoKwds
 ) -> None:
     kwds = _into_kwds(into_kwds)
     assert_equal_eager(nwp.read_parquet(parquet_path, backend=backend, **kwds), data)
 
 
 @lazy_core_backend
-def test_read_parquet_raise_with_lazy(backend: _LazyOnly) -> None:
+def test_read_parquet_raise_with_lazy(backend: Lazy) -> None:
     pytest.importorskip(backend)
     with pytest.raises(ValueError, match="support in Narwhals is lazy-only"):
-        nwp.read_parquet("unused.parquet", backend=backend)  # type: ignore[call-overload]
+        nwp.read_parquet("unused.parquet", backend=backend)  # type: ignore[arg-type]
 
 
 # TODO @dangotbanned: Transform steps, change the schema

--- a/tests/plan/frame_scan_read_test.py
+++ b/tests/plan/frame_scan_read_test.py
@@ -11,12 +11,13 @@ from tests.utils import PANDAS_VERSION
 
 pytest.importorskip("polars")
 pytest.importorskip("pyarrow")
+from collections.abc import Callable
 from pathlib import Path
 
 import polars as pl
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Mapping
     from typing import TypeAlias
 
     from narwhals._typing import BackendName
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
 
 
 IOSourceKind: TypeAlias = Literal["str", "Path", "PathLike"]
-IntoKwds: TypeAlias = "dict[str, Any] | Callable[[], dict[str, Any]]"
+IntoKwds: TypeAlias = dict[str, Any] | Callable[[], dict[str, Any]]
 """Keyword-arguments, or a callback that returns them."""
 
 
@@ -186,7 +187,7 @@ def test_scan_csv(csv_path: FileSource, backend: BackendName) -> None:
 @scan_backend
 def test_read_parquet_schema(parquet_path: FileSource, backend: BackendName) -> None:
     schema = nwp.read_parquet_schema(parquet_path, backend=backend)
-    expected = pl.scan_parquet(Path(parquet_path)).collect_schema()
+    expected = pl.scan_parquet(Path(parquet_path)).collect().schema
     result = schema.to_polars()
     assert result == expected
 
@@ -194,7 +195,7 @@ def test_read_parquet_schema(parquet_path: FileSource, backend: BackendName) -> 
 @scan_backend
 def test_read_csv_schema(csv_path: FileSource, backend: BackendName) -> None:
     schema = nwp.read_csv_schema(csv_path, backend=backend)
-    expected = pl.scan_csv(Path(csv_path)).collect_schema()
+    expected = pl.scan_csv(Path(csv_path)).collect().schema
     result = schema.to_polars()
     assert result == expected
 
@@ -210,6 +211,6 @@ def test_read_csv_schema_kwargs_pyarrow(
 
     convert = csv.ConvertOptions(include_columns=include_columns)
     schema = nwp.read_csv_schema(csv_path, backend="pyarrow", convert_options=convert)
-    expected = pl.scan_csv(csv_path).select(include_columns).collect_schema()
+    expected = pl.scan_csv(csv_path).select(include_columns).collect().schema
     result = schema.to_polars()
     assert result == expected

--- a/tests/plan/frame_with_row_index_test.py
+++ b/tests/plan/frame_with_row_index_test.py
@@ -20,6 +20,8 @@ def test_with_row_index_eager(dataframe: DataFrame) -> None:
     assert_equal_data(result, expected)
 
 
+# https://github.com/narwhals-dev/narwhals/actions/runs/25753098308/job/75634350024?pr=3617#step:9:1381
+# x12 NotImplementedError: `over(..., order_by=...)` requires `polars>=1.0.0`
 @pytest.mark.parametrize(
     ("order_by", "expected_index"),
     [

--- a/tests/plan/frame_with_row_index_test.py
+++ b/tests/plan/frame_with_row_index_test.py
@@ -8,6 +8,7 @@ import pytest
 import narwhals._plan.selectors as ncs
 from narwhals.exceptions import ColumnNotFoundError
 from tests.plan.utils import DataFrame, assert_equal_data, re_compile
+from tests.utils import POLARS_VERSION
 
 if TYPE_CHECKING:
     from narwhals._plan.typing import ColumnNameOrSelector, OneOrIterable
@@ -20,8 +21,6 @@ def test_with_row_index_eager(dataframe: DataFrame) -> None:
     assert_equal_data(result, expected)
 
 
-# https://github.com/narwhals-dev/narwhals/actions/runs/25753098308/job/75634350024?pr=3617#step:9:1381
-# x12 NotImplementedError: `over(..., order_by=...)` requires `polars>=1.0.0`
 @pytest.mark.parametrize(
     ("order_by", "expected_index"),
     [
@@ -43,9 +42,17 @@ def test_with_row_index_by(
     dataframe: DataFrame,
     order_by: OneOrIterable[ColumnNameOrSelector],
     expected_index: list[int],
+    request: pytest.FixtureRequest,
 ) -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3289
     data = {"a": ["A", "B", "A"], "b": [1, 2, 3], "c": [9, 2, 4]}
+
+    dataframe.xfail(
+        request,
+        dataframe.is_polars() and POLARS_VERSION < (1, 0),
+        reason="polars needs `over(order_by=...)`",
+        raises=NotImplementedError,
+    )
     result = dataframe(data).with_row_index(name="index", order_by=order_by).sort("b")
     expected = {"index": expected_index, **data}
     assert_equal_data(result, expected)

--- a/tests/plan/hist_test.py
+++ b/tests/plan/hist_test.py
@@ -6,12 +6,12 @@ import pytest
 
 import narwhals as nw
 import narwhals._plan as nwp
-from tests.plan.utils import assert_equal_data
+from tests.plan.utils import Eager, assert_equal_data
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from narwhals.typing import EagerAllowed, IntoDType
+    from narwhals.typing import IntoDType
     from tests.conftest import Data
 
 pytest.importorskip("pyarrow")
@@ -62,8 +62,8 @@ def column_data_missing(request: pytest.FixtureRequest) -> str:
 
 
 @pytest.fixture(scope="module", params=["pyarrow"])
-def backend(request: pytest.FixtureRequest) -> EagerAllowed:
-    result: EagerAllowed = request.param
+def backend(request: pytest.FixtureRequest) -> Eager:
+    result: Eager = request.param
     return result
 
 
@@ -74,7 +74,7 @@ def include_breakpoint(request: pytest.FixtureRequest) -> bool:
 
 
 def _series(
-    name: str, source: Data, schema: nw.Schema, backend: EagerAllowed, /
+    name: str, source: Data, schema: nw.Schema, backend: Eager, /
 ) -> nwp.Series[Any]:
     values, dtype = (source[name], schema[name])
     return nwp.Series.from_iterable(values, name=name, dtype=dtype, backend=backend)
@@ -111,7 +111,7 @@ bins_cases = pytest.mark.parametrize(
 def test_hist_bins(
     data: Data,
     schema_data: nw.Schema,
-    backend: EagerAllowed,
+    backend: Eager,
     column_data: str,
     bins: Sequence[float],
     expected_count: Sequence[int],
@@ -129,7 +129,7 @@ def test_hist_bins(
 def test_hist_bins_shifted(
     data: Data,
     schema_data: nw.Schema,
-    backend: EagerAllowed,
+    backend: Eager,
     column_data: str,
     bins: Sequence[float],
     expected_count: Sequence[int],
@@ -149,7 +149,7 @@ def test_hist_bins_shifted(
 def test_hist_bins_missing(
     data_missing: Data,
     schema_data_missing: nw.Schema,
-    backend: EagerAllowed,
+    backend: Eager,
     column_data_missing: str,
     bins: Sequence[float],
     expected_count: Sequence[int],
@@ -181,7 +181,7 @@ bin_count_cases = pytest.mark.parametrize(
 def test_hist_bin_count(
     data: Data,
     schema_data: nw.Schema,
-    backend: EagerAllowed,
+    backend: Eager,
     column_data: str,
     bin_count: int,
     expected_bins: Sequence[float],
@@ -253,7 +253,7 @@ def test_hist_bin_count(
 def test_hist_expr_counts_only(
     data: Data,
     schema_data: nw.Schema,
-    backend: EagerAllowed,
+    backend: Eager,
     expr: nwp.Expr,
     expected: dict[str, Any],
 ) -> None:
@@ -262,9 +262,7 @@ def test_hist_expr_counts_only(
     assert_equal_data(result, expected)
 
 
-def test_hist_expr_breakpoint(
-    data: Data, schema_data: nw.Schema, backend: EagerAllowed
-) -> None:
+def test_hist_expr_breakpoint(data: Data, schema_data: nw.Schema, backend: Eager) -> None:
     df = nwp.DataFrame.from_dict(data, schema_data, backend=backend)
     expr = nwp.all().hist(bin_count=3, include_breakpoint=True)
     result = df.select(expr)
@@ -317,7 +315,7 @@ def test_hist_expr_breakpoint(
 def test_hist_bin_count_missing(
     data_missing: Data,
     schema_data_missing: nw.Schema,
-    backend: EagerAllowed,
+    backend: Eager,
     column_data_missing: str,
     bin_count: int,
     expected_bins: Sequence[float],
@@ -345,7 +343,7 @@ def test_hist_bin_count_missing(
     ],
 )
 def test_hist_bin_count_no_spread(
-    backend: EagerAllowed,
+    backend: Eager,
     column: str,
     bin_count: int,
     expected_breakpoint: Sequence[float],
@@ -360,7 +358,7 @@ def test_hist_bin_count_no_spread(
 
 @pytest.mark.parametrize("bins", [[1, 5, 10]])
 def test_hist_bins_no_data(
-    backend: EagerAllowed, bins: list[int], *, include_breakpoint: bool
+    backend: Eager, bins: list[int], *, include_breakpoint: bool
 ) -> None:
     s = nwp.Series.from_iterable([], dtype=nw.Float64(), backend=backend)
     result = s.hist(bins, include_breakpoint=include_breakpoint)
@@ -370,7 +368,7 @@ def test_hist_bins_no_data(
 
 @pytest.mark.parametrize("bin_count", [1, 10])
 def test_hist_bin_count_no_data(
-    backend: EagerAllowed, bin_count: int, *, include_breakpoint: bool
+    backend: Eager, bin_count: int, *, include_breakpoint: bool
 ) -> None:
     s = nwp.Series.from_iterable([], dtype=nw.Float64(), backend=backend)
     result = s.hist(bin_count=bin_count, include_breakpoint=include_breakpoint)
@@ -384,13 +382,13 @@ def test_hist_bin_count_no_data(
             assert bps[-1] == 1
 
 
-def test_hist_bins_none(backend: EagerAllowed) -> None:
+def test_hist_bins_none(backend: Eager) -> None:
     s = nwp.Series.from_iterable([1, 2, 3], backend=backend)
     result = s.hist(bins=None, bin_count=None)
     assert len(result) == 10
 
 
-def test_hist_series_compat_flag(backend: EagerAllowed) -> None:
+def test_hist_series_compat_flag(backend: Eager) -> None:
     # NOTE: Mainly for verifying `Expr.hist` has handled naming/collecting as struct
     # The flag itself is not desirable
     values = [1, 3, 8, 8, 2, 1, 3]

--- a/tests/plan/lazyframe_test.py
+++ b/tests/plan/lazyframe_test.py
@@ -62,7 +62,7 @@ def assert_equal_schema(
     result: nwp.LazyFrame[pl.LazyFrame], expected: pl.LazyFrame
 ) -> None:
     actual_schema = result.collect_schema()
-    expected_schema = actual_schema.from_polars(expected.collect_schema())
+    expected_schema = actual_schema.from_polars(expected.collect().schema)
     assert len(actual_schema) == len(expected_schema)
     assert actual_schema == expected_schema
 

--- a/tests/plan/pivot_test.py
+++ b/tests/plan/pivot_test.py
@@ -342,6 +342,7 @@ def test_pivot_no_values(dataframe: DataFrame, request: pytest.FixtureRequest) -
         "N1": [1, 2, 2, 4, 2],
         "N2": [1, 2, 2, 4, 2],
     }
+    dataframe.xfail_eager_pivot_too_old(request)
     dataframe.xfail(
         request,
         dataframe.is_pyarrow(),

--- a/tests/plan/pivot_test.py
+++ b/tests/plan/pivot_test.py
@@ -183,7 +183,7 @@ def test_pivot_agg(
     dataframe: DataFrame,
 ) -> None:
     df = dataframe(data)
-    dataframe.xfail_pyarrow_pivot_too_old(request)
+    dataframe.xfail_eager_pivot_too_old(request)
     dataframe.xfail(
         # TODO @dangotbanned: Add more values for `median`, like in
         # https://github.com/narwhals-dev/narwhals/blob/b3d8c7349bbf7ecb7f11ea590c334e12d5c1d43e/tests/plan/list_agg_test.py#L24-L34
@@ -218,7 +218,7 @@ def test_pivot_sort_columns(
     dataframe: DataFrame,
 ) -> None:
     df = dataframe(data_no_dups_unordered)
-    dataframe.xfail_pyarrow_pivot_too_old(request)
+    dataframe.xfail_eager_pivot_too_old(request)
     values = ["foo", "bar"]
     result = df.pivot("on_lower", index="idx_1", values=values, sort_columns=sort_columns)
     assert result.columns == expected
@@ -261,7 +261,7 @@ def test_pivot_on_multiple_names(
     index = "idx_1"
     data_ = data_no_dups_unordered
     df = dataframe(data_)
-    dataframe.xfail_pyarrow_pivot_too_old(request)
+    dataframe.xfail_eager_pivot_too_old(request)
     result = df.pivot(on, values=values, index=index)
     assert result.columns == expected
     assert_names_match_polars(data_, on, index, values, result_columns=result.columns)
@@ -303,7 +303,7 @@ def test_pivot_on_multiple_names_agg(
 ) -> None:
     index = "idx_1"
     df = dataframe(data)
-    dataframe.xfail_pyarrow_pivot_too_old(request)
+    dataframe.xfail_eager_pivot_too_old(request)
     result = df.pivot(on, values=values, aggregate_function="min", index=index)
     assert result.columns == expected
     assert_names_match_polars(
@@ -314,7 +314,7 @@ def test_pivot_on_multiple_names_agg(
 def test_pivot_no_agg_duplicated(
     data: Data, request: pytest.FixtureRequest, dataframe: DataFrame
 ) -> None:
-    dataframe.xfail_pyarrow_pivot_too_old(request)
+    dataframe.xfail_eager_pivot_too_old(request)
     with pytest.raises((ValueError, NarwhalsError)):
         dataframe(data).pivot("on_lower", index="idx_1")
 
@@ -322,7 +322,7 @@ def test_pivot_no_agg_duplicated(
 def test_pivot_no_agg_no_duplicates(
     data_no_dups: Data, request: pytest.FixtureRequest, dataframe: DataFrame
 ) -> None:
-    dataframe.xfail_pyarrow_pivot_too_old(request)
+    dataframe.xfail_eager_pivot_too_old(request)
     result = dataframe(data_no_dups).pivot("on_lower", index="idx_1")
     expected = {
         "idx_1": [1, 2],
@@ -430,7 +430,7 @@ def test_pivot_implicit_index(
     data_no_dups: Data, dataframe: DataFrame, request: pytest.FixtureRequest
 ) -> None:
     df = dataframe(data_no_dups)
-    dataframe.xfail_pyarrow_pivot_too_old(request)
+    dataframe.xfail_eager_pivot_too_old(request)
     expected = {
         "idx_1": [1, 1, 2, 2],
         "bar": ["x", "y", "w", "z"],
@@ -445,7 +445,7 @@ def test_pivot_test_scores_1(
     scores: Data, request: pytest.FixtureRequest, dataframe: DataFrame
 ) -> None:
     df = dataframe(scores)
-    dataframe.xfail_pyarrow_pivot_too_old(request)
+    dataframe.xfail_eager_pivot_too_old(request)
     expected = {"name": ["Cady", "Karen"], "maths": [98, 61], "physics": [99, 58]}
     result = df.pivot("subject", index="name", values="test_1")
     assert_equal_data(result, expected)
@@ -459,7 +459,7 @@ def test_pivot_test_scores_2(
     scores: Data, request: pytest.FixtureRequest, dataframe: DataFrame
 ) -> None:
     df = dataframe(scores)
-    dataframe.xfail_pyarrow_pivot_too_old(request)
+    dataframe.xfail_eager_pivot_too_old(request)
     expected = {
         "name": ["Cady", "Karen"],
         "test_1_maths": [98, 61],
@@ -492,7 +492,7 @@ def test_pivot_aggregate(
     df = dataframe(
         {"a": [1, 1, 2, 2, 3], "b": ["a", "a", "b", "b", "b"], "c": [2, 4, None, 8, 10]}
     )
-    dataframe.xfail_pyarrow_pivot_too_old(request)
+    dataframe.xfail_eager_pivot_too_old(request)
     dataframe.xfail(
         # TODO @dangotbanned: Consider fixing this?
         # The `pandas` impl on `main` has the same issue

--- a/tests/plan/plugins_test.py
+++ b/tests/plan/plugins_test.py
@@ -13,6 +13,7 @@ from narwhals._typing import Arrow, Polars
 from narwhals._typing_compat import assert_never
 from narwhals._utils import Implementation, Version
 from tests.plan.utils import re_compile
+from tests.utils import POLARS_VERSION
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -31,15 +32,41 @@ SupportedBackend: TypeAlias = Literal[Arrow, Polars]
 BuiltinName: TypeAlias = Literal["polars", "pyarrow"]
 BUILTIN_NAMES = ("polars", "pyarrow")
 
+POLARS_PARTIAL_INIT_BUG: Final = bool(POLARS_VERSION and POLARS_VERSION < (1, 34, 0))
+"""Prior to ([#24610]), removing `"polars"` from `sys.modules` cause failures like:
+
+    FAILED tests/plan/plugins_test.py::test_plugin_is_imported[polars]
+    AttributeError: partially initialized module 'polars' has no attribute '_cpu_check' (most likely due to a circular import)
+
+To accurately test import checking, the `plugin` fixture does some (temporarily) destructive operations on `sys.modules`.
+
+This **is not** something that `PluginManager` does, but is needed here and so will fail on old polars.
+
+[#24610]: https://github.com/pola-rs/polars/pull/24610
+"""
+
+if POLARS_PARTIAL_INIT_BUG:  # pragma: no cover
+
+    @pytest.fixture
+    def _sys_modules_delete_names() -> tuple[BuiltinName, ...]:
+        return tuple[BuiltinName, ...](name for name in BUILTIN_NAMES if name != "polars")
+else:
+
+    @pytest.fixture
+    def _sys_modules_delete_names() -> tuple[BuiltinName, ...]:
+        return BUILTIN_NAMES
+
 
 @pytest.fixture
-def plugin(eager: BuiltinName) -> Generator[BuiltinAny, Any, None]:
+def plugin(
+    eager: BuiltinName, _sys_modules_delete_names: tuple[BuiltinName, ...]
+) -> Generator[BuiltinAny, Any, None]:
     """Yields the result of `load_plugin(eager)`.
 
     We use a context manager to first clear and then reset (related) changes to `sys.modules`.
     """
     with pytest.MonkeyPatch.context() as mp:
-        for name in BUILTIN_NAMES:
+        for name in _sys_modules_delete_names:
             mp.delitem(sys.modules, name, raising=False)
         yield load_plugin(eager)
 
@@ -59,27 +86,27 @@ def test_load_plugin_invalid() -> None:
         load_plugin("i dont exist")
 
 
-# https://github.com/narwhals-dev/narwhals/actions/runs/25753098308/job/75634350024?pr=3617#step:9:1379
 def test_plugin_is_imported(plugin: BuiltinAny) -> None:
-    assert not plugin.is_imported()
+    if not POLARS_PARTIAL_INIT_BUG or plugin.name != "polars":
+        assert not plugin.is_imported()
+    else:  # pragma: no cover
+        ...
     manager().import_modules(plugin.name)
-
     assert plugin.is_imported()
     assert manager().plugin(plugin.name).is_imported()
 
 
-# https://github.com/narwhals-dev/narwhals/actions/runs/25753098308/job/75634350024?pr=3617#step:9:1378
 def test_plugin_can_import(plugin: BuiltinAny) -> None:
-    assert not plugin.is_imported()
+    if not POLARS_PARTIAL_INIT_BUG or plugin.name != "polars":
+        assert not plugin.is_imported()
+    else:  # pragma: no cover
+        ...
     assert plugin.can_import()
-
     manager().import_modules(plugin.name)
     assert plugin.is_imported()
     assert plugin.can_import()
-    assert load_plugin(plugin.name).can_import()
-
+    assert manager().plugin(plugin.name).can_import()
     manager().import_modules(plugin.name)
-    assert plugin.can_import()
 
 
 def test_plugin_manager_known() -> None:

--- a/tests/plan/plugins_test.py
+++ b/tests/plan/plugins_test.py
@@ -59,6 +59,7 @@ def test_load_plugin_invalid() -> None:
         load_plugin("i dont exist")
 
 
+# https://github.com/narwhals-dev/narwhals/actions/runs/25753098308/job/75634350024?pr=3617#step:9:1379
 def test_plugin_is_imported(plugin: BuiltinAny) -> None:
     assert not plugin.is_imported()
     manager().import_modules(plugin.name)
@@ -67,6 +68,7 @@ def test_plugin_is_imported(plugin: BuiltinAny) -> None:
     assert manager().plugin(plugin.name).is_imported()
 
 
+# https://github.com/narwhals-dev/narwhals/actions/runs/25753098308/job/75634350024?pr=3617#step:9:1378
 def test_plugin_can_import(plugin: BuiltinAny) -> None:
     assert not plugin.is_imported()
     assert plugin.can_import()
@@ -91,6 +93,7 @@ def test_plugin_manager_importable() -> None:
         assert plug_man.plugin(name).is_imported()
 
 
+# https://github.com/narwhals-dev/narwhals/actions/runs/25753098308/job/75634350024?pr=3617#step:9:1377
 def test_plugin_manager_imported(plugin: BuiltinAny) -> None:
     plug_man = manager()
     name = plugin.name

--- a/tests/plan/plugins_test.py
+++ b/tests/plan/plugins_test.py
@@ -39,10 +39,8 @@ def plugin(eager: BuiltinName) -> Generator[BuiltinAny, Any, None]:
     We use a context manager to first clear and then reset (related) changes to `sys.modules`.
     """
     with pytest.MonkeyPatch.context() as mp:
-        sys_modules = tuple(sys.modules)
-        for sys_modules_name in sys_modules:
-            if sys_modules_name.startswith(BUILTIN_NAMES):
-                mp.delitem(sys.modules, sys_modules_name, raising=False)
+        for name in BUILTIN_NAMES:
+            mp.delitem(sys.modules, name, raising=False)
         yield load_plugin(eager)
 
 

--- a/tests/plan/plugins_test.py
+++ b/tests/plan/plugins_test.py
@@ -39,8 +39,10 @@ def plugin(eager: BuiltinName) -> Generator[BuiltinAny, Any, None]:
     We use a context manager to first clear and then reset (related) changes to `sys.modules`.
     """
     with pytest.MonkeyPatch.context() as mp:
-        for name in BUILTIN_NAMES:
-            mp.delitem(sys.modules, name, raising=False)
+        sys_modules = tuple(sys.modules)
+        for sys_modules_name in sys_modules:
+            if sys_modules_name.startswith(BUILTIN_NAMES):
+                mp.delitem(sys.modules, sys_modules_name, raising=False)
         yield load_plugin(eager)
 
 

--- a/tests/plan/plugins_test.py
+++ b/tests/plan/plugins_test.py
@@ -113,22 +113,6 @@ def test_plugin_manager_known() -> None:
     assert sorted(manager().known()) == ["polars", "pyarrow"]
 
 
-def test_plugin_manager_importable() -> None:
-    plug_man = manager()
-    for name in plug_man.importable():
-        plug_man.import_modules(name)
-        assert plug_man.plugin(name).is_imported()
-
-
-# https://github.com/narwhals-dev/narwhals/actions/runs/25753098308/job/75634350024?pr=3617#step:9:1377
-def test_plugin_manager_imported(plugin: BuiltinAny) -> None:
-    plug_man = manager()
-    name = plugin.name
-    assert name not in set(plug_man.imported())
-    plug_man.import_modules(name)
-    assert name in set(plug_man.imported())
-
-
 @pytest.mark.parametrize("version", Version)
 def test_plugin_manager_dataframe(eager: BuiltinName, version: Version) -> None:
     data = {"a": [1, 2, 3, 4], "b": [1.3, 1.9, None, None]}

--- a/tests/plan/plugins_test.py
+++ b/tests/plan/plugins_test.py
@@ -48,12 +48,12 @@ This **is not** something that `PluginManager` does, but is needed here and so w
 if POLARS_PARTIAL_INIT_BUG:  # pragma: no cover
 
     @pytest.fixture
-    def _sys_modules_delete_names() -> tuple[BuiltinName, ...]:
-        return tuple[BuiltinName, ...](name for name in BUILTIN_NAMES if name != "polars")
+    def _sys_modules_delete_names() -> tuple[Any, ...]:
+        return tuple(name for name in BUILTIN_NAMES if name != "polars")
 else:
 
     @pytest.fixture
-    def _sys_modules_delete_names() -> tuple[BuiltinName, ...]:
+    def _sys_modules_delete_names() -> tuple[Any, ...]:
         return BUILTIN_NAMES
 
 

--- a/tests/plan/range_test.py
+++ b/tests/plan/range_test.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Final, Literal
+from typing import TYPE_CHECKING, Any, Final
 
 import pytest
 
@@ -13,12 +13,20 @@ import datetime as dt
 
 import narwhals as nw
 from narwhals import _plan as nwp
-from tests.plan.utils import assert_equal_data, assert_equal_series, dataframe
+from tests.plan.utils import (
+    Eager,
+    EagerOrFalse,
+    assert_equal_data,
+    assert_equal_series,
+    dataframe,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from narwhals.typing import ClosedInterval, EagerAllowed, IntoDType
+    from typing_extensions import LiteralString
+
+    from narwhals.typing import ClosedInterval, IntoDType
 
 
 @pytest.fixture(scope="module")
@@ -105,7 +113,7 @@ def test_date_range(
     assert_equal_data(result, expected)
 
 
-def test_date_range_eager_leap(eager: EagerAllowed, leap_year: int) -> None:
+def test_date_range_eager_leap(eager: Eager, leap_year: int) -> None:
     series_leap = nwp.date_range(
         dt.date(leap_year, 2, 25), dt.date(leap_year, 3, 25), eager=eager
     )
@@ -132,7 +140,7 @@ def test_date_range_eager(
     interval: str | dt.timedelta,
     closed: ClosedInterval,
     expected: list[dt.date],
-    eager: EagerAllowed,
+    eager: Eager,
 ) -> None:
     ser = nwp.date_range(start, end, interval=interval, closed=closed, eager=eager)
     result = ser.to_list()
@@ -157,7 +165,7 @@ def test_int_range(
     assert_equal_data(result, expected)
 
 
-def test_int_range_eager(eager: EagerAllowed) -> None:
+def test_int_range_eager(eager: Eager) -> None:
     ser = nwp.int_range(50, eager=eager)
     assert isinstance(ser, nwp.Series)
     assert ser.to_list() == list(range(50))
@@ -173,7 +181,7 @@ def test_linear_space_values(
     num_samples: int,
     interval: ClosedInterval,
     *,
-    eager_or_false: EagerAllowed | Literal[False],
+    eager_or_false: EagerOrFalse,
 ) -> None:
     # NOTE: Adapted from https://github.com/pola-rs/polars/blob/1684cc09dfaa46656dfecc45ab866d01aa69bc78/py-polars/tests/unit/functions/range/test_linear_space.py#L19-L56
     if eager_or_false:

--- a/tests/plan/range_test.py
+++ b/tests/plan/range_test.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Final
 import pytest
 
 from narwhals.exceptions import ShapeError
-from tests.utils import PYARROW_VERSION
+from tests.utils import POLARS_VERSION, PYARROW_VERSION
 
 if PYARROW_VERSION < (21,):  # pragma: no cover
     pytest.importorskip("numpy")
@@ -48,6 +48,17 @@ def data() -> dict[str, Any]:
 def leap_year(request: pytest.FixtureRequest) -> int:
     result: int = request.param
     return result
+
+
+def skip_if(condition: bool, /, reason: LiteralString) -> None:  # noqa: FBT001
+    if condition:
+        pytest.skip(reason)
+
+
+def skip_if_polars_linear_space(is_polars: bool, /) -> None:  # noqa: FBT001
+    skip_if(
+        is_polars and POLARS_VERSION < (1, 21), reason="too old for `polars.linear_space`"
+    )
 
 
 EXPECTED_DATE_1: Final = [
@@ -171,7 +182,7 @@ def test_int_range_eager(eager: Eager) -> None:
     assert ser.to_list() == list(range(50))
 
 
-# TODO @dangotbanned: Add polars: `linear_space`, `DataFrame.select`
+# TODO @dangotbanned: Add polars (lazy) `linear_space`
 @pytest.mark.parametrize(("start", "end"), [(0, 0), (0, 1), (-1, 0), (-2.1, 3.4)])
 @pytest.mark.parametrize("num_samples", [0, 1, 2, 5, 1_000])
 @pytest.mark.parametrize("interval", ["both", "left", "right", "none"])
@@ -185,6 +196,7 @@ def test_linear_space_values(
 ) -> None:
     # NOTE: Adapted from https://github.com/pola-rs/polars/blob/1684cc09dfaa46656dfecc45ab866d01aa69bc78/py-polars/tests/unit/functions/range/test_linear_space.py#L19-L56
     if eager_or_false:
+        skip_if_polars_linear_space(eager_or_false == "polars")
         result = nwp.linear_space(
             start, end, num_samples, closed=interval, eager=eager_or_false
         ).rename("ls")

--- a/tests/plan/utils.py
+++ b/tests/plan/utils.py
@@ -27,11 +27,7 @@ from narwhals._plan import Expr, Selector, _expansion, _parse, expressions as ir
 from narwhals._plan.compliant.typing import Native as NativeLazyFrame
 from narwhals._plan.typing import NativeDataFrameT_co, NativeSeriesT_co
 from narwhals._utils import Implementation, Version, qualified_type_name
-from tests.utils import (
-    POLARS_VERSION,
-    PYARROW_VERSION,
-    assert_equal_data as _assert_equal_data,
-)
+from tests.utils import assert_equal_data as _assert_equal_data
 
 pytest.importorskip("pyarrow")
 
@@ -287,7 +283,9 @@ def cols(name: str, *names: str) -> Iterator[nwp.Expr]:
 _lock = threading.Lock()
 
 
-def _parse_identifiers(ids: OneOrIterable[Identifier], /) -> frozenset[Identifier]:
+def _parse_identifiers(
+    ids: OneOrIterable[Identifier], /
+) -> frozenset[Identifier]:  # pragma: no cover
     return frozenset((ids,) if isinstance(ids, str) else ids)
 
 
@@ -326,19 +324,31 @@ class TestBackend(Generic[NativeLazyFrame, NativeDataFrameT_co, NativeSeriesT_co
     )
 
     def lazyframe(
-        self, data: Mapping[str, Any], /, **kwds: Any
+        self, data: Mapping[str, Any], /, *, schema: Schema | None = None, **kwds: Any
     ) -> nwp.LazyFrame[NativeLazyFrame]:
-        return nwp.LazyFrame.from_native(self.native_lazyframe(data, **kwds))
+        return nwp.LazyFrame.from_native(
+            self.native_lazyframe(data, schema=schema, **kwds)
+        )
 
     def dataframe(
-        self, data: Mapping[str, Any], /, **kwds: Any
+        self, data: Mapping[str, Any], /, *, schema: Schema | None = None, **kwds: Any
     ) -> nwp.DataFrame[NativeDataFrameT_co, NativeSeriesT_co]:
-        return nwp.DataFrame.from_native(self.native_dataframe(data, **kwds))
+        return nwp.DataFrame.from_native(
+            self.native_dataframe(data, schema=schema, **kwds)
+        )
 
     def series(
-        self, values: Iterable[Any], /, **kwds: Any
+        self,
+        values: Iterable[Any],
+        /,
+        name: str = "",
+        *,
+        dtype: IntoDType | None = None,
+        **kwds: Any,
     ) -> nwp.Series[NativeSeriesT_co]:
-        return nwp.Series.from_native(self.native_series(values, **kwds))
+        return nwp.Series.from_native(
+            self.native_series(values, dtype=dtype, **kwds), name=name
+        )
 
     def native_lazyframe(
         self, data: Mapping[str, Any], /, **kwds: Any
@@ -380,7 +390,7 @@ class TestBackend(Generic[NativeLazyFrame, NativeDataFrameT_co, NativeSeriesT_co
         - Should be built entirely from **literal string(s)**, to support predictable filtering
         """
         if self.implementation is Implementation.UNKNOWN:
-            return self.import_or_skip_module
+            return self.import_or_skip_module  # pragma: no cover
         return self.implementation.value
 
     def try_get_constructor(
@@ -406,7 +416,9 @@ class TestBackend(Generic[NativeLazyFrame, NativeDataFrameT_co, NativeSeriesT_co
         cls, *, import_or_skip_module: ModuleName | None = None, **kwds: Any
     ) -> None:
         super().__init_subclass__(**kwds)
-        if not (hasattr(cls, "backend_eager") or hasattr(cls, "backend_lazy")):
+        if not (
+            hasattr(cls, "backend_eager") or hasattr(cls, "backend_lazy")
+        ):  # pragma: no cover
             msg = f"At least one of `backend_eager` or `backend_lazy` must be set as a class attribute for {cls!r}"
             raise TypeError(msg)
         if module := import_or_skip_module:
@@ -414,12 +426,12 @@ class TestBackend(Generic[NativeLazyFrame, NativeDataFrameT_co, NativeSeriesT_co
         elif not (
             hasattr(cls, "import_or_skip_module")
             and (module := cls.import_or_skip_module)
-        ):
+        ):  # pragma: no cover
             msg = f"`import_or_skip_module` is a required argument for direct subclasses of `EagerBackend`, got: {import_or_skip_module=} for {cls!r}"
             raise TypeError(msg)
         if cls.implementation is Implementation.UNKNOWN and cls.import_or_skip_module in {
             impl.value for impl in Implementation
-        }:
+        }:  # pragma: no cover
             msg = (
                 f"`{cls.import_or_skip_module=}` implies {cls!r} should use {Implementation(import_or_skip_module)!r},\n"
                 f"but got: `{cls.implementation=}`"
@@ -451,10 +463,10 @@ class TestBackend(Generic[NativeLazyFrame, NativeDataFrameT_co, NativeSeriesT_co
                 (backend_tps for name, backend_tps in known.items() if find_spec(name))
             )
             selected = (tp() for tp in installed)
-            if include != "ALL":
+            if include != "ALL":  # pragma: no cover
                 including = _parse_identifiers(include)
                 selected = (b for b in selected if b.identifier in including)
-            if exclude is not None:
+            if exclude is not None:  # pragma: no cover
                 excluding = _parse_identifiers(exclude)
                 selected = (b for b in selected if b.identifier not in excluding)
             return tuple(sorted(selected, key=attrgetter("identifier")))
@@ -559,8 +571,8 @@ class Constructor(Generic[R_co]):
         """Fail either polars or pyarrow below the version(s) they introduced `pivot`."""
         self.xfail(
             request,
-            (self.is_pyarrow() and PYARROW_VERSION < (20, 0, 0))
-            or (self.is_polars() and POLARS_VERSION < (1, 0, 0)),
+            (self.is_pyarrow() and self.backend_version() < (20, 0, 0))
+            or (self.is_polars() and self.backend_version() < (1, 0, 0)),
             reason=f"{self.identifier} too old for `pivot` support",
             raises=NotImplementedError,
         )

--- a/tests/plan/utils.py
+++ b/tests/plan/utils.py
@@ -50,15 +50,9 @@ if TYPE_CHECKING:
     from typing_extensions import LiteralString, ReadOnly
 
     from narwhals._plan.typing import IntoExpr, OneOrIterable, Seq
-    from narwhals._typing import BackendName
+    from narwhals._typing import BackendName, _EagerAllowed, _LazyAllowed
     from narwhals.schema import Schema
-    from narwhals.typing import (
-        EagerAllowed,
-        IntoBackend,
-        IntoDType,
-        IntoSchema,
-        LazyAllowed,
-    )
+    from narwhals.typing import IntoBackend, IntoDType, IntoSchema
 
     if sys.version_info >= (3, 11):
         _Flags: TypeAlias = "int | re.RegexFlag"
@@ -315,10 +309,10 @@ class TestBackend(Generic[NativeLazyFrame, NativeDataFrameT_co, NativeSeriesT_co
     implementation: ClassVar[Implementation] = Implementation.UNKNOWN
     """Required for internal backends, plugins use the default `UNKNOWN`."""
 
-    backend_eager: ClassVar[IntoBackend[EagerAllowed]]
+    backend_eager: ClassVar[IntoBackend[Eager]]
     """Argument passed to `backend` or `eager` for `DataFrame`, `Series` constructors."""
 
-    backend_lazy: ClassVar[IntoBackend[LazyAllowed]]
+    backend_lazy: ClassVar[IntoBackend[Lazy]]
     """Argument passed to `backend` for `LazyFrame` constructors."""
 
     supports: ClassVar[SupportProfile]
@@ -580,6 +574,16 @@ DataFrame: TypeAlias = Constructor[nwp.DataFrame[Any, Any]]
 
 Series: TypeAlias = Constructor[nwp.Series[Any]]
 """The type of the `series` fixture."""
+
+
+Eager: TypeAlias = "_EagerAllowed"
+"""The type of the `eager` fixture."""
+
+EagerOrFalse: TypeAlias = "Eager | Literal[False]"
+"""The type of the `eager_or_false` fixture."""
+
+Lazy: TypeAlias = "_LazyAllowed"
+"""The type of the `lazy` fixture."""
 
 
 class PolarsBackend(

--- a/tests/plan/utils.py
+++ b/tests/plan/utils.py
@@ -27,7 +27,11 @@ from narwhals._plan import Expr, Selector, _expansion, _parse, expressions as ir
 from narwhals._plan.compliant.typing import Native as NativeLazyFrame
 from narwhals._plan.typing import NativeDataFrameT_co, NativeSeriesT_co
 from narwhals._utils import Implementation, Version, qualified_type_name
-from tests.utils import PYARROW_VERSION, assert_equal_data as _assert_equal_data
+from tests.utils import (
+    POLARS_VERSION,
+    PYARROW_VERSION,
+    assert_equal_data as _assert_equal_data,
+)
 
 pytest.importorskip("pyarrow")
 
@@ -557,11 +561,13 @@ class Constructor(Generic[R_co]):
             request, self.is_polars(), "with_columns", raises=raises
         )
 
-    def xfail_pyarrow_pivot_too_old(self, request: FixtureRequest, /) -> None:
+    def xfail_eager_pivot_too_old(self, request: FixtureRequest, /) -> None:
+        """Fail either polars or pyarrow below the version(s) they introduced `pivot`."""
         self.xfail(
             request,
-            (self.is_pyarrow() and PYARROW_VERSION < (20, 0, 0)),
-            reason="pyarrow too old for `pivot` support",
+            (self.is_pyarrow() and PYARROW_VERSION < (20, 0, 0))
+            or (self.is_polars() and POLARS_VERSION < (1, 0, 0)),
+            reason=f"{self.identifier} too old for `pivot` support",
             raises=NotImplementedError,
         )
 


### PR DESCRIPTION
# Description
Among *maybe* one or two other things, (#3611) made a dent into adding `polars` support.

This one should clean up some of the mess I made

## Related issues

- Child of #2572
- Follow-up to #3611


## Tasks
- [x] `polars` compat
  - [x] `over`
  - [x] `pivot`
  - [x] `collect_schema`
  - [x] `sort(nulls_last=...)`
  - [x] `linear_space`
  - [x] `has_nulls`
  - [x] `is_nan`
  - [x] `is_not_nan`
  - [x] `pl.len`
  - [x] `over(order_by=...)` on `>=1.0.0; <1.30.0`
- [x] Partially `polars` compat
  - [x] [Fix 3x](https://github.com/narwhals-dev/narwhals/actions/runs/25762173049/job/75665858951?pr=3617#step:9:489) `AttributeError: partially initialized module 'polars' has no attribute '_cpu_check' (most likely due to a circular import))`
    - https://github.com/pola-rs/polars/pull/24610
    - (https://github.com/narwhals-dev/narwhals/pull/3617/commits/bf2dd7210738fb33ea3df3cf764ca11483b7d6cc)


## Follow-ups to get CI fully green
These are entirely unrelated to `polars`
- [Typing failures](https://github.com/narwhals-dev/narwhals/actions/runs/25806336590/job/75810020602?pr=3617#step:8:37) for `Immutable.__replace__` pre-`3.13`
- More [coverage gaps](https://github.com/narwhals-dev/narwhals/actions/runs/25806336573/job/75810019841?pr=3617#logs)