### PR TITLE
fix(expr-ir): Add more compat for old `polars`

### DIFF
--- a/narwhals/_plan/dataframe.py
+++ b/narwhals/_plan/dataframe.py
@@ -615,6 +615,7 @@ class DataFrame(
                 values=values_,
                 aggregate_function=aggregate_function,
                 separator=separator,
+                sort_columns=sort_columns,
             )
         )
 

--- a/narwhals/_plan/polars/compat.py
+++ b/narwhals/_plan/polars/compat.py
@@ -41,7 +41,8 @@ Prior this this version, `nulls_last` was [only available on `*Frame` and `Expr`
 [only available on `*Frame` and `Expr`]: https://github.com/pola-rs/polars/issues/13788
 """
 
-HAS_LEN: Final = BACKEND_VERSION >= (0, 20, 6)
+HAS_LEN: Final = BACKEND_VERSION >= (0, 20, 5)
+"""https://github.com/pola-rs/polars/pull/13719"""
 
 DUNDER_ARRAY_SUPPORTS_COPY: Final = BACKEND_VERSION >= (0, 20, 29)
 """https://github.com/pola-rs/polars/pull/16401"""

--- a/narwhals/_plan/polars/expr.py
+++ b/narwhals/_plan/polars/expr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import polars as pl
@@ -80,15 +81,18 @@ else:
         return pl.count().alias("len")
 
 
-# TODO @dangotbanned: (low-priority) Support without triggering
-# `over(..., order_by=...)` requires `polars>=1.0.0`
 def row_index(
     name: str = "index", order_by: Sequence[str] = (), *, nulls_last: bool = False
 ) -> pl.Expr:
-    expr = pl.int_range(len())
-    if order_by:
-        expr = over(expr, order_by=order_by, nulls_last=nulls_last)
-    return expr.alias(name)
+    int_range = pl.int_range(len()).alias(name)
+    if not order_by:
+        return int_range
+    if compat.OVER_RESPECTS_NULLS_LAST:
+        return int_range.over(order_by=order_by, nulls_last=nulls_last)
+    # NOTE: `nulls_last` isn't the missing feature,
+    # but the behavior is more predictable following that change
+    by = pl.col(order_by) if builtins.len(order_by) == 1 else pl.struct(order_by)
+    return int_range.sort_by(by.arg_sort(nulls_last=nulls_last))
 
 
 class PolarsExpr(CompliantExpr["DataFrame", pl.Expr, pl.Expr]):

--- a/tests/plan/frame_with_row_index_test.py
+++ b/tests/plan/frame_with_row_index_test.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
@@ -20,35 +20,30 @@ def test_with_row_index_eager(dataframe: DataFrame) -> None:
     assert_equal_data(result, expected)
 
 
-# TODO @dangotbanned: Remove after debugging CI
-def _fmt(obj: OneOrIterable[ColumnNameOrSelector]) -> str:
-    if isinstance(obj, ncs.Selector):
-        return repr(obj._ir)
-    if isinstance(obj, str):
-        return repr(obj)
-    if isinstance(obj, list) and all(isinstance(el, int) for el in obj):
-        return repr(obj)
-    s = ", ".join(_fmt(el) for el in obj)
-    return f"[{s}]"
+IDX_1: Final = [0, 2, 1]
+IDX_2: Final = [2, 0, 1]
+IDX_3: Final = [1, 2, 0]
+first, last = ncs.first(), ncs.last()
 
 
 @pytest.mark.parametrize(
     ("order_by", "expected_index"),
     [
-        (["a"], [0, 2, 1]),
-        (ncs.first(), [0, 2, 1]),
-        (ncs.string(), [0, 2, 1]),
-        (["c"], [2, 0, 1]),
-        (ncs.last(), [2, 0, 1]),
-        (ncs.integer() - ncs.by_index(1), [2, 0, 1]),
-        (["a", "c"], [1, 2, 0]),
-        ([ncs.first(), "c"], [1, 2, 0]),
-        (["a", ncs.by_name("c")], [1, 2, 0]),
-        (["c", "a"], [2, 0, 1]),
-        ([ncs.by_index(-1, 0)], [2, 0, 1]),
-        ([ncs.last(), ncs.first()], [2, 0, 1]),
+        pytest.param(["a"], IDX_1, id="['a']"),
+        pytest.param(first, IDX_1, id="first()"),
+        pytest.param(ncs.string(), IDX_1, id="string()"),
+        pytest.param(["c"], IDX_2, id="['c']"),
+        pytest.param(last, IDX_2, id="last()"),
+        pytest.param(
+            ncs.integer() - ncs.by_index(1), IDX_2, id="integer() - by_index(1)"
+        ),
+        pytest.param(["a", "c"], IDX_3, id="['a', 'c']"),
+        pytest.param([first, "c"], IDX_3, id="[first(), 'c']"),
+        pytest.param(["a", ncs.by_name("c")], IDX_3, id="['a', by_name('c')]"),
+        pytest.param(["c", "a"], IDX_2, id="['c', 'a']"),
+        pytest.param([ncs.by_index(-1, 0)], IDX_2, id="[by_index(-1, 0)]"),
+        pytest.param([last, first], IDX_2, id="[last(), first()]"),
     ],
-    ids=_fmt,
 )
 def test_with_row_index_by(
     dataframe: DataFrame,

--- a/tests/plan/frame_with_row_index_test.py
+++ b/tests/plan/frame_with_row_index_test.py
@@ -21,6 +21,18 @@ def test_with_row_index_eager(dataframe: DataFrame) -> None:
     assert_equal_data(result, expected)
 
 
+# TODO @dangotbanned: Remove after debugging CI
+def _fmt(obj: OneOrIterable[ColumnNameOrSelector]) -> str:
+    if isinstance(obj, ncs.Selector):
+        return repr(obj._ir)
+    if isinstance(obj, str):
+        return repr(obj)
+    if isinstance(obj, list) and all(isinstance(el, int) for el in obj):
+        return repr(obj)
+    s = ", ".join(_fmt(el) for el in obj)
+    return f"[{s}]"
+
+
 @pytest.mark.parametrize(
     ("order_by", "expected_index"),
     [
@@ -37,6 +49,7 @@ def test_with_row_index_eager(dataframe: DataFrame) -> None:
         ([ncs.by_index(-1, 0)], [2, 0, 1]),
         ([ncs.last(), ncs.first()], [2, 0, 1]),
     ],
+    ids=_fmt,
 )
 def test_with_row_index_by(
     dataframe: DataFrame,

--- a/tests/plan/frame_with_row_index_test.py
+++ b/tests/plan/frame_with_row_index_test.py
@@ -8,7 +8,6 @@ import pytest
 import narwhals._plan.selectors as ncs
 from narwhals.exceptions import ColumnNotFoundError
 from tests.plan.utils import DataFrame, assert_equal_data, re_compile
-from tests.utils import POLARS_VERSION
 
 if TYPE_CHECKING:
     from narwhals._plan.typing import ColumnNameOrSelector, OneOrIterable
@@ -55,17 +54,10 @@ def test_with_row_index_by(
     dataframe: DataFrame,
     order_by: OneOrIterable[ColumnNameOrSelector],
     expected_index: list[int],
-    request: pytest.FixtureRequest,
 ) -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3289
     data = {"a": ["A", "B", "A"], "b": [1, 2, 3], "c": [9, 2, 4]}
 
-    dataframe.xfail(
-        request,
-        dataframe.is_polars() and POLARS_VERSION < (1, 0),
-        reason="polars needs `over(order_by=...)`",
-        raises=NotImplementedError,
-    )
     result = dataframe(data).with_row_index(name="index", order_by=order_by).sort("b")
     expected = {"index": expected_index, **data}
     assert_equal_data(result, expected)


### PR DESCRIPTION
# Description
Keep uncovering more quirks for `1.0.0` and `1.1.0`.
I've reproduced both locally for  `1.0.0` now, so hopefully will get them dealt with

- [x] Fix `pivot(sort_columns=True)` before (https://github.com/pola-rs/polars/pull/25016)
- [x] Fix `test_with_row_index_by`
	- via backporting `over(order_by=...)` in (https://github.com/narwhals-dev/narwhals/pull/3624/commits/209a7b098f370f334219172f96baa5f2c58448d5)


## Related issues

- The sequel to #3617
- Child of #2572

