### PR TITLE
refactor: remove redundant self-import in ArrowDataFrame.collect

### DIFF
--- a/src/narwhals/_arrow/dataframe.py
+++ b/src/narwhals/_arrow/dataframe.py
@@ -643,8 +643,6 @@ class ArrowDataFrame(
         self, backend: _EagerAllowedImpl | None, **kwargs: Any
     ) -> CompliantDataFrameAny:
         if backend is Implementation.PYARROW or backend is None:
-            from narwhals._arrow.dataframe import ArrowDataFrame
-
             return ArrowDataFrame(
                 self.native, version=self._version, validate_column_names=False
             )


### PR DESCRIPTION
## Summary
- Small drive-by cleanup spotted while enabling pyrefly on `src`: `ArrowDataFrame.collect` re-imported `ArrowDataFrame` from its own module inside a method of that very class, which is redundant since the name is already available in module scope.

## Test plan
- [x] `ruff check` / `ruff format` (via pre-commit)
- [x] Manual smoke test: `df.lazy().collect(backend="pyarrow")` still round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmR4kQ7EGUaNjRLjz57fBR