### PR TITLE
ci: Simplify prek CI run

### DIFF
--- a/.github/workflows/pre-commit-hooks.yml
+++ b/.github/workflows/pre-commit-hooks.yml
@@ -16,14 +16,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: "true"
-          cache-suffix: pre-commit-hooks
-          cache-dependency-glob: "pyproject.toml"
-      - name: Run prek
-        run: uvx prek run --all-files --show-diff-on-failure --color=always
+      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,21 +65,21 @@ repos:
       name: check-api-reference
       pass_filenames: false
       entry: uv run --extra polars utils/check_api_reference.py
-      language: system
+      language: python
     - id: sort-api-reference
       name: sort-api-reference
       pass_filenames: false
       entry: uv run utils/sort_api_reference.py
-      language: system
+      language: python
     - id: check-slotted-classes
       name: check-slotted-classes
       pass_filenames: false
       entry: uv run utils/check_slotted_classes.py
-      language: system
+      language: python
     - id: imports-are-banned
       name: import are banned (use `get_pandas` instead of `import pandas`)
       entry: uv run utils/import_check.py
-      language: system
+      language: python
       files: ^src/narwhals/
       exclude: ^src/narwhals/dependencies\.py
     - id: self-self


### PR DESCRIPTION
# Description

It's not much, but yesterday I discovered the prek action. So we can avoid manually doing it ourselves.

From https://github.com/j178/prek-action:

> prek is always invoked as:
>
> ```terminal
> prek run --show-diff-on-failure --color=always <extra-args>
> ```

