### PR TITLE
fix: Allow to select polars Categorical with fixed categories

### DIFF
--- a/src/narwhals/_polars/utils.py
+++ b/src/narwhals/_polars/utils.py
@@ -144,9 +144,6 @@ def native_to_narwhals_dtype(  # noqa: C901, PLR0912
     if dtype == pl.Object:
         return dtypes.Object()
     if isinstance(dtype, pl.Categorical):
-        # `isinstance` (not `==`): a `pl.Categorical` with explicitly defined
-        # categories, e.g. `pl.Categorical(categories=pl.Categories("name"))`, does
-        # not compare equal to the `pl.Categorical` class. See narwhals#3719.
         return dtypes.Categorical()
     if isinstance(dtype, pl.Enum):
         if version is Version.V1:

--- a/src/narwhals/_polars/utils.py
+++ b/src/narwhals/_polars/utils.py
@@ -143,7 +143,10 @@ def native_to_narwhals_dtype(  # noqa: C901, PLR0912
         return dtypes.Boolean()
     if dtype == pl.Object:
         return dtypes.Object()
-    if dtype == pl.Categorical:
+    if isinstance(dtype, pl.Categorical):
+        # `isinstance` (not `==`): a `pl.Categorical` with explicitly defined
+        # categories, e.g. `pl.Categorical(categories=pl.Categories("name"))`, does
+        # not compare equal to the `pl.Categorical` class. See narwhals#3719.
         return dtypes.Categorical()
     if isinstance(dtype, pl.Enum):
         if version is Version.V1:

--- a/tests/dtypes/dtypes_test.py
+++ b/tests/dtypes/dtypes_test.py
@@ -552,6 +552,26 @@ def test_enum_repr_pl() -> None:
     assert "Enum(categories=['broccoli', 'cabbage'])" in repr(dtype)
 
 
+@pytest.mark.skipif(
+    POLARS_VERSION < (1, 32), reason="`pl.Categories` was introduced in 1.32"
+)
+def test_polars_categorical_with_defined_categories() -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3719
+    pytest.importorskip("polars")
+    import polars as pl
+
+    import narwhals.selectors as ncs
+
+    dtype = pl.Categorical(categories=pl.Categories("my_name"))
+    df = nw.from_native(
+        pl.DataFrame({"cat": pl.Series(["a", "b", "a", "c"], dtype=dtype)})
+    )
+
+    assert df.schema["cat"] == nw.Categorical
+    assert isinstance(df.schema["cat"], nw.Categorical)
+    assert df.select(ncs.categorical()).columns == ["cat"]
+
+
 def test_enum_repr() -> None:
     result = nw.Enum(["a", "b"])
     assert "Enum(categories=['a', 'b'])" in repr(result)


### PR DESCRIPTION
# Description

This PR enables to select polars categorical columns with defined categories. _Technically_ fixes #3719, but does not allow to roundtrip (see https://github.com/narwhals-dev/narwhals/issues/3719#issuecomment-4835165026 on why).

For an attempt to add `nw.Categories` see [feat/add-categories branch](https://github.com/narwhals-dev/narwhals/tree/feat/add-categories)

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other
