### PR TITLE
fix: `is_in` propagates nulls and ignores nulls in the member collection

### DIFF
--- a/docs/concepts/boolean.md
+++ b/docs/concepts/boolean.md
@@ -58,6 +58,10 @@ so we hope that the classical NumPy dtypes not supporting null values will just
 be a temporary legacy pandas issue which will eventually go
 away anyway.
 
+The same rule applies to `nw.col('a').is_in([1, 2])`: a null input gives a null result.
+A null in the collection being searched is ignored, so `nw.col('a').is_in([1, 2])` and
+`nw.col('a').is_in([1, 2, None])` always produce the same result.
+
 ```python exec="yes" source="above" session="boolean"
 from narwhals.typing import FrameT
 

--- a/src/narwhals/_arrow/series.py
+++ b/src/narwhals/_arrow/series.py
@@ -570,7 +570,12 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
             value_set: ArrayOrChunkedArray = other
         else:
             value_set = pa.array(other)
-        return self._with_native(pc.is_in(self.native, value_set=value_set))
+        result = pc.is_in(self.native, value_set=value_set)
+        # `SetLookupOptions` can't express "null in, null out", so restore nulls
+        # ourselves. This also stops a null in `value_set` from matching null inputs.
+        return self._with_native(
+            pc.if_else(pc.is_null(self.native), lit(None, pa.bool_()), result)
+        )
 
     def arg_true(self) -> Self:
         import numpy as np  # ignore-banned-import

--- a/src/narwhals/_dask/expr.py
+++ b/src/narwhals/_dask/expr.py
@@ -16,7 +16,11 @@ from narwhals._dask.utils import (
 )
 from narwhals._expression_parsing import evaluate_nodes, evaluate_output_names_and_aliases
 from narwhals._pandas_like.expr import window_kwargs_to_pandas_equivalent
-from narwhals._pandas_like.utils import get_dtype_backend, native_to_narwhals_dtype
+from narwhals._pandas_like.utils import (
+    get_dtype_backend,
+    isin_preserving_nulls,
+    native_to_narwhals_dtype,
+)
 from narwhals._utils import (
     NO_DEFAULT,
     Implementation,
@@ -521,7 +525,9 @@ class DaskExpr(
         return self._with_callable(func)
 
     def is_in(self, other: Any) -> Self:
-        return self._with_callable(lambda expr: expr.isin(other))
+        return self._with_callable(
+            lambda expr: isin_preserving_nulls(expr, other, self._implementation)
+        )
 
     def null_count(self) -> Self:
         return self._with_callable(lambda expr: expr.isna().sum().to_series())

--- a/src/narwhals/_ibis/expr.py
+++ b/src/narwhals/_ibis/expr.py
@@ -267,7 +267,12 @@ class IbisExpr(SQLExpr["IbisLazyFrame", "ir.Value"]):
         return self._with_callable(func)
 
     def is_in(self, other: Sequence[Any]) -> Self:
-        return self._with_callable(lambda expr: expr.isin(other))
+        # Polars ignores nulls in the member collection, whereas SQL `IN` would make
+        # non-matching rows null, so drop them up front.
+        values = [x for x in other if x is not None]
+        return self._with_callable(
+            lambda expr: ibis.ifelse(expr.isnull(), None, expr.isin(values))
+        )
 
     def fill_null(self, value: Self | None, strategy: Any, limit: int | None) -> Self:
         # Ibis doesn't yet allow ignoring nulls in first/last with window functions, which makes forward/backward

--- a/src/narwhals/_pandas_like/series.py
+++ b/src/narwhals/_pandas_like/series.py
@@ -17,6 +17,7 @@ from narwhals._pandas_like.utils import (
     broadcast_series_to_index,
     get_dtype_backend,
     import_array_module,
+    isin_preserving_nulls,
     narwhals_to_native_dtype,
     native_to_narwhals_dtype,
     object_native_to_narwhals_dtype,
@@ -371,7 +372,9 @@ class PandasLikeSeries(EagerSeries[Any]):
         return self._with_native(res).alias(ser.name)
 
     def is_in(self, other: Any) -> Self:
-        return self._with_native(self.native.isin(other))
+        return self._with_native(
+            isin_preserving_nulls(self.native, other, self._implementation)
+        )
 
     def arg_true(self) -> Self:
         ser = self.native

--- a/src/narwhals/_pandas_like/utils.py
+++ b/src/narwhals/_pandas_like/utils.py
@@ -365,6 +365,25 @@ def get_dtype_backend(dtype: Any, implementation: Implementation) -> DTypeBacken
     return "numpy_nullable" if is_dtype_numpy_nullable(dtype) else None
 
 
+NULLABLE_BOOL: Mapping[str, str] = {
+    "pyarrow": "bool[pyarrow]",
+    "numpy_nullable": "boolean",
+}
+
+
+def isin_preserving_nulls(native: Any, other: Any, implementation: Implementation) -> Any:
+    """`Series.isin`, but null-in-null-out, to match Polars.
+
+    `isin` reports `False` for a null input, and (for pyarrow dtypes) lets a null in
+    `other` match it. Boolean columns backed by classic NumPy dtypes can't hold nulls,
+    so those keep the `False`.
+    """
+    result = native.isin(other)
+    if backend := get_dtype_backend(native.dtype, implementation):
+        result = result.astype(NULLABLE_BOOL[backend]).mask(native.isna())
+    return result
+
+
 # NOTE: Use this to avoid annotating inline
 def iter_dtype_backends(
     dtypes: Iterable[Any], implementation: Implementation

--- a/src/narwhals/_spark_like/expr.py
+++ b/src/narwhals/_spark_like/expr.py
@@ -307,8 +307,15 @@ class SparkLikeExpr(SQLExpr["SparkLikeLazyFrame", "Column"]):
         return self._with_elementwise(_is_finite)
 
     def is_in(self, other: Sequence[Any]) -> Self:
+        # Polars ignores nulls in the member collection, whereas SQL `IN` would make
+        # non-matching rows null, so drop them up front.
+        values = [x for x in other if x is not None]
+
         def _is_in(expr: Column) -> Column:
-            return expr.isin(other) if other else self._F.lit(False)
+            if values:
+                return expr.isin(values)
+            # `isin()` with no arguments isn't allowed, and nulls stay null.
+            return self._F.when(self._F.isnull(expr), None).otherwise(self._F.lit(False))
 
         return self._with_elementwise(_is_in)
 

--- a/src/narwhals/expr.py
+++ b/src/narwhals/expr.py
@@ -980,6 +980,10 @@ class Expr:
     def is_in(self, other: Any) -> Self:
         """Check if elements of this expression are present in the other iterable.
 
+        Null values give null results, and nulls in `other` are ignored. See
+        [null preservation](../concepts/boolean.md#null-preservation) for the
+        exception which applies to pandas with classical NumPy dtypes.
+
         Arguments:
             other: iterable
 

--- a/src/narwhals/series.py
+++ b/src/narwhals/series.py
@@ -972,6 +972,10 @@ class Series(Generic[IntoSeriesT]):
     def is_in(self, other: Any) -> Self:
         """Check if the elements of this Series are in the other sequence.
 
+        Null values give null results, and nulls in `other` are ignored. See
+        [null preservation](../concepts/boolean.md#null-preservation) for the
+        exception which applies to pandas with classical NumPy dtypes.
+
         Arguments:
             other: Sequence of primitive type.
 

--- a/tests/expr_and_series/is_in_test.py
+++ b/tests/expr_and_series/is_in_test.py
@@ -1,13 +1,29 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 import pytest
 
 import narwhals as nw
+from tests.conftest import (
+    dask_lazy_p1_constructor,
+    dask_lazy_p2_constructor,
+    modin_constructor,
+    pandas_constructor,
+)
 from tests.utils import Constructor, ConstructorEager, assert_equal_data
 
 data = {"a": [1, 4, 2, 5]}
+data_with_nulls = {"a": [1, 4, 2, None]}
+
+# Boolean columns for these backends can't hold nulls, so a null input gives `False`.
+NON_NULLABLE_CONSTRUCTORS = [
+    pandas_constructor,
+    dask_lazy_p1_constructor,
+    dask_lazy_p2_constructor,
+    modin_constructor,
+]
 
 
 def test_expr_is_in(constructor: Constructor) -> None:
@@ -49,4 +65,85 @@ def test_filter_is_in_with_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.filter(nw.col("a").is_in(df["b"]))
     expected = {"a": [1, 2], "b": [1, 2]}
+    assert_equal_data(result, expected)
+
+
+def test_expr_is_in_nulls(constructor: Constructor) -> None:
+    df = nw.from_native(constructor(data_with_nulls))
+    result = df.select(nw.col("a").is_in([4, 5]))
+
+    expected: dict[str, list[Any]]
+    if any(constructor is c for c in NON_NULLABLE_CONSTRUCTORS):
+        expected = {"a": [False, True, False, False]}
+    else:
+        expected = {"a": [False, True, False, None]}
+
+    assert result.lazy().collect_schema()["a"] == nw.Boolean
+    assert_equal_data(result, expected)
+
+
+def test_expr_is_in_null_in_member_list(constructor: Constructor) -> None:
+    # A null member is ignored, so it must not change the mask.
+    df = nw.from_native(constructor(data_with_nulls))
+    result = df.select(nw.col("a").is_in([4, 5, None]))
+
+    expected: dict[str, list[Any]]
+    if any(constructor is c for c in NON_NULLABLE_CONSTRUCTORS):
+        expected = {"a": [False, True, False, False]}
+    else:
+        expected = {"a": [False, True, False, None]}
+
+    assert_equal_data(result, expected)
+
+
+def test_expr_is_in_empty_list_with_nulls(constructor: Constructor) -> None:
+    df = nw.from_native(constructor(data_with_nulls))
+    result = df.select(nw.col("a").is_in([]))
+
+    expected: dict[str, list[Any]]
+    if any(constructor is c for c in NON_NULLABLE_CONSTRUCTORS):
+        expected = {"a": [False, False, False, False]}
+    else:
+        expected = {"a": [False, False, False, None]}
+
+    assert_equal_data(result, expected)
+
+
+def test_ser_is_in_nulls(constructor_eager: ConstructorEager) -> None:
+    ser = nw.from_native(constructor_eager(data_with_nulls), eager_only=True)["a"]
+    result = {"a": ser.is_in([4, 5])}
+
+    expected: dict[str, list[Any]]
+    if any(constructor_eager is c for c in NON_NULLABLE_CONSTRUCTORS):
+        expected = {"a": [False, True, False, False]}
+    else:
+        expected = {"a": [False, True, False, None]}
+
+    assert_equal_data(result, expected)
+
+
+def test_expr_is_in_nulls_dask_nullable() -> None:
+    # The `dask` constructor only produces NumPy dtypes, so cover nullable ones here.
+    pytest.importorskip("dask")
+    import dask.dataframe as dd
+    import pandas as pd
+
+    native = dd.from_pandas(pd.DataFrame({"a": pd.array([1, 4, 2, None], dtype="Int64")}))
+    result = nw.from_native(native).select(nw.col("a").is_in([4, 5]))
+
+    assert_equal_data(result, {"a": [False, True, False, None]})
+
+
+def test_filter_is_in_nulls(constructor: Constructor) -> None:
+    # `~is_in(...)` keeps the null row on backends which emit `False` instead of null,
+    # so the same filter returns a different number of rows depending on the backend.
+    df = nw.from_native(constructor(data_with_nulls))
+    result = df.filter(~nw.col("a").is_in([4, 5]))
+
+    expected: dict[str, list[Any]]
+    if any(constructor is c for c in NON_NULLABLE_CONSTRUCTORS):
+        expected = {"a": [1, 2, None]}
+    else:
+        expected = {"a": [1, 2]}
+
     assert_equal_data(result, expected)


### PR DESCRIPTION
# Description

`is_in` returned `False` for a null input on PyArrow and pandas where Polars returns null, and the backends also disagreed on whether a null in the member collection matches, so `filter(~col.is_in(...))` gave a different row count depending on the backend.

Fixed by restoring nulls after the lookup on PyArrow and pandas-like/dask, and by dropping nulls from the collection on spark-like/ibis; DuckDB was already correct and is unchanged, as is pandas with classical NumPy dtypes, which cannot hold a null in a boolean column.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3851

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

I used Claude Code (Opus) for research and scaffolding. I chose the approach and scope, and measured every claim myself before writing it up. I can explain and defend each line in review.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes
