### PR TITLE
fix: `str.slice(..., length=0)` returns empty string on pandas and dask

### DIFF
--- a/src/narwhals/_dask/expr_str.py
+++ b/src/narwhals/_dask/expr_str.py
@@ -89,7 +89,7 @@ class DaskExprStringNamespace(LazyExprNamespace["DaskExpr"], StringNamespace["Da
     def slice(self, offset: int, length: int | None) -> DaskExpr:
         return self.compliant._with_callable(
             lambda expr: expr.str.slice(
-                start=offset, stop=offset + length if length else None
+                start=offset, stop=offset + length if length is not None else None
             )
         )
 

--- a/src/narwhals/_pandas_like/series_str.py
+++ b/src/narwhals/_pandas_like/series_str.py
@@ -87,7 +87,7 @@ class PandasLikeSeriesStringNamespace(
         )
 
     def slice(self, offset: int, length: int | None) -> PandasLikeSeries:
-        stop = offset + length if length else None
+        stop = offset + length if length is not None else None
         return self.with_native(self.native.str.slice(start=offset, stop=stop))
 
     def split(self, by: str) -> PandasLikeSeries:

--- a/tests/expr_and_series/str/slice_test.py
+++ b/tests/expr_and_series/str/slice_test.py
@@ -12,7 +12,12 @@ data = {"a": ["fdas", "edfas"]}
 
 @pytest.mark.parametrize(
     ("offset", "length", "expected"),
-    [(1, 2, {"a": ["da", "df"]}), (-2, None, {"a": ["as", "as"]})],
+    [
+        (1, 2, {"a": ["da", "df"]}),
+        (-2, None, {"a": ["as", "as"]}),
+        # length=0 must slice to an empty string, not be treated as "to the end".
+        (1, 0, {"a": ["", ""]}),
+    ],
 )
 def test_str_slice(
     constructor: Constructor, offset: int, length: int | None, expected: Any
@@ -24,7 +29,12 @@ def test_str_slice(
 
 @pytest.mark.parametrize(
     ("offset", "length", "expected"),
-    [(1, 2, {"a": ["da", "df"]}), (-2, None, {"a": ["as", "as"]})],
+    [
+        (1, 2, {"a": ["da", "df"]}),
+        (-2, None, {"a": ["as", "as"]}),
+        # length=0 must slice to an empty string, not be treated as "to the end".
+        (1, 0, {"a": ["", ""]}),
+    ],
 )
 def test_str_slice_series(
     constructor_eager: ConstructorEager, offset: int, length: int | None, expected: Any


### PR DESCRIPTION
# Description

I noticed `str.slice(offset, length=0)` gives different results depending on the backend. On pandas and dask it returns the rest of the string, but on Polars, PyArrow and the SQL backends it correctly returns an empty string:

```python
import narwhals as nw, pandas as pd, polars as pl
data = {"s": ["abcdef", "xyz"]}
nw.from_native(pd.DataFrame(data)).select(nw.col("s").str.slice(1, 0)).to_native()["s"].tolist()
# ['bcdef', 'yz']   <- wrong
nw.from_native(pl.DataFrame(data)).select(nw.col("s").str.slice(1, 0)).to_native()["s"].to_list()
# ['', '']          <- correct
```

The cause is in `_pandas_like/series_str.py` and `_dask/expr_str.py`, which compute the stop as `offset + length if length else None`. A `length` of `0` is falsy, so it's treated the same as `None` ("slice to the end"). The Arrow and SQL backends already use `length is not None`, so this just brings pandas and dask in line with them.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

Found while reading the string namespace, no existing issue.

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

I used Claude Code to help find the divergence and draft the test. I read the code, reproduced it across all backends, and understand and stand behind every line.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes (behaviour fix, no doc change needed)
- [x] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

This is my first PR here. I can't attach an image in the PR body, so here is the terminal output of the slice tests passing across the backends I have installed locally (pandas, pandas[pyarrow], pyarrow, polars eager+lazy, dask):

```
$ pytest tests/expr_and_series/str/slice_test.py \
    --constructors=pandas,pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask

tests/expr_and_series/str/slice_test.py ..............................   [100%]
============================== 30 passed in 0.61s ==============================
```

The new `(1, 0, {"a": ["", ""]})` case fails on `main` for pandas/dask and passes with this change; happy to attach a screenshot too if you'd prefer.
