### PR TITLE
[codex] Fix Polars from_numpy row orientation

### DIFF
--- a/src/narwhals/_polars/dataframe.py
+++ b/src/narwhals/_polars/dataframe.py
@@ -393,7 +393,7 @@ class PolarsDataFrame(PolarsBaseFrame[pl.DataFrame]):
             if isinstance(schema, (Mapping, Schema))
             else schema
         )
-        return cls.from_native(pl.from_numpy(data, pl_schema), context=context)
+        return cls.from_native(pl.from_numpy(data, pl_schema, orient="row"), context=context)
 
     def to_narwhals(self) -> DataFrame[pl.DataFrame]:
         return self._version.dataframe(self, level="full")

--- a/tests/from_numpy_test.py
+++ b/tests/from_numpy_test.py
@@ -47,6 +47,19 @@ def test_from_numpy_schema_list(constructor_eager: ConstructorEager) -> None:
     assert result.columns == schema
 
 
+def test_from_numpy_polars_schema_preserves_fortran_rows() -> None:
+    pl = pytest.importorskip("polars")
+
+    native = pl.DataFrame(np.arange(9, dtype=float).reshape(3, 3))
+    result = nw.from_numpy(
+        native.to_numpy(),
+        backend=pl,
+        schema=["a", "b", "c"],
+    )
+
+    np.testing.assert_array_equal(result.to_numpy(), native.to_numpy())
+
+
 def test_from_numpy_schema_notvalid(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data))
     backend = nw.get_native_namespace(df)


### PR DESCRIPTION
# Description

Closes #3716.

`narwhals.from_numpy(..., backend=polars, schema=...)` now passes `orient="row"` through to `polars.from_numpy`, matching Narwhals' documented row-oriented behavior. Without this, Polars can infer column orientation for square Fortran-contiguous arrays, which silently transposes data during a `to_numpy()` -> `from_numpy()` round trip.

Added a regression test that round-trips a square NumPy array produced by `polars.DataFrame.to_numpy()` with an explicit schema and checks that row order is preserved.

AI disclosure: This PR was prepared with assistance from OpenAI Codex. Codex identified the small backend change from the issue discussion, edited the implementation and regression test, and ran targeted validation locally.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3716

## Validation

- `PYTHONPATH=src python3` manual reproduction now preserves the original array.
- `.venv/bin/python -m pytest tests/from_numpy_test.py -k "from_numpy_polars_schema_preserves_fortran_rows or from_numpy_schema_list" --constructors="polars[eager]"`
- `.venv/bin/python -m pytest tests/from_numpy_test.py tests/frame/from_numpy_test.py --constructors="polars[eager]"`

Limitations: `uv` was not installed in this environment, so I used a local virtualenv with pytest, pytest-env, numpy, and polars rather than the repo's recommended `uv sync --group local-dev` setup.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes
