### PR TITLE
fix(polars): Backport `is_close` for `Decimal` dtype and `join(how={"semi", "anti"})` on null's

### DIFF
--- a/src/narwhals/_compliant/expr.py
+++ b/src/narwhals/_compliant/expr.py
@@ -121,6 +121,12 @@ class CompliantExpr(
         context: _LimitedContext,
     ) -> Self: ...
     def broadcast(self) -> Self: ...
+    def _is_close_float_promote(self) -> Self:
+        # Default float promotion for `is_close`: equivalent to `self + 0.0`, letting
+        # each backend pick its float type (broadcast mirrors the node-evaluation path).
+        # Polars overrides this to align old versions (see `PolarsExpr`).
+        plx = self.__narwhals_namespace__()
+        return self + plx.lit(0.0, None).broadcast()
 
     # NOTE: `polars`
     def alias(self, name: str) -> Self: ...

--- a/src/narwhals/_polars/dataframe.py
+++ b/src/narwhals/_polars/dataframe.py
@@ -221,9 +221,15 @@ class PolarsBaseFrame(Generic[NativePolarsFrame]):
         how_native = (
             "outer" if (self._backend_version < (0, 20, 29) and how == "full") else how
         )
+        other_native = other.native
+        if how in {"semi", "anti"} and self._backend_version < (0, 20, 22):
+            # Polars < 0.20.22 treats `null == null` as a match in semi/anti joins.
+            # Dropping rows with null keys on the right removes these spurious matches,
+            # which is always valid since narwhals treats nulls as non-matching.
+            other_native = other_native.drop_nulls(subset=right_on)
         return self._with_native(
             self.native.join(
-                other=other.native,
+                other=other_native,
                 how=how_native,
                 left_on=left_on,
                 right_on=right_on,

--- a/src/narwhals/_polars/dataframe.py
+++ b/src/narwhals/_polars/dataframe.py
@@ -223,7 +223,8 @@ class PolarsBaseFrame(Generic[NativePolarsFrame]):
             "outer" if (self._backend_version < (0, 20, 29) and how == "full") else how
         )
         other_native = other.native
-        if how in {"semi", "anti"} and not RESPECT_JOIN_NULL_SEMI_ANTI:
+        is_semi_or_anti = how in {"semi", "anti"}
+        if is_semi_or_anti and not RESPECT_JOIN_NULL_SEMI_ANTI:  # pragma: no cover
             other_native = other_native.drop_nulls(subset=right_on)
         return self._with_native(
             self.native.join(

--- a/src/narwhals/_polars/dataframe.py
+++ b/src/narwhals/_polars/dataframe.py
@@ -9,6 +9,7 @@ from narwhals._polars.namespace import PolarsNamespace
 from narwhals._polars.series import PolarsSeries
 from narwhals._polars.utils import (
     FROM_DICTS_ACCEPTS_MAPPINGS,
+    RESPECT_JOIN_NULL_SEMI_ANTI,
     catch_polars_exception,
     extract_args_kwargs,
     narwhals_to_native_dtype,
@@ -222,10 +223,7 @@ class PolarsBaseFrame(Generic[NativePolarsFrame]):
             "outer" if (self._backend_version < (0, 20, 29) and how == "full") else how
         )
         other_native = other.native
-        if how in {"semi", "anti"} and self._backend_version < (0, 20, 22):
-            # Polars < 0.20.22 treats `null == null` as a match in semi/anti joins.
-            # Dropping rows with null keys on the right removes these spurious matches,
-            # which is always valid since narwhals treats nulls as non-matching.
+        if how in {"semi", "anti"} and not RESPECT_JOIN_NULL_SEMI_ANTI:
             other_native = other_native.drop_nulls(subset=right_on)
         return self._with_native(
             self.native.join(

--- a/src/narwhals/_polars/expr.py
+++ b/src/narwhals/_polars/expr.py
@@ -152,6 +152,18 @@ class PolarsExpr:
             native = pl.when(self.native.is_not_null()).then(self.native.is_finite())
         return self._with_native(native)
 
+    def _is_close_float_promote(self) -> Self:
+        # Polars >= 1.34 upcasts `Decimal + float` to `Float64` (matching `int`/`Float32`
+        # promotion), so `+ 0.0` is enough. Earlier versions keep `Decimal`, which then
+        # breaks `is_finite`/`clip` inside `is_close`; cast to `Float64` to align. This is
+        # scoped to `is_close` (Boolean output), so widening `Float32` here is harmless.
+        native = (
+            self.native + 0.0
+            if self._backend_version >= (1, 34)
+            else self.native.cast(pl.Float64)
+        )
+        return self._with_native(native)
+
     def over(self, partition_by: Sequence[str], order_by: Sequence[str]) -> Self:
         # Use `pl.repeat(1, pl.len())` instead of `pl.lit(1)` to avoid issues for
         # non-numeric types: https://github.com/pola-rs/polars/issues/24756.

--- a/src/narwhals/_polars/expr.py
+++ b/src/narwhals/_polars/expr.py
@@ -6,6 +6,7 @@ import polars as pl
 
 from narwhals._polars.utils import (
     BACKEND_VERSION,
+    BINARY_ADD_UPCASTS_DECIMAL_TO_FLOAT,
     PolarsAnyNamespace,
     PolarsCatNamespace,
     PolarsDateTimeNamespace,
@@ -153,13 +154,11 @@ class PolarsExpr:
         return self._with_native(native)
 
     def _is_close_float_promote(self) -> Self:
-        # Polars >= 1.34 upcasts `Decimal + float` to `Float64` (matching `int`/`Float32`
-        # promotion), so `+ 0.0` is enough. Earlier versions keep `Decimal`, which then
-        # breaks `is_finite`/`clip` inside `is_close`; cast to `Float64` to align. This is
-        # scoped to `is_close` (Boolean output), so widening `Float32` here is harmless.
+        # This is scoped to `is_close` (Boolean output), so widening `Float16/Float32`
+        # here is harmless for the final result.
         native = (
             self.native + 0.0
-            if self._backend_version >= (1, 34)
+            if BINARY_ADD_UPCASTS_DECIMAL_TO_FLOAT
             else self.native.cast(pl.Float64)
         )
         return self._with_native(native)

--- a/src/narwhals/_polars/utils.py
+++ b/src/narwhals/_polars/utils.py
@@ -52,20 +52,35 @@ BACKEND_VERSION = Implementation.POLARS._backend_version()
 SERIES_ACCEPTS_PD_INDEX: Final[bool] = BACKEND_VERSION >= (0, 20, 7)
 """`pl.Series(values: pd.Index)` fixed in https://github.com/pola-rs/polars/pull/14087"""
 
+RESPECT_JOIN_NULL_SEMI_ANTI: Final[bool] = BACKEND_VERSION >= (0, 20, 22)
+"""Polars < 0.20.22 treats `null == null` as a match in semi/anti joins.
+
+Dropping rows with null keys on the right removes these spurious matches,
+which is always valid since narwhals treats nulls as non-matching.
+
+Fixed in https://github.com/pola-rs/polars/pull/15696
+"""
+
 SERIES_RESPECTS_DTYPE: Final[bool] = BACKEND_VERSION >= (0, 20, 26)
 """`pl.Series(dtype=...)` fixed in https://github.com/pola-rs/polars/pull/15962
 
 Includes `SERIES_ACCEPTS_PD_INDEX`.
 """
 
-HAS_INT_128 = BACKEND_VERSION >= (1, 18, 0)
+HAS_INT_128: Final[bool] = BACKEND_VERSION >= (1, 18, 0)
 """https://github.com/pola-rs/polars/pull/20232"""
 
 FROM_DICTS_ACCEPTS_MAPPINGS: Final[bool] = BACKEND_VERSION >= (1, 30, 0)
 """`pl.from_dicts(data: Iterable[Mapping[str, Any]])` since https://github.com/pola-rs/polars/pull/22638"""
 
-HAS_UINT_128 = BACKEND_VERSION >= (1, 34, 0)
+HAS_UINT_128: Final[bool] = BACKEND_VERSION >= (1, 34, 0)
 """https://github.com/pola-rs/polars/pull/24346"""
+
+BINARY_ADD_UPCASTS_DECIMAL_TO_FLOAT: Final[bool] = BACKEND_VERSION >= (1, 34, 0)
+"""Polars >= 1.34 upcasts `Decimal + float` to `Float64` (matching `int`/`Float32` promotion).
+
+https://github.com/pola-rs/polars/pull/24594
+"""
 
 
 @overload

--- a/src/narwhals/expr.py
+++ b/src/narwhals/expr.py
@@ -2347,6 +2347,16 @@ class Expr:
         """
         return self._append_node(ExprNode(ExprKind.ELEMENTWISE, "sqrt"))
 
+    def _is_close_float_promote(self) -> Self:
+        # Promote to float for `is_close`, letting each backend pick the appropriate
+        # float type. Dispatched (rather than inlined as `self + 0.0`) so backends can
+        # align old behavior with current: e.g. Polars < 1.34 does not upcast
+        # `Decimal + float` to `Float64` in the lazy engine, which breaks the downstream
+        # `is_finite`/`clip`. See `PolarsExpr._is_close_float_promote`.
+        return self._append_node(
+            ExprNode(ExprKind.ELEMENTWISE, "_is_close_float_promote")
+        )
+
     def is_close(  # noqa: PLR0914
         self,
         other: Expr | Series[Any] | NumericLiteral,
@@ -2426,8 +2436,7 @@ class Expr:
         other_is_not_inf: Expr | Series[Any] | bool
 
         # Promote to float to handle non-float numeric types (e.g. Decimal, integers).
-        # Adding 0.0 lets each backend decide the appropriate float type.
-        self_f = self + 0.0
+        self_f = self._is_close_float_promote()
 
         if isinstance(other, (float, int, Decimal)):
             from math import isinf, isnan
@@ -2444,7 +2453,11 @@ class Expr:
             other_is_not_inf = not other_is_inf
 
         else:
-            other_f = other + 0.0
+            other_f = (
+                other._is_close_float_promote()
+                if isinstance(other, Expr)
+                else other + 0.0
+            )
             other_abs, other_is_nan = other_f.abs(), other_f.is_nan()
             other_is_not_inf = other_f.is_finite() | other_is_nan
             other_is_inf = ~other_is_not_inf

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -885,6 +885,24 @@ def test_join_on_null_values(
 # fmt: on
 
 
+@pytest.mark.parametrize(
+    ("how", "expected"),
+    [("semi", {"a": [1], "x": [10]}), ("anti", {"a": [2, None], "x": [20, 30]})],
+)
+def test_join_on_null_values_single_key(
+    constructor: Constructor, how: JoinStrategy, expected: dict[str, list[Any]]
+) -> None:
+    # Single-key semi/anti join: nulls must not match nulls. Polars < 0.20.22
+    # incorrectly matched `null == null` here (the two-key case in
+    # `test_join_on_null_values` only triggers it on 0.20.21).
+    # See https://github.com/narwhals-dev/narwhals/issues/3307
+    df_left = from_native_lazy(constructor({"a": [1, 2, None], "x": [10, 20, 30]}))
+    df_right = from_native_lazy(constructor({"a": [1, None], "y": [1.2, 3.4]}))
+
+    result = df_left.join(df_right, on="a", how=how).sort("a", nulls_last=True)
+    assert_equal_data(result, expected)
+
+
 @pytest.mark.filterwarnings(
     "ignore:.*Merging dataframes with merge column data type mismatches:UserWarning:dask"
 )


### PR DESCRIPTION
# Description

Related #3623

Fixes two polars failures that happens when running the random-version CI 

1. `is_close` raises on `Decimal` for polars `[1.1.0, 1.34.0)` The promotion is now a dispatched operation (`_is_close_float_promote`) so the polars backend can branch by version.

2. semi/anti join matches `null == null` for polars `< 0.20.22` in semi/anti joins

---

Run for all "old" versions that are in the matrix used for random version generation:

<details><summary>Commands</summary>
<p>

```terminal
uv run --isolated --with polars=="0.20.4"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.5"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.6"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.7"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.8"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.9"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.10"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.13"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.14"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.15"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.16"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.17"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.18"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.19"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.21"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.22"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.23"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.25"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.26"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.30"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="0.20.31"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="1.0.0"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
uv run --isolated --with polars=="1.1.0"  --group tests pytest --constructors "polars[eager],polars[lazy]" --runslow
```

</p>
</details> 


## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other
