### PR TITLE
fix(expr-ir): Allow `struct.field` to select from it's own context

### DIFF
--- a/src/narwhals/_plan/expressions/struct.py
+++ b/src/narwhals/_plan/expressions/struct.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
     from narwhals._plan.expressions import FunctionExpr, StructExpr
     from narwhals._plan.schema import FrozenSchema
-    from narwhals.dtypes import DType, Field, Struct
+    from narwhals.dtypes import DType
 
 STRUCT = Version.MAIN.dtypes.Struct
 # NOTE: See https://github.com/astral-sh/ty/issues/1777#issuecomment-3618906859
@@ -52,24 +52,19 @@ class FieldByName(
     def needs_expansion(self) -> bool:
         return True
 
-    def _field(self, dtype: Struct) -> Field:
-        if field := next((f for f in dtype.fields if f.name == self.name), None):
-            return field
-        raise not_found_error(self.name)  # pragma: no cover
-
     def resolve_dtype(self, node: FunctionExpr[Self], schema: FrozenSchema, /) -> DType:
-        arg = node.args[0]
+        prev = node.args[0]
+        name = self.name
         if (
-            (struct_name := arg.meta.output_name(raise_if_undetermined=False))
-            and (
-                (struct := schema.get(struct_name))
-                or (not schema and (struct := arg.resolve_dtype(schema)))
+            (
+                (not schema and (dtype := prev.resolve_dtype(schema)))
+                or (dtype := schema.get(prev.meta.output_name()))
             )
-            and isinstance(struct, STRUCT)
+            and isinstance(dtype, STRUCT)
+            and (field := next((f for f in dtype.fields if f.name == name), None))
         ):
-            return into_dtype(self._field(struct).dtype)
-
-        raise not_found_error(self.name)
+            return into_dtype(field.dtype)
+        raise not_found_error(name)
 
 
 class IRStructNamespace(IRNamespace):

--- a/src/narwhals/_plan/expressions/struct.py
+++ b/src/narwhals/_plan/expressions/struct.py
@@ -57,15 +57,18 @@ class FieldByName(
             return field
         raise not_found_error(self.name)  # pragma: no cover
 
-    # TODO @dangotbanned: Fix initial empty schema/lit edge case
-    #   `nwp.select(nwp.lit({"a": 1}).struct.field("a"), lazy="polars")`
     def resolve_dtype(self, node: FunctionExpr[Self], schema: FrozenSchema, /) -> DType:
+        arg = node.args[0]
         if (
-            (struct_name := node.args[0].meta.output_name(raise_if_undetermined=False))
-            and (struct := schema.get(struct_name))
+            (struct_name := arg.meta.output_name(raise_if_undetermined=False))
+            and (
+                (struct := schema.get(struct_name))
+                or (not schema and (struct := arg.resolve_dtype(schema)))
+            )
             and isinstance(struct, STRUCT)
         ):
             return into_dtype(self._field(struct).dtype)
+
         raise not_found_error(self.name)
 
 

--- a/tests/plan/select_test.py
+++ b/tests/plan/select_test.py
@@ -67,19 +67,19 @@ def test_lazy(
     named_exprs: dict[str, IntoExpr],
     expected: Data,
     lazy: Lazy,
-    request: pytest.FixtureRequest,
 ) -> None:
-    request.applymarker(
-        pytest.mark.xfail(
-            lazy == "polars"
-            and POLARS_VERSION < (1, 17, 0)
-            and expected == {"literal": [None]},
+    if (
+        lazy == "polars"
+        and POLARS_VERSION < (1, 17, 0)
+        and expected == {"literal": [None]}
+    ):
+        # NOTE: This was a regression, but unclear when it stopped working
+        pytest.skip(
             reason=(
                 "PanicException: `arg_sort` operation not supported for dtype `null`.\n"
                 "https://github.com/pola-rs/polars/pull/20135"
-            ),
+            )
         )
-    )
     result = nwp.select(*exprs, lazy=lazy, **named_exprs).collect().sort(ncs.first())
     assert_equal_data(result, expected)
 

--- a/tests/plan/select_test.py
+++ b/tests/plan/select_test.py
@@ -139,10 +139,6 @@ def test_both() -> None:
         nwp.select(1, eager="polars", lazy="polars")  # type: ignore[call-overload]
 
 
-@pytest.mark.xfail(
-    raises=InvalidOperationError,
-    reason="BUG: Searching for struct in an empty schema, when it is defined in the current context",
-)
 @pytest.mark.parametrize(
     ("exprs", "expected"),
     [
@@ -170,6 +166,7 @@ def test_lit_struct_field_lazy(
         (nwp.lit({"a": 1}).struct.field("b"), "b"),
         (
             nwp.lit({"a": {"b": {"c": "d"}}})
+            .struct.field("a")
             .struct.field("b")
             .struct.field("c")
             .struct.field("e"),


### PR DESCRIPTION
# Description

The equivalent of this was previously raising:

```py
>>> import polars as pl
>>> pl.select(pl.lit({"a": 1, "b": 2}).struct.field("b"), eager=False).collect()
shape: (1, 1)
┌─────┐
│ b   │
│ --- │
│ i64 │
╞═════╡
│ 2   │
└─────┘
```




## Related issues

- Follow-up to a bug found in #3647
- Child of #2572


