### PR TITLE
fix: consistently place null's in `with_row_index(order_by=...)`

### DIFF
--- a/src/narwhals/_arrow/dataframe.py
+++ b/src/narwhals/_arrow/dataframe.py
@@ -546,7 +546,7 @@ class ArrowDataFrame(
             )
             return self.select(row_index, plx.all())
         sorting: list[tuple[str, Order]] = [(name, "ascending") for name in order_by]
-        indices = sort_indices(sortable_table(self.native, order_by), sorting, "at_end")
+        indices = sort_indices(sortable_table(self.native, order_by), sorting, "at_start")
         if self._backend_version < (20,):
             new_col = data.take(pc.sort_indices(indices))
         else:

--- a/src/narwhals/_dask/dataframe.py
+++ b/src/narwhals/_dask/dataframe.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 import dask.dataframe as dd
 
-from narwhals._dask.utils import evaluate_exprs
+from narwhals._dask.utils import add_row_index, evaluate_exprs
 from narwhals._pandas_like.utils import native_to_narwhals_dtype, select_columns_by_name
 from narwhals._typing_compat import assert_never
 from narwhals._utils import (
@@ -223,9 +223,12 @@ class DaskLazyFrame(
 
         return self._with_native(self.native.drop(columns=to_drop))
 
-    def with_row_index(self, name: str, order_by: Sequence[str]) -> Self:
+    def with_row_index(self, name: str, order_by: Sequence[str] | None) -> Self:
         # Implementation is based on the following StackOverflow reply:
         # https://stackoverflow.com/questions/60831518/in-dask-how-does-one-add-a-range-of-integersauto-increment-to-a-new-column/60852409#60852409
+        if order_by is None:
+            # Keep for backcompat, Narwhals used to allow no `order_by` in Dask.
+            return self._with_native(add_row_index(self.native, name))
         plx = self.__narwhals_namespace__()
         columns = self.columns
         const_expr = plx.lit(1, dtype=None).alias(name).broadcast()

--- a/src/narwhals/_dask/dataframe.py
+++ b/src/narwhals/_dask/dataframe.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 import dask.dataframe as dd
 
-from narwhals._dask.utils import add_row_index, evaluate_exprs
+from narwhals._dask.utils import evaluate_exprs
 from narwhals._pandas_like.utils import native_to_narwhals_dtype, select_columns_by_name
 from narwhals._typing_compat import assert_never
 from narwhals._utils import (
@@ -223,11 +223,9 @@ class DaskLazyFrame(
 
         return self._with_native(self.native.drop(columns=to_drop))
 
-    def with_row_index(self, name: str, order_by: Sequence[str] | None) -> Self:
+    def with_row_index(self, name: str, order_by: Sequence[str]) -> Self:
         # Implementation is based on the following StackOverflow reply:
         # https://stackoverflow.com/questions/60831518/in-dask-how-does-one-add-a-range-of-integersauto-increment-to-a-new-column/60852409#60852409
-        if order_by is None:
-            return self._with_native(add_row_index(self.native, name))
         plx = self.__narwhals_namespace__()
         columns = self.columns
         const_expr = plx.lit(1, dtype=None).alias(name).broadcast()

--- a/src/narwhals/_duckdb/dataframe.py
+++ b/src/narwhals/_duckdb/dataframe.py
@@ -558,9 +558,6 @@ class DuckDBLazyFrame(
 
     @requires.backend_version((1, 3))
     def with_row_index(self, name: str, order_by: Sequence[str]) -> Self:
-        if order_by is None:
-            msg = "Cannot pass `order_by` to `with_row_index` for DuckDB"
-            raise TypeError(msg)
         expr = (window_expression(F("row_number"), order_by=order_by) - lit(1)).alias(
             name
         )

--- a/src/narwhals/_duckdb/dataframe.py
+++ b/src/narwhals/_duckdb/dataframe.py
@@ -558,6 +558,9 @@ class DuckDBLazyFrame(
 
     @requires.backend_version((1, 3))
     def with_row_index(self, name: str, order_by: Sequence[str]) -> Self:
+        if not order_by:
+            msg = "Must pass `order_by` to `with_row_index` for DuckDB"
+            raise TypeError(msg)
         expr = (window_expression(F("row_number"), order_by=order_by) - lit(1)).alias(
             name
         )

--- a/src/narwhals/_ibis/dataframe.py
+++ b/src/narwhals/_ibis/dataframe.py
@@ -408,11 +408,7 @@ class IbisLazyFrame(
         return self._with_native(unpivoted.select(*final_columns))
 
     def with_row_index(self, name: str, order_by: Sequence[str]) -> Self:
-        sort_cols = (
-            list(IbisExpr._sort(*order_by, descending=False, nulls_last=False))
-            if order_by
-            else None
-        )
+        sort_cols = list(IbisExpr._sort(*order_by, descending=False, nulls_last=False))
         to_select = [
             ibis.row_number().over(ibis.window(order_by=sort_cols)).name(name),
             ibis.selectors.all(),

--- a/src/narwhals/_ibis/dataframe.py
+++ b/src/narwhals/_ibis/dataframe.py
@@ -408,8 +408,13 @@ class IbisLazyFrame(
         return self._with_native(unpivoted.select(*final_columns))
 
     def with_row_index(self, name: str, order_by: Sequence[str]) -> Self:
+        sort_cols = (
+            list(IbisExpr._sort(*order_by, descending=False, nulls_last=False))
+            if order_by
+            else None
+        )
         to_select = [
-            ibis.row_number().over(ibis.window(order_by=order_by)).name(name),
+            ibis.row_number().over(ibis.window(order_by=sort_cols)).name(name),
             ibis.selectors.all(),
         ]
         return self._with_native(self.native.select(*to_select))

--- a/src/narwhals/_ibis/dataframe.py
+++ b/src/narwhals/_ibis/dataframe.py
@@ -408,7 +408,14 @@ class IbisLazyFrame(
         return self._with_native(unpivoted.select(*final_columns))
 
     def with_row_index(self, name: str, order_by: Sequence[str]) -> Self:
-        sort_cols = list(IbisExpr._sort(*order_by, descending=False, nulls_last=False))
+        if not order_by:
+            msg = "Must pass `order_by` to `with_row_index` for Ibis"
+            raise TypeError(msg)
+        sort_cols = (
+            list(IbisExpr._sort(*order_by, descending=False, nulls_last=False))
+            if order_by
+            else None
+        )
         to_select = [
             ibis.row_number().over(ibis.window(order_by=sort_cols)).name(name),
             ibis.selectors.all(),

--- a/src/narwhals/_pandas_like/dataframe.py
+++ b/src/narwhals/_pandas_like/dataframe.py
@@ -34,7 +34,6 @@ from narwhals._utils import (
 )
 from narwhals.dependencies import is_pandas_like_dataframe
 from narwhals.exceptions import InvalidOperationError, ShapeError
-from narwhals.functions import col as nw_col
 
 if TYPE_CHECKING:
     from io import BytesIO
@@ -468,22 +467,22 @@ class PandasLikeDataFrame(
 
     def with_row_index(self, name: str, order_by: Sequence[str] | None) -> Self:
         plx = self.__narwhals_namespace__()
-        if order_by is None:
-            data = self._array_funcs.arange(len(self))
-            row_index = plx._expr._from_series(
-                plx._series.from_iterable(
-                    data, context=self, index=self.native.index, name=name
-                )
+        data = plx._series.from_iterable(
+            self._array_funcs.arange(len(self)),
+            context=self,
+            index=self.native.index,
+            name=name,
+        )
+        if order_by is not None:
+            token = generate_temporary_column_name(8, order_by)
+            sorting_indices = (
+                self.simple_select(*order_by)
+                .with_row_index(token, order_by=None)
+                .sort(*order_by, descending=False, nulls_last=False)
+                .get_column(token)
             )
-        else:
-            rank = cast(
-                "PandasLikeExpr",
-                nw_col(order_by[0]).rank(method="ordinal")._to_compliant_expr(plx),
-            )
-            row_index = (
-                rank.over(partition_by=[], order_by=order_by)
-                - plx.lit(1, None).broadcast()
-            ).alias(name)
+            data.scatter(sorting_indices, data, in_place=True)
+        row_index = plx._expr._from_series(data)
         return self.select(row_index, plx.all())
 
     def row(self, index: int) -> tuple[Any, ...]:

--- a/src/narwhals/_polars/dataframe.py
+++ b/src/narwhals/_polars/dataframe.py
@@ -289,6 +289,9 @@ class PolarsBaseFrame(Generic[NativePolarsFrame]):
         if order_by is None:
             result = frame.with_row_index(name)
         else:
+            if self._backend_version < (1, 10):
+                msg = "Cannot pass `order_by` to `with_row_index` for Polars<1.1"
+                raise NotImplementedError(msg)
             result = frame.select(
                 pl.int_range(pl.len()).over(order_by=order_by).alias(name), pl.all()
             )

--- a/src/narwhals/_polars/dataframe.py
+++ b/src/narwhals/_polars/dataframe.py
@@ -290,7 +290,7 @@ class PolarsBaseFrame(Generic[NativePolarsFrame]):
             result = frame.with_row_index(name)
         else:
             if self._backend_version < (1, 10):
-                msg = "Cannot pass `order_by` to `with_row_index` for Polars<1.1"
+                msg = "Cannot pass `order_by` to `with_row_index` for Polars<1.10"
                 raise NotImplementedError(msg)
             result = frame.select(
                 pl.int_range(pl.len()).over(order_by=order_by).alias(name), pl.all()

--- a/src/narwhals/_spark_like/dataframe.py
+++ b/src/narwhals/_spark_like/dataframe.py
@@ -562,9 +562,6 @@ class SparkLikeLazyFrame(
         return self._with_native(unpivoted_native_frame)
 
     def with_row_index(self, name: str, order_by: Sequence[str]) -> Self:
-        if order_by is None:
-            msg = "Cannot pass `order_by` to `with_row_index` for PySpark-like"
-            raise TypeError(msg)
         row_index_expr = (
             self._F.row_number().over(
                 self._Window.partitionBy(self._F.lit(1)).orderBy(

--- a/src/narwhals/_spark_like/dataframe.py
+++ b/src/narwhals/_spark_like/dataframe.py
@@ -562,6 +562,9 @@ class SparkLikeLazyFrame(
         return self._with_native(unpivoted_native_frame)
 
     def with_row_index(self, name: str, order_by: Sequence[str]) -> Self:
+        if not order_by:
+            msg = "Must pass `order_by` to `with_row_index` for PySpark-like"
+            raise TypeError(msg)
         row_index_expr = (
             self._F.row_number().over(
                 self._Window.partitionBy(self._F.lit(1)).orderBy(

--- a/src/narwhals/_spark_like/dataframe.py
+++ b/src/narwhals/_spark_like/dataframe.py
@@ -567,7 +567,9 @@ class SparkLikeLazyFrame(
             raise TypeError(msg)
         row_index_expr = (
             self._F.row_number().over(
-                self._Window.partitionBy(self._F.lit(1)).orderBy(*order_by)
+                self._Window.partitionBy(self._F.lit(1)).orderBy(
+                    *[self._F.asc_nulls_first(x) for x in order_by]
+                )
             )
             - 1
         ).alias(name)

--- a/src/narwhals/dataframe.py
+++ b/src/narwhals/dataframe.py
@@ -2624,6 +2624,9 @@ class LazyFrame(BaseFrame[LazyFrameT]):
             └──────────────────┘
         """
         order_by_ = [order_by] if isinstance(order_by, str) else order_by
+        if not order_by:
+            msg = "`order_by` must be specified when calling `LazyFrame.with_row_index`"
+            raise TypeError(msg)
         return self._with_compliant(
             self._compliant_frame.with_row_index(name, order_by=order_by_)
         )

--- a/src/narwhals/dataframe.py
+++ b/src/narwhals/dataframe.py
@@ -2624,9 +2624,6 @@ class LazyFrame(BaseFrame[LazyFrameT]):
             └──────────────────┘
         """
         order_by_ = [order_by] if isinstance(order_by, str) else order_by
-        if not order_by:
-            msg = "`order_by` must be specified when calling `LazyFrame.with_row_index`"
-            raise TypeError(msg)
         return self._with_compliant(
             self._compliant_frame.with_row_index(name, order_by=order_by_)
         )

--- a/src/narwhals/dataframe.py
+++ b/src/narwhals/dataframe.py
@@ -1318,7 +1318,7 @@ class DataFrame(BaseFrame[DataFrameT]):
 
         Arguments:
             name: The name of the column as a string. The default is "index".
-            order_by: Column(s) to order by when computing the row index.
+            order_by: Column(s) to order by when computing the row index. Nulls are placed first.
 
         Examples:
             >>> import pyarrow as pa
@@ -1652,7 +1652,7 @@ class DataFrame(BaseFrame[DataFrameT]):
                 * 'last': Keep last unique row.
             maintain_order: Keep the same order as the original DataFrame. This may be more
                 expensive to compute.
-            order_by: Column(s) to order by when computing the row index.
+            order_by: Column(s) to order by when computing the row index. Nulls are placed first.
 
         Examples:
             >>> import pandas as pd
@@ -2590,7 +2590,7 @@ class LazyFrame(BaseFrame[LazyFrameT]):
 
         Arguments:
             name: The name of the column as a string. The default is "index".
-            order_by: Column(s) to order by when computing the row index.
+            order_by: Column(s) to order by when computing the row index. Nulls are placed first.
 
         Examples:
             >>> import duckdb
@@ -2855,7 +2855,7 @@ class LazyFrame(BaseFrame[LazyFrameT]):
                 * 'none': Don't keep duplicate rows.
                 * 'first': Keep the first row. Requires `order_by` to be specified.
                 * 'last': Keep the last row. Requires `order_by` to be specified.
-            order_by: Column(s) to order by when computing the row index.
+            order_by: Column(s) to order by when computing the row index. Nulls are placed first.
 
         Examples:
             >>> import duckdb

--- a/tests/frame/with_row_index_test.py
+++ b/tests/frame/with_row_index_test.py
@@ -106,6 +106,10 @@ def test_with_row_index_order_by_w_null(
 ) -> None:
     if "dask" in str(constructor):
         request.node.add_marker(pytest.mark.xfail(reason="not implemented in dask"))
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 10):
+        pytest.skip()
+    if "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3):
+        pytest.skip()
 
     df = nw.from_native(constructor({"c": ["dog", "cat", None], "n": [1, 2, 3]}))
     result = df.with_row_index("i", order_by="c").sort("n").select("i", "n")

--- a/tests/frame/with_row_index_test.py
+++ b/tests/frame/with_row_index_test.py
@@ -105,7 +105,7 @@ def test_with_row_index_order_by_w_null(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:
     if "dask" in str(constructor):
-        request.node.add_marker(pytest.mark.xfail(reason="not implemented in dask"))
+        request.applymarker(pytest.mark.xfail(reason="not implemented in dask"))
     if "polars" in str(constructor) and POLARS_VERSION < (1, 10):
         pytest.skip()
     if "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3):

--- a/tests/frame/with_row_index_test.py
+++ b/tests/frame/with_row_index_test.py
@@ -101,7 +101,12 @@ def test_with_row_index_order_by_categorical(constructor: Constructor) -> None:
     assert_equal_data(result, {"i": [2, 1, 0], "n": [1, 2, 3]})
 
 
-def test_with_row_index_order_by_w_null(constructor: Constructor) -> None:
+def test_with_row_index_order_by_w_null(
+    constructor: Constructor, request: pytest.FixtureRequest
+) -> None:
+    if "dask" in str(constructor):
+        request.node.add_marker(pytest.mark.xfail(reason="not implemented in dask"))
+
     df = nw.from_native(constructor({"c": ["dog", "cat", None], "n": [1, 2, 3]}))
     result = df.with_row_index("i", order_by="c").sort("n").select("i", "n")
     assert_equal_data(result, {"i": [2, 1, 0], "n": [1, 2, 3]})

--- a/tests/frame/with_row_index_test.py
+++ b/tests/frame/with_row_index_test.py
@@ -99,3 +99,9 @@ def test_with_row_index_order_by_categorical(constructor: Constructor) -> None:
         .select("i", "n")
     )
     assert_equal_data(result, {"i": [2, 1, 0], "n": [1, 2, 3]})
+
+
+def test_with_row_index_order_by_w_null(constructor: Constructor) -> None:
+    df = nw.from_native(constructor({"c": ["dog", "cat", None], "n": [1, 2, 3]}))
+    result = df.with_row_index("i", order_by="c").sort("n").select("i", "n")
+    assert_equal_data(result, {"i": [2, 1, 0], "n": [1, 2, 3]})

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -481,10 +481,10 @@ def test_with_row_index(constructor: Constructor) -> None:
 
     frame = nw_v1.from_native(constructor(data))
 
-    msg = "Cannot pass `order_by`"
+    msg = "Must pass `order_by`"
     context = (
         pytest.raises(TypeError, match=msg)
-        if any(x in str(constructor) for x in ("duckdb", "pyspark"))
+        if any(x in str(constructor) for x in ("duckdb", "pyspark", "ibis"))
         else does_not_raise()
     )
 


### PR DESCRIPTION
follow-up to #3862

<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
