### PR TITLE
fix: preserve nulls in pandas-like Expr.dt.ordinal_day

### DIFF
--- a/src/narwhals/_pandas_like/series_dt.py
+++ b/src/narwhals/_pandas_like/series_dt.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any
 
 from narwhals._compliant.any_namespace import DateTimeNamespace
 from narwhals._constants import (
-    EPOCH_YEAR,
     MS_PER_SECOND,
     NS_PER_SECOND,
     SECONDS_PER_DAY,
@@ -89,15 +88,7 @@ class PandasLikeSeriesDateTimeNamespace(
         return self.microsecond() * 1_000 + self.native.dt.nanosecond
 
     def ordinal_day(self) -> PandasLikeSeries:
-        year_start = self.native.dt.year
-        result = (
-            self.native.to_numpy().astype("datetime64[D]")
-            - (year_start.to_numpy() - EPOCH_YEAR).astype("datetime64[Y]")
-        ).astype("int32") + 1
-        dtype = "Int64[pyarrow]" if self._is_pyarrow() else "int32"
-        return self.with_native(
-            type(self.native)(result, dtype=dtype, name=year_start.name)
-        )
+        return self.with_native(self.native.dt.dayofyear)
 
     def weekday(self) -> PandasLikeSeries:
         # Pandas is 0-6 while Polars is 1-7

--- a/src/narwhals/_pandas_like/series_dt.py
+++ b/src/narwhals/_pandas_like/series_dt.py
@@ -88,7 +88,11 @@ class PandasLikeSeriesDateTimeNamespace(
         return self.microsecond() * 1_000 + self.native.dt.nanosecond
 
     def ordinal_day(self) -> PandasLikeSeries:
-        return self.with_native(self.native.dt.dayofyear)
+        # Use ``day_of_year`` rather than the ``dayofyear`` alias: the two are
+        # equivalent on all supported pandas versions (the alias exists since
+        # 1.1.0), but ``dayofyear`` is deprecated on pandas' main branch, which
+        # turns the nightly CI (warnings-as-errors) red.
+        return self.with_native(self.native.dt.day_of_year)
 
     def weekday(self) -> PandasLikeSeries:
         # Pandas is 0-6 while Polars is 1-7

--- a/src/narwhals/_pandas_like/series_dt.py
+++ b/src/narwhals/_pandas_like/series_dt.py
@@ -88,10 +88,6 @@ class PandasLikeSeriesDateTimeNamespace(
         return self.microsecond() * 1_000 + self.native.dt.nanosecond
 
     def ordinal_day(self) -> PandasLikeSeries:
-        # Use ``day_of_year`` rather than the ``dayofyear`` alias: the two are
-        # equivalent on all supported pandas versions (the alias exists since
-        # 1.1.0), but ``dayofyear`` is deprecated on pandas' main branch, which
-        # turns the nightly CI (warnings-as-errors) red.
         return self.with_native(self.native.dt.day_of_year)
 
     def weekday(self) -> PandasLikeSeries:

--- a/tests/expr_and_series/dt/datetime_attributes_test.py
+++ b/tests/expr_and_series/dt/datetime_attributes_test.py
@@ -92,6 +92,15 @@ def test_datetime_attributes_series(
     assert_equal_data(result, {"a": expected})
 
 
+def test_ordinal_day_preserves_null(constructor: Constructor) -> None:
+    # ordinal_day previously dropped nulls on the pandas-like backend (it
+    # returned 1 for NaT), unlike every other datetime attribute.
+    data_with_null = {"a": [datetime(2021, 3, 1), None]}
+    df = nw.from_native(constructor(data_with_null))
+    result = df.select(nw.col("a").dt.ordinal_day())
+    assert_equal_data(result, {"a": [60, None]})
+
+
 def test_datetime_chained_attributes(
     request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:

--- a/tests/expr_and_series/dt/datetime_attributes_test.py
+++ b/tests/expr_and_series/dt/datetime_attributes_test.py
@@ -93,8 +93,6 @@ def test_datetime_attributes_series(
 
 
 def test_ordinal_day_preserves_null(constructor: Constructor) -> None:
-    # ordinal_day previously dropped nulls on the pandas-like backend (it
-    # returned 1 for NaT), unlike every other datetime attribute.
     data_with_null = {"a": [datetime(2021, 3, 1), None]}
     df = nw.from_native(constructor(data_with_null))
     result = df.select(nw.col("a").dt.ordinal_day())


### PR DESCRIPTION
# Description

While comparing datetime behaviour across backends I noticed `Expr.dt.ordinal_day()` drops nulls on the pandas-like backend: for a `NaT` it returns `1` instead of null, while Polars and PyArrow (and every other datetime attribute) return null.

The cause is that `ordinal_day` was computed with a manual numpy round-trip (`.astype("datetime64[D]") - ... .astype("int32") + 1`); casting `NaT` through `.astype("int32")` collapses it to a garbage integer that resolves to `1`. Every sibling attribute (`year`, `month`, `day`, `weekday`, …) uses the native pandas accessor and preserves nulls, so `ordinal_day` was the odd one out.

The fix replaces the manual computation with `self.native.dt.dayofyear`, which preserves nulls and matches the other backends. It also removes the now-unused `EPOCH_YEAR` import (the constant stays in `_constants.py`, used elsewhere).

```python
import narwhals as nw
import pandas as pd
from datetime import datetime
df = nw.from_native(pd.DataFrame({"a": [datetime(2021, 1, 1), None]}))
df.select(nw.col("a").dt.ordinal_day()).to_native()["a"].to_list()
# before: [1, 1]      <- null became 1
# after:  [1.0, nan]  <- null preserved, matching polars/pyarrow
```

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- No existing issue; found while reviewing cross-backend datetime consistency.

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes
- [x] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

![tests passing locally](https://raw.githubusercontent.com/vidigoat/narwhals/assets/ordinal-day-tests-passing.png)
