### PR TITLE
feat: add nulls_equal to join

### DIFF
--- a/src/narwhals/_arrow/dataframe.py
+++ b/src/narwhals/_arrow/dataframe.py
@@ -421,6 +421,7 @@ class ArrowDataFrame(
         left_on: Sequence[str] | None,
         right_on: Sequence[str] | None,
         suffix: str,
+        nulls_equal: bool,
     ) -> Self:
         how_to_join_map: dict[str, JoinType] = {
             "anti": "left anti",
@@ -450,6 +451,11 @@ class ArrowDataFrame(
                 .drop([key_token])
             )
 
+        if nulls_equal and left_on and right_on:
+            return self._join_nulls_equal(
+                other, how, left_on, right_on, suffix, how_to_join_map[how]
+            )
+
         coalesce_keys = how != "full"  # polars full join does not coalesce keys
         return self._with_native(
             self.native.join(
@@ -461,6 +467,57 @@ class ArrowDataFrame(
                 coalesce_keys=coalesce_keys,
             )
         )
+
+    def _join_nulls_equal(
+        self,
+        other: Self,
+        how: JoinStrategy,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        suffix: str,
+        join_type: JoinType,
+        /,
+    ) -> Self:
+        # pyarrow drops null join keys, so join on a null-safe encoding per key: an
+        # `is_null` flag and the value cast to string, so a real "" stays distinct from null.
+        token = generate_temporary_column_name(8, [*self.columns, *other.columns])
+        left, right = self.native, other.native
+        keys: list[str] = []
+        for i, (left_key, right_key) in enumerate(zip(left_on, right_on, strict=True)):
+            filled, missing = f"{token}_v{i}", f"{token}_n{i}"
+            left_filled = pc.fill_null(
+                pc.cast(self.native[left_key], pa.large_string()),
+                "",  # type: ignore[type-var]  # pyright: ignore[reportArgumentType]
+            )
+            right_filled = pc.fill_null(
+                pc.cast(other.native[right_key], pa.large_string()),
+                "",  # type: ignore[type-var]  # pyright: ignore[reportArgumentType]
+            )
+            left = left.append_column(filled, left_filled).append_column(  # type: ignore[arg-type]
+                missing, pc.is_null(self.native[left_key])
+            )
+            right = right.append_column(filled, right_filled).append_column(  # type: ignore[arg-type]
+                missing, pc.is_null(other.native[right_key])
+            )
+            keys.extend((filled, missing))
+
+        joined = left.join(
+            right,
+            keys=keys,
+            right_keys=keys,
+            join_type=join_type,
+            right_suffix=suffix,
+            coalesce_keys=how != "full",
+        )
+        joined = joined.drop([c for c in joined.column_names if c.startswith(token)])
+        if how not in {"full", "anti", "semi"}:
+            # polars coalesces the key columns; drop the right key that pyarrow kept.
+            drop = dict.fromkeys(
+                f"{right_key}{suffix}" if right_key in self.columns else right_key
+                for right_key in right_on
+            )
+            joined = joined.drop(list(drop))
+        return self._with_native(joined)
 
     join_asof = not_implemented()
 

--- a/src/narwhals/_arrow/dataframe.py
+++ b/src/narwhals/_arrow/dataframe.py
@@ -422,6 +422,7 @@ class ArrowDataFrame(
         left_on: Sequence[str] | None,
         right_on: Sequence[str] | None,
         suffix: str,
+        nulls_equal: bool,
     ) -> Self:
         how_to_join_map: dict[str, JoinType] = {
             "anti": "left anti",
@@ -451,6 +452,11 @@ class ArrowDataFrame(
                 .drop([key_token])
             )
 
+        if nulls_equal and left_on and right_on:
+            return self._join_nulls_equal(
+                other, how, left_on, right_on, suffix, how_to_join_map[how]
+            )
+
         coalesce_keys = how != "full"  # polars full join does not coalesce keys
         return self._with_native(
             self.native.join(
@@ -462,6 +468,57 @@ class ArrowDataFrame(
                 coalesce_keys=coalesce_keys,
             )
         )
+
+    def _join_nulls_equal(
+        self,
+        other: Self,
+        how: JoinStrategy,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        suffix: str,
+        join_type: JoinType,
+        /,
+    ) -> Self:
+        # pyarrow drops null join keys, so join on a null-safe encoding per key: an
+        # `is_null` flag and the value cast to string, so a real "" stays distinct from null.
+        token = generate_temporary_column_name(8, [*self.columns, *other.columns])
+        left, right = self.native, other.native
+        keys: list[str] = []
+        for i, (left_key, right_key) in enumerate(zip(left_on, right_on, strict=True)):
+            filled, missing = f"{token}_v{i}", f"{token}_n{i}"
+            left_filled = pc.fill_null(
+                pc.cast(self.native[left_key], pa.large_string()),
+                "",  # type: ignore[type-var]  # pyright: ignore[reportArgumentType]
+            )
+            right_filled = pc.fill_null(
+                pc.cast(other.native[right_key], pa.large_string()),
+                "",  # type: ignore[type-var]  # pyright: ignore[reportArgumentType]
+            )
+            left = left.append_column(filled, left_filled).append_column(  # type: ignore[arg-type]
+                missing, pc.is_null(self.native[left_key])
+            )
+            right = right.append_column(filled, right_filled).append_column(  # type: ignore[arg-type]
+                missing, pc.is_null(other.native[right_key])
+            )
+            keys.extend((filled, missing))
+
+        joined = left.join(
+            right,
+            keys=keys,
+            right_keys=keys,
+            join_type=join_type,
+            right_suffix=suffix,
+            coalesce_keys=how != "full",
+        )
+        joined = joined.drop([c for c in joined.column_names if c.startswith(token)])
+        if how not in {"full", "anti", "semi"}:
+            # polars coalesces the key columns; drop the right key that pyarrow kept.
+            drop = dict.fromkeys(
+                f"{right_key}{suffix}" if right_key in self.columns else right_key
+                for right_key in right_on
+            )
+            joined = joined.drop(list(drop))
+        return self._with_native(joined)
 
     join_asof = not_implemented()
 

--- a/src/narwhals/_arrow/expr.py
+++ b/src/narwhals/_arrow/expr.py
@@ -188,6 +188,7 @@ class ArrowExpr(EagerExpr["ArrowDataFrame", ArrowSeries]):
                     left_on=partition_by,
                     right_on=partition_by,
                     suffix="_right",
+                    nulls_equal=False,
                 )
                 return [tmp.get_column(alias) for alias in aliases]
 
@@ -226,6 +227,7 @@ class ArrowExpr(EagerExpr["ArrowDataFrame", ArrowSeries]):
                 right_on=group_keys,
                 how="inner",
                 suffix="_right",
+                nulls_equal=False,
             )
             return [ret.get_column(alias) for alias in aliases]
 

--- a/src/narwhals/_compliant/dataframe.py
+++ b/src/narwhals/_compliant/dataframe.py
@@ -138,6 +138,7 @@ class CompliantFrame(
         left_on: Sequence[str] | None,
         right_on: Sequence[str] | None,
         suffix: str,
+        nulls_equal: bool,
     ) -> Self: ...
     def join_asof(
         self,

--- a/src/narwhals/_dask/dataframe.py
+++ b/src/narwhals/_dask/dataframe.py
@@ -297,9 +297,18 @@ class DaskLazyFrame(
         )
 
     def _join_inner(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str], suffix: str
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        suffix: str,
+        nulls_equal: bool,
     ) -> dd.DataFrame:
-        return self.native.dropna(subset=left_on, how="any").merge(
+        left_native = (
+            self.native if nulls_equal else self.native.dropna(subset=left_on, how="any")
+        )
+        return left_native.merge(
             other.native,
             left_on=left_on,
             right_on=right_on,
@@ -308,10 +317,21 @@ class DaskLazyFrame(
         )
 
     def _join_left(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str], suffix: str
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        suffix: str,
+        nulls_equal: bool,
     ) -> dd.DataFrame:
+        right_native = (
+            other.native
+            if nulls_equal
+            else other.native.dropna(subset=right_on, how="any")
+        )
         result_native = self.native.merge(
-            other.native.dropna(subset=right_on, how="any"),
+            right_native,
             how="left",
             left_on=left_on,
             right_on=right_on,
@@ -325,7 +345,13 @@ class DaskLazyFrame(
         return result_native.drop(columns=extra)
 
     def _join_full(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str], suffix: str
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        suffix: str,
+        nulls_equal: bool,
     ) -> dd.DataFrame:
         # dask does not retain keys post-join
         # we must append the suffix to each key before-hand
@@ -334,6 +360,16 @@ class DaskLazyFrame(
         other_native = other.native.rename(columns=right_on_mapper)
         check_column_names_are_unique(other_native.columns)
         right_suffixed = list(right_on_mapper.values())
+
+        if nulls_equal:
+            # dask merges null keys natively, so a plain outer merge is enough.
+            return self_native.merge(
+                other_native,
+                left_on=left_on,
+                right_on=right_suffixed,
+                how="outer",
+                suffixes=("", suffix),
+            )
 
         left_null_mask = self_native[list(left_on)].isna().any(axis=1)
         right_null_mask = other_native[right_suffixed].isna().any(axis=1)
@@ -374,19 +410,32 @@ class DaskLazyFrame(
         )
 
     def _join_semi(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str]
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        nulls_equal: bool,
     ) -> dd.DataFrame:
         other_native = self._join_filter_rename(
             other=other,
             columns_to_select=list(right_on),
             columns_mapping=dict(zip(right_on, left_on, strict=False)),
         )
-        return self.native.dropna(subset=left_on, how="any").merge(
+        left_native = (
+            self.native if nulls_equal else self.native.dropna(subset=left_on, how="any")
+        )
+        return left_native.merge(
             other_native, how="inner", left_on=left_on, right_on=left_on
         )
 
     def _join_anti(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str]
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        nulls_equal: bool,
     ) -> dd.DataFrame:
         indicator_token = generate_temporary_column_name(
             n_bytes=8, columns=(*self.columns, *other.columns), prefix="join_indicator_"
@@ -396,8 +445,13 @@ class DaskLazyFrame(
             columns_to_select=list(right_on),
             columns_mapping=dict(zip(right_on, left_on, strict=False)),
         )
+        right_native = (
+            other_native
+            if nulls_equal
+            else other_native.dropna(subset=left_on, how="any")
+        )
         df = self.native.merge(
-            other_native.dropna(subset=left_on, how="any"),
+            right_native,
             how="left",
             indicator=indicator_token,  # pyright: ignore[reportArgumentType]
             left_on=left_on,
@@ -430,6 +484,7 @@ class DaskLazyFrame(
         left_on: Sequence[str] | None,
         right_on: Sequence[str] | None,
         suffix: str,
+        nulls_equal: bool,
     ) -> Self:
         if how == "cross":
             result = self._join_cross(other=other, suffix=suffix)
@@ -439,19 +494,35 @@ class DaskLazyFrame(
 
         elif how == "inner":
             result = self._join_inner(
-                other=other, left_on=left_on, right_on=right_on, suffix=suffix
+                other=other,
+                left_on=left_on,
+                right_on=right_on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         elif how == "anti":
-            result = self._join_anti(other=other, left_on=left_on, right_on=right_on)
+            result = self._join_anti(
+                other=other, left_on=left_on, right_on=right_on, nulls_equal=nulls_equal
+            )
         elif how == "semi":
-            result = self._join_semi(other=other, left_on=left_on, right_on=right_on)
+            result = self._join_semi(
+                other=other, left_on=left_on, right_on=right_on, nulls_equal=nulls_equal
+            )
         elif how == "left":
             result = self._join_left(
-                other=other, left_on=left_on, right_on=right_on, suffix=suffix
+                other=other,
+                left_on=left_on,
+                right_on=right_on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         elif how == "full":
             result = self._join_full(
-                other=other, left_on=left_on, right_on=right_on, suffix=suffix
+                other=other,
+                left_on=left_on,
+                right_on=right_on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         else:
             assert_never(how)

--- a/src/narwhals/_duckdb/dataframe.py
+++ b/src/narwhals/_duckdb/dataframe.py
@@ -56,6 +56,15 @@ if TYPE_CHECKING:
     from narwhals.typing import AsofJoinStrategy, JoinStrategy, UniqueKeepStrategy
 
 
+def _join_key_condition(
+    lhs: Expression, rhs: Expression, *, nulls_equal: bool
+) -> Expression:
+    # `IS NOT DISTINCT FROM` when nulls should match, plain equality otherwise.
+    if nulls_equal:
+        return (lhs == rhs) | (lhs.isnull() & rhs.isnull())  # noqa: PD003
+    return lhs == rhs
+
+
 class DuckDBLazyFrame(
     SQLLazyFrame[
         "DuckDBExpr",
@@ -296,6 +305,7 @@ class DuckDBLazyFrame(
         left_on: Sequence[str] | None,
         right_on: Sequence[str] | None,
         suffix: str,
+        nulls_equal: bool,
     ) -> Self:
         native_how: Literal["inner", "left", "outer", "cross", "semi", "anti"] = (
             "outer" if how == "full" else how
@@ -311,7 +321,9 @@ class DuckDBLazyFrame(
             assert left_on is not None  # noqa: S101
             assert right_on is not None  # noqa: S101
             it = (
-                col(f'lhs."{left}"') == col(f'rhs."{right}"')
+                _join_key_condition(
+                    col(f'lhs."{left}"'), col(f'rhs."{right}"'), nulls_equal=nulls_equal
+                )
                 for left, right in zip(left_on, right_on, strict=True)
             )
             condition: Expression = reduce(and_, it)

--- a/src/narwhals/_duckdb/dataframe.py
+++ b/src/narwhals/_duckdb/dataframe.py
@@ -56,6 +56,15 @@ if TYPE_CHECKING:
     from narwhals.typing import AsofJoinStrategy, JoinStrategy, UniqueKeepStrategy
 
 
+def _join_key_condition(
+    lhs: Expression, rhs: Expression, *, nulls_equal: bool
+) -> Expression:
+    # `IS NOT DISTINCT FROM` when nulls should match, plain equality otherwise.
+    if nulls_equal:
+        return (lhs == rhs) | (lhs.isnull() & rhs.isnull())  # noqa: PD003
+    return lhs == rhs
+
+
 class DuckDBLazyFrame(
     SQLLazyFrame[
         "DuckDBExpr",
@@ -294,6 +303,7 @@ class DuckDBLazyFrame(
         left_on: Sequence[str] | None,
         right_on: Sequence[str] | None,
         suffix: str,
+        nulls_equal: bool,
     ) -> Self:
         native_how: Literal["inner", "left", "outer", "cross", "semi", "anti"] = (
             "outer" if how == "full" else how
@@ -309,7 +319,9 @@ class DuckDBLazyFrame(
             assert left_on is not None  # noqa: S101
             assert right_on is not None  # noqa: S101
             it = (
-                col(f'lhs."{left}"') == col(f'rhs."{right}"')
+                _join_key_condition(
+                    col(f'lhs."{left}"'), col(f'rhs."{right}"'), nulls_equal=nulls_equal
+                )
                 for left, right in zip(left_on, right_on, strict=True)
             )
             condition: Expression = reduce(and_, it)

--- a/src/narwhals/_ibis/dataframe.py
+++ b/src/narwhals/_ibis/dataframe.py
@@ -248,6 +248,7 @@ class IbisLazyFrame(
         left_on: Sequence[str] | None,
         right_on: Sequence[str] | None,
         suffix: str,
+        nulls_equal: bool,
     ) -> Self:
         how_native = "outer" if how == "full" else how
         rname = "{name}" + suffix
@@ -260,7 +261,9 @@ class IbisLazyFrame(
         # help mypy
         assert left_on is not None  # noqa: S101
         assert right_on is not None  # noqa: S101
-        predicates = self._convert_predicates(other, left_on, right_on)
+        predicates = self._convert_predicates(
+            other, left_on, right_on, nulls_equal=nulls_equal
+        )
         joined = self.native.join(other.native, predicates, how=how_native, rname=rname)
         if how_native == "left":
             right_names = (n + suffix for n in right_on)
@@ -274,6 +277,11 @@ class IbisLazyFrame(
                     to_drop.append(right)
             if to_drop:
                 joined = joined.drop(*to_drop)
+        elif nulls_equal and how_native == "inner":
+            # `identical_to` keeps both key columns; drop the duplicate right key to
+            # coalesce, like the name-based join.
+            right_names = (n + suffix for n in right_on)
+            joined = self._join_drop_duplicate_columns(joined, right_names)
         return self._with_native(joined)
 
     def join_asof(
@@ -305,10 +313,24 @@ class IbisLazyFrame(
         return self._with_native(joined)
 
     def _convert_predicates(
-        self, other: Self, left_on: Sequence[str], right_on: Sequence[str]
+        self,
+        other: Self,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        *,
+        nulls_equal: bool = False,
     ) -> JoinPredicates:
-        if left_on == right_on:
+        if left_on == right_on and not nulls_equal:
             return left_on
+        if nulls_equal:
+            # `identical_to` is a null-safe equality (null matches null).
+            return [
+                cast(
+                    "ir.BooleanColumn",
+                    self.native[left].identical_to(other.native[right]),
+                )
+                for left, right in zip(left_on, right_on, strict=True)
+            ]
         return [
             cast("ir.BooleanColumn", (self.native[left] == other.native[right]))
             for left, right in zip(left_on, right_on, strict=True)

--- a/src/narwhals/_pandas_like/dataframe.py
+++ b/src/narwhals/_pandas_like/dataframe.py
@@ -606,9 +606,18 @@ class PandasLikeDataFrame(
         return PandasLikeGroupBy(self, keys, drop_null_keys=drop_null_keys)
 
     def _join_inner(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str], suffix: str
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        suffix: str,
+        nulls_equal: bool,
     ) -> pd.DataFrame:
-        return self.native.dropna(subset=left_on, how="any").merge(
+        left_native = (
+            self.native if nulls_equal else self.native.dropna(subset=left_on, how="any")
+        )
+        return left_native.merge(
             other.native,
             left_on=left_on,
             right_on=right_on,
@@ -617,10 +626,21 @@ class PandasLikeDataFrame(
         )
 
     def _join_left(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str], suffix: str
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        suffix: str,
+        nulls_equal: bool,
     ) -> pd.DataFrame:
+        right_native = (
+            other.native
+            if nulls_equal
+            else other.native.dropna(subset=right_on, how="any")
+        )
         result_native = self.native.merge(
-            other.native.dropna(subset=right_on, how="any"),
+            right_native,
             how="left",
             left_on=left_on,
             right_on=right_on,
@@ -640,7 +660,13 @@ class PandasLikeDataFrame(
         return result_native.drop(columns=extra)
 
     def _join_full(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str], suffix: str
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        suffix: str,
+        nulls_equal: bool,
     ) -> pd.DataFrame:
         # Pandas coalesces keys in full joins unless there's no collision
         ns = self.__narwhals_namespace__()
@@ -649,6 +675,16 @@ class PandasLikeDataFrame(
         other_native = other.native.rename(columns=right_on_mapper)
         check_column_names_are_unique(other_native.columns)
         right_suffixed = list(right_on_mapper.values())
+
+        if nulls_equal:
+            # pandas merges null keys natively, so a plain outer merge is enough.
+            return self_native.merge(
+                other_native,
+                left_on=left_on,
+                right_on=right_suffixed,
+                how="outer",
+                suffixes=("", suffix),
+            )
 
         left_null_mask = self_native[list(left_on)].isna().any(axis=1)
         right_null_mask = other_native[right_suffixed].isna().any(axis=1)
@@ -696,28 +732,43 @@ class PandasLikeDataFrame(
         return self.native.merge(other.native, how="cross", suffixes=("", suffix))
 
     def _join_semi(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str]
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        nulls_equal: bool,
     ) -> pd.DataFrame:
         other_native = self._join_filter_rename(
             other=other,
             columns_to_select=list(right_on),
             columns_mapping=dict(zip(right_on, left_on, strict=False)),
         )
-        return self.native.dropna(subset=left_on, how="any").merge(
+        left_native = (
+            self.native if nulls_equal else self.native.dropna(subset=left_on, how="any")
+        )
+        return left_native.merge(
             other_native, how="inner", left_on=left_on, right_on=left_on
         )
 
     def _join_anti(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str]
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        nulls_equal: bool,
     ) -> pd.DataFrame:
         impl = self._implementation
 
         if impl.is_cudf():
+            right_native = (
+                other.native
+                if nulls_equal
+                else other.native.dropna(subset=left_on, how="any")
+            )
             return self.native.merge(
-                other.native.dropna(subset=left_on, how="any"),
-                how="leftanti",
-                left_on=left_on,
-                right_on=right_on,
+                right_native, how="leftanti", left_on=left_on, right_on=right_on
             )
 
         indicator_token = generate_temporary_column_name(
@@ -729,8 +780,13 @@ class PandasLikeDataFrame(
             columns_to_select=list(right_on),
             columns_mapping=dict(zip(right_on, left_on, strict=True)),
         )
+        right_native = (
+            other_native
+            if nulls_equal
+            else other_native.dropna(subset=left_on, how="any")
+        )
         result_native = self.native.merge(
-            other_native.dropna(subset=left_on, how="any"),
+            right_native,
             # TODO(FBruzzesi): See https://github.com/modin-project/modin/issues/7384
             how="left" if impl.is_pandas() else "outer",
             indicator=indicator_token,
@@ -773,6 +829,7 @@ class PandasLikeDataFrame(
         left_on: Sequence[str] | None,
         right_on: Sequence[str] | None,
         suffix: str,
+        nulls_equal: bool,
     ) -> Self:
         if how == "cross":
             result = self._join_cross(other=other, suffix=suffix)
@@ -782,19 +839,35 @@ class PandasLikeDataFrame(
 
         elif how == "inner":
             result = self._join_inner(
-                other=other, left_on=left_on, right_on=right_on, suffix=suffix
+                other=other,
+                left_on=left_on,
+                right_on=right_on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         elif how == "anti":
-            result = self._join_anti(other=other, left_on=left_on, right_on=right_on)
+            result = self._join_anti(
+                other=other, left_on=left_on, right_on=right_on, nulls_equal=nulls_equal
+            )
         elif how == "semi":
-            result = self._join_semi(other=other, left_on=left_on, right_on=right_on)
+            result = self._join_semi(
+                other=other, left_on=left_on, right_on=right_on, nulls_equal=nulls_equal
+            )
         elif how == "left":
             result = self._join_left(
-                other=other, left_on=left_on, right_on=right_on, suffix=suffix
+                other=other,
+                left_on=left_on,
+                right_on=right_on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         elif how == "full":
             result = self._join_full(
-                other=other, left_on=left_on, right_on=right_on, suffix=suffix
+                other=other,
+                left_on=left_on,
+                right_on=right_on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         else:
             assert_never(how)

--- a/src/narwhals/_pandas_like/dataframe.py
+++ b/src/narwhals/_pandas_like/dataframe.py
@@ -603,9 +603,18 @@ class PandasLikeDataFrame(
         return PandasLikeGroupBy(self, keys, drop_null_keys=drop_null_keys)
 
     def _join_inner(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str], suffix: str
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        suffix: str,
+        nulls_equal: bool,
     ) -> pd.DataFrame:
-        return self.native.dropna(subset=left_on, how="any").merge(
+        left_native = (
+            self.native if nulls_equal else self.native.dropna(subset=left_on, how="any")
+        )
+        return left_native.merge(
             other.native,
             left_on=left_on,
             right_on=right_on,
@@ -614,10 +623,21 @@ class PandasLikeDataFrame(
         )
 
     def _join_left(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str], suffix: str
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        suffix: str,
+        nulls_equal: bool,
     ) -> pd.DataFrame:
+        right_native = (
+            other.native
+            if nulls_equal
+            else other.native.dropna(subset=right_on, how="any")
+        )
         result_native = self.native.merge(
-            other.native.dropna(subset=right_on, how="any"),
+            right_native,
             how="left",
             left_on=left_on,
             right_on=right_on,
@@ -637,7 +657,13 @@ class PandasLikeDataFrame(
         return result_native.drop(columns=extra)
 
     def _join_full(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str], suffix: str
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        suffix: str,
+        nulls_equal: bool,
     ) -> pd.DataFrame:
         # Pandas coalesces keys in full joins unless there's no collision
         ns = self.__narwhals_namespace__()
@@ -646,6 +672,16 @@ class PandasLikeDataFrame(
         other_native = other.native.rename(columns=right_on_mapper)
         check_column_names_are_unique(other_native.columns)
         right_suffixed = list(right_on_mapper.values())
+
+        if nulls_equal:
+            # pandas merges null keys natively, so a plain outer merge is enough.
+            return self_native.merge(
+                other_native,
+                left_on=left_on,
+                right_on=right_suffixed,
+                how="outer",
+                suffixes=("", suffix),
+            )
 
         left_null_mask = self_native[list(left_on)].isna().any(axis=1)
         right_null_mask = other_native[right_suffixed].isna().any(axis=1)
@@ -693,28 +729,43 @@ class PandasLikeDataFrame(
         return self.native.merge(other.native, how="cross", suffixes=("", suffix))
 
     def _join_semi(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str]
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        nulls_equal: bool,
     ) -> pd.DataFrame:
         other_native = self._join_filter_rename(
             other=other,
             columns_to_select=list(right_on),
             columns_mapping=dict(zip(right_on, left_on, strict=False)),
         )
-        return self.native.dropna(subset=left_on, how="any").merge(
+        left_native = (
+            self.native if nulls_equal else self.native.dropna(subset=left_on, how="any")
+        )
+        return left_native.merge(
             other_native, how="inner", left_on=left_on, right_on=left_on
         )
 
     def _join_anti(
-        self, other: Self, *, left_on: Sequence[str], right_on: Sequence[str]
+        self,
+        other: Self,
+        *,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        nulls_equal: bool,
     ) -> pd.DataFrame:
         impl = self._implementation
 
         if impl.is_cudf():
+            right_native = (
+                other.native
+                if nulls_equal
+                else other.native.dropna(subset=left_on, how="any")
+            )
             return self.native.merge(
-                other.native.dropna(subset=left_on, how="any"),
-                how="leftanti",
-                left_on=left_on,
-                right_on=right_on,
+                right_native, how="leftanti", left_on=left_on, right_on=right_on
             )
 
         indicator_token = generate_temporary_column_name(
@@ -726,8 +777,13 @@ class PandasLikeDataFrame(
             columns_to_select=list(right_on),
             columns_mapping=dict(zip(right_on, left_on, strict=True)),
         )
+        right_native = (
+            other_native
+            if nulls_equal
+            else other_native.dropna(subset=left_on, how="any")
+        )
         result_native = self.native.merge(
-            other_native.dropna(subset=left_on, how="any"),
+            right_native,
             # TODO(FBruzzesi): See https://github.com/modin-project/modin/issues/7384
             how="left" if impl.is_pandas() else "outer",
             indicator=indicator_token,
@@ -770,6 +826,7 @@ class PandasLikeDataFrame(
         left_on: Sequence[str] | None,
         right_on: Sequence[str] | None,
         suffix: str,
+        nulls_equal: bool,
     ) -> Self:
         if how == "cross":
             result = self._join_cross(other=other, suffix=suffix)
@@ -779,19 +836,35 @@ class PandasLikeDataFrame(
 
         elif how == "inner":
             result = self._join_inner(
-                other=other, left_on=left_on, right_on=right_on, suffix=suffix
+                other=other,
+                left_on=left_on,
+                right_on=right_on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         elif how == "anti":
-            result = self._join_anti(other=other, left_on=left_on, right_on=right_on)
+            result = self._join_anti(
+                other=other, left_on=left_on, right_on=right_on, nulls_equal=nulls_equal
+            )
         elif how == "semi":
-            result = self._join_semi(other=other, left_on=left_on, right_on=right_on)
+            result = self._join_semi(
+                other=other, left_on=left_on, right_on=right_on, nulls_equal=nulls_equal
+            )
         elif how == "left":
             result = self._join_left(
-                other=other, left_on=left_on, right_on=right_on, suffix=suffix
+                other=other,
+                left_on=left_on,
+                right_on=right_on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         elif how == "full":
             result = self._join_full(
-                other=other, left_on=left_on, right_on=right_on, suffix=suffix
+                other=other,
+                left_on=left_on,
+                right_on=right_on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         else:
             assert_never(how)

--- a/src/narwhals/_polars/dataframe.py
+++ b/src/narwhals/_polars/dataframe.py
@@ -217,6 +217,7 @@ class PolarsBaseFrame(Generic[NativePolarsFrame]):
         left_on: Sequence[str] | None,
         right_on: Sequence[str] | None,
         suffix: str,
+        nulls_equal: bool,
     ) -> Self:
         how_native = (
             "outer" if (self._backend_version < (0, 20, 29) and how == "full") else how
@@ -225,6 +226,13 @@ class PolarsBaseFrame(Generic[NativePolarsFrame]):
         is_semi_or_anti = how in {"semi", "anti"}
         if is_semi_or_anti and not RESPECT_JOIN_NULL_SEMI_ANTI:  # pragma: no cover
             other_native = other_native.drop_nulls(subset=right_on)
+        extra: dict[str, Any] = {}
+        if nulls_equal:
+            # polars renamed `join_nulls` to `nulls_equal` in 1.24.
+            if self._backend_version >= (1, 24):
+                extra["nulls_equal"] = True
+            else:  # pragma: no cover
+                extra["join_nulls"] = True
         return self._with_native(
             self.native.join(
                 other=other_native,
@@ -232,6 +240,7 @@ class PolarsBaseFrame(Generic[NativePolarsFrame]):
                 left_on=left_on,
                 right_on=right_on,
                 suffix=suffix,
+                **extra,
             )
         )
 
@@ -659,10 +668,16 @@ class PolarsDataFrame(PolarsBaseFrame[pl.DataFrame]):
         left_on: Sequence[str] | None,
         right_on: Sequence[str] | None,
         suffix: str,
+        nulls_equal: bool,
     ) -> Self:
         try:
             return super().join(
-                other=other, how=how, left_on=left_on, right_on=right_on, suffix=suffix
+                other=other,
+                how=how,
+                left_on=left_on,
+                right_on=right_on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         except Exception as e:  # noqa: BLE001
             raise catch_polars_exception(e) from None

--- a/src/narwhals/_spark_like/dataframe.py
+++ b/src/narwhals/_spark_like/dataframe.py
@@ -393,6 +393,47 @@ class SparkLikeLazyFrame(
         )
         return self._with_native(df)
 
+    def _join_nulls_equal(
+        self,
+        other: Self,
+        how: JoinStrategy,
+        left_on: Sequence[str],
+        right_on: Sequence[str],
+        suffix: str,
+        left_columns: Sequence[str],
+        right_columns: Sequence[str],
+        /,
+    ) -> Self:
+        # Keep the right key columns distinct (do not rename them onto the left names) so
+        # the explicit `eqNullSafe` condition is unambiguous.
+        rename_mapping = {
+            name: f"{name}{suffix}" if name in left_columns else name
+            for name in right_columns
+        }
+        other_native = other.native.select(
+            [self._F.col(old).alias(new) for old, new in rename_mapping.items()]
+        )
+        right_remapped = [rename_mapping[name] for name in right_on]
+        condition = reduce(
+            and_,
+            (
+                getattr(self.native, left_key).eqNullSafe(
+                    getattr(other_native, right_key)
+                )
+                for left_key, right_key in zip(left_on, right_remapped, strict=True)
+            ),
+        )
+        if how == "full":
+            col_order = [*left_columns, *(rename_mapping[c] for c in right_columns)]
+        elif how in {"inner", "left"}:
+            extra = [rename_mapping[c] for c in right_columns if c not in right_on]
+            col_order = [*left_columns, *extra]
+        else:  # semi, anti
+            col_order = list(left_columns)
+        how_native = "full_outer" if how == "full" else how
+        joined = self.native.join(other_native, on=condition, how=how_native)
+        return self._with_native(joined.select(col_order))
+
     def join(
         self,
         other: Self,
@@ -401,12 +442,18 @@ class SparkLikeLazyFrame(
         left_on: Sequence[str] | None,
         right_on: Sequence[str] | None,
         suffix: str,
+        nulls_equal: bool,
     ) -> Self:
         left_columns = self.columns
         right_columns = other.columns
 
         right_on_: list[str] = list(right_on) if right_on is not None else []
         left_on_: list[str] = list(left_on) if left_on is not None else []
+
+        if nulls_equal and how != "cross":
+            return self._join_nulls_equal(
+                other, how, left_on_, right_on_, suffix, left_columns, right_columns
+            )
 
         # create a mapping for columns on other
         # `right_on` columns will be renamed as `left_on`

--- a/src/narwhals/dataframe.py
+++ b/src/narwhals/dataframe.py
@@ -294,6 +294,7 @@ class BaseFrame(Generic[_FrameT]):
         left_on: str | list[str] | None,
         right_on: str | list[str] | None,
         suffix: str,
+        nulls_equal: bool = False,
     ) -> Self:
         _supported_joins = ("inner", "left", "full", "cross", "anti", "semi")
         on = [on] if isinstance(on, str) else on
@@ -310,7 +311,12 @@ class BaseFrame(Generic[_FrameT]):
                 msg = "Can not pass `left_on`, `right_on` or `on` keys for cross join"
                 raise ValueError(msg)
             result = compliant.join(
-                other, how=how, left_on=None, right_on=None, suffix=suffix
+                other,
+                how=how,
+                left_on=None,
+                right_on=None,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         elif on is None:
             if left_on is None or right_on is None:
@@ -320,14 +326,24 @@ class BaseFrame(Generic[_FrameT]):
                 msg = "`left_on` and `right_on` must have the same length."
                 raise ValueError(msg)
             result = compliant.join(
-                other, how=how, left_on=left_on, right_on=right_on, suffix=suffix
+                other,
+                how=how,
+                left_on=left_on,
+                right_on=right_on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         else:
             if left_on is not None or right_on is not None:
                 msg = f"If `on` is specified, `left_on` and `right_on` should be None for {how}."
                 raise ValueError(msg)
             result = compliant.join(
-                other, how=how, left_on=on, right_on=on, suffix=suffix
+                other,
+                how=how,
+                left_on=on,
+                right_on=on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         return self._with_compliant(result)
 
@@ -1893,6 +1909,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         left_on: str | list[str] | None = None,
         right_on: str | list[str] | None = None,
         suffix: str = "_right",
+        nulls_equal: bool = False,
     ) -> Self:
         r"""Join in SQL-like fashion.
 
@@ -1911,6 +1928,8 @@ class DataFrame(BaseFrame[DataFrameT]):
             left_on: Join column of the left DataFrame.
             right_on: Join column of the right DataFrame.
             suffix: Suffix to append to columns with a duplicate name.
+            nulls_equal: If True, null keys match other null keys. If False (the default),
+                null keys never match, as in polars.
 
         Examples:
             >>> import pandas as pd
@@ -1927,7 +1946,13 @@ class DataFrame(BaseFrame[DataFrameT]):
             └──────────────────┘
         """
         return super().join(
-            other, how=how, left_on=left_on, right_on=right_on, on=on, suffix=suffix
+            other,
+            how=how,
+            left_on=left_on,
+            right_on=right_on,
+            on=on,
+            suffix=suffix,
+            nulls_equal=nulls_equal,
         )
 
     def join_asof(
@@ -3142,6 +3167,7 @@ class LazyFrame(BaseFrame[LazyFrameT]):
         left_on: str | list[str] | None = None,
         right_on: str | list[str] | None = None,
         suffix: str = "_right",
+        nulls_equal: bool = False,
     ) -> Self:
         r"""Add a join operation to the Logical Plan.
 
@@ -3160,6 +3186,8 @@ class LazyFrame(BaseFrame[LazyFrameT]):
             left_on: Join column of the left DataFrame.
             right_on: Join column of the right DataFrame.
             suffix: Suffix to append to columns with a duplicate name.
+            nulls_equal: If True, null keys match other null keys. If False (the default),
+                null keys never match, as in polars.
 
         Examples:
             >>> import duckdb
@@ -3185,7 +3213,13 @@ class LazyFrame(BaseFrame[LazyFrameT]):
             └─────────────────────────────┘
         """
         return super().join(
-            other, how=how, left_on=left_on, right_on=right_on, on=on, suffix=suffix
+            other,
+            how=how,
+            left_on=left_on,
+            right_on=right_on,
+            on=on,
+            suffix=suffix,
+            nulls_equal=nulls_equal,
         )
 
     def join_asof(

--- a/src/narwhals/dataframe.py
+++ b/src/narwhals/dataframe.py
@@ -299,6 +299,7 @@ class BaseFrame(Generic[_FrameT]):
         left_on: str | list[str] | None,
         right_on: str | list[str] | None,
         suffix: str,
+        nulls_equal: bool = False,
     ) -> Self:
         _supported_joins = ("inner", "left", "full", "cross", "anti", "semi")
         on = [on] if isinstance(on, str) else on
@@ -315,7 +316,12 @@ class BaseFrame(Generic[_FrameT]):
                 msg = "Can not pass `left_on`, `right_on` or `on` keys for cross join"
                 raise ValueError(msg)
             result = compliant.join(
-                other, how=how, left_on=None, right_on=None, suffix=suffix
+                other,
+                how=how,
+                left_on=None,
+                right_on=None,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         elif on is None:
             if left_on is None or right_on is None:
@@ -325,14 +331,24 @@ class BaseFrame(Generic[_FrameT]):
                 msg = "`left_on` and `right_on` must have the same length."
                 raise ValueError(msg)
             result = compliant.join(
-                other, how=how, left_on=left_on, right_on=right_on, suffix=suffix
+                other,
+                how=how,
+                left_on=left_on,
+                right_on=right_on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         else:
             if left_on is not None or right_on is not None:
                 msg = f"If `on` is specified, `left_on` and `right_on` should be None for {how}."
                 raise ValueError(msg)
             result = compliant.join(
-                other, how=how, left_on=on, right_on=on, suffix=suffix
+                other,
+                how=how,
+                left_on=on,
+                right_on=on,
+                suffix=suffix,
+                nulls_equal=nulls_equal,
             )
         return self._with_compliant(result)
 
@@ -1908,6 +1924,7 @@ class DataFrame(BaseFrame[DataFrameT]):
         left_on: str | list[str] | None = None,
         right_on: str | list[str] | None = None,
         suffix: str = "_right",
+        nulls_equal: bool = False,
     ) -> Self:
         r"""Join in SQL-like fashion.
 
@@ -1926,6 +1943,8 @@ class DataFrame(BaseFrame[DataFrameT]):
             left_on: Join column of the left DataFrame.
             right_on: Join column of the right DataFrame.
             suffix: Suffix to append to columns with a duplicate name.
+            nulls_equal: If True, null keys match other null keys. If False (the default),
+                null keys never match, as in polars.
 
         Examples:
             >>> import pandas as pd
@@ -1942,7 +1961,13 @@ class DataFrame(BaseFrame[DataFrameT]):
             └──────────────────┘
         """
         return super().join(
-            other, how=how, left_on=left_on, right_on=right_on, on=on, suffix=suffix
+            other,
+            how=how,
+            left_on=left_on,
+            right_on=right_on,
+            on=on,
+            suffix=suffix,
+            nulls_equal=nulls_equal,
         )
 
     def join_asof(
@@ -3157,6 +3182,7 @@ class LazyFrame(BaseFrame[LazyFrameT]):
         left_on: str | list[str] | None = None,
         right_on: str | list[str] | None = None,
         suffix: str = "_right",
+        nulls_equal: bool = False,
     ) -> Self:
         r"""Add a join operation to the Logical Plan.
 
@@ -3175,6 +3201,8 @@ class LazyFrame(BaseFrame[LazyFrameT]):
             left_on: Join column of the left DataFrame.
             right_on: Join column of the right DataFrame.
             suffix: Suffix to append to columns with a duplicate name.
+            nulls_equal: If True, null keys match other null keys. If False (the default),
+                null keys never match, as in polars.
 
         Examples:
             >>> import duckdb
@@ -3200,7 +3228,13 @@ class LazyFrame(BaseFrame[LazyFrameT]):
             └─────────────────────────────┘
         """
         return super().join(
-            other, how=how, left_on=left_on, right_on=right_on, on=on, suffix=suffix
+            other,
+            how=how,
+            left_on=left_on,
+            right_on=right_on,
+            on=on,
+            suffix=suffix,
+            nulls_equal=nulls_equal,
         )
 
     def join_asof(

--- a/tests/frame/join_test.py
+++ b/tests/frame/join_test.py
@@ -945,3 +945,58 @@ def test_join_on_strings(constructor: Constructor) -> None:
     result = df_l.join(df_r, on="a").sort("a")
     expected = {"a": ["one", "two", "two"], "b": [5, 6, 6]}
     assert_equal_data(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("how", "expected"),
+    [
+        ("inner", {"a": [1, None], "x": [1, 2], "y": [10, 20]}),
+        ("left", {"a": [1, None, 2], "x": [1, 2, 3], "y": [10, 20, None]}),
+        ("semi", {"a": [1, None], "x": [1, 2]}),
+        ("anti", {"a": [2], "x": [3]}),
+    ],
+)
+def test_join_nulls_equal(
+    constructor: Constructor, how: JoinStrategy, expected: dict[str, list[Any]]
+) -> None:
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 0):
+        pytest.skip()  # `nulls_equal` needs a newer polars
+    df_left = from_native_lazy(constructor({"a": [1, None, 2], "x": [1, 2, 3]}))
+    df_right = from_native_lazy(constructor({"a": [1, None, 3], "y": [10, 20, 30]}))
+    result = df_left.join(df_right, on="a", how=how, nulls_equal=True).sort(
+        "x", nulls_last=True
+    )
+    assert_equal_data(result, expected)
+
+
+def test_join_nulls_equal_full(constructor: Constructor) -> None:
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 0):
+        pytest.skip()  # `nulls_equal` needs a newer polars
+    df_left = from_native_lazy(constructor({"a": [1, None, 2], "x": [1, 2, 3]}))
+    df_right = from_native_lazy(constructor({"a": [1, None, 3], "y": [10, 20, 30]}))
+    result = (
+        df_left.join(df_right, on="a", how="full", nulls_equal=True)
+        .select("a", "x", "a_right", "y")
+        .sort("x", nulls_last=True)
+    )
+    expected = {
+        "a": [1, None, 2, None],
+        "x": [1, 2, 3, None],
+        "a_right": [1, None, None, 3],
+        "y": [10, 20, None, 30],
+    }
+    assert_equal_data(result, expected)
+
+
+def test_join_nulls_equal_left_right_on(constructor: Constructor) -> None:
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 0):
+        pytest.skip()  # `nulls_equal` needs a newer polars
+    df_left = from_native_lazy(constructor({"a": [1, None, 2], "x": [1, 2, 3]}))
+    df_right = from_native_lazy(constructor({"b": [1, None, 3], "y": [10, 20, 30]}))
+    result = (
+        df_left.join(df_right, left_on="a", right_on="b", how="inner", nulls_equal=True)
+        .select("a", "x", "y")
+        .sort("x")
+    )
+    expected = {"a": [1, None], "x": [1, 2], "y": [10, 20]}
+    assert_equal_data(result, expected)


### PR DESCRIPTION
# Description

Adds a `nulls_equal` parameter to `DataFrame.join` and `LazyFrame.join`, matching polars.
It defaults to `False` (null keys never match, the current behaviour); with `nulls_equal=True`
a null key matches another null key.

```python
df.join(other, on="key", how="inner", nulls_equal=True)
```

Each backend needs a different mechanism, since their default null handling differs:

- **polars**: passthrough (`nulls_equal`, or `join_nulls` before 1.24).
- **pandas / dask**: their `merge` already matches nulls, so the existing `dropna` on the
  keys is skipped when `nulls_equal=True`.
- **duckdb**: the join predicate becomes `IS NOT DISTINCT FROM` (`(a = b) OR (a IS NULL AND b IS NULL)`).
- **spark-like**: `Column.eqNullSafe`.
- **ibis**: `Column.identical_to`.
- **pyarrow**: pyarrow joins drop null keys, so it joins on a null-safe encoding (an
  `is_null` flag plus the value cast to string with null filled). The flag keeps a real
  `""` distinct from a null, so it is collision-free.

`nulls_equal` applies to every strategy except `cross` (which has no keys).

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3615

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes
