### PR TITLE
fix(typing): Stableify selectors

### DIFF
--- a/src/narwhals/stable/v1/__init__.py
+++ b/src/narwhals/stable/v1/__init__.py
@@ -27,6 +27,7 @@ from narwhals.exceptions import InvalidIntoExprError, NarwhalsUnstableWarning
 from narwhals.expr import Expr as NwExpr
 from narwhals.functions import _new_series_impl, concat, show_versions
 from narwhals.schema import Schema as NwSchema
+from narwhals.selectors import Selector as NwSelector
 from narwhals.series import Series as NwSeries
 from narwhals.stable.v1 import dependencies, dtypes, selectors
 from narwhals.stable.v1.dtypes import (
@@ -496,6 +497,11 @@ class Expr(NwExpr):
         return self._append_node(
             ExprNode(ExprKind.AGGREGATION, "any_value", ignore_nulls=ignore_nulls)
         )
+
+
+class Selector(NwSelector, Expr):
+    def _to_expr(self) -> Expr:
+        return Expr(*self._nodes)
 
 
 class Schema(NwSchema):

--- a/src/narwhals/stable/v1/selectors.py
+++ b/src/narwhals/stable/v1/selectors.py
@@ -1,16 +1,90 @@
 from __future__ import annotations
 
-from narwhals.selectors import (
-    all,
-    boolean,
-    by_dtype,
-    categorical,
-    datetime,
-    enum,
-    matches,
-    numeric,
-    string,
-)
+from typing import TYPE_CHECKING
+
+from narwhals import selectors as nw_s
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from datetime import timezone
+
+    from narwhals.dtypes import DType
+    from narwhals.stable.v1 import Selector
+    from narwhals.typing import TimeUnit
+
+
+def _stableify(obj: nw_s.Selector, /) -> Selector:
+    from narwhals.stable.v1 import Selector
+
+    return Selector(*obj._nodes)
+
+
+def all() -> Selector:
+    """Select all columns."""
+    return _stableify(nw_s.all())
+
+
+def boolean() -> Selector:
+    """Select boolean columns."""
+    return _stableify(nw_s.boolean())
+
+
+def by_dtype(*dtypes: DType | type[DType] | Iterable[DType | type[DType]]) -> Selector:
+    """Select columns based on their dtype.
+
+    Arguments:
+        dtypes: one or data types to select
+    """
+    return _stableify(nw_s.by_dtype(*dtypes))
+
+
+def categorical() -> Selector:
+    """Select categorical columns."""
+    return _stableify(nw_s.categorical())
+
+
+def datetime(
+    time_unit: TimeUnit | Iterable[TimeUnit] | None = None,
+    time_zone: str | timezone | Iterable[str | timezone | None] | None = ("*", None),
+) -> Selector:
+    """Select all datetime columns, optionally filtering by time unit/zone.
+
+    Arguments:
+        time_unit: One (or more) of the allowed timeunit precision strings, "ms", "us",
+            "ns" and "s". Omit to select columns with any valid timeunit.
+        time_zone: Specify which timezone(s) to select
+
+            * One or more timezone strings, as defined in zoneinfo (to see valid options
+                run `import zoneinfo; zoneinfo.available_timezones()` for a full list).
+            * Set `None` to select Datetime columns that do not have a timezone.
+            * Set `"*"` to select Datetime columns that have *any* timezone.
+    """
+    return _stableify(nw_s.datetime(time_unit, time_zone))
+
+
+def enum() -> Selector:
+    """Select enum columns."""
+    return _stableify(nw_s.enum())
+
+
+def matches(pattern: str) -> Selector:
+    """Select all columns that match the given regex pattern.
+
+    Arguments:
+        pattern: A valid regular expression pattern.
+    """
+    return _stableify(nw_s.matches(pattern))
+
+
+def numeric() -> Selector:
+    """Select numeric columns."""
+    return _stableify(nw_s.numeric())
+
+
+def string() -> Selector:
+    """Select string columns."""
+    return _stableify(nw_s.string())
+
 
 __all__ = [
     "all",

--- a/src/narwhals/stable/v2/__init__.py
+++ b/src/narwhals/stable/v2/__init__.py
@@ -57,6 +57,7 @@ from narwhals.exceptions import NarwhalsUnstableWarning
 from narwhals.expr import Expr as NwExpr
 from narwhals.functions import _new_series_impl, concat, show_versions
 from narwhals.schema import Schema as NwSchema
+from narwhals.selectors import Selector as NwSelector
 from narwhals.series import Series as NwSeries
 from narwhals.stable.v2 import dependencies, dtypes, selectors
 from narwhals.stable.v2.typing import (
@@ -350,6 +351,11 @@ class Expr(NwExpr):
     def last(self) -> Self:  # type: ignore[override]
         """Get the last value."""
         return self._append_node(ExprNode(ExprKind.ORDERABLE_AGGREGATION, "last"))
+
+
+class Selector(NwSelector, Expr):
+    def _to_expr(self) -> Expr:
+        return Expr(*self._nodes)
 
 
 class Schema(NwSchema):

--- a/src/narwhals/stable/v2/selectors.py
+++ b/src/narwhals/stable/v2/selectors.py
@@ -1,3 +1,99 @@
 from __future__ import annotations
 
-from narwhals.selectors import *  # noqa: F403
+from typing import TYPE_CHECKING
+
+from narwhals import selectors as nw_s
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from datetime import timezone
+
+    from narwhals.dtypes import DType
+    from narwhals.stable.v2 import Selector
+    from narwhals.typing import TimeUnit
+
+
+def _stableify(obj: nw_s.Selector, /) -> Selector:
+    from narwhals.stable.v2 import Selector
+
+    return Selector(*obj._nodes)
+
+
+def all() -> Selector:
+    """Select all columns."""
+    return _stableify(nw_s.all())
+
+
+def boolean() -> Selector:
+    """Select boolean columns."""
+    return _stableify(nw_s.boolean())
+
+
+def by_dtype(*dtypes: DType | type[DType] | Iterable[DType | type[DType]]) -> Selector:
+    """Select columns based on their dtype.
+
+    Arguments:
+        dtypes: one or data types to select
+    """
+    return _stableify(nw_s.by_dtype(*dtypes))
+
+
+def categorical() -> Selector:
+    """Select categorical columns."""
+    return _stableify(nw_s.categorical())
+
+
+def datetime(
+    time_unit: TimeUnit | Iterable[TimeUnit] | None = None,
+    time_zone: str | timezone | Iterable[str | timezone | None] | None = ("*", None),
+) -> Selector:
+    """Select all datetime columns, optionally filtering by time unit/zone.
+
+    Arguments:
+        time_unit: One (or more) of the allowed timeunit precision strings, "ms", "us",
+            "ns" and "s". Omit to select columns with any valid timeunit.
+        time_zone: Specify which timezone(s) to select
+
+            * One or more timezone strings, as defined in zoneinfo (to see valid options
+                run `import zoneinfo; zoneinfo.available_timezones()` for a full list).
+            * Set `None` to select Datetime columns that do not have a timezone.
+            * Set `"*"` to select Datetime columns that have *any* timezone.
+    """
+    return _stableify(nw_s.datetime(time_unit, time_zone))
+
+
+def enum() -> Selector:
+    """Select enum columns."""
+    return _stableify(nw_s.enum())
+
+
+def matches(pattern: str) -> Selector:
+    """Select all columns that match the given regex pattern.
+
+    Arguments:
+        pattern: A valid regular expression pattern.
+    """
+    return _stableify(nw_s.matches(pattern))
+
+
+def numeric() -> Selector:
+    """Select numeric columns."""
+    return _stableify(nw_s.numeric())
+
+
+def string() -> Selector:
+    """Select string columns."""
+    return _stableify(nw_s.string())
+
+
+__all__ = [
+    "all",
+    "boolean",
+    "by_dtype",
+    "categorical",
+    "datetime",
+    "enum",
+    "matches",
+    "numeric",
+    "string",
+]

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -1247,3 +1247,35 @@ def test_schema_from_generator() -> None:
     )
     assert schema == nw_v1.Schema({"a": nw_v1.Int64(), "b": nw_v1.String()})
     assert schema._version is Version.V1
+
+
+def test_selectors_are_stable_v1(constructor_eager: ConstructorEager) -> None:
+    # Selectors built from `narwhals.stable.v1.selectors` must behave like `v1`
+    # expressions, not like main-namespace ones.
+    selector = nw_v1.selectors.numeric()
+    assert isinstance(selector, nw_v1.Expr)
+    assert isinstance(selector | nw_v1.selectors.string(), nw_v1.Expr)
+    assert isinstance(selector + 1, nw_v1.Expr)
+
+    df = nw_v1.from_native(constructor_eager({"a": [3, 1, 2]}), eager_only=True)
+    # `Expr.head` only exists in `stable.v1`.
+    assert_equal_data(df.select(nw_v1.selectors.numeric().sort().head(2)), {"a": [1, 2]})
+
+
+def test_selectors_all_stableified_v1() -> None:
+    args: dict[str, tuple[Any, ...]] = {
+        "all": (),
+        "boolean": (),
+        "by_dtype": (nw_v1.Int64,),
+        "categorical": (),
+        "datetime": (),
+        "enum": (),
+        "matches": ("^a$",),
+        "numeric": (),
+        "string": (),
+    }
+    # Fail if a new selector is added but not covered here.
+    assert set(args) == set(nw_v1.selectors.__all__)
+
+    for name, arg in args.items():
+        assert isinstance(getattr(nw_v1.selectors, name)(*arg), nw_v1.Expr), name

--- a/tests/v2_test.py
+++ b/tests/v2_test.py
@@ -586,3 +586,35 @@ def test_schema_from_generator() -> None:
     )
     assert schema == nw_v2.Schema({"a": nw_v2.Int64(), "b": nw_v2.String()})
     assert schema._version is Version.V2
+
+
+def test_selectors_are_stable_v2() -> None:
+    # Selectors built from `narwhals.stable.v2.selectors` must behave like `v2`
+    # expressions, not like main-namespace ones.
+    selector = nw_v2.selectors.numeric()
+    assert isinstance(selector, nw_v2.Expr)
+    assert isinstance(selector | nw_v2.selectors.string(), nw_v2.Expr)
+    assert isinstance(selector + 1, nw_v2.Expr)
+
+    # Only `stable.v2` warns that `any_value` is unstable.
+    with pytest.warns(NarwhalsUnstableWarning):
+        nw_v2.selectors.numeric().any_value()
+
+
+def test_selectors_all_stableified_v2() -> None:
+    args: dict[str, tuple[Any, ...]] = {
+        "all": (),
+        "boolean": (),
+        "by_dtype": (nw_v2.Int64,),
+        "categorical": (),
+        "datetime": (),
+        "enum": (),
+        "matches": ("^a$",),
+        "numeric": (),
+        "string": (),
+    }
+    # Fail if a new selector is added but not covered here.
+    assert set(args) == set(nw_v2.selectors.__all__)
+
+    for name, arg in args.items():
+        assert isinstance(getattr(nw_v2.selectors, name)(*arg), nw_v2.Expr), name


### PR DESCRIPTION
# Description

Spotted while working on #3902 

`narwhals.stable.v*.selectors` return main-namespace `Selectors`, which made stable selectors silently behave like main-namespace expressions.

---

Comment ported from #3902:

> First implementation was _much more compact_ (see https://github.com/narwhals-dev/narwhals/pull/3902/commits/5a6b822ffacf7d7484246f38325de73e36aadacf). `typing` was failing with a warning. It did feel like a pyrefly shortcoming but didn't went down such rabbithole.
>
> Same applies to `src/narwhals/stable/v2/selectors.py`

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

