### PR TITLE
fix: support generators in is_in (#3195)

### DIFF
--- a/src/narwhals/expr.py
+++ b/src/narwhals/expr.py
@@ -1000,6 +1000,10 @@ class Expr:
             └──────────────────┘
         """
         if isinstance(other, Iterable) and not isinstance(other, (str, bytes)):
+            if iter(other) is other:
+                # One-shot iterators (e.g. generators) can only be consumed once,
+                # which some backends don't handle; materialise so they can reuse it.
+                other = list(other)
             return self._append_node(
                 ExprNode(
                     ExprKind.ELEMENTWISE,

--- a/src/narwhals/series.py
+++ b/src/narwhals/series.py
@@ -990,6 +990,14 @@ class Series(Generic[IntoSeriesT]):
               ]
             ]
         """
+        if (
+            isinstance(other, Iterable)
+            and not isinstance(other, (str, bytes))
+            and iter(other) is other
+        ):
+            # One-shot iterators (e.g. generators) can only be consumed once,
+            # which some backends don't handle; materialise so they can reuse it.
+            other = list(other)
         return self._with_compliant(
             self._compliant_series.is_in(to_native(other, pass_through=True))
         )

--- a/tests/expr_and_series/is_in_test.py
+++ b/tests/expr_and_series/is_in_test.py
@@ -1,13 +1,26 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 import narwhals as nw
 from tests.utils import Constructor, ConstructorEager, assert_equal_data
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 data = {"a": [1, 4, 2, 5]}
+
+# `is_in` documents and accepts any non-str/bytes `Iterable`, but only `list` was
+# tested. One-shot iterators (e.g. generators) used to raise on some backends.
+iterable_factories: list[Callable[[], Any]] = [
+    lambda: (4, 5),
+    lambda: {4, 5},
+    lambda: range(4, 6),
+    lambda: (x for x in (4, 5)),  # one-shot generator (the regression)
+]
 
 
 def test_expr_is_in(constructor: Constructor) -> None:
@@ -29,6 +42,28 @@ def test_expr_is_in_empty_list(constructor: Constructor) -> None:
 def test_ser_is_in(constructor_eager: ConstructorEager) -> None:
     ser = nw.from_native(constructor_eager(data), eager_only=True)["a"]
     result = {"a": ser.is_in([4, 5])}
+    expected = {"a": [False, True, False, True]}
+
+    assert_equal_data(result, expected)
+
+
+@pytest.mark.parametrize("make_other", iterable_factories)
+def test_expr_is_in_iterables(
+    constructor: Constructor, make_other: Callable[[], Any]
+) -> None:
+    df = nw.from_native(constructor(data))
+    result = df.select(nw.col("a").is_in(make_other()))
+    expected = {"a": [False, True, False, True]}
+
+    assert_equal_data(result, expected)
+
+
+@pytest.mark.parametrize("make_other", iterable_factories)
+def test_ser_is_in_iterables(
+    constructor_eager: ConstructorEager, make_other: Callable[[], Any]
+) -> None:
+    ser = nw.from_native(constructor_eager(data), eager_only=True)["a"]
+    result = {"a": ser.is_in(make_other())}
     expected = {"a": [False, True, False, True]}
 
     assert_equal_data(result, expected)


### PR DESCRIPTION
Closes #3195.

`is_in` says it accepts any iterable, but in practice only lists were really tested. It turns out lists, tuples, sets, and ranges all work fine everywhere — but passing a **generator** raises on polars (both eager and lazy) and dask, while quietly working on the others.

The reason is that a generator can only be read once. Most backends happen to copy the values into a list internally, so they're fine — but polars and dask receive the raw generator and either reject it or try to read it more than once.

The fix is to spot a one-shot iterator and turn it into a list before handing it off, at the two public entry points (`Expr.is_in` and `Series.is_in`). The check (`iter(x) is x`) is only ever true for generators and similar single-use iterators — lists, tuples, sets, ranges, and native Series/arrays are all left exactly as they are today, so nothing that already works changes. It also avoids a subtle case where a generator could get used up partway through on lazy or partitioned backends.

Added regression tests covering tuple, set, range, and generator inputs for both `Expr` and `Series`.

---

One design call worth flagging: the issue suggested doing `list(other)` per-backend (like duckdb already does). I went with one shared check at the public layer instead — partly because polars is a passthrough with no backend file to patch, and partly to avoid repeating the same line across backends. Happy to switch to the per-backend approach if you'd prefer.
