### PR TITLE
fix: Include test data in sdist

### DIFF
--- a/.github/workflows/extremes.yml
+++ b/.github/workflows/extremes.yml
@@ -30,7 +30,7 @@ jobs:
           cache-suffix: min-versions-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
       - name: Run pytest
-        run: make run-ci DEPS="--group extreme-minimum-versions" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=50 --runslow --constructors=pandas,pyarrow,polars[eager],polars[lazy],duckdb"
+        run: make run-ci DEPS="--group extreme-minimum-versions --group plugins" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=50 --runslow --constructors=pandas,pyarrow,polars[eager],polars[lazy],duckdb"
 
   pretty_old_versions:
     strategy:
@@ -48,7 +48,7 @@ jobs:
           cache-suffix: pretty-old-versions-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
       - name: Run pytest
-        run: make run-ci DEPS="--group extreme-pretty-old-versions" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=50 --runslow --constructors=pandas,pyarrow,polars[eager],polars[lazy],duckdb"
+        run: make run-ci DEPS="--group extreme-pretty-old-versions --group plugins" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=50 --runslow --constructors=pandas,pyarrow,polars[eager],polars[lazy],duckdb"
 
   not_so_old_versions:
     strategy:
@@ -66,7 +66,7 @@ jobs:
           cache-suffix: not-so-old-versions-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
       - name: Run pytest
-        run: make run-ci DEPS="--group extreme-not-so-old-versions" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=50 --runslow --constructors=pandas,pyarrow,polars[eager],polars[lazy],dask,duckdb"
+        run: make run-ci DEPS="--group extreme-not-so-old-versions --group plugins" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=50 --runslow --constructors=pandas,pyarrow,polars[eager],polars[lazy],dask,duckdb"
 
   nightlies:
     strategy:
@@ -90,7 +90,7 @@ jobs:
       - name: Create venv
         run: uv venv --python ${{ matrix.python-version }}
       - name: install-reqs
-        run: uv pip install -e . --group tests
+        run: uv pip install -e . --group tests --group plugins
       - name: install polars pre-release
         run: |
           uv pip uninstall polars

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -75,6 +75,12 @@ jobs:
     permissions:
       contents: read
 
+  test-sdist:
+    name: Test sdist
+    uses: ./.github/workflows/test_sdist.yml
+    permissions:
+      contents: read
+
   build:
     name: Build distribution 📦
     needs:
@@ -86,6 +92,7 @@ jobs:
       - downstream-tests
       - check-docs-build
       - pre-commit-hooks
+      - test-sdist
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,7 +32,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: Run pytest
         shell: bash
-        run: make run-ci DEPS="--group tests --extra pandas --extra polars --extra pyarrow" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=75 --constructors=pandas,pyarrow,polars[eager],polars[lazy]"
+        run: make run-ci DEPS="--group tests --group plugins --extra pandas --extra polars --extra pyarrow" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=75 --constructors=pandas,pyarrow,polars[eager],polars[lazy]"
 
   pytest-windows:
     if: github.head_ref != 'bump-version'
@@ -53,7 +53,7 @@ jobs:
       # we are not testing pyspark, modin, or dask on Windows here because nobody got time for that
       - name: Run pytest
         shell: bash
-        run: make run-ci DEPS="--group core-tests --group extra --extra pandas" CMD="pytest tests --cov=src --cov=tests --runslow --cov-fail-under=95 --durations=30 --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe"
+        run: make run-ci DEPS="--group core-tests --group extra --group plugins --extra pandas" CMD="pytest tests --cov=src --cov=tests --runslow --cov-fail-under=95 --durations=30 --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe"
 
   pytest-full-coverage:
     if: github.head_ref != 'bump-version'
@@ -77,7 +77,7 @@ jobs:
           cache-suffix: pytest-full-coverage-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
       - name: Run pytest
-        run: make run-ci DEPS="--extra pandas --extra dask --group core-tests --group extra" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=100 --runslow --durations=30 --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
+        run: make run-ci DEPS="--extra pandas --extra dask --group core-tests --group extra --group plugins" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=100 --runslow --durations=30 --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
       - name: Run doctests
         # reprs differ between versions, so we only run doctests on the latest Python
         if: matrix.python-version == '3.13'
@@ -126,7 +126,7 @@ jobs:
           cache-suffix: python-314-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
       - name: Run pytest
-        run: make run-ci DEPS="--group core-tests --extra pandas" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=50 --runslow --durations=30 --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe"
+        run: make run-ci DEPS="--group core-tests --group plugins --extra pandas" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=50 --runslow --durations=30 --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe"
 
   python-314t:
     if: github.head_ref != 'bump-version'
@@ -148,4 +148,4 @@ jobs:
           cache-suffix: python-314t-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
       - name: Run pytest
-        run: make run-ci DEPS="--pre --group tests --extra pandas --extra pyarrow" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=50 --runslow --durations=30 --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow"
+        run: make run-ci DEPS="--pre --group tests --group plugins --extra pandas --extra pyarrow" CMD="pytest tests --cov=src --cov=tests --cov-fail-under=50 --runslow --durations=30 --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow"

--- a/.github/workflows/random_ci_pytest.yml
+++ b/.github/workflows/random_ci_pytest.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Generate random versions
         run: uv run --no-project python utils/generate_random_versions.py
       - name: Show dependencies
-        run: uv pip compile random-requirements.txt --group tests
+        run: uv pip compile random-requirements.txt --group tests --group plugins
       - name: Run pytest with random versions
         run: |
-          uv run --group tests --with-requirements random-requirements.txt \
+          uv run --group tests --group plugins --with-requirements random-requirements.txt \
           pytest tests --cov=src --cov=tests --cov-fail-under=75 \
           --constructors="pandas,pyarrow,polars[eager],polars[lazy]"

--- a/.github/workflows/test_sdist.yml
+++ b/.github/workflows/test_sdist.yml
@@ -1,0 +1,68 @@
+name: Test sdist is installable and self-contained
+
+# Builds the sdist, unpacks it OUTSIDE the repo (so there is no workspace,
+# mirroring a downstream packager unpacking the PyPI tarball), installs it with
+# the `tests` dependency group via plain `pip`, and runs the test suite from the
+# unpacked tree. This guards against regressions like https://github.com/narwhals-dev/narwhals/pull/3664,
+# where the sdist shipped without `tests/data/` and the suite could not run from the tarball.
+#
+# NOTE: `pip` (not `uv pip`) is used on purpose.
+
+on:
+  pull_request:
+  workflow_call:
+
+env:
+  PY_COLORS: 1
+  PYTEST_ADDOPTS: "--numprocesses=logical"
+
+permissions:
+  contents: read
+
+jobs:
+  test-sdist:
+    if: github.head_ref != 'bump-version'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.13"
+          enable-cache: "true"
+          cache-suffix: test-sdist
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Build the sdist
+        run: uv build --sdist
+
+      - name: Unpack the sdist outside the repo
+        run: |
+          mkdir -p "${RUNNER_TEMP}/sdist"
+          tar xzf dist/*.tar.gz -C "${RUNNER_TEMP}/sdist"
+          # Fail loudly if the workspace leaked into the tarball: its presence
+          # would mask exactly the kind of bug this job is meant to catch.
+          if [ -d "${RUNNER_TEMP}/sdist"/narwhals-*/packages ]; then
+            echo "::error::Unexpected 'packages/' (workspace) directory inside the sdist"
+            exit 1
+          fi
+
+      - name: Create an isolated venv with a recent pip
+        run: |
+          uv venv "${RUNNER_TEMP}/venv" --python 3.13
+          uv pip install --python "${RUNNER_TEMP}/venv" "pip>=25.1"
+
+      - name: Install the unpacked sdist with the tests group (via pip)
+        run: |
+          src=$(echo "${RUNNER_TEMP}/sdist"/narwhals-*)
+          "${RUNNER_TEMP}/venv/bin/python" -m pip install \
+            "${src}[pandas,pyarrow,polars]" \
+            --group "${src}/pyproject.toml:tests"
+
+      - name: Run the test suite from the unpacked sdist
+        run: |
+          # Validate that the sdist is complete and usable
+          src=$(echo "${RUNNER_TEMP}/sdist"/narwhals-*)
+          cd "${src}"
+          "${RUNNER_TEMP}/venv/bin/python" -m pytest tests \
+            --constructors="pandas,pyarrow,polars[eager],polars[lazy]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,15 @@ tests = [
   "pytest-randomly",
   "pytest-xdist",
   "hypothesis>=6.0.0",
-  {include-group = "plugins"},
 ]
+# NOTE: `plugins` is deliberately NOT included within `tests`.
+# `test-plugin` is a workspace member, so pulling it into `tests` makes the group unresolvable
+# outside the workspace (e.g. `pip install --group tests` from an unpacked sdist,
+# as hit by downstream packagers). `tests/plugins_test.py` uses `importorskip`,
+# so it skips gracefully when the plugin is absent.
+# CI jobs that measure `tests/` coverage add `--group plugins` explicitly.
+# See https://github.com/narwhals-dev/narwhals/pull/3664 and https://github.com/narwhals-dev/narwhals/pull/3665
+
 extra = [  # heavier dependencies we don't necessarily need in every testing job
   "scikit-learn",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,13 +176,12 @@ min-pyspark-version = [
 ]
 
 [tool.uv.build-backend]
-source-include = [
-  "src/*",
-  "tests/*",
-]
-wheel-include = [
-  "src/*",
-]
+# The `src/narwhals` module, pyproject.toml, README and LICENSE are shipped by
+# default. We only need to add `tests/` to the sdist; `/**` recurses into
+# subdirectories (a bare `*` would not, dropping e.g. `tests/data/`).
+# See: https://docs.astral.sh/uv/reference/settings/#build-backend_source-exclude
+# > Glob expressions which files and directories to additionally include in the source distribution.
+source-include = ["tests/**"]
 
 [tool.uv]
 # NOTE: When updating these conflicts, every entry in a single inner list is

--- a/utils/check_dist_content.py
+++ b/utils/check_dist_content.py
@@ -1,5 +1,7 @@
+# ruff: noqa: S603, S607
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 from tarfile import TarFile
@@ -9,35 +11,77 @@ dist_path = Path("dist")
 wheel_path = next(dist_path.glob("*.whl"))
 sdist_path = next(dist_path.glob("*.tar.gz"))
 
+
+def git_tracked(*pathspecs: str) -> set[str]:
+    """Return the set of git-tracked files under the given pathspecs.
+
+    This is the source of truth for what *must* end up in the distributions:
+    if a file is tracked under `src/` or `tests/` it has to be shipped.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "-z", *pathspecs], capture_output=True, text=True, check=True
+    )
+    return {name for name in result.stdout.split("\0") if name}
+
+
+tracked_src = git_tracked("src")
+tracked_tests = git_tracked("tests")
+
+errors: list[str] = []
+
 with ZipFile(wheel_path) as wheel_file:
-    # Allow only 'narwhals' and 'narwhals-<version>.dist-info' (metadata)
+    wheel_names = set(wheel_file.namelist())
+
+    # Allow only 'narwhals' and 'narwhals-<version>.dist-info' (metadata).
     unexpected_wheel_dirs = {
         dir_name
-        for name in wheel_file.namelist()
+        for name in wheel_names
         if not (dir_name := name.split("/")[0]).startswith("narwhals")
     }
-
     if unexpected_wheel_dirs:
-        print(f"🚨 Unexpected directories in wheel: {unexpected_wheel_dirs}")
-        sys.exit(1)
+        errors.append(f"Unexpected directories in wheel: {unexpected_wheel_dirs}")
+
+    # Every tracked source file must ship in the wheel: `src/narwhals/X` -> `narwhals/X`.
+    missing_wheel = {
+        name for name in tracked_src if name.removeprefix("src/") not in wheel_names
+    }
+    if missing_wheel:
+        errors.append(f"Source files missing from wheel: {sorted(missing_wheel)}")
 
 with TarFile.open(sdist_path, mode="r:gz") as sdist_file:
-    # Allow only 'narwhals' and 'tests' folders, and some extra files
-    sdist_dirs = {
-        parts[1] for m in sdist_file.getmembers() if len(parts := m.name.split("/")) > 1
+    # Members are prefixed with 'narwhals-<version>/'; strip that leading component.
+    sdist_names = {
+        rest
+        for m in sdist_file.getmembers()
+        if m.isfile() and len(parts := m.name.split("/", 1)) == 2 and (rest := parts[1])
     }
-    allowed_sdist_dirs = {
+
+    # Top-level entries that must always be present (source dirs + metadata).
+    required_sdist_top_level = {
         "src",
         "tests",
         "pyproject.toml",
         "PKG-INFO",
         "LICENSE.md",
         "README.md",
-        ".gitignore",
     }
 
-    if unexpected_sdist_dirs := sdist_dirs - allowed_sdist_dirs:
-        print(f"🚨 Unexpected directories or files in sdist: {unexpected_sdist_dirs}")
-        sys.exit(1)
+    sdist_top_level = {name.split("/")[0] for name in sdist_names}
+    if unexpected := sdist_top_level - required_sdist_top_level:
+        errors.append(f"Unexpected top-level entries in sdist: {unexpected}")
+    if missing := required_sdist_top_level - sdist_top_level:
+        errors.append(f"Missing required top-level entries in sdist: {missing}")
 
+    # Every tracked file under src/ and tests/ must ship in the sdist.
+    # This is the check that guards against regressions like incomplete glob patterns
+    # dropping `tests/data/` or other nested directories (see issue #3664).
+    if missing_sdist := (tracked_src | tracked_tests) - sdist_names:
+        errors.append(f"Tracked files missing from sdist: {sorted(missing_sdist)}")
+
+if errors:
+    for error in errors:
+        print(f"🚨 {error}")
+    sys.exit(1)
+
+print("✅ Distribution content looks good.")
 sys.exit(0)

--- a/uv.lock
+++ b/uv.lock
@@ -1882,7 +1882,6 @@ core-tests = [
     { name = "pytest-env" },
     { name = "pytest-randomly" },
     { name = "pytest-xdist" },
-    { name = "test-plugin" },
 ]
 dev = [
     { name = "covdefaults" },
@@ -1894,7 +1893,6 @@ dev = [
     { name = "pytest-randomly" },
     { name = "pytest-xdist" },
     { name = "ruff" },
-    { name = "test-plugin" },
 ]
 dev-core = [
     { name = "covdefaults" },
@@ -1910,7 +1908,6 @@ dev-core = [
     { name = "pytest-randomly" },
     { name = "pytest-xdist" },
     { name = "ruff" },
-    { name = "test-plugin" },
 ]
 docs = [
     { name = "black" },
@@ -1949,7 +1946,6 @@ extreme-minimum-versions = [
     { name = "scikit-learn", version = "1.1.0", source = { registry = "https://pypi.org/simple" } },
     { name = "scipy", version = "1.7.3", source = { registry = "https://pypi.org/simple" } },
     { name = "setuptools" },
-    { name = "test-plugin" },
     { name = "tzdata" },
 ]
 extreme-not-so-old-versions = [
@@ -1970,7 +1966,6 @@ extreme-not-so-old-versions = [
     { name = "scikit-learn", version = "1.3.0", source = { registry = "https://pypi.org/simple" } },
     { name = "scipy", version = "1.8.0", source = { registry = "https://pypi.org/simple" } },
     { name = "setuptools" },
-    { name = "test-plugin" },
     { name = "tzdata" },
 ]
 extreme-pretty-old-versions = [
@@ -1990,7 +1985,6 @@ extreme-pretty-old-versions = [
     { name = "scikit-learn", version = "1.1.0", source = { registry = "https://pypi.org/simple" } },
     { name = "scipy", version = "1.8.0", source = { registry = "https://pypi.org/simple" } },
     { name = "setuptools" },
-    { name = "test-plugin" },
     { name = "tzdata" },
 ]
 local-dev = [
@@ -2028,7 +2022,6 @@ min-pyspark-version = [
     { name = "pytest-env" },
     { name = "pytest-randomly" },
     { name = "pytest-xdist" },
-    { name = "test-plugin" },
 ]
 plugins = [
     { name = "test-plugin" },
@@ -2041,7 +2034,6 @@ tests = [
     { name = "pytest-env" },
     { name = "pytest-randomly" },
     { name = "pytest-xdist" },
-    { name = "test-plugin" },
 ]
 typing = [
     { name = "hypothesis" },
@@ -2097,7 +2089,6 @@ core-tests = [
     { name = "pytest-env" },
     { name = "pytest-randomly" },
     { name = "pytest-xdist" },
-    { name = "test-plugin", editable = "packages/test-plugin" },
 ]
 dev = [
     { name = "covdefaults" },
@@ -2109,7 +2100,6 @@ dev = [
     { name = "pytest-randomly" },
     { name = "pytest-xdist" },
     { name = "ruff" },
-    { name = "test-plugin", editable = "packages/test-plugin" },
 ]
 dev-core = [
     { name = "covdefaults" },
@@ -2124,7 +2114,6 @@ dev-core = [
     { name = "pytest-randomly" },
     { name = "pytest-xdist" },
     { name = "ruff" },
-    { name = "test-plugin", editable = "packages/test-plugin" },
 ]
 docs = [
     { name = "black", specifier = ">=26.3.1" },
@@ -2154,7 +2143,6 @@ extreme-minimum-versions = [
     { name = "scikit-learn", specifier = "==1.1.0" },
     { name = "scipy", specifier = "==1.7.3" },
     { name = "setuptools" },
-    { name = "test-plugin", editable = "packages/test-plugin" },
     { name = "tzdata" },
 ]
 extreme-not-so-old-versions = [
@@ -2175,7 +2163,6 @@ extreme-not-so-old-versions = [
     { name = "scikit-learn", specifier = "==1.3.0" },
     { name = "scipy", specifier = "==1.8.0" },
     { name = "setuptools" },
-    { name = "test-plugin", editable = "packages/test-plugin" },
     { name = "tzdata" },
 ]
 extreme-pretty-old-versions = [
@@ -2195,7 +2182,6 @@ extreme-pretty-old-versions = [
     { name = "scikit-learn", specifier = "==1.1.0" },
     { name = "scipy", specifier = "==1.8.0" },
     { name = "setuptools" },
-    { name = "test-plugin", editable = "packages/test-plugin" },
     { name = "tzdata" },
 ]
 local-dev = [
@@ -2232,7 +2218,6 @@ min-pyspark-version = [
     { name = "pytest-env" },
     { name = "pytest-randomly" },
     { name = "pytest-xdist" },
-    { name = "test-plugin", editable = "packages/test-plugin" },
 ]
 plugins = [{ name = "test-plugin", editable = "packages/test-plugin" }]
 tests = [
@@ -2243,7 +2228,6 @@ tests = [
     { name = "pytest-env" },
     { name = "pytest-randomly" },
     { name = "pytest-xdist" },
-    { name = "test-plugin", editable = "packages/test-plugin" },
 ]
 typing = [
     { name = "hypothesis", specifier = ">=6.0.0" },


### PR DESCRIPTION
# Description

The `tool.uv.build-backend` include patterns used a single-level glob (`tests/*`), which does not recurse into subdirectories. This PR changes:

* `pyproject.toml`: replace `tests/*` with `tests/**` so the whole tree is shipped. Dropped the redundant `src/**/*` / `wheel-include` entries: the `src/narwhals` module is included by default in both sdist and wheel.
* `utils/check_dist_content.py`: the old check only inspected top-level entries, so a present-but-empty `tests/` passed. It now diffs the dist against `git ls-files src tests` and fails if any tracked source/test file is missing from the sdist (and any module file from the wheel), catching this class of regression.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3664

