### PR TITLE
fix(expr-ir): Backport `__replace__` typing for `<3.13`

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -15,7 +15,8 @@ jobs:
     if: github.head_ref != 'bump-version'
     strategy:
       matrix:
-        python-version: ["3.12"]
+        # See https://github.com/narwhals-dev/narwhals/pull/3620#discussion_r3235918155
+        python-version: ["3.13"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/narwhals/_plan/_expr_ir.py
+++ b/narwhals/_plan/_expr_ir.py
@@ -1025,7 +1025,7 @@ class NamedIR(Immutable, Generic[ExprIRT_co]):
         """
         return NamedIR.__replace__(self, expr=function(self.expr.map_ir(function)))
 
-    def __replace__(
+    def __replace__(  # pyright: ignore[reportIncompatibleMethodOverride]
         self, *, expr: ExprIR | None = None, name: str | None = None
     ) -> NamedIR[ExprIR]:
         name = self.name if name is None else name

--- a/narwhals/_plan/_immutable.py
+++ b/narwhals/_plan/_immutable.py
@@ -237,7 +237,12 @@ class Immutable(metaclass=ImmutableMeta):
             raise _init_error(self, kwds)
 
     if TYPE_CHECKING:
-        ...
+        import sys
+
+        if sys.version_info < (3, 13):
+
+            def __replace__(self, **changes: Any) -> Self:
+                return self
     else:
         # NOTE: Everything here is synthesized by `@dataclass_transform`
         # Having it visible to a type checker can cause weird things to happen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -377,7 +377,9 @@ exclude_also = [
 ]
 
 [tool.mypy]
-files = ["narwhals", "tests", "test-plugin"]
+# NOTE: Re-enable `mypy` for `main` when it isn't pinned to `1.15`
+# https://github.com/narwhals-dev/narwhals/issues/3606#issuecomment-4440007049
+files = ["narwhals/_plan", "tests/plan"]
 pretty = true
 strict = true
 check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ typing = [  # keep some of these pinned and bump periodically so there's fewer s
   "pandas-stubs==2.3.0.250703",
   "typing_extensions",
   "mypy==1.20.1", # Will break CI, only testing on `_plan` locally
-  "pyrefly==0.64.0",
+  "pyrefly==1.0.0",
   "pyright==1.1.408",  # https://github.com/narwhals-dev/narwhals/issues/3584
   "pyarrow<24", # https://github.com/narwhals-dev/narwhals/issues/3560
   "pyarrow-stubs==19.2",
@@ -438,7 +438,30 @@ ignore = [
 defineConstant = { "MYPY" = false }
 
 [tool.pyrefly]
-project-includes = ["tests"]
+project-includes = ["narwhals/_plan", "tests"]
+project-excludes = [
+    # - waaaaaaaay too many things to deal with any time soon (`pyrefly==1.0.0`)
+    # - lots of false positives which spiral out
+    # - ([not-a-type], [bad-override], [bad-specialization], [invalid-type-var])
+    "narwhals/_plan/_dispatch.py",
+    "narwhals/_plan/_dtype.py",
+    "narwhals/_plan/_flags.py",
+    "narwhals/_plan/_parameters.py",
+    "narwhals/_plan/arrow",
+    "narwhals/_plan/common.py",
+    "narwhals/_plan/compliant",
+    "narwhals/_plan/dataframe.py",
+    "narwhals/_plan/expr.py",
+    "narwhals/_plan/expressions/temporal.py",
+    "narwhals/_plan/functions",
+    "narwhals/_plan/lazyframe.py",
+    "narwhals/_plan/plans/conversion.py",
+    "narwhals/_plan/polars",
+    "narwhals/_plan/schema.py",
+    "narwhals/_plan/selectors.py",
+    "narwhals/_plan/series.py",
+    "narwhals/_plan/translate.py",
+]
 ignore-missing-imports = [
     "cudf.*",
     "cupy.*",

--- a/tests/plan/expr_ir_meta_test.py
+++ b/tests/plan/expr_ir_meta_test.py
@@ -61,7 +61,7 @@ def test_known_field_specifiers() -> None:
     e2s2 = E2S2(a=1, b=e1, c="c", d=(e2s1,))
 
     with pytest.raises(TypeError):
-        E1(a=1, b=e1, c="c", d=(e2s1,))  # pyright: ignore[reportCallIssue]
+        E1(a=1, b=e1, c="c", d=(e2s1,))  # pyright: ignore[reportCallIssue]  # pyrefly: ignore [unexpected-keyword]
 
     with pytest.raises(TypeError):
         E2(a=1, b=e1, c="c", d=1.0)  # type: ignore[call-arg]

--- a/tests/plan/immutable_test.py
+++ b/tests/plan/immutable_test.py
@@ -79,13 +79,13 @@ def test_immutable_delattr(
     empty_derived: EmptyDerived, one: OneSlot, two: TwoSlot
 ) -> None:
     with pytest.raises(AttributeError, match=r"EmptyDerived.+immutable.+'a'"):
-        del empty_derived.a  # pyright: ignore[reportAttributeAccessIssue]
+        del empty_derived.a  # pyright: ignore[reportAttributeAccessIssue]  # pyrefly: ignore [read-only]
     with pytest.raises(AttributeError, match=r"OneSlot.+immutable.+'a'"):
-        del one.a  # pyright: ignore[reportAttributeAccessIssue]
+        del one.a  # pyright: ignore[reportAttributeAccessIssue] # pyrefly: ignore [read-only]
     with pytest.raises(AttributeError, match=r"OneSlot.+immutable.+'b'"):
         del one.b  # type: ignore[attr-defined]
     with pytest.raises(AttributeError, match=r"TwoSlot.+immutable.+'a'"):
-        del two.a, two.b  # pyright: ignore[reportAttributeAccessIssue]
+        del two.a, two.b  # pyright: ignore[reportAttributeAccessIssue] # pyrefly: ignore [read-only]
 
 
 def test_immutable_hash(
@@ -138,7 +138,7 @@ def test_immutable_copy(two: TwoSlot, function: Callable[[TwoSlot], TwoSlot]) ->
 
 def test_immutable_invalid_constructor() -> None:
     with pytest.raises(TypeError):
-        Empty(a=1)  # pyright: ignore[reportCallIssue]
+        Empty(a=1)  # pyright: ignore[reportCallIssue]  # pyrefly: ignore [unexpected-keyword]
     with pytest.raises(AttributeError):
         EmptyDerived(b="two")  # type: ignore[call-arg]
     with pytest.raises(TypeError):

--- a/tests/plan/over_test.py
+++ b/tests/plan/over_test.py
@@ -457,14 +457,14 @@ def data_order() -> Mapping[str, list[NonNestedLiteral]]:
 
 
 def order_case(
-    columns: ValueColumn | list[ValueColumn],
+    columns: ValueColumn | Sequence[ValueColumn],
     aggregation: Agg,
     /,
     order_by: OrderColumn | Sequence[OrderColumn],
     *,
     descending: bool = False,
     nulls_last: bool = False,
-    expected: NonNestedLiteral | list[NonNestedLiteral],
+    expected: NonNestedLiteral | Sequence[NonNestedLiteral],
 ) -> ParameterSet:
     """Generate `Expr`s and an expected dataset for ordered aggregations.
 

--- a/tests/plan/over_test.py
+++ b/tests/plan/over_test.py
@@ -11,6 +11,8 @@ from tests.utils import PYARROW_VERSION
 pytest.importorskip("pyarrow")
 
 
+from collections.abc import Iterable
+
 import narwhals as nw
 import narwhals._plan as nwp
 from narwhals._plan import selectors as ncs
@@ -18,7 +20,7 @@ from narwhals.exceptions import InvalidOperationError
 from tests.plan.utils import assert_equal_data, dataframe, re_compile
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Mapping, Sequence
+    from collections.abc import Callable, Mapping, Sequence
     from typing import TypeAlias
 
     from _pytest.mark import ParameterSet
@@ -427,10 +429,6 @@ def test_over_partition_by_order_by(
     assert_equal_data(result, expected)
 
 
-def _ensure_list(arg: T | list[T]) -> list[T]:
-    return [arg] if not isinstance(arg, list) else arg
-
-
 ValueColumn: TypeAlias = Literal["v1", "v2", "v3"]
 OrderColumn: TypeAlias = Literal["o1", "o2", "o3", "o4", "o5"]
 Agg: TypeAlias = Literal["first", "last"]
@@ -478,7 +476,15 @@ def order_case(
     test_id = f"{columns}_{aggregation}-{ordering}"
 
     # Generating what our expected dataset should be
-    names_values = list(zip(_ensure_list(columns), _ensure_list(expected), strict=True))  # type: ignore[arg-type]
+    names_values = list(
+        zip(
+            (columns,) if isinstance(columns, str) else tuple(columns),
+            (expected,)
+            if isinstance(expected, (str, bytes)) or not isinstance(expected, Iterable)
+            else tuple(expected),
+            strict=True,
+        )
+    )
     result_data = {
         f"{name}{suffix}": [expect]
         for suffix in (suffix_over, suffix_sort_by)

--- a/tests/plan/plugins_test.py
+++ b/tests/plan/plugins_test.py
@@ -243,7 +243,7 @@ if TYPE_CHECKING:
 
         # Until `mypy` supports PEP 675 it won't report anything
         # https://github.com/python/mypy/issues/12554
-        manager().plugin(too_dynamic)  # pyright: ignore[reportArgumentType, reportCallIssue]
+        manager().plugin(too_dynamic)  # pyright: ignore[reportArgumentType, reportCallIssue] # pyrefly: ignore [no-matching-overload]
 
         MYPY: Final = False  # noqa: N806
 
@@ -280,7 +280,7 @@ if TYPE_CHECKING:
             # Can't represent this yet
             # https://github.com/python/typing/issues/213
             # https://github.com/CarliJoy/intersection_examples/issues/53
-            assert_type(df_polars, pl.LazyFrame)  # pyright: ignore[reportAssertTypeFailure]
+            assert_type(df_polars, pl.LazyFrame)  # pyright: ignore[reportAssertTypeFailure] # pyrefly: ignore [assert-type]
 
         if not plugin.is_native_dataframe(polars_or_pandas):
             assert_type(polars_or_pandas, pd.DataFrame)
@@ -317,20 +317,20 @@ if TYPE_CHECKING:
         lazy = manager().plugin(backend)
         assert_type(lazy, PluginAny | BuiltinAny)
         classes = lazy.__narwhals_classes__
-        assert_type(classes, PolarsClasses | ArrowClasses | Any)
+        assert_type(classes, PolarsClasses | ArrowClasses | Any)  # pyrefly: ignore[assert-type, missing-attribute]
         if cc.can_lazy(classes):
             evaluator = classes.evaluator
             _assign_evaluator: type[pl_main.PlanEvaluator] = evaluator
             if cc.can_v2(classes):
-                assert_type(classes.v2.lazyframe, type[pl_v2.LazyFrame])
+                assert_type(classes.v2.lazyframe, type[pl_v2.LazyFrame])  # pyrefly: ignore[assert-type, missing-attribute]
             if cc.can_v1(classes):
-                assert_type(classes.v1.lazyframe, type[pl_v1.LazyFrame])
+                assert_type(classes.v1.lazyframe, type[pl_v1.LazyFrame])  # pyrefly: ignore [assert-type, missing-attribute]
 
     def typing_versioned_classes_eager(backend: IntoPlugin) -> None:
         eager = manager().plugin(backend)
         assert_type(eager, PluginAny | BuiltinAny)
         classes = eager.__narwhals_classes__
-        assert_type(classes, PolarsClasses | ArrowClasses | Any)
+        assert_type(classes, PolarsClasses | ArrowClasses | Any)  # pyrefly: ignore[assert-type, missing-attribute]
         if cc.can_eager(classes):
             _evaluator = classes.evaluator  # type: ignore[union-attr]
             _assign_dataframe: type[pl_main.DataFrame | pa_main.DataFrame] = (

--- a/tests/plan/utils.py
+++ b/tests/plan/utils.py
@@ -551,7 +551,7 @@ class Constructor(Generic[R_co]):
         self.xfail(
             request,
             condition,
-            reason=f"TODO @dangotbanned: `{self.fixture_name}[{self.identifier}].{method}`",
+            reason=f"TODO @dangotbanned: `{self.fixture_name}[{self.identifier}].{method}`",  # pyrefly: ignore [bad-argument-type]
             raises=raises,
         )
 
@@ -682,7 +682,9 @@ def dataframe(
 
 # TODO @dangotbanned: Finish replacing with `tests.plan.conftest.series`
 def series(values: Iterable[Any], /) -> nwp.Series[pa.ChunkedArray[Any]]:
-    return nwp.Series.from_native(pa.chunked_array([values]))
+    array: Incomplete = pa.chunked_array
+    ca: pa.ChunkedArray[Any] = array([values])
+    return nwp.Series.from_native(ca)
 
 
 def assert_equal_data(


### PR DESCRIPTION
# Description

Aiming to fix this noise:

```
./.venv/bin/uv run --no-sync pyright
/home/runner/work/narwhals/narwhals/narwhals/_plan/_nodes.py
  /home/runner/work/narwhals/narwhals/narwhals/_plan/_nodes.py:528:33 - error: Cannot access attribute "__replace__" for class "ExprIR"
    Attribute "__replace__" is unknown (reportAttributeAccessIssue)
  /home/runner/work/narwhals/narwhals/narwhals/_plan/_nodes.py:533:28 - error: Cannot access attribute "__replace__" for class "ExprIR"
    Attribute "__replace__" is unknown (reportAttributeAccessIssue)
  /home/runner/work/narwhals/narwhals/narwhals/_plan/_nodes.py:636:28 - error: Cannot access attribute "__replace__" for class "ExprIR"
    Attribute "__replace__" is unknown (reportAttributeAccessIssue)
  /home/runner/work/narwhals/narwhals/narwhals/_plan/_nodes.py:648:43 - error: Cannot access attribute "__replace__" for class "ExprIR"
    Attribute "__replace__" is unknown (reportAttributeAccessIssue)
  /home/runner/work/narwhals/narwhals/narwhals/_plan/_nodes.py:661:36 - error: Cannot access attribute "__replace__" for class "ExprIR"
    Attribute "__replace__" is unknown (reportAttributeAccessIssue)
  /home/runner/work/narwhals/narwhals/narwhals/_plan/_nodes.py:686:33 - error: Cannot access attribute "__replace__" for class "ExprIR"
    Attribute "__replace__" is unknown (reportAttributeAccessIssue)
/home/runner/work/narwhals/narwhals/narwhals/_plan/expressions/function_expr.py
  /home/runner/work/narwhals/narwhals/narwhals/_plan/expressions/function_expr.py:122:24 - error: Cannot access attribute "__replace__" for class "FunctionExpr[FunctionT_co@FunctionExpr]*"
    Attribute "__replace__" is unknown (reportAttributeAccessIssue)
/home/runner/work/narwhals/narwhals/narwhals/_plan/plans/conversion.py
  /home/runner/work/narwhals/narwhals/narwhals/_plan/plans/conversion.py:552:57 - error: Cannot access attribute "__replace__" for class "SortMultipleOptions"
    Attribute "__replace__" is unknown (reportAttributeAccessIssue)
8 errors, 0 warnings, 0 informations

```

## Related issues
- Follow-up from #3617
- Child of #2572
