### PR TITLE
fix: narrow `dt.timestamp` `time_unit` annotation to the units it accepts

### DIFF
--- a/src/narwhals/expr_dt.py
+++ b/src/narwhals/expr_dt.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, Literal, TypeVar
 
 from narwhals._expression_parsing import ExprKind, ExprNode
 
 if TYPE_CHECKING:
     from narwhals.expr import Expr
-    from narwhals.typing import TimeUnit
 
 ExprT = TypeVar("ExprT", bound="Expr")
 
@@ -609,7 +608,7 @@ class ExprDateTimeNamespace(Generic[ExprT]):
             ExprNode(ExprKind.ELEMENTWISE, "dt.convert_time_zone", time_zone=time_zone)
         )
 
-    def timestamp(self, time_unit: TimeUnit = "us") -> ExprT:
+    def timestamp(self, time_unit: Literal["ns", "us", "ms"] = "us") -> ExprT:
         """Return a timestamp in the given time unit.
 
         Arguments:

--- a/src/narwhals/series_dt.py
+++ b/src/narwhals/series_dt.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic
+from typing import Generic, Literal
 
 from narwhals.typing import SeriesT
-
-if TYPE_CHECKING:
-    from narwhals.typing import TimeUnit
 
 
 class SeriesDateTimeNamespace(Generic[SeriesT]):
@@ -549,7 +546,7 @@ class SeriesDateTimeNamespace(Generic[SeriesT]):
             self._narwhals_series._compliant_series.dt.convert_time_zone(time_zone)
         )
 
-    def timestamp(self, time_unit: TimeUnit) -> SeriesT:
+    def timestamp(self, time_unit: Literal["ns", "us", "ms"]) -> SeriesT:
         """Return a timestamp in the given time unit.
 
         Arguments:

--- a/tests/expr_and_series/dt/timestamp_test.py
+++ b/tests/expr_and_series/dt/timestamp_test.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal, get_args, get_type_hints
 
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given
 
 import narwhals as nw
+from narwhals.expr_dt import ExprDateTimeNamespace
+from narwhals.series_dt import SeriesDateTimeNamespace
 from tests.utils import (
     PANDAS_VERSION,
     POLARS_VERSION,
@@ -19,6 +21,8 @@ from tests.utils import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from narwhals.typing import IntoSeriesT
 
 data = {
@@ -205,8 +209,10 @@ def test_timestamp_invalid_date(
         df_num.select(nw.col("a").dt.timestamp())
 
 
-def test_timestamp_invalid_unit_expr(constructor: Constructor) -> None:
-    time_unit_invalid = "i"
+@pytest.mark.parametrize("time_unit_invalid", ["i", "s"])
+def test_timestamp_invalid_unit_expr(
+    constructor: Constructor, time_unit_invalid: str
+) -> None:
     msg = (
         "invalid `time_unit`"
         f"\n\nExpected one of {{'ns', 'us', 'ms'}}, got {time_unit_invalid!r}."
@@ -217,14 +223,26 @@ def test_timestamp_invalid_unit_expr(constructor: Constructor) -> None:
         )
 
 
-def test_timestamp_invalid_unit_series(constructor_eager: ConstructorEager) -> None:
-    time_unit_invalid = "i"
+@pytest.mark.parametrize("time_unit_invalid", ["i", "s"])
+def test_timestamp_invalid_unit_series(
+    constructor_eager: ConstructorEager, time_unit_invalid: str
+) -> None:
     msg = (
         "invalid `time_unit`"
         f"\n\nExpected one of {{'ns', 'us', 'ms'}}, got {time_unit_invalid!r}."
     )
     with pytest.raises(ValueError, match=msg):
         nw.from_native(constructor_eager(data))["a"].dt.timestamp(time_unit_invalid)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "method", [ExprDateTimeNamespace.timestamp, SeriesDateTimeNamespace.timestamp]
+)
+def test_timestamp_unit_annotation(method: Callable[..., Any]) -> None:
+    # `narwhals.typing.TimeUnit` also allows 's', which `nw.Datetime` accepts
+    # but `timestamp` rejects at runtime.
+    hints = get_type_hints(method)
+    assert set(get_args(hints["time_unit"])) == {"ns", "us", "ms"}
 
 
 @given(


### PR DESCRIPTION
# Description

#1822 added `'s'` to `TimeUnit` for the `datetime` selector and, in the same commit, replaced the inline `Literal["ns", "us", "ms"]` on `dt.timestamp` with that alias. The runtime guard stayed at three units, so `nw.col("a").dt.timestamp("s")` passes every type checker this repo runs, then raises `ValueError`.

I rejected implementing `'s'` instead. Polars' own `TimeUnit` has no second precision, so that would take `dt.timestamp` outside the Polars subset, and `_TIMESTAMP_DATETIME_OP_FACTOR` carries no `(*, 's')` entries in either eager backend.

A named alias in `narwhals.typing` would read closer to `RankMethod`, but a new public name cannot land in `stable.v1` or `stable.v2`, and the fix has to reach both since they inherit these classes. The inline literal is the only form that covers all three namespaces without growing the public API.

Type-only change, covered by the "more precise type hints" exception in `docs/backcompat.md`. `test_timestamp_unit_annotation` fails if the alias comes back. The two runtime `'s'` cases pass before and after, so they pin the decision rather than catch a regression.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

None.

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

Claude Code (Opus 5).

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes (the docstring lists only `'ns'`, `'us'`, `'ms'`, so it needed no edit)
- [x] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI)

Output of the command in the template, on this branch:

```
================================ tests coverage ================================
______________ coverage: platform darwin, python 3.12.13-final-0 _______________
Required test coverage of 80.0% reached. Total coverage: 100.00%
=============== 14811 passed, 218 skipped, 882 xfailed in 28.00s ===============
```

`make typing` is also clean (mypy, pyright, pyrefly), as is `pytest src --doctest-modules`.

