### PR TITLE
perf: Speedup pandas-like `is_finite`, `sqrt`, `kurtosis` and `skew`

### DIFF
--- a/src/narwhals/_pandas_like/series.py
+++ b/src/narwhals/_pandas_like/series.py
@@ -560,8 +560,9 @@ class PandasLikeSeries(EagerSeries[Any]):
         if len(ser_not_null) == 2:
             return 0.0
         m = ser_not_null - ser_not_null.mean()
-        m2 = (m**2).mean()
-        m3 = (m**3).mean()
+        m_squared = m * m
+        m2 = m_squared.mean()
+        m3 = (m_squared * m).mean()
         return m3 / (m2**1.5) if m2 != 0 else float("nan")
 
     def kurtosis(self) -> float | None:
@@ -571,8 +572,9 @@ class PandasLikeSeries(EagerSeries[Any]):
         if len(ser_not_null) == 1:
             return float("nan")
         m = ser_not_null - ser_not_null.mean()
-        m2 = (m**2).mean()
-        m4 = (m**4).mean()
+        m_squared = m * m
+        m2 = m_squared.mean()
+        m4 = (m_squared * m_squared).mean()
         return m4 / (m2**2) - 3.0 if m2 != 0 else float("nan")
 
     def len(self) -> int:
@@ -1146,7 +1148,21 @@ class PandasLikeSeries(EagerSeries[Any]):
         return self._with_native(result_native)
 
     def sqrt(self) -> Self:
-        return self._with_native(self.native.pow(0.5))
+        native = self.native
+        if self.is_native_dtype_pyarrow(native.dtype):
+            import pyarrow as pa  # ignore-banned-import()
+            import pyarrow.compute as pc
+
+            def pc_sqrt(ca: ChunkedArrayAny) -> ChunkedArrayAny:
+                result = pc.sqrt(pc.cast(ca, pa.float64()))
+                null = pa.scalar(None, pa.float64())
+                return pc.if_else(pc.is_nan(result), null, result)
+
+            result_native = self._apply_pyarrow_compute_func(native, pc_sqrt)
+        else:
+            array_func = self._array_funcs.sqrt
+            result_native = self._apply_array_func(native, array_func)
+        return self._with_native(result_native)
 
     def sin(self) -> Self:
         native = self.native

--- a/src/narwhals/_pandas_like/series.py
+++ b/src/narwhals/_pandas_like/series.py
@@ -1047,8 +1047,18 @@ class PandasLikeSeries(EagerSeries[Any]):
         return self.native.isna().any() if other is None else (self.native == other).any()
 
     def is_finite(self) -> Self:
-        s = self.native
-        return self._with_native((s > float("-inf")) & (s < float("inf")))
+        native = self.native
+        if self.is_native_dtype_pyarrow(native.dtype):
+            import pyarrow.compute as pc
+
+            result_native = self._apply_pyarrow_compute_func(
+                native,
+                pc.is_finite,  # type: ignore[arg-type]
+            )
+        else:
+            array_func = self._array_funcs.isfinite
+            result_native = self._apply_array_func(native, array_func)
+        return self._with_native(result_native)
 
     def rank(self, method: RankMethod, *, descending: bool) -> Self:
         pd_method = "first" if method == "ordinal" else method


### PR DESCRIPTION
# Description

Drive by https://github.com/feature-engine/feature_engine/pull/965#discussion_r3841412859

For `is_finite` numbers are consistent with those reported in the comment. For the remaining methods speedup is between 1.1x to 9x depending on pandas dtype backend

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

