### PR TITLE
fix: tighten `assert_equal_data`

### DIFF
--- a/tests/frame/select_test.py
+++ b/tests/frame/select_test.py
@@ -63,9 +63,9 @@ def test_select_boolean_cols() -> None:
 
     df = nw.from_native(pd.DataFrame({True: [1, 2], False: [3, 4]}), eager_only=True)
     result = df.group_by(True).agg(nw.col(False).max())  # type: ignore[arg-type, call-overload]
-    assert_equal_data(result.to_dict(as_series=False), {True: [1, 2]})  # type: ignore[dict-item]
-    result = df.select(nw.col([False, True]))  # type: ignore[list-item]
     assert_equal_data(result.to_dict(as_series=False), {True: [1, 2], False: [3, 4]})  # type: ignore[dict-item]
+    result = df.select(nw.col([False, True]))  # type: ignore[list-item]
+    assert_equal_data(result.to_dict(as_series=False), {False: [3, 4], True: [1, 2]})  # type: ignore[dict-item]
 
 
 def test_select_boolean_cols_multi_group_by() -> None:
@@ -82,7 +82,7 @@ def test_select_boolean_cols_multi_group_by() -> None:
     )
 
     result = df.select(nw.col([False, True]))  # type: ignore[list-item]
-    assert_equal_data(result.to_dict(as_series=False), {True: [1, 2], False: [3, 4]})  # type: ignore[dict-item]
+    assert_equal_data(result.to_dict(as_series=False), {False: [3, 4], True: [1, 2]})  # type: ignore[dict-item]
 
 
 def test_comparison_with_list_error_message() -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -111,15 +111,13 @@ def assert_equal_data(result: Any, expected: Mapping[str, Any]) -> None:
 
         result = result.collect(**kwargs.get(result.implementation, {}))
 
-    if hasattr(result, "columns"):
-        for idx, (col, key) in enumerate(
-            zip(result.columns, list(expected.keys()), strict=True)
-        ):
-            assert col == key, f"Expected column name {key} at index {idx}, found {col}"
-    result = {key: _to_comparable_list(result[key]) for key in expected}
-    assert list(result.keys()) == list(expected.keys()), (
-        f"Result keys {result.keys()}, expected keys: {expected.keys()}"
+    result_keys = (
+        list(result.columns) if hasattr(result, "columns") else list(result.keys())
     )
+    assert result_keys == list(expected.keys()), (
+        f"Result keys {result_keys}, expected keys: {list(expected.keys())}"
+    )
+    result = {key: _to_comparable_list(result[key]) for key in expected}
 
     for key, expected_value in expected.items():
         result_value = result[key]

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -683,3 +683,22 @@ def test_assert_equal_data_object_dtype_eq_returns_truthy_non_bool() -> None:
     )
     with pytest.raises(AssertionError, match="Mismatch at index 1"):
         assert_equal_data(df, {"a": [1, 2, 2]})
+
+
+def test_assert_equal_data_more_keys_in_result() -> None:
+    df = nw.from_native(pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}))
+    with pytest.raises(AssertionError):
+        assert_equal_data(df, {"a": [1, 2], "b": [3, 4]})
+
+
+def test_assert_equal_data_wrong_key_order() -> None:
+    df = nw.from_native(pd.DataFrame({"a": [1, 2], "b": [3, 4]}))
+    with pytest.raises(AssertionError):
+        assert_equal_data(df, {"b": [3, 4], "a": [1, 2]})
+
+
+def test_assert_equal_data_more_keys_in_result_dict() -> None:
+    # `result` need not be a narwhals object with `.columns` -- plain dicts
+    # are also a supported input, and must be checked the same way.
+    with pytest.raises(AssertionError):
+        assert_equal_data({"a": [1, 2], "b": [3, 4]}, {"a": [1, 2]})


### PR DESCRIPTION
addresses https://github.com/narwhals-dev/narwhals/pull/3667#issue-4573998314

<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):
    
    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
