### PR TITLE
fix: honor schema column selection/order in pandas-like from_dicts

### DIFF
--- a/src/narwhals/_pandas_like/dataframe.py
+++ b/src/narwhals/_pandas_like/dataframe.py
@@ -207,13 +207,9 @@ class PandasLikeDataFrame(
             native = DataFrame.from_records(data)
         else:
             native = DataFrame.from_dict({col: [] for col in schema})
-        if schema and data:
-            # `DataFrame.from_records` derives columns from the row dicts'
-            # keys, ignoring `schema`. Reindex so the result matches
-            # `schema`'s column selection and order, adding any missing
-            # columns (filled with null) and dropping any extra ones.
-            native = native.reindex(columns=list(schema))
         if schema:
+            # https://github.com/narwhals-dev/narwhals/issues/3837
+            native = native.reindex(columns=list(schema))
             backends: Iterable[DTypeBackend]
             if data:
                 backends = iter_dtype_backends(native.dtypes, implementation)

--- a/src/narwhals/_pandas_like/dataframe.py
+++ b/src/narwhals/_pandas_like/dataframe.py
@@ -203,18 +203,14 @@ class PandasLikeDataFrame(
         implementation = context._implementation
         ns = implementation.to_native_namespace()
         DataFrame = cast("type[pd.DataFrame]", ns.DataFrame)
-        if data or not schema:
-            native = DataFrame.from_records(data)
-        else:
-            native = DataFrame.from_dict({col: [] for col in schema})
+        # NOTE: `DataFrame.from_records` returns *zero* rows when every mapping is
+        # empty, while the constructor keeps `len(data)` (empty) rows.
+        native = DataFrame(data)
         if schema:
-            # https://github.com/narwhals-dev/narwhals/issues/3837
+            # Missing columns become all-null, extra ones are dropped, and the schema
+            # order wins: https://github.com/narwhals-dev/narwhals/issues/3837
             native = native.reindex(columns=list(schema))
-            backends: Iterable[DTypeBackend]
-            if data:
-                backends = iter_dtype_backends(native.dtypes, implementation)
-            else:
-                backends = (None for _ in range(len(schema)))
+            backends = iter_dtype_backends(native.dtypes, implementation)
             native_schema = {
                 key: narwhals_to_native_dtype(
                     dtype,

--- a/src/narwhals/_pandas_like/dataframe.py
+++ b/src/narwhals/_pandas_like/dataframe.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from itertools import chain, product
-from typing import TYPE_CHECKING, Any, Literal, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast, overload
 
 import numpy as np
 
@@ -71,6 +71,9 @@ if TYPE_CHECKING:
     )
 
     Constructor: TypeAlias = Callable[..., pd.DataFrame]
+
+    class CopyKwargs(TypedDict, total=False):
+        copy: bool
 
 
 CLASSICAL_NUMPY_DTYPES: frozenset[np.dtype[Any]] = frozenset(
@@ -207,9 +210,14 @@ class PandasLikeDataFrame(
         # empty, while the constructor keeps `len(data)` (empty) rows.
         native = DataFrame(data)
         if schema:
+            kwds: CopyKwargs = (
+                {"copy": False}
+                if implementation.is_pandas() and implementation._backend_version() < (3,)
+                else {}
+            )
             # Missing columns become all-null, extra ones are dropped, and the schema
             # order wins: https://github.com/narwhals-dev/narwhals/issues/3837
-            native = native.reindex(columns=list(schema))
+            native = native.reindex(columns=list(schema), **kwds)
             backends = iter_dtype_backends(native.dtypes, implementation)
             native_schema = {
                 key: narwhals_to_native_dtype(
@@ -221,7 +229,7 @@ class PandasLikeDataFrame(
                 for ((key, dtype), backend) in zip(schema.items(), backends, strict=False)
                 if dtype is not None
             }
-            native = native.astype(native_schema)
+            native = native.astype(native_schema, **kwds)
         return cls.from_native(native, context=context)
 
     @staticmethod

--- a/src/narwhals/_pandas_like/dataframe.py
+++ b/src/narwhals/_pandas_like/dataframe.py
@@ -207,6 +207,12 @@ class PandasLikeDataFrame(
             native = DataFrame.from_records(data)
         else:
             native = DataFrame.from_dict({col: [] for col in schema})
+        if schema and data:
+            # `DataFrame.from_records` derives columns from the row dicts'
+            # keys, ignoring `schema`. Reindex so the result matches
+            # `schema`'s column selection and order, adding any missing
+            # columns (filled with null) and dropping any extra ones.
+            native = native.reindex(columns=list(schema))
         if schema:
             backends: Iterable[DTypeBackend]
             if data:

--- a/src/narwhals/dataframe.py
+++ b/src/narwhals/dataframe.py
@@ -637,9 +637,9 @@ class DataFrame(BaseFrame[DataFrameT]):
             Keys missing from some (or all) rows are filled with null.
 
             For pandas-like dataframes, conversion to schema is applied after dataframe
-            creation, and missing keys are filled with `NaN`. A `schema` requesting a dtype
-            which cannot hold nulls (e.g. `Int64` or `Boolean` with the default numpy
-            dtypes) will therefore coerce or raise on those values.
+            creation. A `schema` requesting a dtype which cannot hold null values (e.g.
+            `Int64` or `Boolean` with the default numpy dtypes) will therefore coerce or
+            raise on those missing values.
 
         Arguments:
             data: Sequence with dictionaries mapping column name to value.

--- a/src/narwhals/dataframe.py
+++ b/src/narwhals/dataframe.py
@@ -634,8 +634,12 @@ class DataFrame(BaseFrame[DataFrameT]):
         """Instantiate DataFrame from a sequence of dictionaries representing rows.
 
         Notes:
+            Keys missing from some (or all) rows are filled with null.
+
             For pandas-like dataframes, conversion to schema is applied after dataframe
-            creation.
+            creation, and missing keys are filled with `NaN`. A `schema` requesting a dtype
+            which cannot hold nulls (e.g. `Int64` or `Boolean` with the default numpy
+            dtypes) will therefore coerce or raise on those values.
 
         Arguments:
             data: Sequence with dictionaries mapping column name to value.

--- a/src/narwhals/functions.py
+++ b/src/narwhals/functions.py
@@ -337,8 +337,12 @@ def from_dicts(
     """Instantiate DataFrame from a sequence of dictionaries representing rows.
 
     Notes:
+        Keys missing from some (or all) rows are filled with null.
+
         For pandas-like dataframes, conversion to schema is applied after dataframe
-        creation.
+        creation, and missing keys are filled with `NaN`. A `schema` requesting a dtype
+        which cannot hold nulls (e.g. `Int64` or `Boolean` with the default numpy
+        dtypes) will therefore coerce or raise on those values.
 
     Arguments:
         data: Sequence with dictionaries mapping column name to value.

--- a/src/narwhals/functions.py
+++ b/src/narwhals/functions.py
@@ -340,9 +340,9 @@ def from_dicts(
         Keys missing from some (or all) rows are filled with null.
 
         For pandas-like dataframes, conversion to schema is applied after dataframe
-        creation, and missing keys are filled with `NaN`. A `schema` requesting a dtype
-        which cannot hold nulls (e.g. `Int64` or `Boolean` with the default numpy
-        dtypes) will therefore coerce or raise on those values.
+        creation. A `schema` requesting a dtype which cannot hold null values (e.g.
+        `Int64` or `Boolean` with the default numpy dtypes) will therefore coerce or
+        raise on those missing values.
 
     Arguments:
         data: Sequence with dictionaries mapping column name to value.

--- a/tests/frame/from_dicts_test.py
+++ b/tests/frame/from_dicts_test.py
@@ -37,6 +37,41 @@ def test_from_dicts_schema(eager_backend: EagerAllowed) -> None:
     assert result.collect_schema() == schema
 
 
+def test_from_dicts_schema_reordered_keys(eager_backend: EagerAllowed) -> None:
+    # Row dicts have keys in a different order than `schema`: the result
+    # should still follow `schema`'s column order.
+    schema = {"a": nw.Int16(), "b": nw.Float32()}
+    result = nw.DataFrame.from_dicts(
+        [{"b": 5, "a": 1}, {"b": 6, "a": 2}], backend=eager_backend, schema=schema
+    )
+    assert result.columns == list(schema)
+    assert result.collect_schema() == schema
+
+
+def test_from_dicts_schema_extra_key(eager_backend: EagerAllowed) -> None:
+    # Row dicts have a key not present in `schema`: it should be dropped.
+    schema = {"a": nw.Int16(), "b": nw.Float32()}
+    result = nw.DataFrame.from_dicts(
+        [{"a": 1, "b": 5, "c": 100}, {"a": 2, "b": 6, "c": 200}],
+        backend=eager_backend,
+        schema=schema,
+    )
+    assert result.columns == list(schema)
+    assert result.collect_schema() == schema
+
+
+def test_from_dicts_schema_missing_key(eager_backend: EagerAllowed) -> None:
+    # Row dicts are missing a key present in `schema`: it should be added,
+    # filled with nulls.
+    schema = {"a": nw.Int16(), "b": nw.Float32()}
+    result = nw.DataFrame.from_dicts(
+        [{"a": 1}, {"a": 2}], backend=eager_backend, schema=schema
+    )
+    assert result.columns == list(schema)
+    assert result.collect_schema() == schema
+    assert_equal_data(result, {"a": [1, 2], "b": [None, None]})
+
+
 def test_from_dicts_non_eager() -> None:
     pytest.importorskip("duckdb")
     with pytest.raises(ValueError, match="lazy-only"):

--- a/tests/frame/from_dicts_test.py
+++ b/tests/frame/from_dicts_test.py
@@ -37,39 +37,52 @@ def test_from_dicts_schema(eager_backend: EagerAllowed) -> None:
     assert result.collect_schema() == schema
 
 
-def test_from_dicts_schema_reordered_keys(eager_backend: EagerAllowed) -> None:
-    # Row dicts have keys in a different order than `schema`: the result
-    # should still follow `schema`'s column order.
-    schema = {"a": nw.Int16(), "b": nw.Float32()}
-    result = nw.DataFrame.from_dicts(
-        [{"b": 5, "a": 1}, {"b": 6, "a": 2}], backend=eager_backend, schema=schema
-    )
+@pytest.mark.parametrize(
+    ("data", "schema", "expected"),
+    [
+        (
+            [{"b": 5, "a": 1}, {"b": 6, "a": 2}],
+            {"a": nw.Int16(), "b": nw.Float32()},
+            {"a": [1, 2], "b": [5.0, 6.0]},
+        ),
+        (
+            [{"a": 1, "b": 5, "c": 100}, {"a": 2, "b": 6, "c": 200}],
+            {"a": nw.Int16(), "b": nw.Float32()},
+            {"a": [1, 2], "b": [5.0, 6.0]},
+        ),
+        (
+            [{"a": 1}, {"a": 2}],
+            {"a": nw.Int16(), "b": nw.Float32()},
+            {"a": [1, 2], "b": [None, None]},
+        ),
+        ([{}, {}], {"a": nw.Int64()}, {"a": [None, None]}),
+        (
+            [{"a": 1, "b": True}, {"a": 2}],
+            {"a": nw.Int64(), "b": nw.Boolean()},
+            {"a": [1, 2], "b": [True, None]},
+        ),
+    ],
+    ids=["reordered-keys", "extra-key", "missing-key", "empty-rows", "partial-rows"],
+)
+def test_from_dicts_schema_mismatched_keys(
+    eager_backend: EagerAllowed,
+    request: pytest.FixtureRequest,
+    data: list[dict[str, Any]],
+    schema: dict[str, Any],
+    expected: dict[str, Any],
+) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3837
+    if "pandas" in str(eager_backend):
+        if not data[0]:
+            # `DataFrame.from_records` returns 0 rows for all-empty row dicts
+            request.applymarker(pytest.mark.xfail)
+        if nw.Boolean() in schema.values():
+            # NaN -> bool astype coerces missing values to True
+            request.applymarker(pytest.mark.xfail)
+    result = nw.DataFrame.from_dicts(data, backend=eager_backend, schema=schema)
     assert result.columns == list(schema)
     assert result.collect_schema() == schema
-
-
-def test_from_dicts_schema_extra_key(eager_backend: EagerAllowed) -> None:
-    # Row dicts have a key not present in `schema`: it should be dropped.
-    schema = {"a": nw.Int16(), "b": nw.Float32()}
-    result = nw.DataFrame.from_dicts(
-        [{"a": 1, "b": 5, "c": 100}, {"a": 2, "b": 6, "c": 200}],
-        backend=eager_backend,
-        schema=schema,
-    )
-    assert result.columns == list(schema)
-    assert result.collect_schema() == schema
-
-
-def test_from_dicts_schema_missing_key(eager_backend: EagerAllowed) -> None:
-    # Row dicts are missing a key present in `schema`: it should be added,
-    # filled with nulls.
-    schema = {"a": nw.Int16(), "b": nw.Float32()}
-    result = nw.DataFrame.from_dicts(
-        [{"a": 1}, {"a": 2}], backend=eager_backend, schema=schema
-    )
-    assert result.columns == list(schema)
-    assert result.collect_schema() == schema
-    assert_equal_data(result, {"a": [1, 2], "b": [None, None]})
+    assert_equal_data(result, expected)
 
 
 def test_from_dicts_non_eager() -> None:

--- a/tests/frame/from_dicts_test.py
+++ b/tests/frame/from_dicts_test.py
@@ -57,9 +57,9 @@ def test_from_dicts_schema(eager_backend: EagerAllowed) -> None:
         ),
         ([{}, {}], {"a": nw.Float64()}, {"a": [None, None]}),
         (
-            [{"a": 1, "b": "x"}, {"a": 2}],
-            {"a": nw.Int64(), "b": nw.String()},
-            {"a": [1, 2], "b": ["x", None]},
+            [{"a": 1, "b": 5.5}, {"a": 2}],
+            {"a": nw.Int64(), "b": nw.Float64()},
+            {"a": [1, 2], "b": [5.5, None]},
         ),
     ],
     ids=["reordered-keys", "extra-key", "missing-key", "empty-rows", "partial-rows"],

--- a/tests/frame/from_dicts_test.py
+++ b/tests/frame/from_dicts_test.py
@@ -55,34 +55,47 @@ def test_from_dicts_schema(eager_backend: EagerAllowed) -> None:
             {"a": nw.Int16(), "b": nw.Float32()},
             {"a": [1, 2], "b": [None, None]},
         ),
-        ([{}, {}], {"a": nw.Int64()}, {"a": [None, None]}),
+        ([{}, {}], {"a": nw.Float64()}, {"a": [None, None]}),
         (
-            [{"a": 1, "b": True}, {"a": 2}],
-            {"a": nw.Int64(), "b": nw.Boolean()},
-            {"a": [1, 2], "b": [True, None]},
+            [{"a": 1, "b": "x"}, {"a": 2}],
+            {"a": nw.Int64(), "b": nw.String()},
+            {"a": [1, 2], "b": ["x", None]},
         ),
     ],
     ids=["reordered-keys", "extra-key", "missing-key", "empty-rows", "partial-rows"],
 )
 def test_from_dicts_schema_mismatched_keys(
     eager_backend: EagerAllowed,
-    request: pytest.FixtureRequest,
     data: list[dict[str, Any]],
-    schema: dict[str, Any],
+    schema: dict[str, nw.dtypes.DType],
     expected: dict[str, Any],
 ) -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3837
-    if "pandas" in str(eager_backend):
-        if not data[0]:
-            # `DataFrame.from_records` returns 0 rows for all-empty row dicts
-            request.applymarker(pytest.mark.xfail)
-        if nw.Boolean() in schema.values():
-            # NaN -> bool astype coerces missing values to True
-            request.applymarker(pytest.mark.xfail)
     result = nw.DataFrame.from_dicts(data, backend=eager_backend, schema=schema)
     assert result.columns == list(schema)
     assert result.collect_schema() == schema
     assert_equal_data(result, expected)
+
+
+def test_from_dicts_schema_pandas_non_nullable() -> None:
+    """Missing keys are filled with `NaN`, which numpy-backed dtypes may not represent.
+
+    Unlike polars and pyarrow, pandas' default (numpy) `bool` and `int64` have no null,
+    so `astype` either coerces or raises. Narwhals can only avoid this by deviating from
+    the requested schema, e.g. silently using pandas' nullable extension dtypes instead.
+    """
+    pytest.importorskip("pandas")
+    # `bool(nan)` is `True`, so missing values become `True` rather than null
+    result = nw.DataFrame.from_dicts(
+        [{"a": True}, {}], backend="pandas", schema={"a": nw.Boolean()}
+    )
+    assert_equal_data(result, {"a": [True, True]})
+
+    # integer casting is stricter, `pandas.errors.IntCastingNaNError` is surfaced as-is
+    with pytest.raises(ValueError, match="Cannot convert non-finite values"):
+        nw.DataFrame.from_dicts(
+            [{"a": 1}, {}], backend="pandas", schema={"a": nw.Int64()}
+        )
 
 
 def test_from_dicts_non_eager() -> None:


### PR DESCRIPTION
## Summary

Fixes #3837.

`from_dicts` with an explicit `schema` treats the schema as the source of truth for column selection, order, and dtypes on Polars and PyArrow, but on the pandas-like backend it only used the schema as a dtype hint.

Root cause: `PandasLikeDataFrame.from_dicts` builds the native frame with `DataFrame.from_records(data)`, which derives the column set/order purely from the row dicts' key order. The following `native.astype(native_schema)` only casts dtypes for whichever schema keys already happen to be present — it never selects, drops extras, adds missing columns, or reorders to match the schema's key order.

| given | polars | pyarrow | pandas (before) | pandas (after) |
|---|---|---|---|---|
| row keys in a different order than the schema | `['a', 'b']` | `['a', 'b']` | `['b', 'a']` | `['a', 'b']` |
| a key in the data that the schema omits | `['a', 'b']` | `['a', 'b']` | `['a', 'b', 'c']` | `['a', 'b']` |
| a key in the schema that the data omits | `['a', 'b']` | `['a', 'b']` | `['a']` | `['a', 'b']` |

## Fix

In the populated-data branch, `reindex` the native frame to `schema`'s columns before the existing `astype` dtype-casting step, so newly-added missing columns still get their dtype cast. The empty-data branch already builds directly from `schema`, so it needs no change.

## Test plan

- [x] Extended `tests/frame/from_dicts_test.py` with `test_from_dicts_schema_reordered_keys`, `test_from_dicts_schema_extra_key`, and `test_from_dicts_schema_missing_key`, parametrized via the `eager_backend` fixture (pandas/pyarrow/polars).
- [x] Confirmed the 6 new pandas-backend cases fail on `main` and pass after the fix; polars/pyarrow were already passing (used as the reference behavior).
- [x] `uv run pytest tests/frame -q` — 2195 passed, 292 skipped, 72 xfailed (no regressions).
- [x] `uv run ruff check` / `uv run ruff format --check` on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)