### PR TITLE
fix: resolve failing cross-references in documentation

### DIFF
--- a/src/narwhals/dataframe.py
+++ b/src/narwhals/dataframe.py
@@ -564,7 +564,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         """Instantiate DataFrame from dictionary.
 
         Indexes (if present, for pandas-like backends) are aligned following
-        the [left-hand-rule](../concepts/pandas_index.md/).
+        the [left-hand-rule](../concepts/pandas_index.md).
 
         Notes:
             For pandas-like dataframes, conversion to schema is applied after dataframe
@@ -2077,7 +2077,7 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Notes:
             pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
 
         Examples:
             >>> import pyarrow as pa
@@ -2556,7 +2556,7 @@ class LazyFrame(BaseFrame[LazyFrameT]):
 
         Notes:
             pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
 
         Examples:
             >>> import duckdb

--- a/src/narwhals/expr.py
+++ b/src/narwhals/expr.py
@@ -1045,7 +1045,7 @@ class Expr:
 
         Notes:
             pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
 
         Examples:
             >>> import duckdb
@@ -1076,7 +1076,7 @@ class Expr:
 
         Notes:
             pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
 
         Examples:
             >>> import duckdb
@@ -1117,7 +1117,7 @@ class Expr:
 
         Notes:
             - pandas handles null values differently from other libraries.
-              See [null_handling](../concepts/null_handling.md/)
+              See [null_handling](../concepts/null_handling.md)
               for reference.
             - For pandas Series of `object` dtype, `fill_null` will not automatically change the
               Series' dtype as pandas used to do. Explicitly call `cast` if you want the dtype to change.
@@ -1215,7 +1215,7 @@ class Expr:
         Notes:
             This function only fills `'NaN'` values, not null ones, except for pandas
             which doesn't distinguish between them.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
 
         Examples:
             >>> import duckdb
@@ -1245,7 +1245,7 @@ class Expr:
 
         Notes:
             pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
 
         Examples:
             >>> import polars as pl
@@ -1394,7 +1394,7 @@ class Expr:
 
         Notes:
             pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
 
         Examples:
             >>> import pandas as pd
@@ -1767,7 +1767,7 @@ class Expr:
 
         Warning:
             pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
             `is_finite` will return False for NaN and Null's in the Dask and
             pandas non-nullable backend, while for Polars, PyArrow and pandas
             nullable backends null values are kept as such.

--- a/src/narwhals/functions.py
+++ b/src/narwhals/functions.py
@@ -247,7 +247,7 @@ def from_dict(
     """Instantiate DataFrame from dictionary.
 
     Indexes (if present, for pandas-like backends) are aligned following
-    the [left-hand-rule](../concepts/pandas_index.md/).
+    the [left-hand-rule](../concepts/pandas_index.md).
 
     Notes:
         For pandas-like dataframes, conversion to schema is applied after dataframe

--- a/src/narwhals/series.py
+++ b/src/narwhals/series.py
@@ -1020,7 +1020,7 @@ class Series(Generic[IntoSeriesT]):
 
         Notes:
             pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
 
         Examples:
             >>> import pandas as pd
@@ -1406,7 +1406,7 @@ class Series(Generic[IntoSeriesT]):
 
         Notes:
             pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
 
         Examples:
             >>> import pyarrow as pa
@@ -1432,7 +1432,7 @@ class Series(Generic[IntoSeriesT]):
 
         Notes:
             pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
 
         Examples:
             >>> import pandas as pd
@@ -1462,7 +1462,7 @@ class Series(Generic[IntoSeriesT]):
 
         Notes:
             - pandas handles null values differently from other libraries.
-              See [null_handling](../concepts/null_handling.md/)
+              See [null_handling](../concepts/null_handling.md)
               for reference.
             - For pandas Series of `object` dtype, `fill_null` will not automatically change the
               Series' dtype as pandas used to do. Explicitly call `cast` if you want the dtype to change.
@@ -1513,7 +1513,7 @@ class Series(Generic[IntoSeriesT]):
         Notes:
             This function only fills `'NaN'` values, not null ones, except for pandas
             which doesn't distinguish between them.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
 
         Examples:
             >>> import polars as pl
@@ -1849,7 +1849,7 @@ class Series(Generic[IntoSeriesT]):
 
         Notes:
             pandas handles null values differently from Polars and PyArrow.
-            See [null_handling](../concepts/null_handling.md/) for reference.
+            See [null_handling](../concepts/null_handling.md) for reference.
 
         Examples:
             >>> import pyarrow as pa

--- a/src/narwhals/stable/v2/__init__.py
+++ b/src/narwhals/stable/v2/__init__.py
@@ -976,7 +976,7 @@ def from_dict(
     """Instantiate DataFrame from dictionary.
 
     Indexes (if present, for pandas-like backends) are aligned following
-    the [left-hand-rule](../concepts/pandas_index.md/).
+    the [left-hand-rule](../concepts/pandas_index.md).
 
     Notes:
         For pandas-like dataframes, conversion to schema is applied after dataframe


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

Currently, the documentation contains cross-references that lead to `404 - Not found` errors. For example, the `DataFrame.from_dict` [documentation](https://narwhals-dev.github.io/narwhals/api-reference/dataframe/?h=dataframe#narwhals.dataframe.DataFrame.from_dict) contains a reference to [left-hand-rule](https://narwhals-dev.github.io/narwhals/concepts/pandas_index.md/).

The URL contains https://narwhals-dev.github.io/narwhals/concepts/pandas_index.md/.
It should actually be https://narwhals-dev.github.io/narwhals/concepts/pandas_index.

I noticed that failing references contain a forward slash at the end while working references do not. I ran a find-replace on `.md/ -> .md` to fix the failing references.

I verified the example above works by building and serving the docs locally with `make docs-serve` 👍🏻 

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [x] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):
    
    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
