### PR TITLE
fix: follow left-hand-index alignment rule for pandas-like `concat`

### DIFF
--- a/src/narwhals/_pandas_like/dataframe.py
+++ b/src/narwhals/_pandas_like/dataframe.py
@@ -448,7 +448,7 @@ class PandasLikeDataFrame(
             return self._with_native(type(self.native)(), validate_column_names=False)
         new_series = new_series[0]._align_full_broadcast(*new_series)
         namespace = self.__narwhals_namespace__()
-        df = namespace.concat_by_index([s.native for s in new_series])
+        df = namespace._concat_by_index([s.native for s in new_series])
         # `concat` creates a new object, so fine to modify `.columns.name` inplace.
         df.columns.name = self.native.columns.name
         return self._with_native(df, validate_column_names=True)
@@ -511,7 +511,7 @@ class PandasLikeDataFrame(
             to_concat.append(series)
         to_concat.extend(self._extract_comparand(s) for s in name_columns.values())
         namespace = self.__narwhals_namespace__()
-        df = namespace.concat_by_index(to_concat)
+        df = namespace._concat_by_index(to_concat)
         # `concat` creates a new object, so fine to modify `.columns.name` inplace.
         df.columns.name = self.native.columns.name
         return self._with_native(df, validate_column_names=False)

--- a/src/narwhals/_pandas_like/dataframe.py
+++ b/src/narwhals/_pandas_like/dataframe.py
@@ -448,7 +448,7 @@ class PandasLikeDataFrame(
             return self._with_native(type(self.native)(), validate_column_names=False)
         new_series = new_series[0]._align_full_broadcast(*new_series)
         namespace = self.__narwhals_namespace__()
-        df = namespace._concat_horizontal([s.native for s in new_series])
+        df = namespace.concat_by_index([s.native for s in new_series])
         # `concat` creates a new object, so fine to modify `.columns.name` inplace.
         df.columns.name = self.native.columns.name
         return self._with_native(df, validate_column_names=True)
@@ -511,7 +511,7 @@ class PandasLikeDataFrame(
             to_concat.append(series)
         to_concat.extend(self._extract_comparand(s) for s in name_columns.values())
         namespace = self.__narwhals_namespace__()
-        df = namespace._concat_horizontal(to_concat)
+        df = namespace.concat_by_index(to_concat)
         # `concat` creates a new object, so fine to modify `.columns.name` inplace.
         df.columns.name = self.native.columns.name
         return self._with_native(df, validate_column_names=False)

--- a/src/narwhals/_pandas_like/group_by.py
+++ b/src/narwhals/_pandas_like/group_by.py
@@ -122,7 +122,7 @@ class AggExpr:
         elif self.is_len():
             result_single = grouped.size()
             ns = group_by.compliant.__narwhals_namespace__()
-            result = ns._concat_horizontal(
+            result = ns.concat_by_index(
                 [ns.from_native(result_single).alias(name).native for name in names]
             )
         elif self.is_mode():
@@ -143,7 +143,7 @@ class AggExpr:
             # Implementation based on the following suggestion:
             # https://github.com/pandas-dev/pandas/issues/19254#issuecomment-778661578
             ns = compliant.__narwhals_namespace__()
-            result = ns._concat_horizontal(
+            result = ns.concat_by_index(
                 [
                     native.groupby([*keys, col], **kwargs)
                     .size()
@@ -302,7 +302,7 @@ class PandasLikeGroupBy(
             result: pd.DataFrame
             if agg_exprs:
                 ns = self.compliant.__narwhals_namespace__()
-                result = ns._concat_horizontal(self._getitem_aggs(agg_exprs))
+                result = ns.concat_by_index(self._getitem_aggs(agg_exprs))
             else:
                 result = self.compliant.__native_namespace__().DataFrame(
                     list(grouped.groups), columns=self._keys

--- a/src/narwhals/_pandas_like/group_by.py
+++ b/src/narwhals/_pandas_like/group_by.py
@@ -122,7 +122,7 @@ class AggExpr:
         elif self.is_len():
             result_single = grouped.size()
             ns = group_by.compliant.__narwhals_namespace__()
-            result = ns.concat_by_index(
+            result = ns._concat_by_index(
                 [ns.from_native(result_single).alias(name).native for name in names]
             )
         elif self.is_mode():
@@ -143,7 +143,7 @@ class AggExpr:
             # Implementation based on the following suggestion:
             # https://github.com/pandas-dev/pandas/issues/19254#issuecomment-778661578
             ns = compliant.__narwhals_namespace__()
-            result = ns.concat_by_index(
+            result = ns._concat_by_index(
                 [
                     native.groupby([*keys, col], **kwargs)
                     .size()
@@ -302,7 +302,7 @@ class PandasLikeGroupBy(
             result: pd.DataFrame
             if agg_exprs:
                 ns = self.compliant.__narwhals_namespace__()
-                result = ns.concat_by_index(self._getitem_aggs(agg_exprs))
+                result = ns._concat_by_index(self._getitem_aggs(agg_exprs))
             else:
                 result = self.compliant.__native_namespace__().DataFrame(
                     list(grouped.groups), columns=self._keys

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -340,12 +340,10 @@ class PandasLikeNamespace(
             [df.set_axis(arange(len(df)), axis=VERTICAL) for df in dfs],
         )
         concatenated = self._concat_by_index(reset_dfs)
-        ret = set_index(
-            cast("pd.DataFrame", concatenated),
-            target_index,
-            implementation=self._implementation,
+        # Value of type variable "NativeNDFrameT" of "set_index" cannot be "NativeDataFrameT"
+        return set_index(  # type: ignore[type-var]
+            concatenated, target_index, implementation=self._implementation
         )
-        return cast("NativeDataFrameT", ret)
 
     def _concat_vertical(self, dfs: Sequence[NativeDataFrameT], /) -> NativeDataFrameT:
         cols_0 = dfs[0].columns

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -505,7 +505,12 @@ class PandasLikeNamespace(
         def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
             a_series = df._evaluate_single_output_expr(a)
             b_series = df._evaluate_single_output_expr(b)
-            _df = self._concat_by_index([a_series.native, b_series.native])
+            _df = self._concat_by_index(
+                cast(
+                    "list[NativeSeriesT]",
+                    [df._extract_comparand(a_series), df._extract_comparand(b_series)],
+                )
+            )
             corr = _df.corr(method=method).iloc[0, [1]]  # type: ignore[union-attr]
             return [
                 PandasLikeSeries(
@@ -525,7 +530,16 @@ class PandasLikeNamespace(
             a_series = df._evaluate_single_output_expr(a)
             b_series = df._evaluate_single_output_expr(b)
             _df = cast(
-                "pd.DataFrame", self._concat_by_index([a_series.native, b_series.native])
+                "pd.DataFrame",
+                self._concat_by_index(
+                    cast(
+                        "list[NativeSeriesT]",
+                        [
+                            df._extract_comparand(a_series),
+                            df._extract_comparand(b_series),
+                        ],
+                    )
+                ),
             )
             n = _df.count(axis=1).eq(2).sum()
             if ddof == 0 and n == 1:

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -505,12 +505,11 @@ class PandasLikeNamespace(
         def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
             a_series = df._evaluate_single_output_expr(a)
             b_series = df._evaluate_single_output_expr(b)
-            _df = self._concat_by_index(
-                cast(
-                    "list[NativeSeriesT]",
-                    [df._extract_comparand(a_series), df._extract_comparand(b_series)],
-                )
+            aligned = cast(
+                "list[NativeSeriesT]",
+                [df._extract_comparand(a_series), df._extract_comparand(b_series)],
             )
+            _df = self._concat_by_index(aligned)
             corr = _df.corr(method=method).iloc[0, [1]]  # type: ignore[union-attr]
             return [
                 PandasLikeSeries(
@@ -529,18 +528,11 @@ class PandasLikeNamespace(
         def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
             a_series = df._evaluate_single_output_expr(a)
             b_series = df._evaluate_single_output_expr(b)
-            _df = cast(
-                "pd.DataFrame",
-                self._concat_by_index(
-                    cast(
-                        "list[NativeSeriesT]",
-                        [
-                            df._extract_comparand(a_series),
-                            df._extract_comparand(b_series),
-                        ],
-                    )
-                ),
+            aligned = cast(
+                "list[NativeSeriesT]",
+                [df._extract_comparand(a_series), df._extract_comparand(b_series)],
             )
+            _df = cast("pd.DataFrame", self._concat_by_index(aligned))
             n = _df.count(axis=1).eq(2).sum()
             if ddof == 0 and n == 1:
                 value = 0.0

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -335,9 +335,15 @@ class PandasLikeNamespace(
         # Follow the left-hand-rule documented in `docs/concepts/pandas_index.md`.
         target_index = dfs[0].index
         arange = import_array_module(self._implementation).arange
+        # Value of type variable "NativeNDFrameT" of "set_index" cannot be "NativeDataFrameT"
         reset_dfs = cast(
             "list[NativeDataFrameT]",
-            [df.set_axis(arange(len(df)), axis=VERTICAL) for df in dfs],
+            [
+                set_index(  # type: ignore[type-var]
+                    df, arange(len(df)), implementation=self._implementation
+                )
+                for df in dfs
+            ],
         )
         concatenated = self._concat_by_index(reset_dfs)
         # Value of type variable "NativeNDFrameT" of "set_index" cannot be "NativeDataFrameT"

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -335,17 +335,14 @@ class PandasLikeNamespace(
         # Follow the left-hand-rule documented in `docs/concepts/pandas_index.md`.
         target_index = dfs[0].index
         arange = import_array_module(self._implementation).arange
-        # Value of type variable "NativeNDFrameT" of "set_index" cannot be "NativeDataFrameT"
-        reset_dfs = cast(
-            "list[NativeDataFrameT]",
-            [
-                set_index(  # type: ignore[type-var]
-                    df, arange(len(df)), implementation=self._implementation
-                )
-                for df in dfs
-            ],
-        )
-        concatenated = self._concat_by_index(reset_dfs)
+
+        def reset(df: NativeDataFrameT) -> NativeDataFrameT:
+            # Value of type variable "NativeNDFrameT" of "set_index" cannot be "NativeDataFrameT"
+            return set_index(  # type: ignore[type-var]
+                df, arange(len(df)), implementation=self._implementation
+            )
+
+        concatenated = self._concat_by_index([reset(df) for df in dfs])
         # Value of type variable "NativeNDFrameT" of "set_index" cannot be "NativeDataFrameT"
         return set_index(  # type: ignore[type-var]
             concatenated, target_index, implementation=self._implementation

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -336,11 +336,13 @@ class PandasLikeNamespace(
         target_index = dfs[0].index
         arange = import_array_module(self._implementation).arange
         reset_dfs = [df.set_axis(arange(len(df)), axis=VERTICAL) for df in dfs]
-        return set_index(
-            self._concat_by_index(reset_dfs),
+        concatenated = self._concat_by_index(reset_dfs)
+        ret = set_index(
+            cast("pd.DataFrame", concatenated),
             target_index,
             implementation=self._implementation,
         )
+        return cast("NativeDataFrameT", ret)
 
     def _concat_vertical(self, dfs: Sequence[NativeDataFrameT], /) -> NativeDataFrameT:
         cols_0 = dfs[0].columns

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -18,11 +18,7 @@ from narwhals._pandas_like.expr import PandasLikeExpr
 from narwhals._pandas_like.selectors import PandasSelectorNamespace
 from narwhals._pandas_like.series import PandasLikeSeries
 from narwhals._pandas_like.typing import NativeDataFrameT, NativeSeriesT
-from narwhals._pandas_like.utils import (
-    is_dtype_pyarrow,
-    is_non_nullable_boolean,
-    set_index,
-)
+from narwhals._pandas_like.utils import is_dtype_pyarrow, is_non_nullable_boolean
 from narwhals._utils import validate_separators
 
 if TYPE_CHECKING:
@@ -332,17 +328,11 @@ class PandasLikeNamespace(
 
     def _concat_horizontal(self, dfs: Sequence[NativeDataFrameT], /) -> NativeDataFrameT:
         # Follow the left-hand-rule documented in `docs/concepts/pandas_index.md`:
-        # the result takes on the index of the longest input (the left-most
-        # one, in case of a tie), and every other input is aligned to it
-        # *positionally*, ignoring its own index.
-        lengths = [len(df) for df in dfs]
-        target_index = dfs[lengths.index(max(lengths))].index
-        reset_dfs = [df.set_axis(range(len(df)), axis=VERTICAL) for df in dfs]
-        return set_index(
-            self.concat_by_index(reset_dfs),
-            target_index,
-            implementation=self._implementation,
-        )
+        # every input is aligned to the left-most one *positionally*, ignoring
+        # its own index.
+        target_index = dfs[0].index
+        aligned_dfs = [df.set_axis(target_index, axis=VERTICAL) for df in dfs]
+        return self.concat_by_index(aligned_dfs)
 
     def _concat_vertical(self, dfs: Sequence[NativeDataFrameT], /) -> NativeDataFrameT:
         cols_0 = dfs[0].columns

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -309,7 +309,7 @@ class PandasLikeNamespace(
             return self._concat(dfs, axis=VERTICAL, copy=False)
         return self._concat(dfs, axis=VERTICAL)
 
-    def concat_by_index(
+    def _concat_by_index(
         self, dfs: Sequence[NativeDataFrameT | NativeSeriesT], /
     ) -> NativeDataFrameT:
         """Concatenate horizontally, aligning inputs by their (label-based) index.
@@ -339,7 +339,7 @@ class PandasLikeNamespace(
         arange = import_array_module(self._implementation).arange
         reset_dfs = [df.set_axis(arange(len(df)), axis=VERTICAL) for df in dfs]
         return set_index(
-            self.concat_by_index(reset_dfs),
+            self._concat_by_index(reset_dfs),
             target_index,
             implementation=self._implementation,
         )
@@ -504,7 +504,7 @@ class PandasLikeNamespace(
         def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
             a_series = df._evaluate_single_output_expr(a)
             b_series = df._evaluate_single_output_expr(b)
-            _df = self.concat_by_index([a_series.native, b_series.native])
+            _df = self._concat_by_index([a_series.native, b_series.native])
             corr = _df.corr(method=method).iloc[0, [1]]  # type: ignore[union-attr]
             return [
                 PandasLikeSeries(
@@ -524,7 +524,7 @@ class PandasLikeNamespace(
             a_series = df._evaluate_single_output_expr(a)
             b_series = df._evaluate_single_output_expr(b)
             _df = cast(
-                "pd.DataFrame", self.concat_by_index([a_series.native, b_series.native])
+                "pd.DataFrame", self._concat_by_index([a_series.native, b_series.native])
             )
             n = _df.count(axis=1).eq(2).sum()
             if ddof == 0 and n == 1:

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -18,7 +18,12 @@ from narwhals._pandas_like.expr import PandasLikeExpr
 from narwhals._pandas_like.selectors import PandasSelectorNamespace
 from narwhals._pandas_like.series import PandasLikeSeries
 from narwhals._pandas_like.typing import NativeDataFrameT, NativeSeriesT
-from narwhals._pandas_like.utils import is_dtype_pyarrow, is_non_nullable_boolean
+from narwhals._pandas_like.utils import (
+    import_array_module,
+    is_dtype_pyarrow,
+    is_non_nullable_boolean,
+    set_index,
+)
 from narwhals._utils import validate_separators
 
 if TYPE_CHECKING:
@@ -331,8 +336,13 @@ class PandasLikeNamespace(
         # every input is aligned to the left-most one *positionally*, ignoring
         # its own index.
         target_index = dfs[0].index
-        aligned_dfs = [df.set_axis(target_index, axis=VERTICAL) for df in dfs]
-        return self.concat_by_index(aligned_dfs)
+        arange = import_array_module(self._implementation).arange
+        reset_dfs = [df.set_axis(arange(len(df)), axis=VERTICAL) for df in dfs]
+        return set_index(
+            self.concat_by_index(reset_dfs),
+            target_index,
+            implementation=self._implementation,
+        )
 
     def _concat_vertical(self, dfs: Sequence[NativeDataFrameT], /) -> NativeDataFrameT:
         cols_0 = dfs[0].columns

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -335,17 +335,18 @@ class PandasLikeNamespace(
         # Follow the left-hand-rule documented in `docs/concepts/pandas_index.md`.
         target_index = dfs[0].index
         arange = import_array_module(self._implementation).arange
+        impl = self._implementation
 
         def reset(df: NativeDataFrameT) -> NativeDataFrameT:
             # Value of type variable "NativeNDFrameT" of "set_index" cannot be "NativeDataFrameT"
             return set_index(  # type: ignore[type-var]
-                df, arange(len(df)), implementation=self._implementation
+                df, arange(len(df)), implementation=impl
             )
 
         concatenated = self._concat_by_index([reset(df) for df in dfs])
         # Value of type variable "NativeNDFrameT" of "set_index" cannot be "NativeDataFrameT"
         return set_index(  # type: ignore[type-var]
-            concatenated, target_index, implementation=self._implementation
+            concatenated, target_index, implementation=impl
         )
 
     def _concat_vertical(self, dfs: Sequence[NativeDataFrameT], /) -> NativeDataFrameT:

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -335,7 +335,10 @@ class PandasLikeNamespace(
         # Follow the left-hand-rule documented in `docs/concepts/pandas_index.md`.
         target_index = dfs[0].index
         arange = import_array_module(self._implementation).arange
-        reset_dfs = [df.set_axis(arange(len(df)), axis=VERTICAL) for df in dfs]
+        reset_dfs = cast(
+            "list[NativeDataFrameT]",
+            [df.set_axis(arange(len(df)), axis=VERTICAL) for df in dfs],
+        )
         concatenated = self._concat_by_index(reset_dfs)
         ret = set_index(
             cast("pd.DataFrame", concatenated),

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -332,9 +332,7 @@ class PandasLikeNamespace(
         return self._concat(dfs, axis=HORIZONTAL)
 
     def _concat_horizontal(self, dfs: Sequence[NativeDataFrameT], /) -> NativeDataFrameT:
-        # Follow the left-hand-rule documented in `docs/concepts/pandas_index.md`:
-        # every input is aligned to the left-most one *positionally*, ignoring
-        # its own index.
+        # Follow the left-hand-rule documented in `docs/concepts/pandas_index.md`.
         target_index = dfs[0].index
         arange = import_array_module(self._implementation).arange
         reset_dfs = [df.set_axis(arange(len(df)), axis=VERTICAL) for df in dfs]

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -18,7 +18,11 @@ from narwhals._pandas_like.expr import PandasLikeExpr
 from narwhals._pandas_like.selectors import PandasSelectorNamespace
 from narwhals._pandas_like.series import PandasLikeSeries
 from narwhals._pandas_like.typing import NativeDataFrameT, NativeSeriesT
-from narwhals._pandas_like.utils import is_dtype_pyarrow, is_non_nullable_boolean
+from narwhals._pandas_like.utils import (
+    is_dtype_pyarrow,
+    is_non_nullable_boolean,
+    set_index,
+)
 from narwhals._utils import validate_separators
 
 if TYPE_CHECKING:
@@ -304,9 +308,16 @@ class PandasLikeNamespace(
             return self._concat(dfs, axis=VERTICAL, copy=False)
         return self._concat(dfs, axis=VERTICAL)
 
-    def _concat_horizontal(
+    def concat_by_index(
         self, dfs: Sequence[NativeDataFrameT | NativeSeriesT], /
     ) -> NativeDataFrameT:
+        """Concatenate horizontally, aligning inputs by their (label-based) index.
+
+        Use this only when inputs are already known to share a meaningful,
+        aligned index (e.g. multiple aggregations from the same `group_by`).
+        For the general case, where inputs' indices may be unrelated, use
+        `_concat_horizontal` instead.
+        """
         if self._implementation.is_cudf():
             with warnings.catch_warnings():
                 warnings.filterwarnings(
@@ -318,6 +329,20 @@ class PandasLikeNamespace(
         elif self._implementation.is_pandas() and self._backend_version < (3,):
             return self._concat(dfs, axis=HORIZONTAL, copy=False)
         return self._concat(dfs, axis=HORIZONTAL)
+
+    def _concat_horizontal(self, dfs: Sequence[NativeDataFrameT], /) -> NativeDataFrameT:
+        # Follow the left-hand-rule documented in `docs/concepts/pandas_index.md`:
+        # the result takes on the index of the longest input (the left-most
+        # one, in case of a tie), and every other input is aligned to it
+        # *positionally*, ignoring its own index.
+        lengths = [len(df) for df in dfs]
+        target_index = dfs[lengths.index(max(lengths))].index
+        reset_dfs = [df.set_axis(range(len(df)), axis=VERTICAL) for df in dfs]
+        return set_index(
+            self.concat_by_index(reset_dfs),
+            target_index,
+            implementation=self._implementation,
+        )
 
     def _concat_vertical(self, dfs: Sequence[NativeDataFrameT], /) -> NativeDataFrameT:
         cols_0 = dfs[0].columns
@@ -479,7 +504,7 @@ class PandasLikeNamespace(
         def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
             a_series = df._evaluate_single_output_expr(a)
             b_series = df._evaluate_single_output_expr(b)
-            _df = self._concat_horizontal([a_series.native, b_series.native])
+            _df = self.concat_by_index([a_series.native, b_series.native])
             corr = _df.corr(method=method).iloc[0, [1]]  # type: ignore[union-attr]
             return [
                 PandasLikeSeries(
@@ -499,8 +524,7 @@ class PandasLikeNamespace(
             a_series = df._evaluate_single_output_expr(a)
             b_series = df._evaluate_single_output_expr(b)
             _df = cast(
-                "pd.DataFrame",
-                self._concat_horizontal([a_series.native, b_series.native]),
+                "pd.DataFrame", self.concat_by_index([a_series.native, b_series.native])
             )
             n = _df.count(axis=1).eq(2).sum()
             if ddof == 0 and n == 1:

--- a/tests/expr_and_series/corr_test.py
+++ b/tests/expr_and_series/corr_test.py
@@ -142,6 +142,24 @@ def test_corr_over(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
+def test_corr_series_foreign_index() -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3864
+    # A `Series` with an index unrelated to `df`'s own must be aligned
+    # positionally (left-hand-rule), not by pandas' automatic label join.
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df = nw.from_native(
+        pd.DataFrame({"a": [1, 2, 3], "b": [10, 20, 30]}), eager_only=True
+    )
+    foreign = nw.from_native(
+        pd.Series([3, 1, 2], index=[5, 6, 7], name="a"), series_only=True
+    )
+    result = df.select(nw.corr(foreign, nw.col("b")).round(2))
+    expected = {"a": [-0.5]}
+    assert_equal_data(result, expected)
+
+
 def test_corr_pairwise_nulls(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:

--- a/tests/expr_and_series/cov_test.py
+++ b/tests/expr_and_series/cov_test.py
@@ -99,6 +99,24 @@ def test_cov_over(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
+def test_cov_series_foreign_index() -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3864
+    # A `Series` with an index unrelated to `df`'s own must be aligned
+    # positionally (left-hand-rule), not by pandas' automatic label join.
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df = nw.from_native(
+        pd.DataFrame({"a": [1, 2, 3], "b": [10, 20, 30]}), eager_only=True
+    )
+    foreign = nw.from_native(
+        pd.Series([3, 1, 2], index=[5, 6, 7], name="a"), series_only=True
+    )
+    result = df.select(nw.cov(foreign, nw.col("b")))
+    expected = {"a": [-5.0]}
+    assert_equal_data(result, expected)
+
+
 def test_cov_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(

--- a/tests/frame/concat_test.py
+++ b/tests/frame/concat_test.py
@@ -63,6 +63,27 @@ def test_concat_horizontal_mismatched(
     assert_equal_data(result, expected)
 
 
+def test_concat_horizontal_pandas_left_hand_rule() -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3864
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df_left = nw.from_native(
+        pd.DataFrame({"a": [1, 2, 3]}, index=[10, 20, 30]), eager_only=True
+    )
+    df_right = nw.from_native(
+        pd.DataFrame({"b": [4, 5, 6]}, index=[0, 1, 2]), eager_only=True
+    )
+
+    result = nw.concat([df_left, df_right], how="horizontal")
+
+    # the index of the left-most argument is preserved, and the other
+    # argument is aligned to it positionally, rather than by label.
+    assert result.to_native().index.tolist() == [10, 20, 30]
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    assert_equal_data(result, expected)
+
+
 def test_concat_vertical(constructor: Constructor) -> None:
     data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
     df_left = (


### PR DESCRIPTION
# Description

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3864 
