### PR TITLE
fix(test): Fix interchange and concat tests

### DIFF
--- a/tests/frame/concat_test.py
+++ b/tests/frame/concat_test.py
@@ -102,7 +102,7 @@ def test_concat_vertical(constructor: Constructor) -> None:
 
     with pytest.raises(
         (Exception, TypeError),
-        match=r"unable to vstack|inputs should all have the same schema",
+        match=r"unable to vstack|column name mismatch|inputs should all have the same schema",
     ):
         nw.concat([df_left, df_right.rename({"d": "i"})], how="vertical").collect()
     with pytest.raises(

--- a/tests/frame/interchange_native_namespace_test.py
+++ b/tests/frame/interchange_native_namespace_test.py
@@ -6,9 +6,6 @@ import pytest
 
 import narwhals.stable.v1 as nw_v1
 
-pytest.importorskip("polars")
-import polars as pl
-
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -16,8 +13,10 @@ data: Mapping[str, Any] = {"a": [1, 2, 3], "b": [4.5, 6.7, 8.9], "z": ["x", "y",
 
 
 def test_interchange() -> None:
-    df_pl = pl.DataFrame(data)
-    df = nw_v1.from_native(df_pl.__dataframe__(), eager_or_interchange_only=True)
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa
+
+    df = nw_v1.from_native(pa.table(data).__dataframe__(), eager_or_interchange_only=True)
     series = df["a"]
 
     with pytest.raises(
@@ -38,7 +37,9 @@ def test_ibis(
     tmpdir: pytest.TempdirFactory, request: pytest.FixtureRequest
 ) -> None:  # pragma: no cover
     pytest.importorskip("ibis")
+    pytest.importorskip("polars")
     import ibis
+    import polars as pl
 
     try:
         ibis.set_backend("duckdb")
@@ -58,7 +59,9 @@ def test_ibis(
 
 def test_duckdb() -> None:
     pytest.importorskip("duckdb")
+    pytest.importorskip("polars")
     import duckdb
+    import polars as pl
 
     df_pl = pl.DataFrame(data)  # noqa: F841
 

--- a/tests/frame/interchange_schema_test.py
+++ b/tests/frame/interchange_schema_test.py
@@ -5,48 +5,32 @@ from datetime import date, datetime, timedelta
 import pytest
 
 import narwhals.stable.v1 as nw_v1
-from tests.utils import IBIS_VERSION, POLARS_VERSION
-
-pytest.importorskip("polars")
-import polars as pl
+from tests.utils import IBIS_VERSION
 
 
 def test_interchange_schema() -> None:
-    df_pl = pl.DataFrame(
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa
+
+    tbl = pa.table(
         {
-            "a": [1, 1, 2],
-            "b": [4, 5, 6],
-            "c": [4, 5, 6],
-            "d": [4, 5, 6],
-            "e": [4, 5, 6],
-            "f": [4, 5, 6],
-            "g": [4, 5, 6],
-            "h": [4, 5, 6],
-            "i": [4, 5, 6],
-            "j": [4, 5, 6],
-            "k": ["fdafsd", "fdas", "ad"],
-            "l": ["fdafsd", "fdas", "ad"],
-            "m": [date(2021, 1, 1), date(2021, 1, 1), date(2021, 1, 1)],
-            "n": [True, True, False],
-        },
-        schema={
-            "a": pl.Int64,
-            "b": pl.Int32,
-            "c": pl.Int16,
-            "d": pl.Int8,
-            "e": pl.UInt64,
-            "f": pl.UInt32,
-            "g": pl.UInt16,
-            "h": pl.UInt8,
-            "i": pl.Float64,
-            "j": pl.Float32,
-            "k": pl.String,
-            "l": pl.Categorical,
-            "m": pl.Datetime,
-            "n": pl.Boolean,
-        },
+            "a": pa.array([1, 1, 2], pa.int64()),
+            "b": pa.array([4, 5, 6], pa.int32()),
+            "c": pa.array([4, 5, 6], pa.int16()),
+            "d": pa.array([4, 5, 6], pa.int8()),
+            "e": pa.array([4, 5, 6], pa.uint64()),
+            "f": pa.array([4, 5, 6], pa.uint32()),
+            "g": pa.array([4, 5, 6], pa.uint16()),
+            "h": pa.array([4, 5, 6], pa.uint8()),
+            "i": pa.array([4, 5, 6], pa.float64()),
+            "j": pa.array([4, 5, 6], pa.float32()),
+            "k": pa.array(["fdafsd", "fdas", "ad"], pa.string()),
+            "l": pa.array(["fdafsd", "fdas", "ad"], pa.string()).dictionary_encode(),
+            "m": pa.array([datetime(2021, 1, 1)] * 3, pa.timestamp("us")),
+            "n": pa.array([True, True, False], pa.bool_()),
+        }
     )
-    df = nw_v1.from_native(df_pl.__dataframe__(), eager_or_interchange_only=True)
+    df = nw_v1.from_native(tbl.__dataframe__(), eager_or_interchange_only=True)
     result = df.schema
     expected = {
         "a": nw_v1.Int64,
@@ -73,7 +57,9 @@ def test_interchange_schema_ibis(
     tmpdir: pytest.TempdirFactory, request: pytest.FixtureRequest
 ) -> None:  # pragma: no cover
     pytest.importorskip("ibis")
+    pytest.importorskip("polars")
     import ibis
+    import polars as pl
 
     try:
         ibis.set_backend("duckdb")
@@ -166,7 +152,9 @@ def test_interchange_schema_ibis(
 
 def test_interchange_schema_duckdb() -> None:
     pytest.importorskip("duckdb")
+    pytest.importorskip("polars")
     import duckdb
+    import polars as pl
 
     df_pl = pl.DataFrame(  # noqa: F841
         {
@@ -233,15 +221,22 @@ def test_interchange_schema_duckdb() -> None:
     assert df.collect_schema() == expected
 
 
-@pytest.mark.skipif(POLARS_VERSION < (1, 36), reason="Polars added `Float16` in 1.36.0")
 def test_interchange_schema_float16() -> None:
-    df_pl = pl.DataFrame({"a": [1.0, 2.0, 3.0]}, schema={"a": pl.Float16})
-    df = nw_v1.from_native(df_pl.__dataframe__(), eager_or_interchange_only=True)
+    pytest.importorskip("numpy")
+    pytest.importorskip("pyarrow")
+    import numpy as np
+    import pyarrow as pa
+
+    tbl = pa.table({"a": pa.array(np.array([1.0, 2.0, 3.0], dtype=np.float16))})
+    df = nw_v1.from_native(tbl.__dataframe__(), eager_or_interchange_only=True)
     assert df.schema["a"] == nw_v1.Float16
 
 
 def test_invalid() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3]}).__dataframe__()
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa
+
+    df = pa.table({"a": [1, 2, 3]}).__dataframe__()
     with pytest.raises(
         NotImplementedError, match="is not supported for interchange-level dataframes"
     ):

--- a/tests/frame/interchange_to_arrow_test.py
+++ b/tests/frame/interchange_to_arrow_test.py
@@ -11,16 +11,13 @@ if TYPE_CHECKING:
 
 data: Mapping[str, Any] = {"a": [1, 2, 3], "b": [4.0, 5.0, 6.1], "z": ["x", "y", "z"]}
 
-pytest.importorskip("polars")
 pytest.importorskip("pyarrow")
 
 
 def test_interchange_to_arrow() -> None:
-    import polars as pl
     import pyarrow as pa
 
-    df_pl = pl.DataFrame(data)
-    df = nw_v1.from_native(df_pl.__dataframe__(), eager_or_interchange_only=True)
+    df = nw_v1.from_native(pa.table(data).__dataframe__(), eager_or_interchange_only=True)
     result = df.to_arrow()
 
     assert isinstance(result, pa.Table)
@@ -30,6 +27,7 @@ def test_interchange_ibis_to_arrow(
     tmpdir: pytest.TempdirFactory, request: pytest.FixtureRequest
 ) -> None:  # pragma: no cover
     pytest.importorskip("ibis")
+    pytest.importorskip("polars")
 
     import ibis
     import polars as pl
@@ -53,6 +51,7 @@ def test_interchange_ibis_to_arrow(
 
 def test_interchange_duckdb_to_arrow() -> None:
     pytest.importorskip("duckdb")
+    pytest.importorskip("polars")
 
     import duckdb
     import polars as pl

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -424,14 +424,14 @@ def test_is_native_series(is_native_series: Callable[[Any], Any]) -> None:
 
 
 def test_get_level() -> None:
-    pytest.importorskip("polars")
-    import polars as pl
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa
 
-    df = pl.DataFrame({"a": [1, 2, 3]})
-    assert nw_v1.get_level(nw_v1.from_native(df)) == "full"
+    tbl = pa.table({"a": [1, 2, 3]})
+    assert nw_v1.get_level(nw_v1.from_native(tbl)) == "full"
     assert (
         nw_v1.get_level(
-            nw_v1.from_native(df.__dataframe__(), eager_or_interchange_only=True)
+            nw_v1.from_native(tbl.__dataframe__(), eager_or_interchange_only=True)
         )
         == "interchange"
     )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

---

Related to polars v2.0.0rc: use pyarrow for interchange and enlarge the matching message for polars concat error. The CI will still fail with a couple of errors left (Update 2 errors left out of 10 for the nightly build)

The `__contains__` and `is_in` errors are a bit more complex and I am planning to take care separately. Most importantly, we might need to decide if we want to fully align with polars v2 behavior