### PR TITLE
chore: Small performance and robustness cleanups

### DIFF
--- a/src/narwhals/_compliant/expr.py
+++ b/src/narwhals/_compliant/expr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
+from itertools import islice
 from operator import methodcaller
 from typing import TYPE_CHECKING, Any, Generic, Literal, Protocol
 
@@ -229,7 +230,7 @@ class DepthTrackingExpr(
         Elementary expressions are the only ones supported properly in
         pandas, PyArrow, and Dask.
         """
-        return len(list(self._metadata.op_nodes_reversed())) <= 2
+        return len(list(islice(self._metadata.op_nodes_reversed(), 3))) <= 2
 
 
 class EagerExpr(

--- a/src/narwhals/_dask/group_by.py
+++ b/src/narwhals/_dask/group_by.py
@@ -126,8 +126,9 @@ class DaskLazyGroupBy(DepthTrackingGroupBy["DaskLazyFrame", "DaskExpr", Aggregat
             output_names, aliases = evaluate_output_names_and_aliases(
                 expr, self.compliant, exclude
             )
-            last_node = next(expr._metadata.op_nodes_reversed())
-            if len(list(expr._metadata.op_nodes_reversed())) == 1:
+            nodes = list(expr._metadata.op_nodes_reversed())
+            last_node = nodes[0]
+            if len(nodes) == 1:
                 # e.g. `agg(nw.len())`
                 column = self._keys[0]
                 agg_fn = self._remap_expr_name(last_node.name)

--- a/src/narwhals/_duckdb/namespace.py
+++ b/src/narwhals/_duckdb/namespace.py
@@ -85,8 +85,8 @@ class DuckDBNamespace(
     def concat(
         self, items: Iterable[DuckDBLazyFrame], *, how: ConcatMethod
     ) -> DuckDBLazyFrame:
-        native_items = [item._native_frame for item in items]
         items = list(items)
+        native_items = [item._native_frame for item in items]
         first = items[0]
         schema = first.schema
         if how == "vertical" and not all(x.schema == schema for x in items[1:]):

--- a/src/narwhals/_pandas_like/dataframe.py
+++ b/src/narwhals/_pandas_like/dataframe.py
@@ -422,16 +422,13 @@ class PandasLikeDataFrame(
 
     @property
     def schema(self) -> dict[str, DType]:
-        native_dtypes = self.native.dtypes
         return {
-            col: native_to_narwhals_dtype(
-                native_dtypes[col], self._version, self._implementation
-            )
-            if native_dtypes[col] != "object"
+            col: native_to_narwhals_dtype(dtype, self._version, self._implementation)
+            if dtype != "object"
             else object_native_to_narwhals_dtype(
                 self.native[col], self._version, self._implementation
             )
-            for col in self.native.columns
+            for col, dtype in self.native.dtypes.items()
         }
 
     def collect_schema(self) -> dict[str, DType]:

--- a/src/narwhals/_pandas_like/utils.py
+++ b/src/narwhals/_pandas_like/utils.py
@@ -620,7 +620,9 @@ def select_columns_by_name(
     Prefer this over `df.loc[:, column_names]` as it's
     generally more performant.
     """
-    if len(column_names) == df.shape[1] and (df.columns == column_names).all():
+    if len(column_names) == df.shape[1] and all(
+        x == y for x, y in zip(df.columns, column_names, strict=True)
+    ):
         return df
     if (df.columns.dtype.kind == "b") or (
         implementation is Implementation.PANDAS

--- a/src/narwhals/_polars/utils.py
+++ b/src/narwhals/_polars/utils.py
@@ -111,7 +111,7 @@ def extract_args_kwargs(
     return it_args, {k: extract_native(v) for k, v in kwds.items()}
 
 
-@lru_cache(maxsize=16)
+@lru_cache(maxsize=128)
 def native_to_narwhals_dtype(  # noqa: C901, PLR0912
     dtype: pl.DataType, version: Version
 ) -> DType:

--- a/src/narwhals/dataframe.py
+++ b/src/narwhals/dataframe.py
@@ -182,9 +182,7 @@ class BaseFrame(Generic[_FrameT]):
         return Schema(self._compliant_frame.schema.items())
 
     def collect_schema(self) -> Schema:
-        native_schema = dict(self._compliant_frame.collect_schema())
-
-        return Schema(native_schema)
+        return Schema(self._compliant_frame.collect_schema())
 
     def pipe(
         self,


### PR DESCRIPTION
# Description

Similar to #3797, a batch of small, low-risk cleanups:

* `_is_elementary` counts at most 3 metadata nodes (via `islice`) instead of materializing the full op-node chain just to compare its length against 2.
* Walk the node chain once instead of twice in `DaskLazyGroupBy.agg`
* Raise native_to_narwhals_dtype's lru_cache from 16 to 128;
* `DataFrame.collect_schema` passes the compliant mapping straight to `Schema` instead of materializing an intermediate dict.
* `select_columns_by_name` uses a short-circuiting comparison
* Pandas-like schema iterates `native.dtypes.items()` once instead of doing two label-based lookups per column.
* DuckDB materialize items before consuming it

## What type of PR is this? (check all applicable)

- [x] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used: issues spotted with Claude Opus 4.8
