### PR TITLE
fix: Fix `fill_null` for Dask with expressions

### DIFF
--- a/src/narwhals/_dask/expr.py
+++ b/src/narwhals/_dask/expr.py
@@ -403,7 +403,7 @@ class DaskExpr(
     def fill_null(
         self, value: Self | None, strategy: FillNullStrategy | None, limit: int | None
     ) -> Self:
-        def func(expr: dx.Series) -> dx.Series:
+        def func(expr: dx.Series, value: Self | None = None) -> dx.Series:
             if value is not None:
                 res_ser = expr.fillna(value)
             else:
@@ -414,6 +414,8 @@ class DaskExpr(
                 )
             return res_ser
 
+        if value is not None:
+            return self._with_callable(func, value=value)
         return self._with_callable(func)
 
     def clip(self, lower_bound: Self, upper_bound: Self) -> Self:


### PR DESCRIPTION
Looks like this was missed originally, but fortunately this change in pandas https://github.com/pandas-dev/pandas/pull/64959 surfaces the issue! nice one

Currently we get this error on the nightlies

```
E           pandas.errors.Pandas4Warning: 'DaskExpr' is not supported as a fill value for float64 dtype. In a future version, calling fillna with an incompatible value will raise. Explicitly cast to a common dtype before filling.

.venv/lib/python3.13/site-packages/pandas/core/internals/blocks.py:1415: Pandas4Warning
```

The tests were passing ~~so it looks like it got resolved somewhere down the call stack 🤷 Either way, good to have a proper fix now~~ but shouldn't have! due to #3759 

<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):
    
    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
