### PR TITLE
fix: order `Categorical` columns by value in the `pyarrow` backend

### DIFF
--- a/src/narwhals/_arrow/dataframe.py
+++ b/src/narwhals/_arrow/dataframe.py
@@ -13,6 +13,8 @@ from narwhals._arrow.utils import (
     narwhals_to_native_dtype,
     native_to_narwhals_dtype,
     repeat,
+    sort_indices,
+    sortable_table,
 )
 from narwhals._compliant import EagerDataFrame
 from narwhals._utils import (
@@ -44,6 +46,7 @@ if TYPE_CHECKING:
     from narwhals._arrow.namespace import ArrowNamespace
     from narwhals._arrow.typing import (  # type: ignore[attr-defined]
         ChunkedArrayAny,
+        NullPlacement,
         Order,
     )
     from narwhals._compliant.typing import CompliantDataFrameAny, CompliantLazyFrameAny
@@ -486,20 +489,11 @@ class ArrowDataFrame(
                 for key, is_descending in zip(by, descending, strict=True)
             ]
 
-        null_placement = "at_end" if nulls_last else "at_start"
-
-        if self._backend_version < (25,):  # pragma: no cover
-            return self._with_native(
-                self.native.sort_by(sorting, null_placement=null_placement),
-                validate_column_names=False,
-            )
-        # `null_placement` in `SortOptions` is deprecated since 25.0.0;
-        # it must be specified per sort key instead.
-        keyed = [(key, order, null_placement) for key, order in sorting]
-        return self._with_native(
-            self.native.sort_by(keyed),  # type: ignore[arg-type]
-            validate_column_names=False,
-        )
+        null_placement: NullPlacement = "at_end" if nulls_last else "at_start"
+        # NOTE: sort on `sortable_table`, take from the original, so that
+        # dictionary-encoded (categorical) keys keep their encoding in the output.
+        indices = sort_indices(sortable_table(self.native, by), sorting, null_placement)
+        return self._with_native(self.native.take(indices), validate_column_names=False)
 
     def top_k(self, k: int, *, by: Iterable[str], reverse: bool | Sequence[bool]) -> Self:
         if isinstance(reverse, bool):
@@ -510,10 +504,10 @@ class ArrowDataFrame(
                 (key, "ascending" if is_ascending else "descending")
                 for key, is_ascending in zip(by, reverse, strict=True)
             ]
-        return self._with_native(
-            self.native.take(pc.select_k_unstable(self.native, k, sorting)),  # type: ignore[call-overload]
-            validate_column_names=False,
-        )
+        keys = [name for name, _ in sorting]
+        table = sortable_table(self.native, keys)
+        indices = pc.select_k_unstable(table, k, sorting)  # type: ignore[call-overload]
+        return self._with_native(self.native.take(indices), validate_column_names=False)
 
     def to_pandas(self) -> pd.DataFrame:
         return self.native.to_pandas()
@@ -551,7 +545,8 @@ class ArrowDataFrame(
                 plx._series.from_iterable(data, context=self, name=name)
             )
             return self.select(row_index, plx.all())
-        indices = pc.sort_indices(self.native, [(by, "ascending") for by in order_by])
+        sorting: list[tuple[str, Order]] = [(name, "ascending") for name in order_by]
+        indices = sort_indices(sortable_table(self.native, order_by), sorting, "at_end")
         if self._backend_version < (20,):
             new_col = data.take(pc.sort_indices(indices))
         else:

--- a/src/narwhals/_arrow/series.py
+++ b/src/narwhals/_arrow/series.py
@@ -22,6 +22,7 @@ from narwhals._arrow.utils import (
     native_to_narwhals_dtype,
     nulls_like,
     pad_series,
+    sortable,
     zeros,
 )
 from narwhals._compliant import EagerSeries, EagerSeriesHist
@@ -778,7 +779,7 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
         order: Order = "descending" if descending else "ascending"
         null_placement: NullPlacement = "at_end" if nulls_last else "at_start"
         sorted_indices = pc.array_sort_indices(
-            self.native, order=order, null_placement=null_placement
+            sortable(self.native), order=order, null_placement=null_placement
         )
         return self._with_native(self.native.take(sorted_indices))
 
@@ -1008,10 +1009,11 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
         tiebreaker: TieBreaker = "first" if method == "ordinal" else method
 
         native_series: ArrayOrChunkedArray
+        sortable_series = sortable(self.native)
         if self._backend_version < (14, 0, 0):  # pragma: no cover
-            native_series = self.native.combine_chunks()
+            native_series = sortable_series.combine_chunks()
         else:
-            native_series = self.native
+            native_series = sortable_series
 
         null_mask = pc.is_null(native_series)
 

--- a/src/narwhals/_arrow/typing.py
+++ b/src/narwhals/_arrow/typing.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
         Aggregation,  # noqa: F401
     )
     from pyarrow._stubs_typing import (  # pyright: ignore[reportMissingModuleSource]  # pyright: ignore[reportMissingModuleSource]  # pyright: ignore[reportMissingModuleSource]
-        Indices,  # noqa: F401
+        Indices,
         Mask,  # noqa: F401
         Order,  # noqa: F401
     )
@@ -46,6 +46,18 @@ if TYPE_CHECKING:
     ArrayOrChunkedArray: TypeAlias = "ArrayAny | ChunkedArrayAny"
     ScalarAny: TypeAlias = pa.Scalar[Any]
     ArrayOrScalar: TypeAlias = "ArrayOrChunkedArray | ScalarAny"
+
+    class DictionaryArrayAny(pa.Array[Any]):
+        """`pa.DictionaryArray`, declaring the attributes the stubs are missing.
+
+        https://arrow.apache.org/docs/python/generated/pyarrow.DictionaryArray.html
+        """
+
+        @property
+        def dictionary(self) -> ArrayAny: ...
+        @property
+        def indices(self) -> Indices: ...
+
     ArrayOrScalarT1 = TypeVar("ArrayOrScalarT1", ArrayAny, ChunkedArrayAny, ScalarAny)
     ArrayOrScalarT2 = TypeVar("ArrayOrScalarT2", ArrayAny, ChunkedArrayAny, ScalarAny)
     _AsPyType = TypeVar("_AsPyType")

--- a/src/narwhals/_arrow/utils.py
+++ b/src/narwhals/_arrow/utils.py
@@ -590,6 +590,9 @@ def sortable_table(table: pa.Table, keys: Iterable[str], /) -> pa.Table:
     """Replace every `dictionary`-typed column named in `keys` with `sortable` ranks."""
     for name in keys:
         index = table.schema.get_field_index(name)
+        if index == -1:  # pragma: no cover
+            msg = f"Column '{name}' not found in table."
+            raise KeyError(msg)
         if is_dictionary(table.field(index).type):
             table = table.set_column(index, name, sortable(table.column(index)))
     return table

--- a/src/narwhals/_arrow/utils.py
+++ b/src/narwhals/_arrow/utils.py
@@ -8,6 +8,7 @@ import pyarrow.compute as pc
 
 from narwhals._compliant import EagerSeriesNamespace
 from narwhals._utils import Implementation, Version, isinstance_or_issubclass
+from narwhals.exceptions import ColumnNotFoundError
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping, Sequence
@@ -592,7 +593,7 @@ def sortable_table(table: pa.Table, keys: Iterable[str], /) -> pa.Table:
         index = table.schema.get_field_index(name)
         if index == -1:  # pragma: no cover
             msg = f"Column '{name}' not found in table."
-            raise KeyError(msg)
+            raise ColumnNotFoundError(msg)
         if is_dictionary(table.field(index).type):
             table = table.set_column(index, name, sortable(table.column(index)))
     return table

--- a/src/narwhals/_arrow/utils.py
+++ b/src/narwhals/_arrow/utils.py
@@ -10,20 +10,23 @@ from narwhals._compliant import EagerSeriesNamespace
 from narwhals._utils import Implementation, Version, isinstance_or_issubclass
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Mapping
+    from collections.abc import Iterable, Iterator, Mapping, Sequence
     from typing import Literal, TypeAlias
 
     from typing_extensions import TypeIs
 
     from narwhals._arrow.series import ArrowSeries
-    from narwhals._arrow.typing import (
+    from narwhals._arrow.typing import (  # type: ignore[attr-defined]
         ArrayAny,
         ArrayOrScalar,
         ArrayOrScalarT1,
         ArrayOrScalarT2,
         ChunkedArrayAny,
+        DictionaryArrayAny,
         Incomplete,
         NativeIntervalUnit,
+        NullPlacement,
+        Order,
         PromoteOptions,
         ScalarAny,
     )
@@ -53,7 +56,7 @@ if TYPE_CHECKING:
 else:
     from pyarrow.compute import extract_regex
     from pyarrow.types import (
-        is_dictionary,  # noqa: F401
+        is_dictionary,
         is_duration,
         is_fixed_size_list,
         is_large_list,
@@ -560,6 +563,50 @@ def list_agg(
     )
 
 
+def sortable(array: ChunkedArrayAny, /) -> ChunkedArrayAny:
+    """Return an array which orders like `array`, but with a type `pyarrow` can sort.
+
+    `pyarrow` has no ordering kernels for `dictionary` types
+    (https://github.com/apache/arrow/issues/29887), so replace the dictionary indices
+    with the rank of the value they point at. Ranking the (typically small) dictionary
+    is much cheaper than decoding every row, and gives the lexicographic order which
+    `polars` and `pandas` use for (unordered) categoricals.
+    """
+    if not is_dictionary(array.type):
+        return array
+    # NOTE: stubs type the chunks as `Array`, which is missing `DictionaryArray` members
+    chunks = cast("list[DictionaryArrayAny]", array.unify_dictionaries().chunks)
+    if not chunks:
+        return chunked_array([[]], pa.uint64())
+    dictionary = chunks[0].dictionary
+    ranks = pc.rank(dictionary, sort_keys="ascending", tiebreaker="min")
+    if dictionary.null_count:
+        # NOTE: a null *value* must stay null, `rank` would give it a (largest) rank.
+        ranks = pc.if_else(pc.is_null(dictionary), lit(None, ranks.type), ranks)
+    return pa.chunked_array([ranks.take(chunk.indices) for chunk in chunks])
+
+
+def sortable_table(table: pa.Table, keys: Iterable[str], /) -> pa.Table:
+    """Replace every `dictionary`-typed column named in `keys` with `sortable` ranks."""
+    for name in keys:
+        index = table.schema.get_field_index(name)
+        if is_dictionary(table.field(index).type):
+            table = table.set_column(index, name, sortable(table.column(index)))
+    return table
+
+
+def sort_indices(
+    table: pa.Table, sorting: Sequence[tuple[str, Order]], null_placement: NullPlacement
+) -> pa.UInt64Array:
+    """`pc.sort_indices`, hiding how `null_placement` must be passed per version."""
+    if BACKEND_VERSION < (25,):  # pragma: no cover
+        return pc.sort_indices(table, sort_keys=sorting, null_placement=null_placement)
+    # `null_placement` in `SortOptions` is deprecated since 25.0.0;
+    # it must be specified per sort key instead.
+    keyed = [(name, order, null_placement) for name, order in sorting]
+    return pc.sort_indices(table, sort_keys=keyed)  # type: ignore[arg-type]
+
+
 def list_sort(
     array: ChunkedArrayAny, *, descending: bool, nulls_last: bool
 ) -> ChunkedArrayAny:
@@ -577,17 +624,9 @@ def list_sort(
     exploded = pa.Table.from_arrays(
         [pc.list_flatten(array), pc.list_parent_indices(array)], names=[v, idx]
     )
-    if BACKEND_VERSION < (25,):  # pragma: no cover
-        sorted_indices = pc.sort_indices(
-            exploded,
-            sort_keys=[(idx, "ascending"), (v, sort_direction)],
-            null_placement=nulls_position,
-        )
-    else:
-        # `null_placement` in `SortOptions` is deprecated since 25.0.0;
-        # it must be specified per sort key instead.
-        keyed = [(idx, "ascending", nulls_position), (v, sort_direction, nulls_position)]
-        sorted_indices = pc.sort_indices(exploded, sort_keys=keyed)  # type: ignore[arg-type]
+    sorted_indices = sort_indices(
+        exploded, [(idx, "ascending"), (v, sort_direction)], nulls_position
+    )
 
     offsets = not_sorted_part.column(v).combine_chunks().offsets  # type: ignore[attr-defined]
     sorted_imploded = pa.ListArray.from_arrays(

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -8,12 +8,12 @@ import narwhals as nw
 from narwhals.exceptions import InvalidOperationError
 from tests.utils import (
     DUCKDB_VERSION,
-    ID_NO_CATEGORICAL_ORDERING,
     PANDAS_VERSION,
     POLARS_VERSION,
     Constructor,
     ConstructorEager,
     assert_equal_data,
+    skip_if_no_categorical_ordering,
 )
 
 data = {
@@ -434,8 +434,7 @@ def test_over_without_partition_by(
 
 def test_over_without_partition_by_categorical(constructor: Constructor) -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3841
-    if any(x in str(constructor) for x in ID_NO_CATEGORICAL_ORDERING):
-        pytest.skip(reason="cannot order `Categorical` by value")
+    skip_if_no_categorical_ordering(constructor)
     if "polars" in str(constructor) and POLARS_VERSION < (1, 10):
         pytest.skip()
 

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -8,6 +8,7 @@ import narwhals as nw
 from narwhals.exceptions import InvalidOperationError
 from tests.utils import (
     DUCKDB_VERSION,
+    ID_NO_CATEGORICAL_ORDERING,
     PANDAS_VERSION,
     POLARS_VERSION,
     Constructor,
@@ -428,6 +429,24 @@ def test_over_without_partition_by(
         .select("a", "b", "i")
     )
     expected = {"a": [1, 2, -1], "b": [1, 3, 4], "i": [0, 1, 2]}
+    assert_equal_data(result, expected)
+
+
+def test_over_without_partition_by_categorical(constructor: Constructor) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3841
+    if any(x in str(constructor) for x in ID_NO_CATEGORICAL_ORDERING):
+        pytest.skip(reason="cannot order `Categorical` by value")
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 10):
+        pytest.skip()
+
+    df = nw.from_native(constructor({"a": [1, 2, 3], "i": ["dog", "cat", "bird"]}))
+    result = (
+        df.with_columns(nw.col("i").cast(nw.Categorical()))
+        .with_columns(b=nw.col("a").cum_sum().over(order_by="i"))
+        .sort("a")
+        .select("a", "b")
+    )
+    expected = {"a": [1, 2, 3], "b": [6, 5, 3]}
     assert_equal_data(result, expected)
 
 

--- a/tests/expr_and_series/over_test.py
+++ b/tests/expr_and_series/over_test.py
@@ -435,9 +435,6 @@ def test_over_without_partition_by(
 def test_over_without_partition_by_categorical(constructor: Constructor) -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3841
     skip_if_no_categorical_ordering(constructor)
-    if "polars" in str(constructor) and POLARS_VERSION < (1, 10):
-        pytest.skip()
-
     df = nw.from_native(constructor({"a": [1, 2, 3], "i": ["dog", "cat", "bird"]}))
     result = (
         df.with_columns(nw.col("i").cast(nw.Categorical()))

--- a/tests/expr_and_series/rank_test.py
+++ b/tests/expr_and_series/rank_test.py
@@ -8,6 +8,7 @@ import pytest
 import narwhals as nw
 from tests.utils import (
     DUCKDB_VERSION,
+    ID_NO_CATEGORICAL_ORDERING,
     PANDAS_VERSION,
     POLARS_VERSION,
     Constructor,
@@ -423,3 +424,18 @@ def test_rank_with_order_by_and_partition_by(
             "c": [2, 1, 3, 1, 2, 3],
         }
         assert_equal_data(result, expected)
+
+
+def test_rank_categorical(constructor: Constructor) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3841
+    if any(x in str(constructor) for x in ID_NO_CATEGORICAL_ORDERING):
+        pytest.skip(reason="cannot order `Categorical` by value")
+
+    data = {"c": ["dog", "cat", "cat", "bird", "dog"], "i": [1, 2, 3, 4, 5]}
+    df = nw.from_native(constructor(data))
+    result = (
+        df.with_columns(r=nw.col("c").cast(nw.Categorical()).rank("dense"))
+        .sort("i")
+        .select("i", "r")
+    )
+    assert_equal_data(result, {"i": [1, 2, 3, 4, 5], "r": [3, 2, 2, 1, 3]})

--- a/tests/expr_and_series/rank_test.py
+++ b/tests/expr_and_series/rank_test.py
@@ -8,13 +8,13 @@ import pytest
 import narwhals as nw
 from tests.utils import (
     DUCKDB_VERSION,
-    ID_NO_CATEGORICAL_ORDERING,
     PANDAS_VERSION,
     POLARS_VERSION,
     Constructor,
     ConstructorEager,
     assert_equal_data,
     is_windows,
+    skip_if_no_categorical_ordering,
 )
 
 rank_methods = ["average", "min", "max", "dense", "ordinal"]
@@ -428,8 +428,7 @@ def test_rank_with_order_by_and_partition_by(
 
 def test_rank_categorical(constructor: Constructor) -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3841
-    if any(x in str(constructor) for x in ID_NO_CATEGORICAL_ORDERING):
-        pytest.skip(reason="cannot order `Categorical` by value")
+    skip_if_no_categorical_ordering(constructor)
 
     data = {"c": ["dog", "cat", "cat", "bird", "dog"], "i": [1, 2, 3, 4, 5]}
     df = nw.from_native(constructor(data))

--- a/tests/frame/sort_test.py
+++ b/tests/frame/sort_test.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 import narwhals as nw
-from tests.utils import ID_NO_CATEGORICAL_ORDERING, Constructor, assert_equal_data
+from tests.utils import Constructor, assert_equal_data, skip_if_no_categorical_ordering
 
 
 def test_sort(constructor: Constructor) -> None:
@@ -53,8 +53,7 @@ def test_sort_categorical(
 ) -> None:
     # (unordered) categoricals order lexicographically on the value, not on the
     # encoding: https://github.com/narwhals-dev/narwhals/issues/3841
-    if any(x in str(constructor) for x in ID_NO_CATEGORICAL_ORDERING):
-        pytest.skip(reason="cannot order `Categorical` by value")
+    skip_if_no_categorical_ordering(constructor)
 
     data = {"c": ["dog", None, "cat", "bird", None], "n": [1, 2, 3, 4, 5]}
     df = nw.from_native(constructor(data)).with_columns(
@@ -65,8 +64,7 @@ def test_sort_categorical(
 
 
 def test_sort_categorical_empty(constructor: Constructor) -> None:
-    if any(x in str(constructor) for x in ID_NO_CATEGORICAL_ORDERING):
-        pytest.skip(reason="cannot order `Categorical` by value")
+    skip_if_no_categorical_ordering(constructor)
 
     data = {"c": ["dog", "cat"], "n": [1, 2]}
     df = nw.from_native(constructor(data)).with_columns(

--- a/tests/frame/sort_test.py
+++ b/tests/frame/sort_test.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 import narwhals as nw
-from tests.utils import Constructor, assert_equal_data
+from tests.utils import ID_NO_CATEGORICAL_ORDERING, Constructor, assert_equal_data
 
 
 def test_sort(constructor: Constructor) -> None:
@@ -31,3 +33,82 @@ def test_sort_nulls(
     df = nw.from_native(constructor(data))
     result = df.sort("b", descending=True, nulls_last=nulls_last)
     assert_equal_data(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("descending", "nulls_last", "expected"),
+    [
+        (False, True, {"c": ["bird", "cat", "dog", None, None], "n": [4, 3, 1, 2, 5]}),
+        (False, False, {"c": [None, None, "bird", "cat", "dog"], "n": [2, 5, 4, 3, 1]}),
+        (True, True, {"c": ["dog", "cat", "bird", None, None], "n": [1, 3, 4, 2, 5]}),
+        (True, False, {"c": [None, None, "dog", "cat", "bird"], "n": [2, 5, 1, 3, 4]}),
+    ],
+)
+def test_sort_categorical(
+    constructor: Constructor,
+    *,
+    descending: bool,
+    nulls_last: bool,
+    expected: dict[str, Any],
+) -> None:
+    # (unordered) categoricals order lexicographically on the value, not on the
+    # encoding: https://github.com/narwhals-dev/narwhals/issues/3841
+    if any(x in str(constructor) for x in ID_NO_CATEGORICAL_ORDERING):
+        pytest.skip(reason="cannot order `Categorical` by value")
+
+    data = {"c": ["dog", None, "cat", "bird", None], "n": [1, 2, 3, 4, 5]}
+    df = nw.from_native(constructor(data)).with_columns(
+        nw.col("c").cast(nw.Categorical())
+    )
+    result = df.sort("c", "n", descending=[descending, False], nulls_last=nulls_last)
+    assert_equal_data(result, expected)
+
+
+def test_sort_categorical_empty(constructor: Constructor) -> None:
+    if any(x in str(constructor) for x in ID_NO_CATEGORICAL_ORDERING):
+        pytest.skip(reason="cannot order `Categorical` by value")
+
+    data = {"c": ["dog", "cat"], "n": [1, 2]}
+    df = nw.from_native(constructor(data)).with_columns(
+        nw.col("c").cast(nw.Categorical())
+    )
+    result = df.filter(nw.col("n") > 2).sort("c")
+    assert_equal_data(result, {"c": [], "n": []})
+
+
+@pytest.mark.parametrize(
+    ("chunks", "ordered", "expected"),
+    [
+        ([([0, 1, 0], ["a", None])], False, [None, "a", "a"]),
+        ([([2, 0, 1], [3, 1, 2])], False, [1, 2, 3]),
+        ([([0, 1, 2], ["b", "a", "b"])], False, ["a", "b", "b"]),
+        (
+            [([0, 1], ["dog", "cat"]), ([0, 1], ["bird", "dog"])],
+            False,
+            ["bird", "cat", "dog", "dog"],
+        ),
+        ([([0, 1, 2], ["dog", "cat", "bird"])], True, ["bird", "cat", "dog"]),
+    ],
+)
+def test_sort_dictionary_pyarrow(
+    chunks: list[tuple[list[int], list[Any]]], expected: list[Any], *, ordered: bool
+) -> None:
+    """Dictionary layouts which cannot be expressed through a `constructor`."""
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa
+
+    column = pa.chunked_array(
+        [
+            pa.DictionaryArray.from_arrays(
+                pa.array(indices, pa.int32()), pa.array(values)
+            )
+            for indices, values in chunks
+        ]
+    )
+    if ordered:
+        column = column.cast(pa.dictionary(pa.int32(), pa.string(), ordered=True))
+    native = pa.Table.from_arrays([column], names=["c"])
+    result = nw.from_native(native).sort("c", nulls_last=False)
+    assert_equal_data(result, {"c": expected})
+    # ordering does not decode the output
+    assert result.to_native().schema == native.schema

--- a/tests/frame/top_k_test.py
+++ b/tests/frame/top_k_test.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import pytest
 
 import narwhals as nw
-from tests.utils import DUCKDB_VERSION, POLARS_VERSION, Constructor, assert_equal_data
+from tests.utils import (
+    DUCKDB_VERSION,
+    ID_NO_CATEGORICAL_ORDERING,
+    POLARS_VERSION,
+    Constructor,
+    assert_equal_data,
+)
 
 
 def test_top_k(constructor: Constructor) -> None:
@@ -55,3 +61,18 @@ def test_top_k_by_multiple(constructor: Constructor) -> None:
         "sf_c": ["a", "d", "k", "s"],
     }
     assert_equal_data(result.sort("sf_c"), expected)
+
+
+def test_top_k_categorical(constructor: Constructor) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3841
+    if any(x in str(constructor) for x in ID_NO_CATEGORICAL_ORDERING):
+        pytest.skip(reason="cannot order `Categorical` by value")
+
+    data = {"c": ["dog", "cat", "bird"], "n": [1, 2, 3]}
+    df = nw.from_native(constructor(data)).with_columns(
+        nw.col("c").cast(nw.Categorical())
+    )
+    result = df.top_k(2, by="c").sort("n")
+    assert_equal_data(result, {"c": ["dog", "cat"], "n": [1, 2]})
+    result = df.top_k(2, by="c", reverse=True).sort("n")
+    assert_equal_data(result, {"c": ["cat", "bird"], "n": [2, 3]})

--- a/tests/frame/top_k_test.py
+++ b/tests/frame/top_k_test.py
@@ -5,10 +5,10 @@ import pytest
 import narwhals as nw
 from tests.utils import (
     DUCKDB_VERSION,
-    ID_NO_CATEGORICAL_ORDERING,
     POLARS_VERSION,
     Constructor,
     assert_equal_data,
+    skip_if_no_categorical_ordering,
 )
 
 
@@ -65,8 +65,7 @@ def test_top_k_by_multiple(constructor: Constructor) -> None:
 
 def test_top_k_categorical(constructor: Constructor) -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3841
-    if any(x in str(constructor) for x in ID_NO_CATEGORICAL_ORDERING):
-        pytest.skip(reason="cannot order `Categorical` by value")
+    skip_if_no_categorical_ordering(constructor)
 
     data = {"c": ["dog", "cat", "bird"], "n": [1, 2, 3]}
     df = nw.from_native(constructor(data)).with_columns(

--- a/tests/frame/with_row_index_test.py
+++ b/tests/frame/with_row_index_test.py
@@ -7,11 +7,11 @@ import pytest
 import narwhals as nw
 from tests.utils import (
     DUCKDB_VERSION,
-    ID_NO_CATEGORICAL_ORDERING,
     POLARS_VERSION,
     Constructor,
     ConstructorEager,
     assert_equal_data,
+    skip_if_no_categorical_ordering,
 )
 
 if TYPE_CHECKING:
@@ -89,8 +89,7 @@ def test_with_row_index_lazy_meaner_examples(
 
 def test_with_row_index_order_by_categorical(constructor: Constructor) -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3841
-    if any(x in str(constructor) for x in ID_NO_CATEGORICAL_ORDERING):
-        pytest.skip(reason="cannot order `Categorical` by value")
+    skip_if_no_categorical_ordering(constructor)
 
     df = nw.from_native(constructor({"c": ["dog", "cat", "bird"], "n": [1, 2, 3]}))
     result = (

--- a/tests/frame/with_row_index_test.py
+++ b/tests/frame/with_row_index_test.py
@@ -7,6 +7,7 @@ import pytest
 import narwhals as nw
 from tests.utils import (
     DUCKDB_VERSION,
+    ID_NO_CATEGORICAL_ORDERING,
     POLARS_VERSION,
     Constructor,
     ConstructorEager,
@@ -84,3 +85,18 @@ def test_with_row_index_lazy_meaner_examples(
     result = df.with_row_index(name="index", order_by=order_by).sort("b")
     expected = {"index": expected_index, **data}
     assert_equal_data(result, expected)
+
+
+def test_with_row_index_order_by_categorical(constructor: Constructor) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3841
+    if any(x in str(constructor) for x in ID_NO_CATEGORICAL_ORDERING):
+        pytest.skip(reason="cannot order `Categorical` by value")
+
+    df = nw.from_native(constructor({"c": ["dog", "cat", "bird"], "n": [1, 2, 3]}))
+    result = (
+        df.with_columns(nw.col("c").cast(nw.Categorical()))
+        .with_row_index("i", order_by="c")
+        .sort("n")
+        .select("i", "n")
+    )
+    assert_equal_data(result, {"i": [2, 1, 0], "n": [1, 2, 3]})

--- a/tests/series_only/sort_test.py
+++ b/tests/series_only/sort_test.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import narwhals as nw
-from tests.utils import assert_equal_data
+from tests.utils import assert_equal_data, skip_if_no_categorical_ordering
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
@@ -33,6 +33,7 @@ def test_sort_series(
 
 def test_sort_series_categorical(constructor_eager: ConstructorEager) -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3841
+    skip_if_no_categorical_ordering(constructor_eager)
     series = nw.from_native(
         constructor_eager({"a": ["dog", "bird", "cat"]}), eager_only=True
     )["a"].cast(nw.Categorical())

--- a/tests/series_only/sort_test.py
+++ b/tests/series_only/sort_test.py
@@ -29,3 +29,12 @@ def test_sort_series(
     result = series.sort(descending=descending, nulls_last=nulls_last)
 
     assert_equal_data({"a": result}, {"a": expected})
+
+
+def test_sort_series_categorical(constructor_eager: ConstructorEager) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3841
+    series = nw.from_native(
+        constructor_eager({"a": ["dog", "bird", "cat"]}), eager_only=True
+    )["a"].cast(nw.Categorical())
+    assert_equal_data({"a": series.sort()}, {"a": ["bird", "cat", "dog"]})
+    assert_equal_data({"a": series.sort(descending=True)}, {"a": ["dog", "cat", "bird"]})

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -57,13 +57,6 @@ ID_PANDAS_LIKE = frozenset(
     ("pandas", "pandas[nullable]", "pandas[pyarrow]", "modin", "modin[pyarrow]", "cudf")
 )
 ID_CUDF = frozenset(("cudf",))
-ID_NO_CATEGORICAL_ORDERING = ("pyspark", "duckdb", "ibis", "dask")
-"""Backends which cannot order a `Categorical` column by its values.
-
-`pyspark`, `duckdb` and `ibis` have no categorical support at all; `dask` encodes the
-categories per partition, so ordering them by value would need a compute.
-"""
-
 _CONSTRUCTOR_FIXTURE_NAMES = frozenset[str](
     ("constructor_eager", "constructor", "constructor_pandas_like")
 )
@@ -85,6 +78,28 @@ def _to_comparable_list(column_values: Any) -> Any:
     if hasattr(column_values, "to_list"):
         return column_values.to_list()
     return list(column_values)
+
+
+def skip_if_no_categorical_ordering(
+    constructor: Constructor | ConstructorEager, /
+) -> None:
+    """Skip if the backend cannot order a `Categorical` column by its values.
+
+    - `pyspark`, `duckdb` and `ibis` have no categorical dtype.
+    - `dask` encodes the categories per partition, so ordering them by value would
+      need a compute.
+    - `polars<1.32` orders by the physical encoding instead of by value
+      (https://github.com/pola-rs/polars/pull/23779).
+    - `pyarrow<15` cannot cast `string` to `dictionary`, so the column cannot even be
+      created.
+    """
+    id_ = str(constructor)
+    if any(x in id_ for x in ("pyspark", "duckdb", "ibis", "dask")):
+        pytest.skip(reason="no `Categorical` dtype")
+    if "polars" in id_ and POLARS_VERSION < (1, 32):
+        pytest.skip(reason="orders `Categorical` by physical encoding")
+    if "pyarrow_table" in id_ and PYARROW_VERSION < (15,):
+        pytest.skip(reason="cannot cast `string` to `dictionary`")
 
 
 def is_pd_na(value: Any) -> bool:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -57,6 +57,13 @@ ID_PANDAS_LIKE = frozenset(
     ("pandas", "pandas[nullable]", "pandas[pyarrow]", "modin", "modin[pyarrow]", "cudf")
 )
 ID_CUDF = frozenset(("cudf",))
+ID_NO_CATEGORICAL_ORDERING = ("pyspark", "duckdb", "ibis", "dask")
+"""Backends which cannot order a `Categorical` column by its values.
+
+`pyspark`, `duckdb` and `ibis` have no categorical support at all; `dask` encodes the
+categories per partition, so ordering them by value would need a compute.
+"""
+
 _CONSTRUCTOR_FIXTURE_NAMES = frozenset[str](
     ("constructor_eager", "constructor", "constructor_pandas_like")
 )


### PR DESCRIPTION
# Description

`pyarrow` has no ordering kernel for dictionary types, so `DataFrame.{sort,top_k,rank,with_row_index(order_by=)}` and `Series.sort` all failed on a Categorical column, and top_k segfaulted rather than raising. A new sortable helper replaces the dictionary indices with the rank of the value they point at, so those five order lexicographically by value (matching polars and pandas) while the output stays dictionary-encoded.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3841, #3857

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used
	- Tests were generated by Claude
	- Local benchmark script was generated by Claude to check that `sort_indices` + `sortable_table` + `take` does not lead to performance regressions compared to the native `sort_by`
