### PR TITLE
perf: Avoid getting columns to read dtypes, route bare selectors through `simple_select`

### DIFF
--- a/src/narwhals/_compliant/selectors.py
+++ b/src/narwhals/_compliant/selectors.py
@@ -173,8 +173,7 @@ class EagerSelectorNamespace(
     CompliantSelectorNamespace[DataFrameT, SeriesT], Protocol[DataFrameT, SeriesT]
 ):
     def _iter_schema(self, df: DataFrameT, /) -> Iterator[tuple[str, DType]]:
-        for ser in self._iter_columns(df):
-            yield ser.name, ser.dtype
+        yield from df.schema.items()
 
     def _iter_columns(self, df: DataFrameT, /) -> Iterator[SeriesT]:
         yield from df.iter_columns()

--- a/src/narwhals/_compliant/selectors.py
+++ b/src/narwhals/_compliant/selectors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from functools import partial
-from typing import TYPE_CHECKING, Protocol, TypeVar, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol, TypeVar, overload
 
 from narwhals._compliant.expr import CompliantExpr
 from narwhals._utils import (
@@ -41,6 +41,7 @@ __all__ = [
     "CompliantSelectorNamespace",
     "EagerSelectorNamespace",
     "LazySelectorNamespace",
+    "is_compliant_selector",
 ]
 
 
@@ -204,6 +205,12 @@ class CompliantSelector(
     _implementation: Implementation
     _version: Version
 
+    # NOTE: This `Protocol` isn't `runtime_checkable`, and `PolarsExpr.__getattr__`
+    # forwards *any* attribute to the native object, so neither `isinstance` nor
+    # `hasattr` can identify a selector. Subclasses inherit this marker, and
+    # `is_compliant_selector` reads it off the class, which `__getattr__` never sees.
+    _is_compliant_selector: ClassVar[Literal[True]] = True
+
     @classmethod
     def from_callables(
         cls,
@@ -320,6 +327,11 @@ class CompliantSelector(
 
     def __invert__(self) -> CompliantSelector[FrameT, SeriesOrExprT]:
         return self.selectors.all() - self
+
+
+def is_compliant_selector(obj: Any, /) -> TypeIs[CompliantSelector[Any, Any]]:
+    """Check whether `obj` is a `CompliantSelector`."""
+    return getattr(type(obj), "_is_compliant_selector", False)
 
 
 def _eval_lhs_rhs(

--- a/src/narwhals/_duckdb/dataframe.py
+++ b/src/narwhals/_duckdb/dataframe.py
@@ -173,7 +173,7 @@ class DuckDBLazyFrame(
         return self._with_native(self.native.limit(n))
 
     def simple_select(self, *column_names: str) -> Self:
-        return self._with_native(self.native.select(*column_names))
+        return self._with_native(self.native.select(*map(col, column_names)))
 
     def aggregate(self, *exprs: DuckDBExpr) -> Self:
         selection = [

--- a/src/narwhals/_expression_parsing.py
+++ b/src/narwhals/_expression_parsing.py
@@ -39,6 +39,13 @@ def is_expr(obj: Any) -> TypeIs[Expr]:
     return isinstance(obj, Expr)
 
 
+def is_bare_selector(obj: Any) -> bool:
+    """Check whether `obj` is a selector with nothing chained onto it."""
+    return (
+        is_expr(obj) and len(obj._nodes) == 1 and obj._nodes[0].kind is ExprKind.SELECTOR
+    )
+
+
 def is_series(obj: Any) -> TypeIs[Series[Any]]:
     """Check whether `obj` is a Narwhals Expr."""
     from narwhals.series import Series

--- a/src/narwhals/dataframe.py
+++ b/src/narwhals/dataframe.py
@@ -15,10 +15,12 @@ from typing import (
     overload,
 )
 
+from narwhals._compliant.selectors import is_compliant_selector
 from narwhals._exceptions import issue_warning
 from narwhals._expression_parsing import (
     _parse_into_expr,
     check_expressions_preserve_length,
+    is_bare_selector,
     is_scalar_like,
 )
 from narwhals._typing import Arrow, Pandas, _LazyAllowedImpl, _LazyFrameCollectImpl
@@ -234,6 +236,24 @@ class BaseFrame(Generic[_FrameT]):
                     raise error from e
                 raise
         compliant_exprs = self._flatten_and_extract(*flat_exprs, **named_exprs)
+        if (
+            (not named_exprs)
+            and flat_exprs
+            and all(is_bare_selector(x) for x in flat_exprs)
+            and all(is_compliant_selector(x) for x in compliant_exprs)
+        ):
+            # fast path: bare selectors resolve to a subset of the frame's existing
+            # columns, in frame order, which is what `simple_select` does natively.
+            frame = self._compliant_frame
+            names = [
+                name
+                for expr in compliant_exprs
+                for name in expr._evaluate_output_names(frame)
+            ]
+            # An empty selection and duplicate output names both get dedicated handling
+            # further down (an empty frame, and a `DuplicateError`), so leave them be.
+            if names and len(set(names)) == len(names):
+                return self._with_compliant(frame.simple_select(*names))
         if compliant_exprs and all(is_scalar_like(x) for x in compliant_exprs):
             return self._with_compliant(self._compliant_frame.aggregate(*compliant_exprs))
         compliant_exprs = [

--- a/src/narwhals/dataframe.py
+++ b/src/narwhals/dataframe.py
@@ -30,6 +30,7 @@ from narwhals._utils import (
     _Implementation,
     _resolve_sample_size,
     can_lazyframe_collect,
+    check_column_names_are_unique,
     check_columns_exist,
     flatten,
     generate_repr,
@@ -250,10 +251,10 @@ class BaseFrame(Generic[_FrameT]):
                 for expr in compliant_exprs
                 for name in expr._evaluate_output_names(frame)
             ]
-            # An empty selection and duplicate output names both get dedicated handling
-            # further down (an empty frame, and a `DuplicateError`), so leave them be.
-            if names and len(set(names)) == len(names):
-                return self._with_compliant(frame.simple_select(*names))
+            if not names:
+                return self._with_compliant(frame.select())
+            check_column_names_are_unique(names)
+            return self._with_compliant(frame.simple_select(*names))
         if compliant_exprs and all(is_scalar_like(x) for x in compliant_exprs):
             return self._with_compliant(self._compliant_frame.aggregate(*compliant_exprs))
         compliant_exprs = [

--- a/tests/frame/select_test.py
+++ b/tests/frame/select_test.py
@@ -44,6 +44,11 @@ def test_empty_select(constructor_eager: ConstructorEager) -> None:
     assert result.shape == (0, 0)
 
 
+def test_select_selector_matching_nothing(constructor_eager: ConstructorEager) -> None:
+    df = nw.from_native(constructor_eager({"a": [1, 2, 3]}), eager_only=True)
+    assert df.select(ncs.string()).shape == (0, 0)
+
+
 def test_non_string_select() -> None:
     pytest.importorskip("pandas")
     import pandas as pd
@@ -190,11 +195,11 @@ def test_select_duplicates(constructor: Constructor) -> None:
         # cudf already raises its own error
         pytest.skip()
     df = nw.from_native(constructor({"a": [1, 2]})).lazy()
-    with pytest.raises(
-        ValueError,
-        match=r"Expected unique|[Dd]uplicate|more than one|Duplicate column name",
-    ):
+    msg = r"Expected unique|[Dd]uplicate|more than one|Duplicate column name"
+    with pytest.raises(ValueError, match=msg):
         df.select("a", nw.col("a") + 1).collect()
+    with pytest.raises(ValueError, match=msg):
+        df.select(ncs.numeric(), ncs.matches("^a$")).collect()
 
 
 def test_binary_window_aggregation(constructor_eager: ConstructorEager) -> None:

--- a/tests/frame/select_test.py
+++ b/tests/frame/select_test.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 import narwhals as nw
+import narwhals.selectors as ncs
 from narwhals.exceptions import ColumnNotFoundError, InvalidIntoExprError, NarwhalsError
 from tests.utils import (
     DASK_VERSION,
@@ -25,6 +26,17 @@ def test_select(constructor: Constructor) -> None:
     result = df.select("a")
     expected = {"a": [1, 3, 2]}
     assert_equal_data(result, expected)
+
+
+@pytest.mark.parametrize("name", ["order", "SELECT", "my col"])
+def test_select_names_which_are_not_sql_identifiers(
+    constructor: Constructor, name: str
+) -> None:
+    data = {name: [1, 3, 2], "b": ["x", "y", "z"]}
+    df = nw.from_native(constructor(data))
+    assert_equal_data(df.select(name), {name: [1, 3, 2]})
+    assert_equal_data(df.select(ncs.numeric()), {name: [1, 3, 2]})
+    assert_equal_data(df.select(~ncs.numeric()), {"b": ["x", "y", "z"]})
 
 
 def test_empty_select(constructor_eager: ConstructorEager) -> None:

--- a/tests/selectors_test.py
+++ b/tests/selectors_test.py
@@ -264,6 +264,7 @@ def test_datetime_no_tz(constructor: Constructor) -> None:
 
     df = nw.from_native(constructor(data))
     assert df.select(ncs.datetime()).collect_schema().names() == ["ts"]
+    assert_equal_data(df.select(ncs.datetime().dt.year()), {"ts": [2000, 2020]})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Drive by https://github.com/feature-engine/feature_engine/pull/989/changes/8f377c4f286145e6e9209088bfe3a9abc68c8ea1

---

*`_iter_schema` reads `df.schema` rather than every column just to look at its dtype.
* `DataFrame.select` now routes a bare selector (`ncs.numeric()`) to `simple_select` instead of evaluating it to N Series and concatenating them, and eager
* Also fixes `DuckDBLazyFrame.simple_select`

Each one has its own commit - happy to keep any of those (https://github.com/narwhals-dev/narwhals/pull/3875/commits/255e7653e2c0fe0997e5011720e3ae86001a5c6a is really low effort :)) 

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

