### PR TITLE
fix: use exact quantile for median on the pyarrow backend

### DIFF
--- a/src/narwhals/_arrow/series.py
+++ b/src/narwhals/_arrow/series.py
@@ -346,8 +346,11 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
             msg = "`median` operation not supported for non-numeric input type."
             raise InvalidOperationError(msg)
 
+        # `approximate_median` is a t-digest estimate: for a two element input
+        # it returns the lower value rather than the mean. `quantile` is exact.
         return maybe_extract_py_scalar(
-            pc.approximate_median(self.native), _return_py_scalar
+            pc.quantile(self.native, q=0.5, interpolation="linear")[0],
+            _return_py_scalar,
         )
 
     def min(self, *, _return_py_scalar: bool = True) -> Any:

--- a/src/narwhals/_arrow/series.py
+++ b/src/narwhals/_arrow/series.py
@@ -346,11 +346,8 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
             msg = "`median` operation not supported for non-numeric input type."
             raise InvalidOperationError(msg)
 
-        # `approximate_median` is a t-digest estimate: for a two element input
-        # it returns the lower value rather than the mean. `quantile` is exact.
         return maybe_extract_py_scalar(
-            pc.quantile(self.native, q=0.5, interpolation="linear")[0],
-            _return_py_scalar,
+            pc.quantile(self.native, q=0.5, interpolation="linear")[0], _return_py_scalar
         )
 
     def min(self, *, _return_py_scalar: bool = True) -> Any:

--- a/tests/expr_and_series/median_test.py
+++ b/tests/expr_and_series/median_test.py
@@ -45,11 +45,13 @@ def test_median_series(
 def test_median_group_by(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
-    # PyArrow has no exact hashed quantile kernel, only `hash_approximate_median` and
-    # `hash_tdigest`, so a grouped median stays approximate there.
-    # https://github.com/apache/arrow/issues/28985
     if "pyarrow_table" in str(constructor):
-        request.applymarker(pytest.mark.xfail)
+        reason = (
+            "PyArrow has no exact hashed quantile kernel, only `hash_approximate_median` "
+            " and `hash_tdigest`, so a grouped median stays approximate there. "
+            "See: https://github.com/apache/arrow/issues/28985"
+        )
+        request.applymarker(pytest.mark.xfail(reason=reason))
     df = nw.from_native(constructor(group_data))
     result = df.group_by("g").agg(nw.col("a").median()).sort("g")
     assert_equal_data(result, {"g": [1, 2], "a": [1.5, 15.0]})

--- a/tests/expr_and_series/median_test.py
+++ b/tests/expr_and_series/median_test.py
@@ -8,12 +8,15 @@ import narwhals as nw
 from narwhals.exceptions import InvalidOperationError
 from tests.utils import Constructor, ConstructorEager, assert_equal_data
 
+# `a` has an even number of non-null values, where an approximate median disagrees
+# with the exact one.
 data = {
-    "a": [3, 8, 2, None],
+    "a": [3, 8, None, None],
     "b": [5, 5, None, 7],
     "z": [7.0, 8.0, 9.0, None],
     "s": ["f", "a", "x", "x"],
 }
+group_data = {"g": [1, 1, 2, 2], "a": [1.0, 2.0, 10.0, 20.0]}
 
 
 @pytest.mark.parametrize(
@@ -26,11 +29,11 @@ def test_median_expr(
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor(data))
     result = df.select(expr)
-    expected = {"a": [3.0], "b": [5.0], "z": [8.0]}
+    expected = {"a": [5.5], "b": [5.0], "z": [8.0]}
     assert_equal_data(result, expected)
 
 
-@pytest.mark.parametrize(("col", "expected"), [("a", 3.0), ("b", 5.0), ("z", 8.0)])
+@pytest.mark.parametrize(("col", "expected"), [("a", 5.5), ("b", 5.0), ("z", 8.0)])
 def test_median_series(
     constructor_eager: ConstructorEager, col: str, expected: float
 ) -> None:
@@ -39,32 +42,17 @@ def test_median_series(
     assert_equal_data({col: [result]}, {col: [expected]})
 
 
-# Every column in `data` has an odd number of non-null values. An approximate
-# median agrees with the exact one there, so the columns below have an even
-# number of non-null values instead.
-even_data = {"a": [5.0, 1.0, None], "b": [1.0, 2.0, None], "z": [10.0, None, 20.0]}
-
-
-@pytest.mark.parametrize(
-    "expr", [nw.col("a", "b", "z").median(), nw.median("a", "b", "z")]
-)
-def test_median_expr_even_length(
-    constructor: Constructor, expr: nw.Expr, request: pytest.FixtureRequest
+def test_median_group_by(
+    constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
-    if "dask_lazy_p2" in str(constructor):
+    # PyArrow has no exact hashed quantile kernel, only `hash_approximate_median` and
+    # `hash_tdigest`, so a grouped median stays approximate there.
+    # https://github.com/apache/arrow/issues/28985
+    if "pyarrow_table" in str(constructor):
         request.applymarker(pytest.mark.xfail)
-    df = nw.from_native(constructor(even_data))
-    result = df.select(expr)
-    expected = {"a": [3.0], "b": [1.5], "z": [15.0]}
-    assert_equal_data(result, expected)
-
-
-@pytest.mark.parametrize(("col", "expected"), [("a", 3.0), ("b", 1.5), ("z", 15.0)])
-def test_median_series_even_length(
-    constructor_eager: ConstructorEager, col: str, expected: float
-) -> None:
-    series = nw.from_native(constructor_eager(even_data), eager_only=True)[col]
-    assert_equal_data({col: [series.median()]}, {col: [expected]})
+    df = nw.from_native(constructor(group_data))
+    result = df.group_by("g").agg(nw.col("a").median()).sort("g")
+    assert_equal_data(result, {"g": [1, 2], "a": [1.5, 15.0]})
 
 
 @pytest.mark.parametrize("expr", [nw.col("s").median(), nw.median("s")])

--- a/tests/expr_and_series/median_test.py
+++ b/tests/expr_and_series/median_test.py
@@ -39,6 +39,34 @@ def test_median_series(
     assert_equal_data({col: [result]}, {col: [expected]})
 
 
+# Every column in `data` has an odd number of non-null values. An approximate
+# median agrees with the exact one there, so the columns below have an even
+# number of non-null values instead.
+even_data = {"a": [5.0, 1.0, None], "b": [1.0, 2.0, None], "z": [10.0, None, 20.0]}
+
+
+@pytest.mark.parametrize(
+    "expr", [nw.col("a", "b", "z").median(), nw.median("a", "b", "z")]
+)
+def test_median_expr_even_length(
+    constructor: Constructor, expr: nw.Expr, request: pytest.FixtureRequest
+) -> None:
+    if "dask_lazy_p2" in str(constructor):
+        request.applymarker(pytest.mark.xfail)
+    df = nw.from_native(constructor(even_data))
+    result = df.select(expr)
+    expected = {"a": [3.0], "b": [1.5], "z": [15.0]}
+    assert_equal_data(result, expected)
+
+
+@pytest.mark.parametrize(("col", "expected"), [("a", 3.0), ("b", 1.5), ("z", 15.0)])
+def test_median_series_even_length(
+    constructor_eager: ConstructorEager, col: str, expected: float
+) -> None:
+    series = nw.from_native(constructor_eager(even_data), eager_only=True)[col]
+    assert_equal_data({col: [series.median()]}, {col: [expected]})
+
+
 @pytest.mark.parametrize("expr", [nw.col("s").median(), nw.median("s")])
 def test_median_expr_raises_on_str(
     constructor: Constructor, expr: nw.Expr, request: pytest.FixtureRequest


### PR DESCRIPTION
# Description

`median()` on the PyArrow backend called `pc.approximate_median`, a t-digest estimate. For a two element input it returns the lower value rather than the mean, so `median()` of `[5.0, 1.0]` gave `1.0` where pandas and Polars give `3.0`. It also drifts on larger inputs (about 0.09 on 100 random floats, 0.14 on 1000).

Switched to `pc.quantile(q=0.5, interpolation="linear")`, which is exact. This is the same call the existing `quantile` implementation already uses a few hundred lines below, so it is not a new pattern. `None` in and empty input behave as before.

It is also faster, measured from n=2 up to n=10M:

| n | `approximate_median` | `quantile` |
| --- | --- | --- |
| 2 | 162.5 us | 18.3 us |
| 100 | 18.5 us | 8.1 us |
| 10,000 | 496.2 us | 135.6 us |
| 1,000,000 | 57.6 ms | 19.8 ms |
| 10,000,000 | 896.2 ms | 236.7 ms |

Grouped median is not addressed here. PyArrow has no exact `hash_` quantile kernel to switch to, only `hash_approximate_median` and `hash_tdigest`, so `group_by().agg(col.median())` stays approximate on that backend. Asked about reopening apache/arrow#28985 for that.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3853

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

Claude Code was used for research and scaffolding.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes
