### PR TITLE
fix: `is_in` was not preserving nulls where possible

### DIFF
--- a/src/narwhals/_arrow/series.py
+++ b/src/narwhals/_arrow/series.py
@@ -570,7 +570,9 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
             value_set: ArrayOrChunkedArray = other
         else:
             value_set = pa.array(other)
-        return self._with_native(pc.is_in(self.native, value_set=value_set))
+        native = self.native
+        is_in = pc.is_in(native, value_set=value_set)
+        return self._with_native(pc.if_else(native.is_null(), None, is_in))
 
     def arg_true(self) -> Self:
         import numpy as np  # ignore-banned-import

--- a/src/narwhals/_ibis/expr.py
+++ b/src/narwhals/_ibis/expr.py
@@ -267,7 +267,12 @@ class IbisExpr(SQLExpr["IbisLazyFrame", "ir.Value"]):
         return self._with_callable(func)
 
     def is_in(self, other: Sequence[Any]) -> Self:
-        return self._with_callable(lambda expr: expr.isin(other))
+        values = [v for v in other if v is not None]
+
+        def func(expr: ir.Value) -> ir.Value:
+            return ibis.ifelse(expr.isnull(), None, expr.isin(values))
+
+        return self._with_callable(func)
 
     def fill_null(self, value: Self | None, strategy: Any, limit: int | None) -> Self:
         # Ibis doesn't yet allow ignoring nulls in first/last with window functions, which makes forward/backward

--- a/src/narwhals/_pandas_like/series.py
+++ b/src/narwhals/_pandas_like/series.py
@@ -371,7 +371,16 @@ class PandasLikeSeries(EagerSeries[Any]):
         return self._with_native(res).alias(ser.name)
 
     def is_in(self, other: Any) -> Self:
-        return self._with_native(self.native.isin(other))
+        ser = self.native
+        res = ser.isin(other)
+        dtype_backend = get_dtype_backend(ser.dtype, self._implementation)
+        if dtype_backend is not None:
+            res = res.convert_dtypes(dtype_backend=dtype_backend)
+            if self._implementation.is_pandas() and self._backend_version < (3, 0):
+                res.mask(ser.isna(), inplace=True)  # noqa: PD002
+            else:
+                res = res.mask(ser.isna())
+        return self._with_native(res)
 
     def arg_true(self) -> Self:
         ser = self.native

--- a/src/narwhals/_spark_like/expr.py
+++ b/src/narwhals/_spark_like/expr.py
@@ -307,8 +307,11 @@ class SparkLikeExpr(SQLExpr["SparkLikeLazyFrame", "Column"]):
         return self._with_elementwise(_is_finite)
 
     def is_in(self, other: Sequence[Any]) -> Self:
+        values = [v for v in other if v is not None]
+
         def _is_in(expr: Column) -> Column:
-            return expr.isin(other) if other else self._F.lit(False)
+            matches = expr.isin(values) if values else self._F.lit(False)
+            return self._F.when(self._F.isnull(expr), None).otherwise(matches)
 
         return self._with_elementwise(_is_in)
 

--- a/src/narwhals/expr.py
+++ b/src/narwhals/expr.py
@@ -983,6 +983,10 @@ class Expr:
         Arguments:
             other: iterable
 
+        Notes:
+            Null values are preserved, unless `self` is backed by a non-nullable pandas Series
+            (which does not support missing values). See [boolean columns](../concepts/boolean.md) for reference.
+
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw

--- a/src/narwhals/series.py
+++ b/src/narwhals/series.py
@@ -956,6 +956,10 @@ class Series(Generic[IntoSeriesT]):
         Returns:
             A scalar value or `None` if the Series is empty.
 
+        Notes:
+            Null values are preserved, unless `self` is backed by a non-nullable pandas Series
+            (which does not support missing values). See [boolean columns](../concepts/boolean.md) for reference.
+
         Examples:
             >>> import pyarrow as pa
             >>> import narwhals as nw

--- a/tests/expr_and_series/is_in_test.py
+++ b/tests/expr_and_series/is_in_test.py
@@ -1,13 +1,27 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 import pytest
 
 import narwhals as nw
+from tests.conftest import (
+    dask_lazy_p1_constructor,
+    dask_lazy_p2_constructor,
+    modin_constructor,
+    pandas_constructor,
+)
 from tests.utils import Constructor, ConstructorEager, assert_equal_data
 
 data = {"a": [1, 4, 2, 5]}
+
+NON_NULLABLE_CONSTRUCTORS = [
+    pandas_constructor,
+    dask_lazy_p1_constructor,
+    dask_lazy_p2_constructor,
+    modin_constructor,
+]
 
 
 def test_expr_is_in(constructor: Constructor) -> None:
@@ -49,4 +63,68 @@ def test_filter_is_in_with_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.filter(nw.col("a").is_in(df["b"]))
     expected = {"a": [1, 2], "b": [1, 2]}
+    assert_equal_data(result, expected)
+
+
+def test_expr_is_in_with_null(constructor: Constructor) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3851
+    data_with_null = {"a": [1, 2, None, 4]}
+    df = nw.from_native(constructor(data_with_null))
+    result = df.select(nw.col("a").is_in([1, 2]))
+
+    expected: dict[str, list[Any]]
+    if any(constructor is c for c in NON_NULLABLE_CONSTRUCTORS):
+        # Null values are coerced to NaN for non-nullable datatypes, and
+        # `is_in` treats them like a regular (non-matching) value.
+        expected = {"a": [True, True, False, False]}
+    else:
+        expected = {"a": [True, True, None, False]}
+
+    assert_equal_data(result, expected)
+
+
+def test_filter_is_in_with_null(constructor: Constructor) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3851
+    data_with_null = {"a": [1, 2, None, 4]}
+    df = nw.from_native(constructor(data_with_null))
+    result = df.filter(~nw.col("a").is_in([1, 2]))
+
+    expected: dict[str, list[Any]]
+    if any(constructor is c for c in NON_NULLABLE_CONSTRUCTORS):
+        expected = {"a": [None, 4]}
+    else:
+        expected = {"a": [4]}
+
+    assert_equal_data(result, expected)
+
+
+def test_expr_is_in_with_null_in_other(constructor: Constructor) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3851
+    # A `None` in `other` shouldn't match anything (not even a null `a`), and
+    # shouldn't turn non-null, non-matching values into "unknown" either.
+    data_with_null = {"a": [1, 2, None, 4]}
+    df = nw.from_native(constructor(data_with_null))
+    result = df.select(nw.col("a").is_in([1, None]))
+
+    expected: dict[str, list[Any]]
+    if any(constructor is c for c in NON_NULLABLE_CONSTRUCTORS):
+        expected = {"a": [True, False, False, False]}
+    else:
+        expected = {"a": [True, False, None, False]}
+
+    assert_equal_data(result, expected)
+
+
+def test_expr_is_in_with_only_null_in_other(constructor: Constructor) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3851
+    data_with_null = {"a": [1, 2, None, 4]}
+    df = nw.from_native(constructor(data_with_null))
+    result = df.select(nw.col("a").is_in([None]))
+
+    expected: dict[str, list[Any]]
+    if any(constructor is c for c in NON_NULLABLE_CONSTRUCTORS):
+        expected = {"a": [False, False, False, False]}
+    else:
+        expected = {"a": [False, False, None, False]}
+
     assert_equal_data(result, expected)


### PR DESCRIPTION
closes #3851
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
