### PR TITLE
fix `assert_equal_data` for objects where `__eq__` returns non-bool

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ import pytest
 
 import narwhals as nw
 from narwhals._utils import Implementation, parse_version
-from narwhals.dependencies import get_pandas
+from narwhals.dependencies import get_numpy, get_pandas
 from narwhals.translate import from_native
 
 if TYPE_CHECKING:
@@ -156,6 +156,11 @@ def assert_equal_data(result: Any, expected: Mapping[str, Any]) -> None:
                 are_equivalent_values = lhs.replace(tzinfo=None) == rhs
             else:
                 are_equivalent_values = lhs == rhs
+
+            if (np := get_numpy()) is not None and isinstance(
+                are_equivalent_values, np.bool
+            ):
+                are_equivalent_values = bool(are_equivalent_values)
 
             assert are_equivalent_values is True, (
                 f"Mismatch at index {i}, key {key}: {lhs} != {rhs}\nExpected: {expected}\nGot: {result}"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -157,7 +157,7 @@ def assert_equal_data(result: Any, expected: Mapping[str, Any]) -> None:
             else:
                 are_equivalent_values = lhs == rhs
 
-            assert are_equivalent_values, (
+            assert are_equivalent_values is True, (
                 f"Mismatch at index {i}, key {key}: {lhs} != {rhs}\nExpected: {expected}\nGot: {result}"
             )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -158,7 +158,7 @@ def assert_equal_data(result: Any, expected: Mapping[str, Any]) -> None:
                 are_equivalent_values = lhs == rhs
 
             if (np := get_numpy()) is not None and isinstance(
-                are_equivalent_values, np.bool
+                are_equivalent_values, np.bool_
             ):
                 are_equivalent_values = bool(are_equivalent_values)
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -681,4 +681,5 @@ def test_assert_equal_data_object_dtype_eq_returns_truthy_non_bool() -> None:
     df = nw.from_native(
         pl.DataFrame({"a": [1, AlwaysEqual(), 2]}, schema={"a": pl.Object})
     )
-    assert_equal_data(df, {"a": [1, 2, 2]})
+    with pytest.raises(AssertionError, match="Mismatch at index 1"):
+        assert_equal_data(df, {"a": [1, 2, 2]})

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -672,7 +672,7 @@ def test_assert_equal_data_object_dtype_eq_returns_truthy_non_bool() -> None:
     # special-case. For an object whose `__eq__` returns something truthy that
     # isn't a real equality result, this lets the assertion pass vacuously.
     class AlwaysEqual:
-        def __eq__(self, other: object) -> AlwaysEqual:
+        def __eq__(self, other: object) -> AlwaysEqual:  # type: ignore[override]
             return self
 
         def __bool__(self) -> bool:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -675,7 +675,7 @@ def test_assert_equal_data_object_dtype_eq_returns_truthy_non_bool() -> None:
         def __eq__(self, other: object) -> AlwaysEqual:  # type: ignore[override]
             return self
 
-        def __bool__(self) -> bool:
+        def __bool__(self) -> bool:  # pragma: no cover
             return True
 
     df = nw.from_native(

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -20,7 +20,11 @@ from narwhals._utils import (
     parse_version,
     requires,
 )
-from tests.utils import any_integer_like_floats, get_module_version_as_tuple
+from tests.utils import (
+    any_integer_like_floats,
+    assert_equal_data,
+    get_module_version_as_tuple,
+)
 
 pytest.importorskip("pandas")
 import pandas as pd
@@ -658,3 +662,23 @@ def test_deferred_iterable() -> None:
 )
 def test_any_integer_like_floats(values: list[Any], expected: bool) -> None:  # noqa: FBT001
     assert any_integer_like_floats(values) is expected
+
+
+def test_assert_equal_data_object_dtype_eq_returns_truthy_non_bool() -> None:
+    pytest.importorskip("polars")
+    import polars as pl
+
+    # `assert_equal_data` falls back to plain `lhs == rhs` for values it doesn't
+    # special-case. For an object whose `__eq__` returns something truthy that
+    # isn't a real equality result, this lets the assertion pass vacuously.
+    class AlwaysEqual:
+        def __eq__(self, other: object) -> AlwaysEqual:
+            return self
+
+        def __bool__(self) -> bool:
+            return True
+
+    df = nw.from_native(
+        pl.DataFrame({"a": [1, AlwaysEqual(), 2]}, schema={"a": pl.Object})
+    )
+    assert_equal_data(df, {"a": [1, 2, 2]})


### PR DESCRIPTION
closes #3759 

this would need https://github.com/narwhals-dev/narwhals/pull/3758 to get in in order to become green 🥦 

<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):
    
    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
