### PR TITLE
fix: `.over` was mutating expressions in some cases

### DIFF
--- a/src/narwhals/expr.py
+++ b/src/narwhals/expr.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 from narwhals._expression_parsing import ExprKind, ExprNode, evaluate_nodes
@@ -63,7 +64,7 @@ class Expr:
     def _with_over_node(self, node: ExprNode) -> Self:
         # insert `over` before any elementwise operations.
         # check "how it works" page in docs for why we do this.
-        new_nodes = list(self._nodes)
+        new_nodes = deepcopy(list(self._nodes))
         kwargs_no_order_by = {
             key: value if key != "order_by" else []
             for (key, value) in node.kwargs.items()

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -592,6 +592,8 @@ def test_over_when_then_aggregation_partition_by(
 
 
 def test_mutability(constructor: Constructor) -> None:
+    if "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3):
+        pytest.skip()
     df = nw.from_native(constructor({"a": [1, 1, 2], "b": [1, 2, 3]}))
     left = nw.col("a").sum()
     right = nw.col("a").mean()

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -589,3 +589,16 @@ def test_over_when_then_aggregation_partition_by(
     result = df.select("a", "b", c=expr).sort("b")
     expected = {"a": [1, 1, None, 3, 3], "b": [1, 3, 4, 5, 6], "c": expected_c}
     assert_equal_data(result, expected)
+
+
+def test_mutability(constructor: Constructor) -> None:
+    df = nw.from_native(constructor({"a": [1, 1, 2], "b": [1, 2, 3]}))
+    left = nw.col("a").sum()
+    right = nw.col("a").mean()
+    expr = left + right
+    result = df.select(expr)
+    assert_equal_data(result, {"a": [16 / 3]})
+    result = df.with_columns(expr.over("b")).sort("b")
+    assert_equal_data(result, {"a": [2.0, 2.0, 4.0], "b": [1, 2, 3]})
+    result = df.select(expr)
+    assert_equal_data(result, {"a": [16 / 3]})

--- a/tests/expr_and_series/when_test.py
+++ b/tests/expr_and_series/when_test.py
@@ -602,3 +602,16 @@ def test_when_then_composes_with_expr_operations(constructor: Constructor) -> No
 
     expected = {"result": [2, 4, 20, 0]}
     assert_equal_data(result, expected)
+
+
+def test_mutability(constructor: Constructor) -> None:
+    # check .otherwise doesn't mutate the expression
+    df = nw.from_native(constructor({"a": [1, 2, 3, 4]}))
+
+    expr = nw.when(nw.col("a") > 2).then(nw.col("a"))
+    result_before = df.select(expr)
+    assert_equal_data(result_before, {"a": [None, None, 3, 4]})
+    _ = expr.otherwise(0)
+    _ = expr.when(nw.col("a") == 2).then(20).otherwise(30)
+    result_after = df.select(expr)
+    assert_equal_data(result_after, {"a": [None, None, 3, 4]})


### PR DESCRIPTION
thanks @dangotbanned for spotting this on discord https://discord.com/channels/1235257048170762310/1272835922924273694/1492563536696578248

<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
