### PR TITLE
perf: remove redundant work in eager when/then, schema resolution, selectors, and module lookups

### DIFF
--- a/src/narwhals/_compliant/namespace.py
+++ b/src/narwhals/_compliant/namespace.py
@@ -236,10 +236,6 @@ class EagerNamespace(
             if otherwise is None:
                 predicate_s, then_s = align(predicate_s, then_s)
                 result = self._if_then_else(predicate_s.native, then_s.native)
-
-            if otherwise is None:
-                predicate_s, then_s = align(predicate_s, then_s)
-                result = self._if_then_else(predicate_s.native, then_s.native)
             else:
                 otherwise_s = df._evaluate_single_output_expr(otherwise)
                 predicate_s, then_s, otherwise_s = align(predicate_s, then_s, otherwise_s)

--- a/src/narwhals/_compliant/selectors.py
+++ b/src/narwhals/_compliant/selectors.py
@@ -245,15 +245,17 @@ class CompliantSelector(
 
             def series(df: FrameT) -> Sequence[SeriesOrExprT]:
                 lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)
+                rhs_set = frozenset(rhs_names)
                 return [
                     x
                     for x, name in zip(self(df), lhs_names, strict=True)
-                    if name not in rhs_names
+                    if name not in rhs_set
                 ]
 
             def names(df: FrameT) -> Sequence[str]:
                 lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)
-                return [x for x in lhs_names if x not in rhs_names]
+                rhs_set = frozenset(rhs_names)
+                return [x for x in lhs_names if x not in rhs_set]
 
             return self.selectors._selector.from_callables(series, names, context=self)
         return self._to_expr() - other
@@ -271,18 +273,20 @@ class CompliantSelector(
 
             def series(df: FrameT) -> Sequence[SeriesOrExprT]:
                 lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)
+                rhs_set = frozenset(rhs_names)
                 return [
                     *(
                         x
                         for x, name in zip(self(df), lhs_names, strict=True)
-                        if name not in rhs_names
+                        if name not in rhs_set
                     ),
                     *other(df),
                 ]
 
             def names(df: FrameT) -> Sequence[str]:
                 lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)
-                return [*(x for x in lhs_names if x not in rhs_names), *rhs_names]
+                rhs_set = frozenset(rhs_names)
+                return [*(x for x in lhs_names if x not in rhs_set), *rhs_names]
 
             return self.selectors._selector.from_callables(series, names, context=self)
         return self._to_expr() | other
@@ -300,15 +304,17 @@ class CompliantSelector(
 
             def series(df: FrameT) -> Sequence[SeriesOrExprT]:
                 lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)
+                rhs_set = frozenset(rhs_names)
                 return [
                     x
                     for x, name in zip(self(df), lhs_names, strict=True)
-                    if name in rhs_names
+                    if name in rhs_set
                 ]
 
             def names(df: FrameT) -> Sequence[str]:
                 lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)
-                return [x for x in lhs_names if x in rhs_names]
+                rhs_set = frozenset(rhs_names)
+                return [x for x in lhs_names if x in rhs_set]
 
             return self.selectors._selector.from_callables(series, names, context=self)
         return self._to_expr() & other

--- a/src/narwhals/_duckdb/dataframe.py
+++ b/src/narwhals/_duckdb/dataframe.py
@@ -236,7 +236,7 @@ class DuckDBLazyFrame(
             # Note: prefer `self._cached_native_schema` over `functools.cached_property`
             # due to Python3.13 failures.
             self._cached_native_schema = dict(
-                zip(self.columns, self.native.types, strict=False)
+                zip(self.columns, self.native.types, strict=True)
             )
 
         deferred_time_zone = DeferredTimeZone(self.native)
@@ -244,9 +244,7 @@ class DuckDBLazyFrame(
             column_name: native_to_narwhals_dtype(
                 duckdb_dtype, self._version, deferred_time_zone
             )
-            for column_name, duckdb_dtype in zip(
-                self.native.columns, self.native.types, strict=True
-            )
+            for column_name, duckdb_dtype in self._cached_native_schema.items()
         }
 
     @property

--- a/src/narwhals/_expression_parsing.py
+++ b/src/narwhals/_expression_parsing.py
@@ -79,11 +79,12 @@ def evaluate_output_names_and_aliases(
         else output_names
     )
     if exclude and expr._metadata.expansion_kind.is_multi_unnamed():
+        exclude_set = frozenset(exclude)
         output_names, aliases = zip(
             *[
                 (x, alias)
                 for x, alias in zip(output_names, aliases, strict=True)
-                if x not in exclude
+                if x not in exclude_set
             ],
             strict=True,
         )

--- a/src/narwhals/_ibis/dataframe.py
+++ b/src/narwhals/_ibis/dataframe.py
@@ -315,10 +315,7 @@ class IbisLazyFrame(
         ]
 
     def collect_schema(self) -> dict[str, DType]:
-        return {
-            name: native_to_narwhals_dtype(dtype, self._version)
-            for name, dtype in self.native.schema().fields.items()
-        }
+        return self.schema
 
     def unique(
         self,

--- a/src/narwhals/_pandas_like/group_by.py
+++ b/src/narwhals/_pandas_like/group_by.py
@@ -369,11 +369,11 @@ class PandasLikeGroupBy(
 
         def fn(df: pd.DataFrame) -> pd.Series[Any]:
             compliant = self.compliant._with_native(df)
-            results = (
+            results = [
                 (keys.native.iloc[0], keys.name)
                 for expr in exprs
                 for keys in expr(compliant)
-            )
+            ]
             out_group, out_names = zip(*results, strict=True) if results else ([], [])
             return into_series(out_group, index=out_names, context=ns).native
 

--- a/src/narwhals/_pandas_like/series.py
+++ b/src/narwhals/_pandas_like/series.py
@@ -749,18 +749,24 @@ class PandasLikeSeries(EagerSeries[Any]):
         # the default is meant to be None, but pandas doesn't allow it?
         # https://numpy.org/doc/stable/reference/generated/numpy.ndarray.__array__.html
         dtypes = self._version.dtypes
-        if isinstance(self.dtype, dtypes.Datetime) and self.dtype.time_zone is not None:
+        self_dtype = self.dtype
+        if isinstance(self_dtype, dtypes.Datetime) and self_dtype.time_zone is not None:
             s = self.dt.convert_time_zone("UTC").dt.replace_time_zone(None).native
         else:
             s = self.native
 
-        has_missing = s.isna().any()
         kwargs: dict[Any, Any] = {"copy": copy or self._implementation.is_cudf()}
-        if has_missing and str(s.dtype) in PANDAS_TO_NUMPY_DTYPE_MISSING:
-            kwargs.update({"na_value": float("nan")})
-            dtype = dtype or PANDAS_TO_NUMPY_DTYPE_MISSING[str(s.dtype)]
-        if not has_missing and str(s.dtype) in PANDAS_TO_NUMPY_DTYPE_NO_MISSING:
-            dtype = dtype or PANDAS_TO_NUMPY_DTYPE_NO_MISSING[str(s.dtype)]
+        dtype_str = str(s.dtype)
+        if (
+            dtype_str in PANDAS_TO_NUMPY_DTYPE_MISSING
+            or dtype_str in PANDAS_TO_NUMPY_DTYPE_NO_MISSING
+        ):
+            has_missing = s.isna().any()
+            if has_missing and dtype_str in PANDAS_TO_NUMPY_DTYPE_MISSING:
+                kwargs.update({"na_value": float("nan")})
+                dtype = dtype or PANDAS_TO_NUMPY_DTYPE_MISSING[dtype_str]
+            if not has_missing and dtype_str in PANDAS_TO_NUMPY_DTYPE_NO_MISSING:
+                dtype = dtype or PANDAS_TO_NUMPY_DTYPE_NO_MISSING[dtype_str]
         return s.to_numpy(dtype=dtype, **kwargs)
 
     def to_pandas(self) -> pd.Series[Any]:

--- a/src/narwhals/_spark_like/utils.py
+++ b/src/narwhals/_spark_like/utils.py
@@ -221,6 +221,17 @@ def evaluate_exprs(
     return native_results
 
 
+@lru_cache(maxsize=18)
+def _import_sqlframe_module(dialect: str, submodule: str, /) -> ModuleType:
+    return import_module(f"sqlframe.{dialect}.{submodule}")
+
+
+def _sqlframe_dialect() -> str:
+    from sqlframe.base.session import _BaseSession
+
+    return _BaseSession().execution_dialect_name
+
+
 def import_functions(implementation: Implementation, /) -> ModuleType:
     if implementation is Implementation.PYSPARK:
         from pyspark.sql import functions
@@ -230,9 +241,7 @@ def import_functions(implementation: Implementation, /) -> ModuleType:
         from pyspark.sql.connect import functions
 
         return functions
-    from sqlframe.base.session import _BaseSession
-
-    return import_module(f"sqlframe.{_BaseSession().execution_dialect_name}.functions")
+    return _import_sqlframe_module(_sqlframe_dialect(), "functions")
 
 
 def import_native_dtypes(implementation: Implementation, /) -> ModuleType:
@@ -244,9 +253,7 @@ def import_native_dtypes(implementation: Implementation, /) -> ModuleType:
         from pyspark.sql.connect import types
 
         return types
-    from sqlframe.base.session import _BaseSession
-
-    return import_module(f"sqlframe.{_BaseSession().execution_dialect_name}.types")
+    return _import_sqlframe_module(_sqlframe_dialect(), "types")
 
 
 def import_window(implementation: Implementation, /) -> type[Any]:
@@ -259,11 +266,7 @@ def import_window(implementation: Implementation, /) -> type[Any]:
         from pyspark.sql.connect.window import Window
 
         return Window
-    from sqlframe.base.session import _BaseSession
-
-    return import_module(
-        f"sqlframe.{_BaseSession().execution_dialect_name}.window"
-    ).Window
+    return _import_sqlframe_module(_sqlframe_dialect(), "window").Window
 
 
 @overload

--- a/src/narwhals/_utils.py
+++ b/src/narwhals/_utils.py
@@ -257,73 +257,98 @@ class Version(Enum):
 
     @property
     def namespace(self) -> type[Namespace[Any]]:
-        if self is Version.V1:
-            from narwhals.stable.v1._namespace import Namespace as NamespaceV1
-
-            return NamespaceV1
-        if self is Version.V2:
-            from narwhals.stable.v2._namespace import Namespace as NamespaceV2
-
-            return NamespaceV2
-        from narwhals._namespace import Namespace
-
-        return Namespace
+        return _version_namespace(self)
 
     @property
     def dtypes(self) -> DTypes:
-        if self is Version.V1:
-            from narwhals.stable.v1 import dtypes as dtypes_v1
-
-            return dtypes_v1
-        if self is Version.V2:
-            from narwhals.stable.v2 import dtypes as dtypes_v2
-
-            return dtypes_v2
-        from narwhals import dtypes
-
-        return dtypes
+        return _version_dtypes(self)
 
     @property
     def dataframe(self) -> type[DataFrame[Any]]:
-        if self is Version.V1:
-            from narwhals.stable.v1 import DataFrame as DataFrameV1
-
-            return DataFrameV1
-        if self is Version.V2:
-            from narwhals.stable.v2 import DataFrame as DataFrameV2
-
-            return DataFrameV2
-        from narwhals.dataframe import DataFrame
-
-        return DataFrame
+        return _version_dataframe(self)
 
     @property
     def lazyframe(self) -> type[LazyFrame[Any]]:
-        if self is Version.V1:
-            from narwhals.stable.v1 import LazyFrame as LazyFrameV1
-
-            return LazyFrameV1
-        if self is Version.V2:
-            from narwhals.stable.v2 import LazyFrame as LazyFrameV2
-
-            return LazyFrameV2
-        from narwhals.dataframe import LazyFrame
-
-        return LazyFrame
+        return _version_lazyframe(self)
 
     @property
     def series(self) -> type[Series[Any]]:
-        if self is Version.V1:
-            from narwhals.stable.v1 import Series as SeriesV1
+        return _version_series(self)
 
-            return SeriesV1
-        if self is Version.V2:
-            from narwhals.stable.v2 import Series as SeriesV2
 
-            return SeriesV2
-        from narwhals.series import Series
+@lru_cache(maxsize=3)
+def _version_namespace(version: Version, /) -> type[Namespace[Any]]:
+    if version is Version.V1:
+        from narwhals.stable.v1._namespace import Namespace as NamespaceV1
 
-        return Series
+        return NamespaceV1
+    if version is Version.V2:
+        from narwhals.stable.v2._namespace import Namespace as NamespaceV2
+
+        return NamespaceV2
+    from narwhals._namespace import Namespace
+
+    return Namespace
+
+
+@lru_cache(maxsize=3)
+def _version_dtypes(version: Version, /) -> DTypes:
+    if version is Version.V1:
+        from narwhals.stable.v1 import dtypes as dtypes_v1
+
+        return dtypes_v1
+    if version is Version.V2:
+        from narwhals.stable.v2 import dtypes as dtypes_v2
+
+        return dtypes_v2
+    from narwhals import dtypes
+
+    return dtypes
+
+
+@lru_cache(maxsize=3)
+def _version_dataframe(version: Version, /) -> type[DataFrame[Any]]:
+    if version is Version.V1:
+        from narwhals.stable.v1 import DataFrame as DataFrameV1
+
+        return DataFrameV1
+    if version is Version.V2:
+        from narwhals.stable.v2 import DataFrame as DataFrameV2
+
+        return DataFrameV2
+    from narwhals.dataframe import DataFrame
+
+    return DataFrame
+
+
+@lru_cache(maxsize=3)
+def _version_lazyframe(version: Version, /) -> type[LazyFrame[Any]]:
+    if version is Version.V1:
+        from narwhals.stable.v1 import LazyFrame as LazyFrameV1
+
+        return LazyFrameV1
+    if version is Version.V2:
+        from narwhals.stable.v2 import LazyFrame as LazyFrameV2
+
+        return LazyFrameV2
+    from narwhals.dataframe import LazyFrame
+
+    return LazyFrame
+
+
+@lru_cache(maxsize=3)
+def _version_series(version: Version, /) -> type[Series[Any]]:
+    if version is Version.V1:
+        from narwhals.stable.v1 import Series as SeriesV1
+
+        return SeriesV1
+    if version is Version.V2:
+        from narwhals.stable.v2 import Series as SeriesV2
+
+        return SeriesV2
+    from narwhals.series import Series
+
+    return Series
 
 
 class Implementation(NoAutoEnum):


### PR DESCRIPTION
# Description

Each commit addresses one of the following points, and can be reviewed independently:

* Eager when/then: removed a duplicated block in `EagerNamespace.when_then`
* DuckDB schema: the property populated `_cached_native_schema` but then rebuilt the dict
* pandas-like `Series.to_numpy`: the isna().any() scan only runs when the dtype is in the nullable-dtype maps, instead of unconditionally.
* Use frozenset in selectors (`__sub__`/`__or__`/`__and__`) and in `evaluate_output_names_and_aliases`
* Cache `Version` properties
* Use cached schema for ibis `collect_schema`
* Fix dead guard in the complex pandas group-by fallback (generator is always truthy)
* sqlframe imports: the per-access `import_module("sqlframe.<dialect>.*")` is now cached keyed on dialect.

They should all be low risk with no behavior change. Run some microbenchmarks generated with claude

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used. -> for spotting some, and writing micro-benchmarks
