### PR TITLE
fix: reject `eager_only` with an already-narwhals LazyFrame

### DIFF
--- a/src/narwhals/translate.py
+++ b/src/narwhals/translate.py
@@ -284,6 +284,13 @@ def _from_native_impl(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
     # Early returns
     if isinstance(native_object, (DataFrame, LazyFrame)) and not series_only:
+        if isinstance(native_object, LazyFrame) and (
+            eager_only or eager_or_interchange_only
+        ):
+            if not pass_through:
+                msg = "Cannot only use `eager_only` or `eager_or_interchange_only` with lazyframe"
+                raise TypeError(msg)
+            return native_object
         if native_object._version is version:
             return native_object
 

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -233,7 +233,7 @@ def test_init_already_narwhals_lazy_eager_only() -> None:
     # like a native one (https://github.com/narwhals-dev/narwhals/issues/3226).
     lf = nw.from_native(pl.LazyFrame({"a": [1, 2, 3]}))
     with pytest.raises(TypeError, match="Cannot only use `eager_only`"):
-        nw.from_native(lf, eager_only=True)
+        nw.from_native(lf, eager_only=True)  # type: ignore[call-overload]
     # `pass_through` returns the frame unchanged instead of raising.
     assert nw.from_native(lf, eager_only=True, pass_through=True) is lf
     # An already-narwhals DataFrame is eager, so `eager_only` is a no-op.

--- a/tests/translate/from_native_test.py
+++ b/tests/translate/from_native_test.py
@@ -228,6 +228,20 @@ def test_init_already_narwhals_unstable() -> None:
 
 
 @pytest.mark.skipif(lf_pl is None, reason="polars not found")
+def test_init_already_narwhals_lazy_eager_only() -> None:
+    # An already-narwhals LazyFrame must still be rejected by `eager_only`, just
+    # like a native one (https://github.com/narwhals-dev/narwhals/issues/3226).
+    lf = nw.from_native(pl.LazyFrame({"a": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="Cannot only use `eager_only`"):
+        nw.from_native(lf, eager_only=True)
+    # `pass_through` returns the frame unchanged instead of raising.
+    assert nw.from_native(lf, eager_only=True, pass_through=True) is lf
+    # An already-narwhals DataFrame is eager, so `eager_only` is a no-op.
+    df = nw.from_native(pl.DataFrame({"a": [1, 2, 3]}))
+    assert nw.from_native(df, eager_only=True) is df
+
+
+@pytest.mark.skipif(lf_pl is None, reason="polars not found")
 def test_init_already_narwhals_unstable_to_stable() -> None:
     from narwhals.stable import v1 as nw_v1
 


### PR DESCRIPTION
Closes #3226.

`from_native` has an early-return for an object that is *already* a narwhals `DataFrame`/`LazyFrame`, returning it before the `eager_only` / `eager_or_interchange_only` validation runs (`_translate_if_compliant` enforces it, but the early return skips that path). So a native `pl.LazyFrame` was correctly rejected:

```python
nw.from_native(pl.LazyFrame(), eager_only=True)  # TypeError ✅
```

but an already-narwhals one slipped through and was returned unchanged:

```python
lf = nw.from_native(pl.LazyFrame())
nw.from_native(lf, eager_only=True)  # returned the LazyFrame ❌ (should raise)
```

This adds the same guard in the early-return path: a narwhals `LazyFrame` with `eager_only`/`eager_or_interchange_only` now raises (or is returned unchanged under `pass_through=True`), while a narwhals `DataFrame` (which is eager) is still accepted. Regression test added (fails on `main`).

One note: `narwhals.stable.v1.from_native` has the same early-return short-circuit (before it calls `_from_native_impl`), so the v1 entrypoint still passes a narwhals `LazyFrame` through. I left v1 untouched since it's the frozen stable API and the fix there needs the `pass_through` resolution moved above the early return — happy to apply the same guard there if you'd like.