### PR TITLE
fix: avoid potential sql injection in sink_parquet

### DIFF
--- a/src/narwhals/_duckdb/dataframe.py
+++ b/src/narwhals/_duckdb/dataframe.py
@@ -549,10 +549,4 @@ class DuckDBLazyFrame(
         return self._with_native(self.native.select(expr, StarExpression()))
 
     def sink_parquet(self, file: str | Path | BytesIO) -> None:
-        _rel = self.native
-        query = f"""
-            COPY (SELECT * FROM _rel)
-            TO '{file}'
-            (FORMAT parquet)
-            """  # noqa: S608
-        duckdb.sql(query)
+        self.native.write_parquet(str(file))


### PR DESCRIPTION


<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):
    
    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
