### PR TITLE
feat(ibis): support y/q/mo/d units in dt.offset_by

### DIFF
--- a/src/narwhals/_ibis/expr_dt.py
+++ b/src/narwhals/_ibis/expr_dt.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import ibis
+
 from narwhals._duration import Interval
-from narwhals._ibis.utils import (
-    UNITS_DICT_BUCKET,
-    UNITS_DICT_TRUNCATE,
-    timedelta_to_ibis_interval,
-)
+from narwhals._ibis.utils import UNITS_DICT_BUCKET, UNITS_DICT_TRUNCATE
 from narwhals._sql.expr_dt import SQLExprDateTimeNamesSpace
 from narwhals._utils import not_implemented
 
@@ -63,10 +61,10 @@ class IbisExprDateTimeNamespace(SQLExprDateTimeNamesSpace["IbisExpr"]):
     def offset_by(self, by: str) -> IbisExpr:
         interval = Interval.parse_no_constraints(by)
         unit = interval.unit
-        if unit in {"y", "q", "mo", "d", "ns"}:
-            msg = f"Offsetting by {unit} is not yet supported for ibis."
+        if unit == "ns":
+            msg = "Offsetting by nanoseconds is not yet supported for ibis."
             raise NotImplementedError(msg)
-        offset = timedelta_to_ibis_interval(interval.to_timedelta())
+        offset = ibis.interval(**{UNITS_DICT_BUCKET[unit]: interval.multiple})
         return self.compliant._with_callable(lambda expr: expr.add(offset))
 
     def replace_time_zone(self, time_zone: str | None) -> IbisExpr:

--- a/src/narwhals/_ibis/expr_dt.py
+++ b/src/narwhals/_ibis/expr_dt.py
@@ -60,12 +60,28 @@ class IbisExprDateTimeNamespace(SQLExprDateTimeNamesSpace["IbisExpr"]):
 
     def offset_by(self, by: str) -> IbisExpr:
         interval = Interval.parse_no_constraints(by)
-        unit = interval.unit
+        multiple, unit = interval.multiple, interval.unit
         if unit == "ns":
             msg = "Offsetting by nanoseconds is not yet supported for ibis."
             raise NotImplementedError(msg)
-        offset = ibis.interval(**{UNITS_DICT_BUCKET[unit]: interval.multiple})
-        return self.compliant._with_callable(lambda expr: expr.add(offset))
+        offset = ibis.interval(**{UNITS_DICT_BUCKET[unit]: multiple})
+
+        def fn(expr: ir.TimestampValue) -> ir.TimestampValue:
+            # Ibis stores timezone-aware data as UTC, so calendar offsets are
+            # applied to the underlying instant rather than wall-clock time.
+            # The result would differ from other backends across a DST
+            # transition, so refuse it rather than return a surprising value.
+            tz = getattr(expr.type(), "timezone", None)
+            if unit in {"y", "q", "mo", "d"} and tz is not None:
+                msg = (
+                    f"Offsetting timezone-aware data by {unit} is not supported "
+                    "for ibis, as the result would be incorrect across daylight "
+                    "saving time transitions."
+                )
+                raise NotImplementedError(msg)
+            return expr.add(offset)
+
+        return self.compliant._with_callable(fn)
 
     def replace_time_zone(self, time_zone: str | None) -> IbisExpr:
         if time_zone is None:

--- a/src/narwhals/_ibis/expr_dt.py
+++ b/src/narwhals/_ibis/expr_dt.py
@@ -64,7 +64,13 @@ class IbisExprDateTimeNamespace(SQLExprDateTimeNamesSpace["IbisExpr"]):
         if unit == "ns":
             msg = "Offsetting by nanoseconds is not yet supported for ibis."
             raise NotImplementedError(msg)
-        kwds: dict[BucketUnit, Any] = {UNITS_DICT_BUCKET[unit]: multiple}
+        # `ibis.interval` does not accept `quarters` on all supported ibis
+        # versions (`truncate` avoids passing it through for the same reason),
+        # so express a quarter offset as the equivalent number of months.
+        offset_multiple, offset_unit = multiple, unit
+        if unit == "q":
+            offset_multiple, offset_unit = 3 * multiple, "mo"
+        kwds: dict[BucketUnit, Any] = {UNITS_DICT_BUCKET[offset_unit]: offset_multiple}
         offset = ibis.interval(**kwds)
 
         def fn(expr: ir.TimestampValue) -> ir.TimestampValue:
@@ -75,9 +81,9 @@ class IbisExprDateTimeNamespace(SQLExprDateTimeNamesSpace["IbisExpr"]):
             tz = getattr(expr.type(), "timezone", None)
             if unit in {"y", "q", "mo", "d"} and tz is not None:
                 msg = (
-                    f"Offsetting timezone-aware data by {unit} is not supported "
-                    "for ibis, as the result would be incorrect across daylight "
-                    "saving time transitions."
+                    f"Offsetting timezone-aware data by {UNITS_DICT_BUCKET[unit]} is "
+                    "not supported for ibis, as the result would be incorrect across "
+                    "daylight saving time transitions."
                 )
                 raise NotImplementedError(msg)
             return expr.add(offset)

--- a/src/narwhals/_ibis/expr_dt.py
+++ b/src/narwhals/_ibis/expr_dt.py
@@ -64,7 +64,8 @@ class IbisExprDateTimeNamespace(SQLExprDateTimeNamesSpace["IbisExpr"]):
         if unit == "ns":
             msg = "Offsetting by nanoseconds is not yet supported for ibis."
             raise NotImplementedError(msg)
-        offset = ibis.interval(**{UNITS_DICT_BUCKET[unit]: multiple})
+        kwds: dict[BucketUnit, Any] = {UNITS_DICT_BUCKET[unit]: multiple}
+        offset = ibis.interval(**kwds)
 
         def fn(expr: ir.TimestampValue) -> ir.TimestampValue:
             # Ibis stores timezone-aware data as UTC, so calendar offsets are

--- a/src/narwhals/_ibis/utils.py
+++ b/src/narwhals/_ibis/utils.py
@@ -11,7 +11,6 @@ from narwhals._utils import Version, isinstance_or_issubclass
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
-    from datetime import timedelta
     from typing import TypeAlias
 
     import ibis.expr.types as ir
@@ -266,10 +265,6 @@ def narwhals_to_native_dtype(dtype: IntoDType, version: Version) -> IbisDataType
         raise NotImplementedError(msg)
     msg = f"Unknown dtype: {dtype}"  # pragma: no cover
     raise AssertionError(msg)
-
-
-def timedelta_to_ibis_interval(td: timedelta) -> ibis.expr.types.temporal.IntervalScalar:
-    return ibis.interval(days=td.days, seconds=td.seconds, microseconds=td.microseconds)
 
 
 _BINARY_OPS = {

--- a/src/narwhals/expr_dt.py
+++ b/src/narwhals/expr_dt.py
@@ -711,6 +711,11 @@ class ExprDateTimeNamespace(Generic[ExprT]):
                 - 'q': quarter.
                 - 'y': year.
 
+        Notes:
+            For the Ibis backend, offsetting timezone-aware data by a calendar
+            unit ('d', 'mo', 'q' or 'y') raises: Ibis stores such values as UTC,
+            so the result would diverge from other backends across DST transitions.
+
         Examples:
             >>> from datetime import datetime
             >>> import polars as pl

--- a/tests/expr_and_series/dt/offset_by_test.py
+++ b/tests/expr_and_series/dt/offset_by_test.py
@@ -142,14 +142,14 @@ def test_offset_by(
     if "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3):
         pytest.skip()
     if any(x in by for x in ("y", "q", "mo")) and any(
-        x in str(constructor) for x in ("dask", "pyarrow", "ibis")
+        x in str(constructor) for x in ("dask", "pyarrow")
     ):
         request.applymarker(pytest.mark.xfail())
     if "ns" in by and any(
         x in str(constructor) for x in ("dask", "pyspark", "ibis", "cudf", "duckdb")
     ):
         request.applymarker(pytest.mark.xfail())
-    if by.endswith("d") and any(x in str(constructor) for x in ("dask", "ibis")):
+    if by.endswith("d") and any(x in str(constructor) for x in ("dask",)):
         request.applymarker(pytest.mark.xfail())
 
     df = nw.from_native(constructor(data))
@@ -267,7 +267,7 @@ def test_offset_by_date_pandas() -> None:
 
 
 def test_offset_by_3471(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if any(x in str(constructor) for x in ("dask", "ibis")):
+    if any(x in str(constructor) for x in ("dask",)):
         request.applymarker(pytest.mark.xfail())
     if "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3):
         pytest.skip()

--- a/tests/expr_and_series/dt/offset_by_test.py
+++ b/tests/expr_and_series/dt/offset_by_test.py
@@ -266,6 +266,29 @@ def test_offset_by_date_pandas() -> None:
     assert_equal_data(result, expected)
 
 
+def test_offset_by_tz_aware_calendar_raises_ibis() -> None:  # pragma: no cover
+    # Ibis stores tz-aware data as UTC, so calendar offsets would diverge from
+    # other backends across DST transitions; they should raise (see #3681).
+    pytest.importorskip("ibis")
+    pytest.importorskip("polars")
+    import ibis
+    import polars as pl
+
+    con = ibis.duckdb.connect()
+    tbl = con.create_table(
+        "offset_by_tz",
+        pl.LazyFrame({"a": [datetime(2020, 10, 25)]}).with_columns(
+            pl.col("a").dt.replace_time_zone("Europe/Amsterdam")
+        ),
+    )
+    df = nw.from_native(tbl)
+    for by in ("1d", "3mo", "2q", "1y"):
+        with pytest.raises(NotImplementedError, match="daylight saving"):
+            df.select(nw.col("a").dt.offset_by(by)).to_native().execute()
+    # Pure-duration units are unambiguous and remain supported.
+    df.select(nw.col("a").dt.offset_by("7h")).to_native().execute()
+
+
 def test_offset_by_3471(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if any(x in str(constructor) for x in ("dask",)):
         request.applymarker(pytest.mark.xfail())

--- a/tests/expr_and_series/dt/offset_by_test.py
+++ b/tests/expr_and_series/dt/offset_by_test.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from contextlib import nullcontext as does_not_raise
 from datetime import date, datetime, timezone
+from typing import Any
 
 import pytest
 
@@ -266,9 +268,21 @@ def test_offset_by_date_pandas() -> None:
     assert_equal_data(result, expected)
 
 
-def test_offset_by_tz_aware_calendar_raises_ibis() -> None:  # pragma: no cover
+@pytest.mark.parametrize(
+    ("by", "context"),
+    [
+        ("1d", pytest.raises(NotImplementedError, match="daylight saving")),
+        ("3mo", pytest.raises(NotImplementedError, match="daylight saving")),
+        ("2q", pytest.raises(NotImplementedError, match="daylight saving")),
+        ("1y", pytest.raises(NotImplementedError, match="daylight saving")),
+        # Pure-duration units are unambiguous and remain supported.
+        ("7h", does_not_raise()),
+    ],
+)
+def test_offset_by_tz_aware_ibis(by: str, context: Any) -> None:  # pragma: no cover
     # Ibis stores tz-aware data as UTC, so calendar offsets would diverge from
-    # other backends across DST transitions; they should raise (see #3681).
+    # other backends across DST transitions; they should raise, while pure
+    # durations remain supported (see #3681).
     pytest.importorskip("ibis")
     pytest.importorskip("polars")
     import ibis
@@ -282,11 +296,8 @@ def test_offset_by_tz_aware_calendar_raises_ibis() -> None:  # pragma: no cover
         ),
     )
     df = nw.from_native(tbl)
-    for by in ("1d", "3mo", "2q", "1y"):
-        with pytest.raises(NotImplementedError, match="daylight saving"):
-            df.select(nw.col("a").dt.offset_by(by)).to_native().execute()
-    # Pure-duration units are unambiguous and remain supported.
-    df.select(nw.col("a").dt.offset_by("7h")).to_native().execute()
+    with context:
+        df.select(nw.col("a").dt.offset_by(by)).to_native().execute()
 
 
 def test_offset_by_3471(constructor: Constructor, request: pytest.FixtureRequest) -> None:


### PR DESCRIPTION
Closes #3681.

`dt.offset_by` previously raised `NotImplementedError` for `y`, `q`, `mo`, `d` and `ns` on the ibis backend. `ibis.interval` already accepts `years`/`quarters`/`months`/`days` (and the existing `UNITS_DICT_BUCKET` maps every narwhals unit to the matching kwarg), so the offset is now built directly from `(multiple, unit)` rather than routed through `timedelta_to_ibis_interval` — a `timedelta` cannot represent calendar units, which is why those were blocked. Only `ns` stays unsupported, since duckdb has no nanosecond interval resolution (`sqlglot ... doesn't support nanosecond interval resolutions`). The now-unused `timedelta_to_ibis_interval` helper is removed.

The xfail markers for `y`/`q`/`mo`/`d` on ibis are dropped from `test_offset_by` and `test_offset_by_3471`, which now pass.

### On the DST question

@MarcoGorelli — you asked to check timezone-aware DST behaviour. I did, and there is a caveat worth a decision:

* **Naive datetimes:** ibis matches polars exactly on every unit. The generated SQL is `expr + INTERVAL <n> <UNIT>`, identical to the already-supported duckdb backend.
* **tz-aware, crossing a DST boundary:** offsetting `2020-10-25 00:00 Europe/Amsterdam` by `1d` gives
  * polars → `2020-10-26 00:00+01:00` (wall-clock, instant shifts 25h)
  * **duckdb backend** → same as polars (`23:00Z`)
  * **ibis backend** → `22:00Z` (fixed 24h)

  The divergence is because ibis stores tz-aware columns as `timestamp(UTC)` and loses the original zone, so `INTERVAL 1 DAY` is added against UTC rather than wall-clock. This isn't reachable through the current test suite — `convert_time_zone` is still `not_implemented` for ibis, so all the `*_tz` / `*_dst` cases remain xfailed for ibis — but a user passing a native tz-aware ibis table would hit it.

I kept this PR to the naive case (which is correct and now tested). For tz-aware calendar offsets on ibis, the options I see are: (a) document the UTC/fixed-offset semantics, or (b) guard tz-aware + calendar-unit and raise until `convert_time_zone` lands. Happy to follow up with whichever you prefer.