### PR TITLE
Revert "fix: Allow `float('nan')` as value in join for duckdb (#3555)"

### DIFF
--- a/narwhals/_duckdb/dataframe.py
+++ b/narwhals/_duckdb/dataframe.py
@@ -308,13 +308,8 @@ class DuckDBLazyFrame(
             # help mypy
             assert left_on is not None  # noqa: S101
             assert right_on is not None  # noqa: S101
-            # Use `==` to preserve the polars semantic of `null != null` in joins,
-            # and additionally match `NaN = NaN` since `==` in DuckDB treats `NaN`
-            # like SQL `NULL` (see https://github.com/narwhals-dev/narwhals/issues/3554).
-            # `isnan` is safe to apply as it returns `false` for non-float columns.
             it = (
-                (col(f'lhs."{left}"') == col(f'rhs."{right}"'))
-                | (F("isnan", col(f'lhs."{left}"')) & F("isnan", col(f'rhs."{right}"')))
+                col(f'lhs."{left}"') == col(f'rhs."{right}"')
                 for left, right in zip(left_on, right_on, strict=True)
             )
             condition: Expression = reduce(and_, it)

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -921,34 +921,9 @@ def test_full_join_with_overlapping_non_key_columns_and_nulls(
     assert_equal_data(result, expected)
 
 
-def test_join_with_float_nan(
-    request: pytest.FixtureRequest, constructor: Constructor
-) -> None:
-    if any(x in str(constructor) for x in ("cudf", "dask", "modin", "pandas")):
-        request.applymarker(pytest.mark.xfail)
-
-    data = {"a": [0, 0, 0], "b": [0, 0, 0], "c": [0.0, 0.0, float("nan")]}
-    join_cols = ["a", "c"]
-    frame = from_native_lazy(constructor(data))
-
-    result = (
-        frame.join(frame, on=join_cols, how="inner").sort("c", nulls_last=True).collect()
-    )
-
-    zero_cols = ("a", "b", "b_right")
-    for col in zero_cols:
-        assert (result.get_column(col) == 0).all()
-
-    assert (result.get_column("c").is_nan().sum()) == 1
-    """
-    NOTE: polars result is the following:
-    expected = {
-        "a": [0, 0, 0, 0, 0],
-        "b": [0, 0, 0, 0, 0],
-        "c": [0., 0., 0., 0., float("nan")],
-        "b_right": [0, 0, 0, 0, 0],
-    }
-
-    How can we sort the data to use:
+def test_join_on_strings(constructor: Constructor) -> None:
+    df_l = nw.from_native(constructor({"a": ["one", "two", "two"]})).lazy()
+    df_r = nw.from_native(constructor({"a": ["one", "two"], "b": [5, 6]})).lazy()
+    result = df_l.join(df_r, on="a").sort("a")
+    expected = {"a": ["one", "two", "two"], "b": [5, 6, 6]}
     assert_equal_data(result, expected)
-    """


### PR DESCRIPTION
This reverts commit 0d7f3529709973836c134fa36acee3c5352c74ed.


<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
