### PR TITLE
test(expr-ir): Fix invalid tests

### DIFF
--- a/tests/plan/coalesce_test.py
+++ b/tests/plan/coalesce_test.py
@@ -71,9 +71,14 @@ def test_coalesce_strings(
 def test_coalesce_series(data_str: Data, dataframe: DataFrame) -> None:
     df = dataframe(data_str)
     ser = df.get_column("b").alias("b_renamed")
-    exprs = nwp.coalesce(ser, "a", nwp.col("c").fill_null("filled")), nwp.lit("ignored")
-    result = df.select(exprs)
-    assert_equal_data(result, {"b_renamed": ["1", "filled", "3", "5", "3"]})
+    result = df.select(
+        nwp.coalesce(ser, "a", nwp.col("c").fill_null("filled")), nwp.lit("not coalesced")
+    )
+    expected = {
+        "b_renamed": ["1", "filled", "3", "5", "3"],
+        "literal": ["not coalesced"] * 5,
+    }
+    assert_equal_data(result, expected)
 
 
 def test_coalesce_raises_non_expr() -> None:

--- a/tests/plan/compliant_test.py
+++ b/tests/plan/compliant_test.py
@@ -117,7 +117,16 @@ def _ids_ir(expr: nwp.Expr | Any) -> str:
         pytest.param(
             nwp.lit(1).cast(nw.Float64()).name.suffix("_cast"), {"literal_cast": [1.0]}
         ),
-        ([ncs.string().first(), nwp.col("b")], {"a": ["A", "A", "A"], "b": [1, 2, 3]}),
+        pytest.param(
+            [ncs.string().first(), nwp.col("b")],
+            {
+                "a": ["A", "A", "A"],
+                "n": ["dogs", "dogs", "dogs"],
+                "o": ["play", "play", "play"],
+                "b": [1, 2, 3],
+            },
+            id="[ncs.string().first(), col('b')]",
+        ),
         (
             nwp.col("c", "d")
             .sort_by("a", "b", descending=[True, False])

--- a/tests/plan/is_in_test.py
+++ b/tests/plan/is_in_test.py
@@ -115,7 +115,9 @@ def test_expr_is_in_series(data: Data, dataframe: DataFrame) -> None:
     a_ser = df.get_column("a")
     b_ser = df.get_column("b")
 
-    assert_equal_data(df.filter(a.is_in(b_ser)), {"a": [1, 2], "b": [1, 2]})
+    assert_equal_data(
+        df.filter(a.is_in(b_ser)), {"a": [1, 2], "b": [1, 2], "c": [None, "hello"]}
+    )
     assert_equal_data(df.select(a_last.is_in(b_ser)), {"a": [False]})
     assert_equal_data(df.select(a_first.is_in(b_ser)), {"a": [True]})
     assert_equal_data(df.select((a_last - a_first).is_in(a_ser)), {"a": [True]})

--- a/tests/plan/unnest_test.py
+++ b/tests/plan/unnest_test.py
@@ -92,7 +92,12 @@ def test_unnest_frame_multi_struct(data: Data, dataframe: DataFrame) -> None:
     )
     assert_equal_data(df.unnest(name_1, name_2), expected_identical_input)
     assert_equal_data(df.unnest(ncs.struct()), expected_identical_input)
-    assert_equal_data(df.unnest(ncs.by_index(2, 1)), expected_reorder)
+
+    # Unnest does not reorder columns
+    flipped = ncs.by_index(2, 1)
+    assert_equal_data(df.unnest(flipped), expected_identical_input)
+    # You'd need to do that yourself
+    assert_equal_data(df.select(BEFORE, flipped, AFTER).unnest(flipped), expected_reorder)
 
 
 def test_unnest_frame_invalid_operation_error(data: Data, dataframe: DataFrame) -> None:

--- a/tests/plan/utils.py
+++ b/tests/plan/utils.py
@@ -693,6 +693,8 @@ def assert_equal_data(
     got = result.to_dict(as_series=False)
     if check_column_order:
         _assert_column_names_equal(got, expected)
+    else:  # pragma: no cover
+        ...
     _assert_equal_data(got, expected)
 
 

--- a/tests/plan/utils.py
+++ b/tests/plan/utils.py
@@ -680,7 +680,6 @@ else:
         return nwp.DataFrame.from_native(pa.Table.from_pydict(data))
 
 
-# TODO @dangotbanned: Investigate the tests which are failing on `True`
 def assert_equal_data(
     result: nwp.DataFrame[Any, Any],
     expected: Mapping[str, Any] | nwp.DataFrame[Any, Any],

--- a/tests/plan/utils.py
+++ b/tests/plan/utils.py
@@ -685,7 +685,7 @@ def assert_equal_data(
     result: nwp.DataFrame[Any, Any],
     expected: Mapping[str, Any] | nwp.DataFrame[Any, Any],
     *,
-    check_column_order: bool = False,
+    check_column_order: bool = True,
 ) -> None:
     """Adds ordering checks, which aren't part of `tests.utils.assert_equal_data`."""
     __tracebackhide__ = True


### PR DESCRIPTION
# Description
Split out from #3666, since I had to touch unrelated tests.

In (https://github.com/narwhals-dev/narwhals/pull/3666/commits/618ba991549a59a8eb41a0c2bd4ae454c4b7e73c) discovered `assert_equal_data`  silently let through:
- Results that have columns in the wrong order
- Results that have more columns than `expected`

**luckily everything here was a buggy test**, but cc @FBruzzesi, @MarcoGorelli as there *may* be issues on `main` 😬

## Related issues

- Child of #3666
- Would've been caught by #3221

