### PR TITLE
fix(test): xfail polars v2 for `is_in` and `__contains__` tests

### DIFF
--- a/docs/api-reference/series.md
+++ b/docs/api-reference/series.md
@@ -5,6 +5,7 @@
     options:
       members:
         - __arrow_c_stream__
+        - __contains__
         - __getitem__
         - __iter__
         - abs

--- a/src/narwhals/expr.py
+++ b/src/narwhals/expr.py
@@ -987,6 +987,15 @@ class Expr:
             Null values are preserved, unless `self` is backed by a non-nullable pandas Series
             (which does not support missing values). See [boolean columns](../concepts/boolean.md) for reference.
 
+        Warning:
+            Backends disagree on how to compare values against a column of a
+            different dtype: `polars>=2.0` raises an `InvalidOperationError` unless
+            the operands can be coerced losslessly (so looking for floats in an
+            integer column raises), whereas every other backend coerces silently.
+            Cast one of the operands if you need this to behave the same everywhere.
+            See [Polars' upgrade guide](https://docs.pola.rs/releases/upgrade/2/#make-coercion-casts-for-is_in-strict-instead-of-lossy)
+            for details.
+
         Examples:
             >>> import pandas as pd
             >>> import narwhals as nw

--- a/src/narwhals/series.py
+++ b/src/narwhals/series.py
@@ -979,6 +979,15 @@ class Series(Generic[IntoSeriesT]):
         Arguments:
             other: Sequence of primitive type.
 
+        Warning:
+            Backends disagree on how to compare values against a Series of a
+            different dtype: `polars>=2.0` raises an `InvalidOperationError` unless
+            the operands can be coerced losslessly (so looking for floats in an
+            integer Series raises), whereas every other backend coerces silently.
+            Cast one of the operands if you need this to behave the same everywhere.
+            See [Polars' upgrade guide](https://docs.pola.rs/releases/upgrade/2/#make-coercion-casts-for-is_in-strict-instead-of-lossy)
+            for details.
+
         Examples:
             >>> import pyarrow as pa
             >>> import narwhals as nw
@@ -2626,6 +2635,36 @@ class Series(Generic[IntoSeriesT]):
         yield from self._compliant_series.__iter__()
 
     def __contains__(self, other: Any) -> bool:
+        """Check whether `other` is present in the Series.
+
+        Arguments:
+            other: Value to look for. `None` matches null values.
+
+        Returns:
+            Whether the value was found.
+
+        Warning:
+            Backends disagree on how to compare values against a Series of a
+            different dtype: `polars>=2.0` raises an `InvalidOperationError` unless
+            the operands can be coerced losslessly (so looking for floats in an
+            integer Series raises), whereas every other backend coerces silently.
+            Cast one of the operands if you need this to behave the same everywhere.
+            See [Polars' upgrade guide](https://docs.pola.rs/releases/upgrade/2/#make-coercion-casts-for-is_in-strict-instead-of-lossy)
+            for details.
+
+        Examples:
+            >>> import pyarrow as pa
+            >>> import narwhals as nw
+            >>>
+            >>> s_native = pa.chunked_array([[1, 2, None]])
+            >>> s = nw.from_native(s_native, series_only=True)
+            >>> 2 in s
+            True
+            >>> None in s
+            True
+            >>> 3 in s
+            False
+        """
         return self._compliant_series.__contains__(other)
 
     def rank(self, method: RankMethod = "average", *, descending: bool = False) -> Self:

--- a/tests/expr_and_series/is_in_test.py
+++ b/tests/expr_and_series/is_in_test.py
@@ -12,7 +12,7 @@ from tests.conftest import (
     modin_constructor,
     pandas_constructor,
 )
-from tests.utils import Constructor, ConstructorEager, assert_equal_data
+from tests.utils import POLARS_VERSION, Constructor, ConstructorEager, assert_equal_data
 
 data = {"a": [1, 4, 2, 5]}
 
@@ -126,5 +126,19 @@ def test_expr_is_in_with_only_null_in_other(constructor: Constructor) -> None:
         expected = {"a": [False, False, False, False]}
     else:
         expected = {"a": [False, False, None, False]}
+
+    assert_equal_data(result, expected)
+
+
+def test_is_in_incompatible_dtype(
+    constructor: Constructor, request: pytest.FixtureRequest
+) -> None:
+    if "polars" in str(constructor) and POLARS_VERSION >= (2,):
+        reason = "Polars>=2.0 rejects operands which can't be coerced losslessly"
+        request.applymarker(pytest.mark.xfail(reason=reason))
+
+    df = nw.from_native(constructor(data))
+    result = df.select(nw.col("a").is_in([1.0, 2.5]))
+    expected = {"a": [True, False, False, False]}
 
     assert_equal_data(result, expected)

--- a/tests/series_only/__contains___test.py
+++ b/tests/series_only/__contains___test.py
@@ -21,13 +21,14 @@ def test_contains(
     request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
     other: float | None,
-    expected: bool,  # noqa: FBT001
+    *,
+    expected: bool,
 ) -> None:
     if (
         isinstance(other, float)
         and "polars" in str(constructor_eager)
         and POLARS_VERSION >= (2,)
-    ):
+    ):  # pragma: no cover
         reason = "Polars>=2.0 rejects operands which can't be coerced losslessly"
         request.applymarker(pytest.mark.xfail(reason=reason))
 

--- a/tests/series_only/__contains___test.py
+++ b/tests/series_only/__contains___test.py
@@ -6,6 +6,7 @@ import pytest
 
 import narwhals as nw
 from narwhals.exceptions import InvalidOperationError
+from tests.utils import POLARS_VERSION
 
 if TYPE_CHECKING:
     from tests.utils import ConstructorEager
@@ -17,10 +18,19 @@ data = [100, 200, None]
     ("other", "expected"), [(100, True), (None, True), (1, False), (100.314, False)]
 )
 def test_contains(
+    request: pytest.FixtureRequest,
     constructor_eager: ConstructorEager,
-    other: int | None,
+    other: float | None,
     expected: bool,  # noqa: FBT001
 ) -> None:
+    if (
+        isinstance(other, float)
+        and "polars" in str(constructor_eager)
+        and POLARS_VERSION >= (2,)
+    ):
+        reason = "Polars>=2.0 rejects operands which can't be coerced losslessly"
+        request.applymarker(pytest.mark.xfail(reason=reason))
+
     s = nw.from_native(constructor_eager({"a": data}), eager_only=True)["a"]
 
     assert (other in s) == expected


### PR DESCRIPTION
# Description

Short term solution of letting polars error propagate and adapt the tests

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #3900

