### PR TITLE
WIP Pyrefly on src

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -519,7 +519,7 @@ defineConstant = { "MYPY" = false }
 
 [tool.pyrefly]
 search-path = ["src", "."]
-project-includes = ["tests"]
+project-includes = ["src", "tests"]
 ignore-missing-imports = [
     "cudf.*",
     "cupy.*",

--- a/src/narwhals/_arrow/dataframe.py
+++ b/src/narwhals/_arrow/dataframe.py
@@ -585,7 +585,7 @@ class ArrowDataFrame(
         session: SparkSession | None = None,
     ) -> CompliantLazyFrameAny:
         if backend is None:
-            return self
+            return self  # pyrefly: ignore[bad-return]  # pyrefly-issues/01-self-nested-generic.md
         if backend is Implementation.DUCKDB:
             import duckdb  # ignore-banned-import
 
@@ -634,7 +634,10 @@ class ArrowDataFrame(
                 raise ValueError(msg)
 
             return SparkLikeLazyFrame._from_compliant_dataframe(
-                self, session=session, implementation=backend, version=self._version
+                self,
+                session=session,
+                implementation=backend,
+                version=self._version,  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
             )
 
         raise AssertionError  # pragma: no cover
@@ -643,8 +646,6 @@ class ArrowDataFrame(
         self, backend: _EagerAllowedImpl | None, **kwargs: Any
     ) -> CompliantDataFrameAny:
         if backend is Implementation.PYARROW or backend is None:
-            from narwhals._arrow.dataframe import ArrowDataFrame
-
             return ArrowDataFrame(
                 self.native, version=self._version, validate_column_names=False
             )

--- a/src/narwhals/_arrow/expr.py
+++ b/src/narwhals/_arrow/expr.py
@@ -158,13 +158,13 @@ class ArrowExpr(EagerExpr["ArrowDataFrame", ArrowSeries]):
             plx = self.__narwhals_namespace__()
             if meta.prev is not None:
                 df = df.with_columns(cast("ArrowExpr", evaluate_nodes(nodes[:-1], plx)))
-                _, aliases = evaluate_output_names_and_aliases(self, df, [])
+                _, aliases = evaluate_output_names_and_aliases(self, df, [])  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
                 leaf_ce = cast(
                     "ArrowExpr",
                     nw_col(*aliases)._append_node(nodes[-1])._to_compliant_expr(plx),
                 )
             else:
-                _, aliases = evaluate_output_names_and_aliases(self, df, [])
+                _, aliases = evaluate_output_names_and_aliases(self, df, [])  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
                 leaf_ce = self
             if order_by:
                 df = df.sort(*order_by, descending=False, nulls_last=False)
@@ -207,7 +207,7 @@ class ArrowExpr(EagerExpr["ArrowDataFrame", ArrowSeries]):
 
                     indices = plx._series.from_native(
                         (
-                            tbl_native.column(col_name)
+                            tbl_native.column(col_name)  # pyrefly: ignore[missing-attribute]
                             .dictionary_encode("encode")
                             .combine_chunks()
                             .indices  # type: ignore[attr-defined]

--- a/src/narwhals/_arrow/series.py
+++ b/src/narwhals/_arrow/series.py
@@ -173,7 +173,7 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
         if dtype is not None:
             dtype_pa: pa.DataType | None = narwhals_to_native_dtype(dtype, version)
             if is_array_or_scalar(data):
-                data = data.cast(dtype_pa)
+                data = data.cast(dtype_pa)  # pyrefly: ignore[bad-assignment, bad-specialization]
                 dtype_pa = None
             native = data if cls._is_native(data) else chunked_array([data], dtype_pa)
         else:
@@ -328,7 +328,7 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
             _, other_native = extract_native(self, predicate)
         else:
             other_native = predicate
-        return self._with_native(self.native.filter(other_native))
+        return self._with_native(self.native.filter(other_native))  # pyrefly: ignore[bad-argument-type]
 
     def first(self, *, _return_py_scalar: bool = True) -> PythonLiteral:
         result = self.native[0] if len(self.native) else None
@@ -986,7 +986,7 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
                 (rolling_sum_sq - (rolling_sum**2 / count_in_window)).native,
                 None,
             )
-        ) / self._with_native(pc.max_element_wise((count_in_window - ddof).native, 0))
+        ) / self._with_native(pc.max_element_wise((count_in_window - ddof).native, 0))  # pyrefly: ignore[no-matching-overload]
 
         return result._gather_slice(slice(offset, None, None))
 
@@ -1029,7 +1029,7 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
         self, bins: list[float], *, include_breakpoint: bool
     ) -> ArrowDataFrame:
         return (
-            _ArrowHist.from_series(self, include_breakpoint=include_breakpoint)
+            _ArrowHist.from_series(self, include_breakpoint=include_breakpoint)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
             .with_bins(bins)
             .to_frame()
         )
@@ -1038,7 +1038,7 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
         self, bin_count: int, *, include_breakpoint: bool
     ) -> ArrowDataFrame:
         return (
-            _ArrowHist.from_series(self, include_breakpoint=include_breakpoint)
+            _ArrowHist.from_series(self, include_breakpoint=include_breakpoint)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
             .with_bin_count(bin_count)
             .to_frame()
         )
@@ -1064,7 +1064,7 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
             raise InvalidOperationError(msg) from exc
 
     def log(self, base: float) -> Self:
-        return self._with_native(pc.logb(self.native, lit(base)))
+        return self._with_native(pc.logb(self.native, lit(base)))  # pyrefly: ignore[bad-argument-type]
 
     def exp(self) -> Self:
         return self._with_native(pc.exp(self.native))
@@ -1096,7 +1096,7 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
         return ArrowSeriesStringNamespace(self)
 
     @property
-    def list(self) -> ArrowSeriesListNamespace:
+    def list(self) -> ArrowSeriesListNamespace:  # pyrefly: ignore[bad-override]  # pyrefly-issues/01-self-nested-generic.md
         return ArrowSeriesListNamespace(self)
 
     @property
@@ -1109,7 +1109,7 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
 class _ArrowHist(
     EagerSeriesHist["ChunkedArrayAny", "list[ScalarAny] | pa.Int64Array | list[float]"]
 ):
-    _series: ArrowSeries
+    _series: ArrowSeries  # pyrefly: ignore[bad-override-mutable-attribute]  # pyrefly-issues/01-self-nested-generic.md
 
     def to_frame(self) -> ArrowDataFrame:
         # NOTE: Constructor typing is too strict for `TypedDict`
@@ -1170,7 +1170,7 @@ class _ArrowHist(
             is_between_bins = pc.and_(
                 pc.greater_equal(ser, lit(bins[0])), pc.less_equal(ser, lit(bins[1]))
             )
-            count = pc.sum(is_between_bins.cast(pa.uint8()))
+            count = pc.sum(is_between_bins.cast(pa.uint8()))  # pyrefly: ignore[bad-specialization]
             if self._breakpoint:
                 return {"breakpoint": [bins[-1]], "count": [count]}
             return {"count": [count]}

--- a/src/narwhals/_arrow/series_str.py
+++ b/src/narwhals/_arrow/series_str.py
@@ -133,7 +133,7 @@ class ArrowSeriesStringNamespace(ArrowSeriesNamespace, StringNamespace["ArrowSer
         starts_with_hyphen = pc.equal(first_char, hyphen)
         starts_with_plus = pc.equal(first_char, plus)
 
-        conditions = pc.make_struct(
+        conditions = pc.make_struct(  # pyrefly: ignore[no-matching-overload]
             pc.and_(starts_with_hyphen, less_than_width),
             pc.and_(starts_with_plus, less_than_width),
             less_than_width,

--- a/src/narwhals/_arrow/utils.py
+++ b/src/narwhals/_arrow/utils.py
@@ -362,7 +362,7 @@ def cast_for_truediv(
     if pa.types.is_integer(arrow_array.type) and pa.types.is_integer(pa_object.type):
         # GH: 56645.  # noqa: ERA001
         # https://github.com/apache/arrow/issues/35563
-        return arrow_array.cast(pa.float64(), safe=False), pa_object.cast(
+        return arrow_array.cast(pa.float64(), safe=False), pa_object.cast(  # pyrefly: ignore[bad-return]
             pa.float64(), safe=False
         )
 
@@ -623,7 +623,7 @@ def list_sort(
         [arange(start=0, end=len(array), step=1), array], names=[idx, v]
     )
     not_sorted_part = indexed.filter(is_not_sorted)
-    pass_through = indexed.filter(pc.fill_null(pc.invert(is_not_sorted), lit(True)))  # pyright: ignore[reportArgumentType]
+    pass_through = indexed.filter(pc.fill_null(pc.invert(is_not_sorted), lit(True)))  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]
     exploded = pa.Table.from_arrays(
         [pc.list_flatten(array), pc.list_parent_indices(array)], names=[v, idx]
     )

--- a/src/narwhals/_compliant/namespace.py
+++ b/src/narwhals/_compliant/namespace.py
@@ -262,7 +262,7 @@ class EagerNamespace(
             return [then_s._with_native(result)]
 
         return self._expr._from_callable(
-            func=func,
+            func=func,  # pyrefly: ignore[bad-argument-type]
             evaluate_output_names=getattr(
                 then, "_evaluate_output_names", lambda _df: ["literal"]
             ),
@@ -322,4 +322,4 @@ class EagerNamespace(
             native = self._concat_diagonal(dfs)
         else:  # pragma: no cover
             raise NotImplementedError
-        return self._dataframe.from_native(native, context=self)
+        return self._dataframe.from_native(native, context=self)  # pyrefly: ignore[bad-argument-type]

--- a/src/narwhals/_compliant/selectors.py
+++ b/src/narwhals/_compliant/selectors.py
@@ -244,7 +244,7 @@ class CompliantSelector(
         if self._is_selector(other):
 
             def series(df: FrameT) -> Sequence[SeriesOrExprT]:
-                lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)
+                lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
                 rhs_set = frozenset(rhs_names)
                 return [
                     x
@@ -253,7 +253,7 @@ class CompliantSelector(
                 ]
 
             def names(df: FrameT) -> Sequence[str]:
-                lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)
+                lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
                 rhs_set = frozenset(rhs_names)
                 return [x for x in lhs_names if x not in rhs_set]
 
@@ -272,7 +272,7 @@ class CompliantSelector(
         if self._is_selector(other):
 
             def series(df: FrameT) -> Sequence[SeriesOrExprT]:
-                lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)
+                lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
                 rhs_set = frozenset(rhs_names)
                 return [
                     *(
@@ -284,7 +284,7 @@ class CompliantSelector(
                 ]
 
             def names(df: FrameT) -> Sequence[str]:
-                lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)
+                lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
                 rhs_set = frozenset(rhs_names)
                 return [*(x for x in lhs_names if x not in rhs_set), *rhs_names]
 
@@ -303,7 +303,7 @@ class CompliantSelector(
         if self._is_selector(other):
 
             def series(df: FrameT) -> Sequence[SeriesOrExprT]:
-                lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)
+                lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
                 rhs_set = frozenset(rhs_names)
                 return [
                     x
@@ -312,7 +312,7 @@ class CompliantSelector(
                 ]
 
             def names(df: FrameT) -> Sequence[str]:
-                lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)
+                lhs_names, rhs_names = _eval_lhs_rhs(df, self, other)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
                 rhs_set = frozenset(rhs_names)
                 return [x for x in lhs_names if x in rhs_set]
 

--- a/src/narwhals/_dask/expr.py
+++ b/src/narwhals/_dask/expr.py
@@ -74,8 +74,8 @@ def trivial_binary_right(op: Callable[..., dx.Series]) -> Any:
 
 
 class DaskExpr(
-    LazyExpr["DaskLazyFrame", "dx.Series"],  # pyright: ignore[reportInvalidTypeArguments]
-    DepthTrackingExpr["DaskLazyFrame", "dx.Series"],  # pyright: ignore[reportInvalidTypeArguments]
+    LazyExpr["DaskLazyFrame", "dx.Series"],  # pyright: ignore[reportInvalidTypeArguments]  # pyrefly: ignore[bad-specialization]
+    DepthTrackingExpr["DaskLazyFrame", "dx.Series"],  # pyright: ignore[reportInvalidTypeArguments]  # pyrefly: ignore[bad-specialization]
 ):
     _implementation: Implementation = Implementation.DASK
 
@@ -121,7 +121,7 @@ class DaskExpr(
 
     def __init__(
         self,
-        call: EvalSeries[DaskLazyFrame, dx.Series],  # pyright: ignore[reportInvalidTypeForm]
+        call: EvalSeries[DaskLazyFrame, dx.Series],  # pyright: ignore[reportInvalidTypeForm]  # pyrefly: ignore[bad-specialization]
         *,
         evaluate_output_names: EvalNames[DaskLazyFrame],
         alias_output_names: AliasNames | None,
@@ -447,7 +447,7 @@ class DaskExpr(
                 expr.dtype, self._version, self._implementation
             )
             if dtype.is_numeric():
-                return expr != expr  # pyright: ignore[reportReturnType] # noqa: PLR0124
+                return expr != expr  # pyright: ignore[reportReturnType] # noqa: PLR0124  # pyrefly: ignore[bad-return]
             msg = f"`.is_nan` only supported for numeric dtypes and not {dtype}, did you mean `.is_null`?"
             raise InvalidOperationError(msg)
 
@@ -588,7 +588,7 @@ class DaskExpr(
             plx = self.__narwhals_namespace__()
             if meta.prev is not None:
                 df = df.with_columns(cast("DaskExpr", evaluate_nodes(nodes[:-1], plx)))
-            _, aliases = evaluate_output_names_and_aliases(self, df, [])
+            _, aliases = evaluate_output_names_and_aliases(self, df, [])  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
 
             with warnings.catch_warnings():
                 # https://github.com/dask/dask/issues/11804

--- a/src/narwhals/_dask/namespace.py
+++ b/src/narwhals/_dask/namespace.py
@@ -200,7 +200,7 @@ class DaskNamespace(
             )
             num = reduce(lambda x, y: x + y, series)  # pyright: ignore[reportOperatorIssue]
             den = reduce(lambda x, y: x + y, non_na)  # pyright: ignore[reportOperatorIssue]
-            return [cast("dx.Series", num / den)]  # pyright: ignore[reportOperatorIssue]
+            return [cast("dx.Series", num / den)]  # pyright: ignore[reportOperatorIssue]  # pyrefly: ignore[unsupported-operation]
 
         return self._expr(
             call=func,

--- a/src/narwhals/_dask/selectors.py
+++ b/src/narwhals/_dask/selectors.py
@@ -11,13 +11,13 @@ if TYPE_CHECKING:
     from narwhals._dask.dataframe import DaskLazyFrame  # noqa: F401
 
 
-class DaskSelectorNamespace(LazySelectorNamespace["DaskLazyFrame", "dx.Series"]):  # pyright: ignore[reportInvalidTypeArguments]
+class DaskSelectorNamespace(LazySelectorNamespace["DaskLazyFrame", "dx.Series"]):  # pyright: ignore[reportInvalidTypeArguments]  # pyrefly: ignore[bad-specialization]
     @property
     def _selector(self) -> type[DaskSelector]:
         return DaskSelector
 
 
-class DaskSelector(CompliantSelector["DaskLazyFrame", "dx.Series"], DaskExpr):  # pyright: ignore[reportInvalidTypeArguments]
+class DaskSelector(CompliantSelector["DaskLazyFrame", "dx.Series"], DaskExpr):  # pyright: ignore[reportInvalidTypeArguments]  # pyrefly: ignore[bad-specialization]
     def _to_expr(self) -> DaskExpr:
         return DaskExpr(
             self._call,

--- a/src/narwhals/_duckdb/dataframe.py
+++ b/src/narwhals/_duckdb/dataframe.py
@@ -182,7 +182,7 @@ class DuckDBLazyFrame(
         try:
             return self._with_native(self.native.aggregate(selection))
         except Exception as e:  # noqa: BLE001
-            raise catch_duckdb_exception(e, self) from None
+            raise catch_duckdb_exception(e, self) from None  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
 
     def select(self, *exprs: DuckDBExpr) -> Self:
         selection = (
@@ -191,7 +191,7 @@ class DuckDBLazyFrame(
         try:
             return self._with_native(self.native.select(*selection))
         except Exception as e:  # noqa: BLE001
-            raise catch_duckdb_exception(e, self) from None
+            raise catch_duckdb_exception(e, self) from None  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
 
     def drop(self, columns: Sequence[str], *, strict: bool) -> Self:
         columns_to_drop = parse_columns_to_drop(self, columns, strict=strict)
@@ -220,7 +220,7 @@ class DuckDBLazyFrame(
         try:
             return self._with_native(self.native.select(*result))
         except Exception as e:  # noqa: BLE001
-            raise catch_duckdb_exception(e, self) from None
+            raise catch_duckdb_exception(e, self) from None  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
 
     def _filter(self, predicate: DuckDBExpr) -> Self:
         # `[0]` is safe as the predicate's expression only returns a single column
@@ -228,7 +228,7 @@ class DuckDBLazyFrame(
         try:
             return self._with_native(self.native.filter(mask))
         except Exception as e:
-            raise catch_duckdb_exception(e, self) from e
+            raise catch_duckdb_exception(e, self) from e  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
 
     @property
     def schema(self) -> dict[str, DType]:

--- a/src/narwhals/_duckdb/utils.py
+++ b/src/narwhals/_duckdb/utils.py
@@ -174,12 +174,12 @@ def native_to_narwhals_dtype(
         child, size = duckdb_dtype.children
         shape = [size[1]]
 
-        while child[1].id == "array":
-            child, size = child[1].children
+        while child[1].id == "array":  # pyrefly: ignore[missing-attribute]  # pyrefly-issues/03-any-annotation-not-honored-across-branches.md
+            child, size = child[1].children  # pyrefly: ignore[missing-attribute]  # pyrefly-issues/03-any-annotation-not-honored-across-branches.md
             shape.insert(0, size[1])
 
-        inner = native_to_narwhals_dtype(child[1], version, deferred_time_zone)
-        return dtypes.Array(inner=inner, shape=tuple(shape))
+        inner = native_to_narwhals_dtype(child[1], version, deferred_time_zone)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/03-any-annotation-not-honored-across-branches.md
+        return dtypes.Array(inner=inner, shape=tuple(shape))  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/03-any-annotation-not-honored-across-branches.md
 
     if duckdb_dtype_id == "enum":
         if version is Version.V1:
@@ -194,7 +194,7 @@ def native_to_narwhals_dtype(
         precision: Incomplete
         scale: Incomplete
         (_, precision), (_, scale) = duckdb_dtype.children
-        return dtypes.Decimal(precision, scale)
+        return dtypes.Decimal(precision, scale)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/03-any-annotation-not-honored-across-branches.md
 
     return _non_nested_native_to_narwhals_dtype(duckdb_dtype_id, version)
 

--- a/src/narwhals/_ibis/expr.py
+++ b/src/narwhals/_ibis/expr.py
@@ -337,7 +337,7 @@ class IbisExpr(SQLExpr["IbisLazyFrame", "ir.Value"]):
                 msg = "`rank` followed by `over` with `order_by` specified is not supported for Ibis backend."
                 raise NotImplementedError(msg)
             return [
-                _rank(cast("ir.Column", expr)).over(
+                _rank(cast("ir.Column", expr)).over(  # pyrefly: ignore[bad-argument-type]
                     ibis.window(group_by=inputs.partition_by)
                 )
                 for expr in self(df)

--- a/src/narwhals/_ibis/expr_list.py
+++ b/src/narwhals/_ibis/expr_list.py
@@ -49,11 +49,11 @@ class IbisExprListNamespace(LazyExprNamespace["IbisExpr"], ListNamespace["IbisEx
             mid = n // 2
             hi = arr_sorted[mid].cast("float64")
             # Works without the cast, but this satisfies pyright
-            lo = arr_sorted[(mid - 1).cast("int64")].cast("float64")
+            lo = arr_sorted[(mid - 1).cast("int64")].cast("float64")  # pyrefly: ignore[bad-index]
             return cases(
                 (n.isnull(), literal(None)),
                 (n == literal(0), literal(None)),
-                (n % 2 == 0, (lo + hi) / 2),
+                (n % 2 == 0, (lo + hi) / 2),  # pyrefly: ignore[unsupported-operation]
                 else_=hi,
             )
 

--- a/src/narwhals/_ibis/expr_str.py
+++ b/src/narwhals/_ibis/expr_str.py
@@ -67,7 +67,7 @@ class IbisExprStringNamespace(SQLExprStringNamespace["IbisExpr"]):
     def _to_datetime_naive(self, format: str) -> Callable[..., ir.TimestampValue]:
         def fn(expr: ir.StringColumn) -> ir.TimestampValue:
             dtype: Any = Timestamp(timezone=None)
-            return expr.as_timestamp(format).cast(dtype)
+            return expr.as_timestamp(format).cast(dtype)  # pyrefly: ignore[bad-return]
 
         return fn
 

--- a/src/narwhals/_ibis/namespace.py
+++ b/src/narwhals/_ibis/namespace.py
@@ -177,7 +177,7 @@ class IbisNamespace(
         def func(_df: IbisLazyFrame) -> list[ir.Value]:
             a_ = _df._evaluate_single_output_expr(a)
             b_ = _df._evaluate_single_output_expr(b)
-            return [a_.corr(b_, how="pop")]  # pyright: ignore[reportAttributeAccessIssue]
+            return [a_.corr(b_, how="pop")]  # pyright: ignore[reportAttributeAccessIssue]  # pyrefly: ignore[missing-attribute]
 
         return self._expr(
             func,

--- a/src/narwhals/_ibis/utils.py
+++ b/src/narwhals/_ibis/utils.py
@@ -156,7 +156,7 @@ def native_to_narwhals_dtype(ibis_dtype: IbisDataType, version: Version) -> DTyp
         return dtypes.Date()
     if is_timestamp(ibis_dtype):
         _unit = cast("TimestampUnit", ibis_dtype.unit)
-        return dtypes.Datetime(time_unit=_unit.value, time_zone=ibis_dtype.timezone)
+        return dtypes.Datetime(time_unit=_unit.value, time_zone=ibis_dtype.timezone)  # pyrefly: ignore[bad-argument-type]
     if is_interval(ibis_dtype):
         _time_unit = ibis_dtype.unit.value
         if _time_unit not in {"ns", "us", "ms", "s"}:  # pragma: no cover
@@ -248,7 +248,7 @@ def narwhals_to_native_dtype(dtype: IntoDType, version: Version) -> IbisDataType
     if isinstance_or_issubclass(dtype, dtypes.Datetime):
         return ibis_dtypes.Timestamp.from_unit(dtype.time_unit, timezone=dtype.time_zone)
     if isinstance_or_issubclass(dtype, dtypes.Duration):
-        return ibis_dtypes.Interval(unit=dtype.time_unit)  # pyright: ignore[reportArgumentType]
+        return ibis_dtypes.Interval(unit=dtype.time_unit)  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]
     if isinstance_or_issubclass(dtype, dtypes.List):
         inner = narwhals_to_native_dtype(dtype.inner, version)
         return ibis_dtypes.Array(value_type=inner)
@@ -284,7 +284,7 @@ _BINARY_OPS = {
 def function(name: str, *args: ir.Value | PythonLiteral) -> ir.Value:
     # Workaround SQL vs Ibis differences.
     if name in _BINARY_OPS:
-        return _BINARY_OPS[name](*args)
+        return _BINARY_OPS[name](*args)  # pyrefly: ignore[no-matching-overload]  # pyrefly-issues/05-operator-overload-with-star-args.md
     if name == "row_number":
         return ibis.row_number() + lit(1)
     if name == "least":

--- a/src/narwhals/_namespace.py
+++ b/src/narwhals/_namespace.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
         SparkLike,
     )
 
-    EagerAllowedNamespace: TypeAlias = "Namespace[PandasLikeNamespace] | Namespace[ArrowNamespace] | Namespace[PolarsNamespace]"
+    EagerAllowedNamespace: TypeAlias = "Namespace[PandasLikeNamespace] | Namespace[ArrowNamespace] | Namespace[PolarsNamespace]"  # pyrefly: ignore[bad-specialization]  # pyrefly-issues/01-self-nested-generic.md
 
 __all__ = ["Namespace"]
 
@@ -103,7 +103,7 @@ class Namespace(Generic[CompliantNamespaceT_co]):
 
     @overload
     @classmethod
-    def from_backend(cls, backend: Polars, /) -> Namespace[PolarsNamespace]: ...
+    def from_backend(cls, backend: Polars, /) -> Namespace[PolarsNamespace]: ...  # pyrefly: ignore[bad-specialization]  # pyrefly-issues/01-self-nested-generic.md
 
     @overload
     @classmethod
@@ -190,7 +190,7 @@ class Namespace(Generic[CompliantNamespaceT_co]):
     @classmethod
     def from_native_object(
         cls, native: NativePolars, /
-    ) -> Namespace[PolarsNamespace]: ...
+    ) -> Namespace[PolarsNamespace]: ...  # pyrefly: ignore[bad-specialization]  # pyrefly-issues/01-self-nested-generic.md
 
     @overload
     @classmethod

--- a/src/narwhals/_pandas_like/dataframe.py
+++ b/src/narwhals/_pandas_like/dataframe.py
@@ -760,7 +760,7 @@ class PandasLikeDataFrame(
         """
         implementation = self._implementation
         return rename(
-            select_columns_by_name(
+            select_columns_by_name(  # pyrefly: ignore[bad-argument-type]
                 other.native,
                 column_names=columns_to_select,
                 implementation=implementation,
@@ -883,7 +883,7 @@ class PandasLikeDataFrame(
     ) -> CompliantLazyFrameAny:
         pandas_df = self.to_pandas()
         if backend is None:
-            return self
+            return self  # pyrefly: ignore[bad-return]  # pyrefly-issues/01-self-nested-generic.md
         if backend is Implementation.DUCKDB:
             import duckdb  # ignore-banned-import
 

--- a/src/narwhals/_pandas_like/expr.py
+++ b/src/narwhals/_pandas_like/expr.py
@@ -299,7 +299,7 @@ class PandasLikeExpr(EagerExpr["PandasLikeDataFrame", PandasLikeSeries]):
                 df = df.with_columns(
                     cast("PandasLikeExpr", evaluate_nodes(nodes[:-1], plx))
                 )
-            _, aliases = evaluate_output_names_and_aliases(self, df, [])
+            _, aliases = evaluate_output_names_and_aliases(self, df, [])  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
             if function_name == "cum_count":
                 df = df.with_columns(~plx.col(*aliases).is_null())
 
@@ -385,7 +385,7 @@ class PandasLikeExpr(EagerExpr["PandasLikeDataFrame", PandasLikeSeries]):
                     # Ignore settingwithcopy warnings/errors, they're false-positives here.
                     warnings.filterwarnings("ignore", message="\n.*copy of a slice")
                     for s in results:
-                        s.scatter(sorting_indices, s, in_place=True)
+                        s.scatter(sorting_indices, s, in_place=True)  # pyrefly: ignore[unbound-name]
                     return results
             if reverse:
                 return [s._gather_slice(slice(None, None, -1)) for s in results]

--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -566,11 +566,11 @@ class _NativeConcat(Protocol[NativeDataFrameT, NativeSeriesT]):
         copy: bool | None = ...,
     ) -> NativeDataFrameT: ...
     @overload
-    def __call__(
+    def __call__(  # pyrefly: ignore[inconsistent-overload]
         self, objs: Iterable[NativeSeriesT], *, axis: _Vertical, copy: bool | None = ...
     ) -> NativeSeriesT: ...
     @overload
-    def __call__(
+    def __call__(  # pyrefly: ignore[inconsistent-overload]
         self,
         objs: Iterable[NativeDataFrameT | NativeSeriesT],
         *,
@@ -578,7 +578,7 @@ class _NativeConcat(Protocol[NativeDataFrameT, NativeSeriesT]):
         copy: bool | None = ...,
     ) -> NativeDataFrameT: ...
     @overload
-    def __call__(
+    def __call__(  # pyrefly: ignore[inconsistent-overload]
         self,
         objs: Iterable[NativeDataFrameT | NativeSeriesT],
         *,

--- a/src/narwhals/_pandas_like/series.py
+++ b/src/narwhals/_pandas_like/series.py
@@ -900,7 +900,7 @@ class PandasLikeSeries(EagerSeries[Any]):
             *cols, null_col_pd = list(result.columns)
             output_order = [null_col_pd, *cols]
             result = rename(
-                select_columns_by_name(result, output_order, self._implementation),
+                select_columns_by_name(result, output_order, self._implementation),  # pyrefly: ignore[bad-argument-type]
                 columns={null_col_pd: null_col_pl},
                 implementation=self._implementation,
             )
@@ -1091,7 +1091,7 @@ class PandasLikeSeries(EagerSeries[Any]):
         self, bins: list[float], *, include_breakpoint: bool
     ) -> PandasLikeDataFrame:
         return (
-            _PandasHist.from_series(self, include_breakpoint=include_breakpoint)
+            _PandasHist.from_series(self, include_breakpoint=include_breakpoint)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
             .with_bins(bins)
             .to_frame()
         )
@@ -1100,7 +1100,7 @@ class PandasLikeSeries(EagerSeries[Any]):
         self, bin_count: int, *, include_breakpoint: bool
     ) -> PandasLikeDataFrame:
         return (
-            _PandasHist.from_series(self, include_breakpoint=include_breakpoint)
+            _PandasHist.from_series(self, include_breakpoint=include_breakpoint)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
             .with_bin_count(bin_count)
             .to_frame()
         )
@@ -1118,7 +1118,7 @@ class PandasLikeSeries(EagerSeries[Any]):
             log_func = self._array_funcs.log
 
             def array_log(arr: NativeSeriesT) -> NativeSeriesT:
-                return log_func(arr) / log_func(base)  # pyright: ignore[reportArgumentType, reportCallIssue]
+                return log_func(arr) / log_func(base)  # pyright: ignore[reportArgumentType, reportCallIssue]  # pyrefly: ignore[no-matching-overload]
 
             result_native = self._apply_array_func(native, array_log)
         return self._with_native(result_native)
@@ -1214,7 +1214,7 @@ class PandasLikeSeries(EagerSeries[Any]):
         return PandasLikeSeriesCatNamespace(self)
 
     @property
-    def list(self) -> PandasLikeSeriesListNamespace:
+    def list(self) -> PandasLikeSeriesListNamespace:  # pyrefly: ignore[bad-override]  # pyrefly-issues/01-self-nested-generic.md
         if not hasattr(self.native, "list"):
             msg = "Series must be of PyArrow List type to support list namespace."
             raise TypeError(msg)
@@ -1229,7 +1229,7 @@ class PandasLikeSeries(EagerSeries[Any]):
 
 
 class _PandasHist(EagerSeriesHist["pd.Series[Any]", "list[float]"]):
-    _series: PandasLikeSeries
+    _series: PandasLikeSeries  # pyrefly: ignore[bad-override-mutable-attribute]  # pyrefly-issues/01-self-nested-generic.md
 
     def to_frame(self) -> PandasLikeDataFrame:
         from_native = self._series.__narwhals_namespace__()._dataframe.from_native

--- a/src/narwhals/_pandas_like/utils.py
+++ b/src/narwhals/_pandas_like/utils.py
@@ -718,7 +718,7 @@ def binary_string_sum_fallback(  # pragma: no cover
     if left_dtype_str == "large_string[pyarrow]" and isinstance(right, str):
         import pyarrow as pa  # ignore-banned-import
 
-        return left + pa.scalar(right, type=pa.large_string())  # pyright: ignore[reportOperatorIssue]
+        return left + pa.scalar(right, type=pa.large_string())  # pyright: ignore[reportOperatorIssue]  # pyrefly: ignore[unsupported-operation]
     if isinstance(right, pdx.Series):
         right_dtype = right.dtype
         if left_dtype_str == "object":

--- a/src/narwhals/_polars/dataframe.py
+++ b/src/narwhals/_polars/dataframe.py
@@ -227,7 +227,7 @@ class PolarsBaseFrame(Generic[NativePolarsFrame]):
             other_native = other_native.drop_nulls(subset=right_on)
         return self._with_native(
             self.native.join(
-                other=other_native,
+                other=other_native,  # pyrefly: ignore[bad-argument-type]
                 how=how_native,
                 left_on=left_on,
                 right_on=right_on,
@@ -592,7 +592,7 @@ class PolarsDataFrame(PolarsBaseFrame[pl.DataFrame]):
                 raise ValueError(msg)
 
             return SparkLikeLazyFrame._from_compliant_dataframe(
-                self,  # pyright: ignore[reportArgumentType]
+                self,  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
                 session=session,
                 implementation=backend,
                 version=self._version,

--- a/src/narwhals/_polars/namespace.py
+++ b/src/narwhals/_polars/namespace.py
@@ -169,7 +169,7 @@ class PolarsNamespace:
             if how == "horizontal" and self._backend_version >= (1, 42, 1)
             else how
         )
-        result = pl.concat((item.native for item in items), how=_how)
+        result = pl.concat((item.native for item in items), how=_how)  # pyrefly: ignore[bad-specialization]
         if isinstance(result, pl.DataFrame):
             return self._dataframe(result, version=self._version)
         return self._lazyframe.from_native(result, context=self)
@@ -269,9 +269,9 @@ class PolarsNamespace:
     #    i. None of that is useful here
     # 2. We don't have a `PolarsSelector` abstraction, and just use `PolarsExpr`
     @property
-    def selectors(self) -> CompliantSelectorNamespace[PolarsDataFrame, PolarsSeries]:
+    def selectors(self) -> CompliantSelectorNamespace[PolarsDataFrame, PolarsSeries]:  # pyrefly: ignore[bad-specialization]  # pyrefly-issues/01-self-nested-generic.md
         return cast(
-            "CompliantSelectorNamespace[PolarsDataFrame, PolarsSeries]",
+            "CompliantSelectorNamespace[PolarsDataFrame, PolarsSeries]",  # pyrefly: ignore[bad-specialization]  # pyrefly-issues/01-self-nested-generic.md
             PolarsSelectorNamespace(self),
         )
 

--- a/src/narwhals/_spark_like/dataframe.py
+++ b/src/narwhals/_spark_like/dataframe.py
@@ -155,7 +155,7 @@ class SparkLikeLazyFrame(
                 # If we can't convert the type, just set it to `pa.null`, and warn.
                 # Avoid the warning if we're starting from PySpark's void type.
                 # We can avoid the check when we introduce `nw.Null` dtype.
-                null_type = self._native_dtypes.NullType  # pyright: ignore[reportAttributeAccessIssue]
+                null_type = self._native_dtypes.NullType  # pyright: ignore[reportAttributeAccessIssue]  # pyrefly: ignore[missing-attribute]
                 if not isinstance(native_spark_dtype, null_type):
                     issue_warning(
                         f"Could not convert dtype {native_spark_dtype} to PyArrow dtype, {exc!r}",
@@ -261,7 +261,7 @@ class SparkLikeLazyFrame(
             try:
                 return self._with_native(self.native.agg(*new_columns_list))
             except Exception as e:  # noqa: BLE001
-                raise catch_pyspark_sql_exception(e, self) from None
+                raise catch_pyspark_sql_exception(e, self) from None  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
         return self._with_native(self.native.agg(*new_columns_list))
 
     def select(self, *exprs: SparkLikeExpr) -> Self:
@@ -271,7 +271,7 @@ class SparkLikeLazyFrame(
             try:
                 return self._with_native(self.native.select(*new_columns_list))
             except Exception as e:  # noqa: BLE001
-                raise catch_pyspark_sql_exception(e, self) from None
+                raise catch_pyspark_sql_exception(e, self) from None  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
         return self._with_native(self.native.select(*new_columns_list))
 
     def with_columns(self, *exprs: SparkLikeExpr) -> Self:
@@ -280,7 +280,7 @@ class SparkLikeLazyFrame(
             try:
                 return self._with_native(self.native.withColumns(dict(new_columns)))
             except Exception as e:  # noqa: BLE001
-                raise catch_pyspark_sql_exception(e, self) from None
+                raise catch_pyspark_sql_exception(e, self) from None  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
 
         return self._with_native(self.native.withColumns(dict(new_columns)))
 
@@ -291,7 +291,7 @@ class SparkLikeLazyFrame(
             try:
                 return self._with_native(self.native.where(condition))
             except Exception as e:  # noqa: BLE001
-                raise catch_pyspark_sql_exception(e, self) from None
+                raise catch_pyspark_sql_exception(e, self) from None  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
         return self._with_native(self.native.where(condition))
 
     @property
@@ -602,7 +602,7 @@ class SparkLikeLazyFrame(
             data = tuple(frame.iter_rows(named=True, buffer_size=512))
 
         return cls(
-            session.createDataFrame(data),
+            session.createDataFrame(data),  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/03-any-annotation-not-honored-across-branches.md
             version=version,
             implementation=implementation,
             validate_backend_version=True,

--- a/src/narwhals/_spark_like/namespace.py
+++ b/src/narwhals/_spark_like/namespace.py
@@ -122,7 +122,7 @@ class SparkLikeNamespace(
 
     def _function(self, name: str, *args: Column | PythonLiteral) -> Column:
         if name in _BINARY_OPS:
-            return _BINARY_OPS[name](*args)
+            return _BINARY_OPS[name](*args)  # pyrefly: ignore[no-matching-overload]  # pyrefly-issues/05-operator-overload-with-star-args.md
         if name == "isnotnull":
             return args[0].isNotNull()  # type: ignore[union-attr]
         return getattr(self._F, FUNCTION_REMAPPINGS.get(name, name))(*args)

--- a/src/narwhals/_sql/expr.py
+++ b/src/narwhals/_sql/expr.py
@@ -324,8 +324,8 @@ class SQLExpr(LazyExpr[SQLLazyFrameT, NativeExprT], Protocol[SQLLazyFrameT, Nati
         return cls(
             call,
             window_function=window_function,
-            evaluate_output_names=combine_evaluate_output_names(*exprs),
-            alias_output_names=combine_alias_output_names(*exprs),
+            evaluate_output_names=combine_evaluate_output_names(*exprs),  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
+            alias_output_names=combine_alias_output_names(*exprs),  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/01-self-nested-generic.md
             version=context._version,
             implementation=context._implementation,
         )

--- a/src/narwhals/_sql/expr_dt.py
+++ b/src/narwhals/_sql/expr_dt.py
@@ -17,35 +17,35 @@ class SQLExprDateTimeNamesSpace(
         return self.compliant._function(name, *args)  # type: ignore[no-any-return]
 
     def year(self) -> SQLExprT:
-        return self.compliant._with_elementwise(lambda expr: self._function("year", expr))
+        return self.compliant._with_elementwise(lambda expr: self._function("year", expr))  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
 
     def month(self) -> SQLExprT:
         return self.compliant._with_elementwise(
-            lambda expr: self._function("month", expr)
+            lambda expr: self._function("month", expr)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
         )
 
     def day(self) -> SQLExprT:
-        return self.compliant._with_elementwise(lambda expr: self._function("day", expr))
+        return self.compliant._with_elementwise(lambda expr: self._function("day", expr))  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
 
     def hour(self) -> SQLExprT:
-        return self.compliant._with_elementwise(lambda expr: self._function("hour", expr))
+        return self.compliant._with_elementwise(lambda expr: self._function("hour", expr))  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
 
     def minute(self) -> SQLExprT:
         return self.compliant._with_elementwise(
-            lambda expr: self._function("minute", expr)
+            lambda expr: self._function("minute", expr)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
         )
 
     def second(self) -> SQLExprT:
         return self.compliant._with_elementwise(
-            lambda expr: self._function("second", expr)
+            lambda expr: self._function("second", expr)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
         )
 
     def ordinal_day(self) -> SQLExprT:
         return self.compliant._with_elementwise(
-            lambda expr: self._function("dayofyear", expr)
+            lambda expr: self._function("dayofyear", expr)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
         )
 
     def date(self) -> SQLExprT:
         return self.compliant._with_elementwise(
-            lambda expr: self._function("to_date", expr)
+            lambda expr: self._function("to_date", expr)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
         )

--- a/src/narwhals/_sql/expr_str.py
+++ b/src/narwhals/_sql/expr_str.py
@@ -37,18 +37,19 @@ class SQLExprStringNamespace(
             else pattern
         )
         return self.compliant._with_elementwise(
-            func, expression_args={"pattern": compliant_pattern}
+            func,
+            expression_args={"pattern": compliant_pattern},  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
         )
 
     def ends_with(self, suffix: SQLExprT) -> SQLExprT:
         return self.compliant._with_elementwise(
-            lambda expr, suffix: self._function("ends_with", expr, suffix),
+            lambda expr, suffix: self._function("ends_with", expr, suffix),  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
             expression_args={"suffix": suffix},
         )
 
     def len_chars(self) -> SQLExprT:
         return self.compliant._with_elementwise(
-            lambda expr: self._function("length", expr)
+            lambda expr: self._function("length", expr)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
         )
 
     def replace_all(self, value: SQLExprT, pattern: str, *, literal: bool) -> SQLExprT:
@@ -58,7 +59,7 @@ class SQLExprStringNamespace(
         if not literal and self.compliant._implementation.is_duckdb():
             options = [self._lit("g")]
         return self.compliant._with_elementwise(
-            lambda expr, value: self._function(
+            lambda expr, value: self._function(  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
                 fname, expr, self._lit(pattern), value, *options
             ),
             expression_args={"value": value},
@@ -76,7 +77,7 @@ class SQLExprStringNamespace(
             _length = self._lit(length) if length is not None else col_length
             return self._function("substr", expr, _offset, _length)
 
-        return self.compliant._with_elementwise(func)
+        return self.compliant._with_elementwise(func)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
 
     def split(self, by: str) -> SQLExprT:
         # PySpark < 4.0's `split` expects a raw Python string for `pattern`,
@@ -84,12 +85,12 @@ class SQLExprStringNamespace(
         _is_pyspark_pre_4 = is_pyspark_pre_4(self.compliant._implementation)
         split_by = by if _is_pyspark_pre_4 else self._lit(by)
         return self.compliant._with_elementwise(
-            lambda expr: self._function("str_split", expr, split_by)
+            lambda expr: self._function("str_split", expr, split_by)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
         )
 
     def starts_with(self, prefix: SQLExprT) -> SQLExprT:
         return self.compliant._with_elementwise(
-            lambda expr, prefix: self._function("starts_with", expr, prefix),
+            lambda expr, prefix: self._function("starts_with", expr, prefix),  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
             expression_args={"prefix": prefix},
         )
 
@@ -97,7 +98,7 @@ class SQLExprStringNamespace(
         import string
 
         return self.compliant._with_elementwise(
-            lambda expr: self._function(
+            lambda expr: self._function(  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
                 "trim",
                 expr,
                 self._lit(string.whitespace if characters is None else characters),
@@ -106,12 +107,12 @@ class SQLExprStringNamespace(
 
     def to_lowercase(self) -> SQLExprT:
         return self.compliant._with_elementwise(
-            lambda expr: self._function("lower", expr)
+            lambda expr: self._function("lower", expr)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
         )
 
     def to_uppercase(self) -> SQLExprT:
         return self.compliant._with_elementwise(
-            lambda expr: self._function("upper", expr)
+            lambda expr: self._function("upper", expr)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
         )
 
     def zfill(self, width: int) -> SQLExprT:
@@ -149,7 +150,7 @@ class SQLExprStringNamespace(
 
         # can't use `_with_elementwise` due to `when` operator.
         # TODO(unassigned): implement `window_func` like we do in `Expr.cast`
-        return self.compliant._with_callable(func)
+        return self.compliant._with_callable(func)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
 
     def pad_start(self, length: int, fill_char: str) -> SQLExprT:
         # PySpark < 4.0's `lpad` expects raw Python values for `len` and `pad`,
@@ -165,7 +166,7 @@ class SQLExprStringNamespace(
                 expr,
             )
 
-        return self.compliant._with_callable(_pad_start)
+        return self.compliant._with_callable(_pad_start)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
 
     def pad_end(self, length: int, fill_char: str) -> SQLExprT:
         # PySpark < 4.0's `rpad` expects raw Python values for `len` and `pad`,
@@ -181,4 +182,4 @@ class SQLExprStringNamespace(
                 expr,
             )
 
-        return self.compliant._with_callable(_pad_end)
+        return self.compliant._with_callable(_pad_end)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md

--- a/src/narwhals/_sql/namespace.py
+++ b/src/narwhals/_sql/namespace.py
@@ -35,7 +35,7 @@ class SQLNamespace(
                 cols = (self._coalesce(col, self._lit(False)) for col in cols)
             return reduce(operator.or_, cols)
 
-        return self._expr._from_elementwise_horizontal_op(func, *exprs)
+        return self._expr._from_elementwise_horizontal_op(func, *exprs)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
 
     def all_horizontal(self, *exprs: SQLExprT, ignore_nulls: bool) -> SQLExprT:
         def func(cols: Iterable[NativeExprT]) -> NativeExprT:
@@ -43,19 +43,19 @@ class SQLNamespace(
                 cols = (self._coalesce(col, self._lit(True)) for col in cols)
             return reduce(operator.and_, cols)
 
-        return self._expr._from_elementwise_horizontal_op(func, *exprs)
+        return self._expr._from_elementwise_horizontal_op(func, *exprs)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
 
     def max_horizontal(self, *exprs: SQLExprT) -> SQLExprT:
         def func(cols: Iterable[NativeExprT]) -> NativeExprT:
             return self._function("greatest", *cols)
 
-        return self._expr._from_elementwise_horizontal_op(func, *exprs)
+        return self._expr._from_elementwise_horizontal_op(func, *exprs)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
 
     def min_horizontal(self, *exprs: SQLExprT) -> SQLExprT:
         def func(cols: Iterable[NativeExprT]) -> NativeExprT:
             return self._function("least", *cols)
 
-        return self._expr._from_elementwise_horizontal_op(func, *exprs)
+        return self._expr._from_elementwise_horizontal_op(func, *exprs)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
 
     def sum_horizontal(self, *exprs: SQLExprT) -> SQLExprT:
         def func(cols: Iterable[NativeExprT]) -> NativeExprT:
@@ -64,14 +64,14 @@ class SQLNamespace(
                 (self._coalesce(col, self._lit(0)) for col in cols),
             )
 
-        return self._expr._from_elementwise_horizontal_op(func, *exprs)
+        return self._expr._from_elementwise_horizontal_op(func, *exprs)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
 
     # Other
     def coalesce(self, *exprs: SQLExprT) -> SQLExprT:
         def func(cols: Iterable[NativeExprT]) -> NativeExprT:
             return self._coalesce(*cols)
 
-        return self._expr._from_elementwise_horizontal_op(func, *exprs)
+        return self._expr._from_elementwise_horizontal_op(func, *exprs)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
 
     def when_then(
         self, predicate: SQLExprT, then: SQLExprT, otherwise: SQLExprT | None = None
@@ -83,7 +83,10 @@ class SQLNamespace(
             return self._when(cols[1], cols[0], cols[2])
 
         if otherwise is None:
-            return self._expr._from_elementwise_horizontal_op(func, then, predicate)
+            return self._expr._from_elementwise_horizontal_op(func, then, predicate)  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
         return self._expr._from_elementwise_horizontal_op(
-            func_with_otherwise, then, predicate, otherwise
+            func_with_otherwise,
+            then,
+            predicate,
+            otherwise,  # pyrefly: ignore[bad-argument-type]  # pyrefly-issues/04-callable-typevar-through-nested-attr.md
         )

--- a/src/narwhals/_translate.py
+++ b/src/narwhals/_translate.py
@@ -64,7 +64,9 @@ To learn more see [moist], [dry], or [even drier] - depending on how deep you wa
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, Protocol
+
+from typing_extensions import TypedDict
 
 from narwhals._typing_compat import TypeVar
 
@@ -195,16 +197,16 @@ class _ExcludeSeries(TypedDict, total=False):
     allow_series: Literal[False] | None
 
 
-class ExcludeSeries(_ExcludeSeries, total=False):
+class ExcludeSeries(_ExcludeSeries, total=False, closed=True):
     pass_through: bool
 
 
-class ExcludeSeriesV1(_ExcludeSeries, total=False):
+class ExcludeSeriesV1(_ExcludeSeries, total=False, closed=True):
     pass_through: bool | None
     eager_or_interchange_only: Literal[False]
 
 
-class ExcludeSeriesStrictV1(_ExcludeSeries, total=False):
+class ExcludeSeriesStrictV1(_ExcludeSeries, total=False, closed=True):
     strict: bool | None
     eager_or_interchange_only: Literal[False]
 
@@ -215,16 +217,16 @@ class _AllowSeries(TypedDict, total=False):
     allow_series: Required[Literal[True]]
 
 
-class AllowSeries(_AllowSeries, total=False):
+class AllowSeries(_AllowSeries, total=False, closed=True):
     pass_through: bool
 
 
-class AllowSeriesV1(_AllowSeries, total=False):
+class AllowSeriesV1(_AllowSeries, total=False, closed=True):
     pass_through: bool | None
     eager_or_interchange_only: Literal[False]
 
 
-class AllowSeriesStrictV1(_AllowSeries, total=False):
+class AllowSeriesStrictV1(_AllowSeries, total=False, closed=True):
     strict: bool | None
     eager_or_interchange_only: Literal[False]
 
@@ -235,16 +237,16 @@ class _OnlySeries(TypedDict, total=False):
     allow_series: bool | None
 
 
-class OnlySeries(_OnlySeries, total=False):
+class OnlySeries(_OnlySeries, total=False, closed=True):
     pass_through: bool
 
 
-class OnlySeriesV1(_OnlySeries, total=False):
+class OnlySeriesV1(_OnlySeries, total=False, closed=True):
     pass_through: bool | None
     eager_or_interchange_only: Literal[False]
 
 
-class OnlySeriesStrictV1(_OnlySeries, total=False):
+class OnlySeriesStrictV1(_OnlySeries, total=False, closed=True):
     strict: bool | None
     eager_or_interchange_only: Literal[False]
 
@@ -255,11 +257,11 @@ class _OnlyEagerOrInterchange(TypedDict, total=False):
     allow_series: bool | None
 
 
-class OnlyEagerOrInterchange(_OnlyEagerOrInterchange, total=False):
+class OnlyEagerOrInterchange(_OnlyEagerOrInterchange, total=False, closed=True):
     pass_through: bool | None
 
 
-class OnlyEagerOrInterchangeStrict(_OnlyEagerOrInterchange, total=False):
+class OnlyEagerOrInterchangeStrict(_OnlyEagerOrInterchange, total=False, closed=True):
     strict: bool | None
 
 
@@ -269,16 +271,16 @@ class _AllowLazy(TypedDict, total=False):
     allow_series: bool | None
 
 
-class AllowLazy(_AllowLazy, total=False):
+class AllowLazy(_AllowLazy, total=False, closed=True):
     pass_through: bool
 
 
-class AllowLazyV1(_AllowLazy, total=False):
+class AllowLazyV1(_AllowLazy, total=False, closed=True):
     pass_through: bool | None
     eager_or_interchange_only: Literal[False]
 
 
-class AllowLazyStrictV1(_AllowLazy, total=False):
+class AllowLazyStrictV1(_AllowLazy, total=False, closed=True):
     strict: bool | None
     eager_or_interchange_only: Literal[False]
 
@@ -289,16 +291,16 @@ class _AllowAny(TypedDict, total=False):
     allow_series: Required[Literal[True]]
 
 
-class AllowAny(_AllowAny, total=False):
+class AllowAny(_AllowAny, total=False, closed=True):
     pass_through: bool
 
 
-class AllowAnyV1(_AllowAny, total=False):
+class AllowAnyV1(_AllowAny, total=False, closed=True):
     pass_through: bool | None
     eager_or_interchange_only: Literal[False]
 
 
-class AllowAnyStrictV1(_AllowAny, total=False):
+class AllowAnyStrictV1(_AllowAny, total=False, closed=True):
     strict: bool | None
     eager_or_interchange_only: Literal[False]
 
@@ -309,15 +311,15 @@ class _Unknown(TypedDict, total=False):
     allow_series: bool | None
 
 
-class PassThroughUnknown(_Unknown, total=False):
+class PassThroughUnknown(_Unknown, total=False, closed=True):
     pass_through: Required[Literal[True]]
 
 
-class PassThroughUnknownV1(_Unknown, total=False):
+class PassThroughUnknownV1(_Unknown, total=False, closed=True):
     pass_through: Required[Literal[True]]
     eager_or_interchange_only: bool
 
 
-class StrictUnknownV1(_Unknown, total=False):
+class StrictUnknownV1(_Unknown, total=False, closed=True):
     strict: Required[Literal[False]]
     eager_or_interchange_only: bool

--- a/src/narwhals/dtypes.py
+++ b/src/narwhals/dtypes.py
@@ -686,7 +686,7 @@ class Enum(DType):
         elif isinstance(categories, type) and issubclass(categories, enum.Enum):
             self._cached_categories = tuple(member.value for member in categories)
         else:
-            self._cached_categories = tuple(categories)
+            self._cached_categories = tuple(categories)  # pyrefly: ignore[bad-assignment]  # pyrefly-issues/06-isinstance-issubclass-narrowing.md
 
     @property
     def categories(self) -> tuple[str, ...]:

--- a/src/narwhals/functions.py
+++ b/src/narwhals/functions.py
@@ -1357,7 +1357,7 @@ class Then(Expr):
     _otherwise: IntoExpr | NonNestedLiteral | None = None
 
     @property
-    def _nodes(self) -> tuple[ExprNode, ...]:
+    def _nodes(self) -> tuple[ExprNode, ...]:  # pyrefly: ignore[bad-override]  # pyrefly-issues/07-property-overriding-mutable-attribute.md
         if self._cached_nodes:
             return self._cached_nodes
         expr = self._otherwise

--- a/src/narwhals/stable/v1/__init__.py
+++ b/src/narwhals/stable/v1/__init__.py
@@ -236,7 +236,7 @@ class DataFrame(NwDataFrame[IntoDataFrameT]):  # type: ignore[type-var]
         return _stableify(super().lazy(backend=backend, session=session))
 
     @overload  # type: ignore[override]
-    def to_dict(self, *, as_series: Literal[True] = ...) -> dict[str, Series[Any]]: ...
+    def to_dict(self, *, as_series: Literal[True] = ...) -> dict[str, Series[Any]]: ...  # pyrefly: ignore[bad-override]
     @overload
     def to_dict(self, *, as_series: Literal[False]) -> dict[str, list[Any]]: ...
     @overload

--- a/src/narwhals/stable/v2/__init__.py
+++ b/src/narwhals/stable/v2/__init__.py
@@ -223,7 +223,7 @@ class DataFrame(NwDataFrame[IntoDataFrameT]):
         return _stableify(super().lazy(backend=backend, session=session))
 
     @overload  # type: ignore[override]
-    def to_dict(self, *, as_series: Literal[True] = ...) -> dict[str, Series[Any]]: ...
+    def to_dict(self, *, as_series: Literal[True] = ...) -> dict[str, Series[Any]]: ...  # pyrefly: ignore[bad-override]
     @overload
     def to_dict(self, *, as_series: Literal[False]) -> dict[str, list[Any]]: ...
     @overload


### PR DESCRIPTION
this isn't ready to be merged, and won't be for some time, but it's useful and interesting to see how close we are (and to report things upstream as we go)

upstream issues:

- https://github.com/facebook/pyrefly/issues/4618
- https://github.com/facebook/pyrefly/issues/4656
- https://github.com/facebook/pyrefly/issues/4923
- https://github.com/facebook/pyrefly/issues/4933

<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
