### PR TITLE
ci(expr-ir): Fix coverage/tests in ci

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -98,17 +98,20 @@ jobs:
         run: uv pip install -e test-plugin/.
       - name: show-deps
         run: uv pip freeze
+      - name: Run pytest (plan-plugins-globals)
+        # NOTE: These seem to cause failures in other tests due to `sys.modules` monkeypatching
+        run: pytest tests/plan -m unsafe_globals --numprocesses=1 --cov=narwhals/_plan --cov=tests/plan --cov-fail-under=0
       - name: Run pytest (plan)
-        run: pytest tests/plan narwhals/_plan --cov=narwhals/_plan --doctest-modules --runslow --durations=30
+        run: pytest tests/plan narwhals/_plan --cov=narwhals/_plan --cov-append --doctest-modules --runslow --durations=30
       - name: Run pytest (main)
         # NOTE: `narwhals/_plan` has doctests that increase coverage, so they are run first and the `main`
         # run uses `--cov-append`
         # https://pytest-cov.readthedocs.io/en/latest/readme.html#coverage-data-file
-        run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=100 --cov-append --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe --durations=30
+        run: pytest tests --ignore=tests/plan --ignore=narwhals/_plan --cov=narwhals --cov=tests --cov-fail-under=100 --cov-append --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe --durations=30
       - name: Run doctests
         # reprs differ between versions, so we only run doctests on the latest Python
         if: matrix.python-version == '3.13'
-        run: pytest narwhals --doctest-modules
+        run: pytest narwhals --doctest-modules --ignore=narwhals/_plan
 
   # Test against smaller dependency set, used e.g. on Gentoo.
   pytest-narrower-dependencies:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -102,7 +102,7 @@ jobs:
         # NOTE: These seem to cause failures in other tests due to `sys.modules` monkeypatching
         run: pytest tests/plan -m unsafe_globals --numprocesses=1 --cov=narwhals/_plan --cov=tests/plan --cov-fail-under=0
       - name: Run pytest (plan)
-        run: pytest tests/plan narwhals/_plan --cov=narwhals/_plan --cov-append --doctest-modules --runslow --durations=30
+        run: pytest tests/plan narwhals/_plan --cov=narwhals/_plan  --cov=tests/plan --cov-fail-under=0 --cov-append --doctest-modules --runslow --durations=30
       - name: Run pytest (main)
         # NOTE: `narwhals/_plan` has doctests that increase coverage, so they are run first and the `main`
         # run uses `--cov-append`

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -98,8 +98,13 @@ jobs:
         run: uv pip install -e test-plugin/.
       - name: show-deps
         run: uv pip freeze
-      - name: Run pytest
-        run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=100 --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe --durations=30
+      - name: Run pytest (plan)
+        run: pytest tests/plan narwhals/_plan --cov=narwhals/_plan --doctest-modules --runslow --durations=30
+      - name: Run pytest (main)
+        # NOTE: `narwhals/_plan` has doctests that increase coverage, so they are run first and the `main`
+        # run uses `--cov-append`
+        # https://pytest-cov.readthedocs.io/en/latest/readme.html#coverage-data-file
+        run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=100 --cov-append --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe --durations=30
       - name: Run doctests
         # reprs differ between versions, so we only run doctests on the latest Python
         if: matrix.python-version == '3.13'

--- a/narwhals/_plan/_function.py
+++ b/narwhals/_plan/_function.py
@@ -267,8 +267,8 @@ class HorizontalFunction(Function, flags=ELEMENTWISE):
     >>> import narwhals._plan as nw
 
     >>> df = Frame.from_names("a", "b", "c")
-    >>> df.schema
-    Schema({'a': Int64, 'b': Int64, 'c': Int64})
+    >>> dict(df.schema)
+    {'a': Int64, 'b': Int64, 'c': Int64}
 
     We expand multiple inputs into a single output:
     >>> before = nw.sum_horizontal(nw.all())

--- a/narwhals/_plan/compliant/expr.py
+++ b/narwhals/_plan/compliant/expr.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
         type_params=(Frame, NativeExpr_co, NativeScalar_co),
     )
 
-elif sys.version_info >= (3, 12):
+elif sys.version_info >= (3, 12):  # pragma: no cover
     from typing import TypeAliasType
 
     Scalar = TypeAliasType(

--- a/narwhals/_plan/polars/expr.py
+++ b/narwhals/_plan/polars/expr.py
@@ -58,7 +58,7 @@ else:
                 if not compat.OVER_SUPPORTS_DESCENDING:
                     raise compat.over_error("descending")
                 options["descending"] = descending
-            if not partition_by and compat.OVER_WITHOUT_PARTITION_BY:
+            if not partition_by and not compat.OVER_WITHOUT_PARTITION_BY:
                 partition_by = (pl.lit(1),)
         return self.over(*partition_by, **options)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,7 +311,11 @@ filterwarnings = [
   "ignore:.*interchange protocol is deprecated.*:DeprecationWarning"
 ]
 xfail_strict = true
-markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
+markers = [
+  "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+  "unsafe_globals: tests that may trigger failures elsewhere when run in parallel"
+]
+addopts = ["-m not slow and not unsafe_globals"]
 env = [
   "MODIN_ENGINE=python",
   "PYARROW_IGNORE_TIMEZONE=1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,7 +315,7 @@ markers = [
   "slow: marks tests as slow (deselect with '-m \"not slow\"')",
   "unsafe_globals: tests that may trigger failures elsewhere when run in parallel"
 ]
-addopts = ["-m not slow and not unsafe_globals"]
+addopts = ["-m not unsafe_globals"]
 env = [
   "MODIN_ENGINE=python",
   "PYARROW_IGNORE_TIMEZONE=1",

--- a/tests/plan/pivot_test.py
+++ b/tests/plan/pivot_test.py
@@ -502,6 +502,18 @@ def test_pivot_aggregate(
         reason="`sum` & `len` are special-cased in `polars` to always return 0 instead on `None`",
         raises=(AssertionError, NotImplementedError),
     )
+    version = dataframe.backend_version()
+    dataframe.xfail(
+        request,
+        dataframe.is_polars()
+        and (version >= (1, 0, 0) and version < (1, 32, 0))
+        and agg_fn in {"sum", "len"},
+        reason=(
+            "`sum` & `len` were not special-cased in `polars` yet to always return 0 instead on `None`\n"
+            "https://github.com/pola-rs/polars/pull/23586"
+        ),
+        raises=(AssertionError),
+    )
     result = df.pivot(
         "a", index="b", values="c", aggregate_function=agg_fn, sort_columns=True
     )

--- a/tests/plan/plugins_test.py
+++ b/tests/plan/plugins_test.py
@@ -57,12 +57,6 @@ else:
         return BUILTIN_NAMES
 
 
-@pytest.fixture
-def plugin(eager: BuiltinName) -> BuiltinAny:
-    """Use this over `plugin_unsafe` whenever possible."""
-    return load_plugin(eager)
-
-
 # NOTE: Marks dependencies of the fixture (https://github.com/pytest-dev/pytest/issues/1368#issuecomment-2344450259)
 @pytest.fixture(params=[pytest.param(0, marks=pytest.mark.unsafe_globals)])
 def plugin_unsafe(
@@ -94,7 +88,7 @@ def test_load_plugin_invalid() -> None:
 
 
 def test_plugin_is_imported(plugin_unsafe: BuiltinAny) -> None:
-    if not POLARS_PARTIAL_INIT_BUG or plugin.name != "polars":
+    if not POLARS_PARTIAL_INIT_BUG or plugin_unsafe.name != "polars":
         assert not plugin_unsafe.is_imported()
     else:  # pragma: no cover
         ...

--- a/tests/plan/plugins_test.py
+++ b/tests/plan/plugins_test.py
@@ -58,7 +58,14 @@ else:
 
 
 @pytest.fixture
-def plugin(
+def plugin(eager: BuiltinName) -> BuiltinAny:
+    """Use this over `plugin_unsafe` whenever possible."""
+    return load_plugin(eager)
+
+
+# NOTE: Marks dependencies of the fixture (https://github.com/pytest-dev/pytest/issues/1368#issuecomment-2344450259)
+@pytest.fixture(params=[pytest.param(0, marks=pytest.mark.unsafe_globals)])
+def plugin_unsafe(
     eager: BuiltinName, _sys_modules_delete_names: tuple[BuiltinName, ...]
 ) -> Generator[BuiltinAny, Any, None]:
     """Yields the result of `load_plugin(eager)`.
@@ -86,27 +93,27 @@ def test_load_plugin_invalid() -> None:
         load_plugin("i dont exist")
 
 
-def test_plugin_is_imported(plugin: BuiltinAny) -> None:
+def test_plugin_is_imported(plugin_unsafe: BuiltinAny) -> None:
     if not POLARS_PARTIAL_INIT_BUG or plugin.name != "polars":
-        assert not plugin.is_imported()
+        assert not plugin_unsafe.is_imported()
     else:  # pragma: no cover
         ...
-    manager().import_modules(plugin.name)
-    assert plugin.is_imported()
-    assert manager().plugin(plugin.name).is_imported()
+    manager().import_modules(plugin_unsafe.name)
+    assert plugin_unsafe.is_imported()
+    assert manager().plugin(plugin_unsafe.name).is_imported()
 
 
-def test_plugin_can_import(plugin: BuiltinAny) -> None:
-    if not POLARS_PARTIAL_INIT_BUG or plugin.name != "polars":
-        assert not plugin.is_imported()
+def test_plugin_can_import(plugin_unsafe: BuiltinAny) -> None:
+    if not POLARS_PARTIAL_INIT_BUG or plugin_unsafe.name != "polars":
+        assert not plugin_unsafe.is_imported()
     else:  # pragma: no cover
         ...
-    assert plugin.can_import()
-    manager().import_modules(plugin.name)
-    assert plugin.is_imported()
-    assert plugin.can_import()
-    assert manager().plugin(plugin.name).can_import()
-    manager().import_modules(plugin.name)
+    assert plugin_unsafe.can_import()
+    manager().import_modules(plugin_unsafe.name)
+    assert plugin_unsafe.is_imported()
+    assert plugin_unsafe.can_import()
+    assert manager().plugin(plugin_unsafe.name).can_import()
+    manager().import_modules(plugin_unsafe.name)
 
 
 def test_plugin_manager_known() -> None:

--- a/tests/plan/temp_test.py
+++ b/tests/plan/temp_test.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 import hypothesis.strategies as st
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 
 import narwhals as nw
 from narwhals._plan.common import temp
@@ -72,8 +72,12 @@ def test_temp_column_name_n_chars(n_chars: int) -> None:  # pragma: no cover
 
 
 @given(n_new_names=st.integers(10_000, 100_000))
+@settings(max_examples=30, deadline=None)
 @pytest.mark.slow
 def test_temp_column_names_always_new_names(n_new_names: int) -> None:  # pragma: no cover
+    # NOTE: This test *has* to take long because it creates an artificially large iterator in python
+    # `max_examples` is reduced from the default of `100` to offset this
+    # https://hypothesis.readthedocs.io/en/latest/reference/api.html#hypothesis.settings.deadline
     it = temp.column_names(_COLUMNS)
     new_names = set(islice(it, n_new_names))
     assert len(new_names) == n_new_names


### PR DESCRIPTION
# Description
~~Pretty simple, just splits the two runs and uses `--cov-append`~~

Harder than it looked:
- partially resolved by `--cov-append` with multiple runs
- split out tests that are flaky with `pytest-xdist`

## Related issues

- 2nd follow-up to #3611
- Mentioned in #3617
- Child of #2572