### PR TITLE
chore(typing): Enable `allow-redefinition` for `mypy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,6 +338,7 @@ exclude_also = [
 files = ["src/narwhals", "tests", "test-plugin"]
 pretty = true
 strict = true
+allow_redefinition = true  # https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-allow-redefinition
 
 [[tool.mypy.overrides]]
 module = [

--- a/src/narwhals/_arrow/series.py
+++ b/src/narwhals/_arrow/series.py
@@ -600,14 +600,11 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
 
         val_counts = pc.value_counts(self.native)
         values = val_counts.field("values")
-        counts = cast("ChunkedArrayAny", val_counts.field("counts"))
-
+        counts = val_counts.field("counts")
         if normalize:
-            arrays = [values, pc.divide(*cast_for_truediv(counts, pc.sum(counts)))]
-        else:
-            arrays = [values, counts]
-
-        val_count = pa.Table.from_arrays(arrays, names=[index_name_, value_name_])  # type: ignore[arg-type]
+            counts = pc.divide(*cast_for_truediv(counts, pc.sum(counts)))
+        arrays = values, counts
+        val_count = pa.Table.from_arrays(arrays, names=[index_name_, value_name_])
 
         if sort:
             val_count = val_count.sort_by([(value_name_, "descending")])

--- a/src/narwhals/_arrow/series.py
+++ b/src/narwhals/_arrow/series.py
@@ -607,7 +607,7 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
         else:
             arrays = [values, counts]
 
-        val_count = pa.Table.from_arrays(arrays, names=[index_name_, value_name_])
+        val_count = pa.Table.from_arrays(arrays, names=[index_name_, value_name_])  # type: ignore[arg-type]
 
         if sort:
             val_count = val_count.sort_by([(value_name_, "descending")])

--- a/src/narwhals/_pandas_like/utils.py
+++ b/src/narwhals/_pandas_like/utils.py
@@ -195,7 +195,7 @@ def rename(
         result = obj.rename(*args, **kwargs, copy=False, inplace=False)
     else:
         result = obj.rename(*args, **kwargs)
-    return cast("NativeNDFrameT", result)  # type: ignore[redundant-cast]
+    return cast("NativeNDFrameT", result)
 
 
 @functools.lru_cache(maxsize=16)

--- a/src/narwhals/_polars/namespace.py
+++ b/src/narwhals/_polars/namespace.py
@@ -186,7 +186,7 @@ class PolarsNamespace:
                     pl.when(~nm).then(sep).otherwise(pl.lit("")) for nm in null_mask[:-1]
                 ]
 
-                result = pl.fold(  # type: ignore[assignment]
+                result = pl.fold(
                     acc=init_value,
                     function=operator.add,
                     exprs=[s + v for s, v in zip(separators, values, strict=True)],

--- a/src/narwhals/dtypes.py
+++ b/src/narwhals/dtypes.py
@@ -972,6 +972,9 @@ class Array(NestedType):
         # Get leaf type
         dtype: Self | IntoDType = self
         tp_self = type(self)
+        # NOTE: This might look odd, but if we used a `while` loop
+        # it won't trigger a `RecursionError` like `for` does.
+        # https://github.com/narwhals-dev/narwhals/pull/3651
         for _ in self.shape:
             if isinstance(dtype, tp_self):
                 dtype = dtype.inner

--- a/src/narwhals/dtypes.py
+++ b/src/narwhals/dtypes.py
@@ -975,6 +975,9 @@ class Array(NestedType):
         for _ in self.shape:
             if isinstance(dtype, tp_self):
                 dtype = dtype.inner
+            else:  # pragma: no cover
+                msg = "Either something has gone horribly wrong in narwhals, or you've fiddled with the internals!"
+                raise TypeError(msg)
         return f"{tp_self.__name__}({dtype!r}, shape={self.shape})"
 
 

--- a/src/narwhals/dtypes.py
+++ b/src/narwhals/dtypes.py
@@ -972,7 +972,7 @@ class Array(NestedType):
         # Get leaf type
         dtype_ = self
         for _ in self.shape:
-            dtype_ = dtype_.inner  # type: ignore[assignment]
+            dtype_ = dtype_.inner  # type: ignore[union-attr]
 
         class_name = self.__class__.__name__
         return f"{class_name}({dtype_!r}, shape={self.shape})"

--- a/src/narwhals/dtypes.py
+++ b/src/narwhals/dtypes.py
@@ -970,12 +970,11 @@ class Array(NestedType):
 
     def __repr__(self) -> str:
         # Get leaf type
-        dtype_ = self
-        for _ in self.shape:
-            dtype_ = dtype_.inner  # type: ignore[union-attr]
-
-        class_name = self.__class__.__name__
-        return f"{class_name}({dtype_!r}, shape={self.shape})"
+        dtype: Self | IntoDType = self
+        tp_self = type(self)
+        while isinstance(dtype, tp_self):
+            dtype = dtype.inner
+        return f"{tp_self.__name__}({dtype!r}, shape={self.shape})"
 
 
 class Date(TemporalType):

--- a/src/narwhals/dtypes.py
+++ b/src/narwhals/dtypes.py
@@ -972,8 +972,9 @@ class Array(NestedType):
         # Get leaf type
         dtype: Self | IntoDType = self
         tp_self = type(self)
-        while isinstance(dtype, tp_self):
-            dtype = dtype.inner
+        for _ in self.shape:
+            if isinstance(dtype, tp_self):
+                dtype = dtype.inner
         return f"{tp_self.__name__}({dtype!r}, shape={self.shape})"
 
 

--- a/tests/dtypes/dtypes_test.py
+++ b/tests/dtypes/dtypes_test.py
@@ -187,7 +187,7 @@ def test_array_inner_recursive() -> None:
     for dim in shape:
         assert isinstance(dtype, nw.Array)
         assert dtype.size == dim
-        dtype = dtype.inner  # type: ignore[assignment]
+        dtype = dtype.inner
 
 
 def test_array_inner_recursive_repr() -> None:

--- a/tests/frame/group_by_test.py
+++ b/tests/frame/group_by_test.py
@@ -81,7 +81,7 @@ def test_group_by_iter(constructor_eager: ConstructorEager) -> None:
             assert isinstance(sub_df, nw.DataFrame)
         keys.append(key)
     assert sorted(keys) == sorted(expected_keys)
-    expected_keys = [(1, 4), (3, 6)]  # type: ignore[list-item]
+    expected_keys = [(1, 4), (3, 6)]
     keys = []
     for key, _ in df.group_by("a", "b"):
         keys.append(key)

--- a/tests/frame/reindex_test.py
+++ b/tests/frame/reindex_test.py
@@ -27,7 +27,7 @@ def test_reindex(df_raw: Any) -> None:
     assert result_s[1]
     assert not result_s[2]
     result = df.with_columns(s.sort())
-    expected = {"a": [1, 2, 3], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}  # type: ignore[list-item]
+    expected = {"a": [1, 2, 3], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     assert_equal_data(result, expected)
     with pytest.raises(MultiOutputExpressionError):
         nw.to_native(df.with_columns(nw.all() + nw.all()))

--- a/tests/series_only/value_counts_test.py
+++ b/tests/series_only/value_counts_test.py
@@ -29,7 +29,7 @@ def test_value_counts(
     expected_index = [4, 1, 6]
 
     if normalize:
-        expected_count = [v / len(data) for v in expected_count]  # type: ignore[misc]
+        expected_count = [v / len(data) for v in expected_count]
 
     expected_name = name or ("proportion" if normalize else "count")
     expected = {"a": expected_index, expected_name: expected_count}


### PR DESCRIPTION
Closes #3646

# Description
Enables the *opt-in* behavior `mypy` has had since `1.20.0`.

This brings `mypy` closer to all the other type checkers, which **wouldn't describe this as redefining in the first place** [^1].

[^1]: See [pyright/mypy-comparison](https://microsoft.github.io/pyright/#/mypy-comparison?id=variable-type-declarations)

## Related

- Closes  #3646
- https://mypy.readthedocs.io/en/stable/changelog.html#new-behavior-for-allow-redefinition
- https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-allow-redefinition

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
