### PR TITLE
fix: null propagation for str boolean methods

### DIFF
--- a/src/narwhals/_pandas_like/series_str.py
+++ b/src/narwhals/_pandas_like/series_str.py
@@ -30,6 +30,8 @@ class PandasLikeSeriesStringNamespace(
                 result = result.astype(bool, copy=False)
             elif not all_valid:
                 result = result.where(not_na, False).astype(bool)
+            else:  # pragma: no cover
+                pass
         return self.with_native(result)
 
     def len_chars(self) -> PandasLikeSeries:

--- a/src/narwhals/_pandas_like/series_str.py
+++ b/src/narwhals/_pandas_like/series_str.py
@@ -23,10 +23,12 @@ class PandasLikeSeriesStringNamespace(
             result.dtype == object
             and get_dtype_backend(self.native.dtype, self.implementation) is None
         ):
-            if self.implementation._backend_version() < (3,):
+            notna = result.notna()
+            all_valid = notna.all()
+            if not all_valid and self.implementation._backend_version() < (3,):
                 result.where(result.notna(), False, inplace=True)
                 result = result.astype(bool, copy=False)
-            else:
+            elif not all_valid:
                 result = result.where(result.notna(), False).astype(bool)
         return self.with_native(result)
 

--- a/src/narwhals/_pandas_like/series_str.py
+++ b/src/narwhals/_pandas_like/series_str.py
@@ -23,7 +23,11 @@ class PandasLikeSeriesStringNamespace(
             result.dtype == object
             and get_dtype_backend(self.native.dtype, self.implementation) is None
         ):
-            result = result.where(result.notna(), False).astype(bool)
+            if self.implementation._backend_version() < (3,):
+                result.where(result.notna(), False, inplace=True)
+                result = result.astype(bool, copy=False)
+            else:
+                result = result.where(result.notna(), False).astype(bool)
         return self.with_native(result)
 
     def len_chars(self) -> PandasLikeSeries:

--- a/src/narwhals/_pandas_like/series_str.py
+++ b/src/narwhals/_pandas_like/series_str.py
@@ -23,13 +23,13 @@ class PandasLikeSeriesStringNamespace(
             result.dtype == object
             and get_dtype_backend(self.native.dtype, self.implementation) is None
         ):
-            notna = result.notna()
-            all_valid = notna.all()
+            not_na = result.notna()
+            all_valid = not_na.all()
             if not all_valid and self.implementation._backend_version() < (3,):
-                result.where(result.notna(), False, inplace=True)
+                result.where(not_na, False, inplace=True)
                 result = result.astype(bool, copy=False)
             elif not all_valid:
-                result = result.where(result.notna(), False).astype(bool)
+                result = result.where(not_na, False).astype(bool)
         return self.with_native(result)
 
     def len_chars(self) -> PandasLikeSeries:

--- a/src/narwhals/_pandas_like/series_str.py
+++ b/src/narwhals/_pandas_like/series_str.py
@@ -6,6 +6,7 @@ from narwhals._compliant.any_namespace import StringNamespace
 from narwhals._pandas_like.utils import (
     PandasLikeSeriesNamespace,
     align_and_extract_native,
+    get_dtype_backend,
     is_dtype_pyarrow,
 )
 
@@ -16,6 +17,15 @@ if TYPE_CHECKING:
 class PandasLikeSeriesStringNamespace(
     PandasLikeSeriesNamespace, StringNamespace["PandasLikeSeries"]
 ):
+    def _with_native_bool(self, result: Any) -> PandasLikeSeries:
+        # See https://narwhals-dev.github.io/narwhals/concepts/boolean/.
+        if (
+            result.dtype == object
+            and get_dtype_backend(self.native.dtype, self.implementation) is None
+        ):
+            result = result.fillna(False).astype(bool)
+        return self.with_native(result)
+
     def len_chars(self) -> PandasLikeSeries:
         return self.with_native(self.native.str.len())
 
@@ -44,21 +54,21 @@ class PandasLikeSeriesStringNamespace(
         if not isinstance(prefix_native, str):
             msg = f"`.str.starts_with` only supports prefix values for {self.compliant._implementation} backend"
             raise TypeError(msg)
-        return self.with_native(self.native.str.startswith(prefix_native))
+        return self._with_native_bool(self.native.str.startswith(prefix_native))
 
     def ends_with(self, suffix: PandasLikeSeries) -> PandasLikeSeries:
         _, suffix_native = align_and_extract_native(self.compliant, suffix)
         if not isinstance(suffix_native, str):
             msg = f"`.str.ends_with` only supports suffix values for {self.compliant._implementation} backend"
             raise TypeError(msg)
-        return self.with_native(self.native.str.endswith(suffix_native))
+        return self._with_native_bool(self.native.str.endswith(suffix_native))
 
     def contains(self, pattern: PandasLikeSeries, *, literal: bool) -> PandasLikeSeries:
         _, pattern_native = align_and_extract_native(self.compliant, pattern)
         if not isinstance(pattern_native, str):
             msg = f"`.str.contains` only supports str pattern values for {self.compliant._implementation} backend"
             raise TypeError(msg)
-        return self.with_native(
+        return self._with_native_bool(
             self.native.str.contains(pat=pattern_native, regex=not literal)
         )
 

--- a/src/narwhals/_pandas_like/series_str.py
+++ b/src/narwhals/_pandas_like/series_str.py
@@ -23,7 +23,7 @@ class PandasLikeSeriesStringNamespace(
             result.dtype == object
             and get_dtype_backend(self.native.dtype, self.implementation) is None
         ):
-            result = result.fillna(False).astype(bool)
+            result = result.where(result.notna(), False).astype(bool)
         return self.with_native(result)
 
     def len_chars(self) -> PandasLikeSeries:

--- a/src/narwhals/expr_str.py
+++ b/src/narwhals/expr_str.py
@@ -142,6 +142,10 @@ class ExprStringNamespace(Generic[ExprT]):
         Arguments:
             prefix: prefix substring
 
+        Notes:
+            Null values are preserved, unless `self` is backed by a non-nullable pandas Series
+            (which does not support missing values). See [boolean columns](../concepts/boolean.md) for reference.
+
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
@@ -168,6 +172,10 @@ class ExprStringNamespace(Generic[ExprT]):
 
         Arguments:
             suffix: suffix substring
+
+        Notes:
+            Null values are preserved, unless `self` is backed by a non-nullable pandas Series
+            (which does not support missing values). See [boolean columns](../concepts/boolean.md) for reference.
 
         Examples:
             >>> import pandas as pd
@@ -203,6 +211,10 @@ class ExprStringNamespace(Generic[ExprT]):
             Passing an expression as `pattern` is only supported by DuckDB, Ibis, Polars,
             PySpark and SQLFrame. Other backends, such as pandas and PyArrow, will raise
             a `TypeError`.
+
+        Notes:
+            Null values are preserved, unless `self` is backed by a non-nullable pandas Series
+            (which does not support missing values). See [boolean columns](../concepts/boolean.md) for reference.
 
         Examples:
             >>> import pyarrow as pa

--- a/src/narwhals/series_str.py
+++ b/src/narwhals/series_str.py
@@ -116,6 +116,10 @@ class SeriesStringNamespace(Generic[SeriesT]):
         Arguments:
             prefix: prefix substring
 
+        Notes:
+            Null values are preserved, unless `self` is backed by a non-nullable pandas Series
+            (which does not support missing values). See [boolean columns](../concepts/boolean.md) for reference.
+
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw
@@ -138,6 +142,10 @@ class SeriesStringNamespace(Generic[SeriesT]):
 
         Arguments:
             suffix: suffix substring
+
+        Notes:
+            Null values are preserved, unless `self` is backed by a non-nullable pandas Series
+            (which does not support missing values). See [boolean columns](../concepts/boolean.md) for reference.
 
         Examples:
             >>> import pandas as pd
@@ -168,6 +176,10 @@ class SeriesStringNamespace(Generic[SeriesT]):
         Warning:
             Passing a Series as `pattern` is only supported by Polars. Other backends
             will raise a `TypeError`.
+
+        Notes:
+            Null values are preserved, unless `self` is backed by a non-nullable pandas Series
+            (which does not support missing values). See [boolean columns](../concepts/boolean.md) for reference.
 
         Examples:
             >>> import pyarrow as pa

--- a/tests/expr_and_series/str/contains_test.py
+++ b/tests/expr_and_series/str/contains_test.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 
+import pandas as pd
 import pytest
 
 import narwhals as nw
-from tests.utils import PANDAS_VERSION, Constructor, ConstructorEager, assert_equal_data
+from tests.utils import Constructor, ConstructorEager, assert_equal_data
 
 data = {"pets": ["cat", "dog", "rabbit and parrot", "dove", "Parrot|dove", None]}
 """Test data for string literal pattern tests"""
@@ -97,7 +98,7 @@ def test_expr_contains_str_pattern(
         nw.col("pets").str.contains(pattern, literal=literal).alias("match")
     )
 
-    if "pandas_constructor" in str(constructor) and PANDAS_VERSION >= (3,):
+    if "pandas_constructor" in str(constructor):
         expected = expected_without_null
     else:
         expected = expected_with_null
@@ -123,7 +124,7 @@ def test_series_contains_str_pattern(
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(match=df["pets"].str.contains(pattern, literal=literal))
 
-    if "pandas_constructor" in str(constructor_eager) and PANDAS_VERSION >= (3,):
+    if "pandas_constructor" in str(constructor_eager):
         expected = expected_without_null
     else:
         expected = expected_with_null
@@ -173,7 +174,7 @@ def test_expr_contains_literal_vs_regex(constructor: Constructor) -> None:
         nw.col("pets").str.contains("Parrot|dove", literal=False).alias("regex_match"),
         nw.col("pets").str.contains("Parrot|dove", literal=True).alias("literal_match"),
     )
-    if "pandas_constructor" in str(constructor) and PANDAS_VERSION >= (3,):
+    if "pandas_constructor" in str(constructor):
         expected: dict[str, Any] = {
             "regex_match": [False, False, False, True, True, False],
             "literal_match": [False, False, False, False, True, False],
@@ -186,6 +187,18 @@ def test_expr_contains_literal_vs_regex(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
+def test_pandas_object_dtype_contains_null() -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3850
+    df_native = pd.DataFrame(data).astype(object)
+    df = nw.from_native(df_native, eager_only=True)
+
+    mask = df["pets"].str.contains("parrot")
+    assert mask.dtype == nw.Boolean
+    assert_equal_data(
+        {"match": mask}, {"match": [False, False, True, False, False, False]}
+    )
+
+
 def test_series_contains_literal_vs_regex(constructor_eager: ConstructorEager) -> None:
     """Test that literal=True vs literal=False behaves differently for regex patterns."""
     df = nw.from_native(constructor_eager(data), eager_only=True)
@@ -193,7 +206,7 @@ def test_series_contains_literal_vs_regex(constructor_eager: ConstructorEager) -
         regex_match=df["pets"].str.contains("Parrot|dove", literal=False),
         literal_match=df["pets"].str.contains("Parrot|dove", literal=True),
     )
-    if "pandas_constructor" in str(constructor_eager) and PANDAS_VERSION >= (3,):
+    if "pandas_constructor" in str(constructor_eager):
         expected: dict[str, Any] = {
             "regex_match": [False, False, False, True, True, False],
             "literal_match": [False, False, False, False, True, False],

--- a/tests/expr_and_series/str/contains_test.py
+++ b/tests/expr_and_series/str/contains_test.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
 import narwhals as nw
 from tests.utils import Constructor, ConstructorEager, assert_equal_data
+
+if TYPE_CHECKING:
+    from narwhals._pandas_like.series import PandasLikeSeries
 
 data = {"pets": ["cat", "dog", "rabbit and parrot", "dove", "Parrot|dove", None]}
 """Test data for string literal pattern tests"""
@@ -199,6 +202,26 @@ def test_pandas_object_dtype_contains_null() -> None:
     assert_equal_data(
         {"match": mask}, {"match": [False, False, True, False, False, False]}
     )
+
+
+def test_pandas_with_native_bool_all_valid() -> None:
+    """Direct unit test of `_with_native_bool` for an already-all-valid object-dtype result.
+
+    This path isn't reachable through the public API: pandas' string-accessor
+    methods only produce `object`-dtype boolean results when the input contains
+    nulls, and a null input always yields a null (i.e. not-all-valid) output.
+    """
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    compliant = cast(
+        "PandasLikeSeries",
+        nw.from_native(pd.DataFrame({"a": ["x", "y", "z"]}), eager_only=True)[
+            "a"
+        ]._compliant_series,
+    )
+    result = compliant.str._with_native_bool(pd.Series([True, False, True], dtype=object))
+    assert result.to_list() == [True, False, True]
 
 
 def test_series_contains_literal_vs_regex(constructor_eager: ConstructorEager) -> None:

--- a/tests/expr_and_series/str/contains_test.py
+++ b/tests/expr_and_series/str/contains_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pandas as pd
 import pytest
 
 import narwhals as nw
@@ -189,6 +188,9 @@ def test_expr_contains_literal_vs_regex(constructor: Constructor) -> None:
 
 def test_pandas_object_dtype_contains_null() -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3850
+    pytest.importorskip("pandas")
+    import pandas as pd
+
     df_native = pd.DataFrame(data).astype(object)
     df = nw.from_native(df_native, eager_only=True)
 

--- a/tests/expr_and_series/str/starts_with_ends_with_test.py
+++ b/tests/expr_and_series/str/starts_with_ends_with_test.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+from typing import Any
+
+import pandas as pd
 import pytest
 
 import narwhals as nw
+from tests.conftest import modin_constructor, pandas_constructor
 from tests.utils import Constructor, ConstructorEager, assert_equal_data
 
 EXPR_UNSUPPORTED = ("dask", "pyarrow", "pandas", "modin", "cudf")
 data = {"a": ["fdas", "edfas"], "prefix_suffix": ["fda", "fas"]}
+
+NON_NULLABLE_CONSTRUCTORS = [pandas_constructor, modin_constructor]
 
 
 @pytest.mark.parametrize(
@@ -113,3 +119,28 @@ def test_starts_with_series_multi(
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(df["a"].str.starts_with(prefix_series))
     assert_equal_data(result, {"a": expected})
+
+
+def test_starts_with_null(constructor: Constructor) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3850
+    data_with_null = {"a": ["x", "y", None, "z"]}
+    df = nw.from_native(constructor(data_with_null))
+    result = df.select(nw.col("a").str.starts_with("x"))
+
+    expected: dict[str, list[Any]]
+    if any(constructor is c for c in NON_NULLABLE_CONSTRUCTORS):
+        expected = {"a": [True, False, False, False]}
+    else:
+        expected = {"a": [True, False, None, False]}
+
+    assert_equal_data(result, expected)
+
+
+def test_pandas_object_dtype_starts_with_null() -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3850
+    df_native = pd.DataFrame({"a": ["x", "y", None, "z"]}).astype(object)
+    df = nw.from_native(df_native, eager_only=True)
+
+    mask = df["a"].str.starts_with("x")
+    assert mask.dtype == nw.Boolean
+    assert mask.to_list() == [True, False, False, False]

--- a/tests/expr_and_series/str/starts_with_ends_with_test.py
+++ b/tests/expr_and_series/str/starts_with_ends_with_test.py
@@ -138,6 +138,7 @@ def test_starts_with_null(constructor: Constructor) -> None:
 
 def test_pandas_object_dtype_starts_with_null() -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3850
+    pytest.importorskip("pandas")
     df_native = pd.DataFrame({"a": ["x", "y", None, "z"]}).astype(object)
     df = nw.from_native(df_native, eager_only=True)
 

--- a/tests/expr_and_series/str/starts_with_ends_with_test.py
+++ b/tests/expr_and_series/str/starts_with_ends_with_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pandas as pd
 import pytest
 
 import narwhals as nw
@@ -139,6 +138,8 @@ def test_starts_with_null(constructor: Constructor) -> None:
 def test_pandas_object_dtype_starts_with_null() -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3850
     pytest.importorskip("pandas")
+    import pandas as pd
+
     df_native = pd.DataFrame({"a": ["x", "y", None, "z"]}).astype(object)
     df = nw.from_native(df_native, eager_only=True)
 


### PR DESCRIPTION
closes #3850 

<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
