### PR TITLE
add pandas<3 overhead benchmark run

### DIFF
--- a/.github/workflows/benchmark_overhead.yml
+++ b/.github/workflows/benchmark_overhead.yml
@@ -1,0 +1,57 @@
+name: Benchmark Narwhals vs pandas overhead
+
+on:
+  pull_request:
+    paths:
+      - "src/narwhals/**.py"
+      - .github/workflows/benchmark_overhead.yml
+      - pyproject.toml
+      - uv.lock
+
+env:
+  PY_COLORS: 1
+  UV_LOCKED: 1
+  UV_NO_DEV: 1
+
+permissions:
+  contents: read
+
+jobs:
+  overhead:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+        os: [ubuntu-latest]
+        pandas: ["latest", "pandas2"]
+        include:
+          - pandas: "latest"
+            pandas-constraint: ""
+          - pandas: "pandas2"
+            pandas-constraint: "pandas>=2.2,<3"
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: "true"
+          cache-suffix: benchmark-${{ matrix.python-version }}-${{ matrix.pandas }}
+          cache-dependency-glob: "pyproject.toml"
+      - name: generate-data
+        run: make run-ci DEPS="--extra pandas --group core-tests" CMD="--module tpch.generate_data --debug"
+      - name: overhead-tests
+        env:
+          PANDAS_CONSTRAINT: ${{ matrix.pandas-constraint }}
+        run: |
+          RUN_ONLY=""
+          if [ -n "$PANDAS_CONSTRAINT" ]; then
+            RUN_ONLY="--with '$PANDAS_CONSTRAINT'"
+          fi
+          make run-ci DEPS="--extra pandas --group core-tests" \
+            RUN_ONLY="$RUN_ONLY" \
+            CMD="pytest tpch/tests/overhead_test.py -s"

--- a/.github/workflows/check_tpch_queries.yml
+++ b/.github/workflows/check_tpch_queries.yml
@@ -38,4 +38,4 @@ jobs:
       - name: generate-data
         run: make run-ci DEPS="--extra dask --extra pandas --group core-tests" CMD="--module tpch.generate_data --debug"
       - name: tpch-tests
-        run: make run-ci DEPS="--extra dask --extra pandas --group core-tests" CMD="pytest tpch/tests -s"
+        run: make run-ci DEPS="--extra dask --extra pandas --group core-tests" CMD="pytest tpch/tests --ignore=tpch/tests/overhead_test.py"


### PR DESCRIPTION
xref one item of https://github.com/narwhals-dev/narwhals/issues/3877

<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
