### PR TITLE
fix: disable packageRules and enable lockFileMaintenance in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "labels": ["dependencies"],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 6am"]
+    "schedule": ["* 0-5 * * *"]
   },
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":dependencyDashboard"],
-  "rangeStrategy": "update-lockfile",
   "enabledManagers": ["pep621"],
   "labels": ["dependencies"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am"]
+  },
   "packageRules": [
     {
-      "description": "Never propose updates for the workspace package itself",
-      "matchPackageNames": ["narwhals", "test-plugin"],
-      "enabled": false
-    },
-    {
-      "description": "Group all uv.lock bumps into one PR to cut noise",
+      "description": "Never edit pyproject.toml. Disable every dependency version update; uv.lock is refreshed wholesale by lockFileMaintenance, the equivalent of `uv lock -U` (latest versions allowed by the pyproject constraints).",
       "matchManagers": ["pep621"],
-      "groupName": "uv.lock dependencies"
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
# Description

Chatting with Claude suggested this edit to achieve the equivalent of `uv lock -U` whenever a new dependency release happens.

Closes #3703, #3704

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other
