### PR TITLE
chore(typing): Remove redundant `{cast,bool,str}` calls

### DIFF
--- a/src/narwhals/_ibis/expr.py
+++ b/src/narwhals/_ibis/expr.py
@@ -202,7 +202,7 @@ class IbisExpr(SQLExpr["IbisLazyFrame", "ir.Value"]):
 
     @classmethod
     def _alias_native(cls, expr: ExprT, name: str, /) -> ExprT:
-        return cast("ExprT", expr.name(name))
+        return expr.name(name)
 
     def __invert__(self) -> Self:
         invert = cast("Callable[..., ir.Value]", operator.invert)
@@ -327,7 +327,7 @@ class IbisExpr(SQLExpr["IbisLazyFrame", "ir.Value"]):
             elif method == "average":
                 partition = ibis.window(group_by=[expr])
                 cnt = expr.count().over(partition)
-                avg = cast("ir.NumericValue", (cnt - lit(1)) / lit(2.0))
+                avg = (cnt - lit(1)) / lit(2.0)
                 rank_ = rank_ + avg
 
             return ibis.cases((expr.notnull(), rank_))

--- a/src/narwhals/_utils.py
+++ b/src/narwhals/_utils.py
@@ -1330,7 +1330,7 @@ def is_range(obj: Any) -> TypeIs[range]:
 
 
 def is_single_index_selector(obj: Any) -> TypeIs[SingleIndexSelector]:
-    return bool(isinstance(obj, int) and not isinstance(obj, bool))
+    return isinstance(obj, int) and not isinstance(obj, bool)
 
 
 def is_index_selector(

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -87,7 +87,7 @@ def test_to_datetime_infer_fmt(
     expected_pyspark: str,
 ) -> None:
     if (
-        ("polars" in str(constructor) and str(data["a"][0]).isdigit())
+        ("polars" in str(constructor) and data["a"][0].isdigit())
         or "duckdb" in str(constructor)
         or ("pyspark" in str(constructor) and data["a"][0] == "20240101123456")
         or "ibis" in str(constructor)
@@ -136,7 +136,7 @@ def test_to_datetime_series_infer_fmt(
     expected: str,
     expected_cudf: str,
 ) -> None:
-    if "polars" in str(constructor_eager) and str(data["a"][0]).isdigit():
+    if "polars" in str(constructor_eager) and data["a"][0].isdigit():
         request.applymarker(pytest.mark.xfail)
     if "cudf" in str(constructor_eager):
         expected = expected_cudf

--- a/tests/frame/arrow_c_stream_test.py
+++ b/tests/frame/arrow_c_stream_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, NoReturn
+
 import pytest
 
 import narwhals as nw
@@ -17,6 +19,11 @@ import pyarrow as pa
 import pyarrow.compute as pc
 
 
+def _poison(*_: Any) -> NoReturn:
+    msg = "__arrow_c_stream__ was poisoned"
+    raise RuntimeError(msg)
+
+
 def test_arrow_c_stream_test() -> None:
     df = nw.from_native(pl.Series([1, 2, 3]).to_frame("a"), eager_only=True)
     result = pa.table(df)
@@ -26,11 +33,9 @@ def test_arrow_c_stream_test() -> None:
 
 def test_arrow_c_stream_test_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
     # "poison" the dunder method to make sure it actually got called above
-    monkeypatch.setattr(
-        "narwhals.dataframe.DataFrame.__arrow_c_stream__", lambda *_: 1 / 0
-    )
+    monkeypatch.setattr("narwhals.dataframe.DataFrame.__arrow_c_stream__", _poison)
     df = nw.from_native(pl.Series([1, 2, 3]).to_frame("a"), eager_only=True)
-    with pytest.raises(ZeroDivisionError, match="division by zero"):
+    with pytest.raises(RuntimeError, match="poisoned"):
         pa.table(df)
 
 

--- a/tests/series_only/arrow_c_stream_test.py
+++ b/tests/series_only/arrow_c_stream_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, NoReturn
+
 import pytest
 
 import narwhals as nw
@@ -12,6 +14,11 @@ pytest.importorskip("pyarrow.compute")
 import polars as pl
 import pyarrow as pa
 import pyarrow.compute as pc
+
+
+def _poison(*_: Any) -> NoReturn:
+    msg = "__arrow_c_stream__ was poisoned"
+    raise RuntimeError(msg)
 
 
 @pytest.mark.skipif(POLARS_VERSION < (1, 3), reason="too old for pycapsule in Polars")
@@ -31,9 +38,9 @@ def test_arrow_c_stream_test() -> None:
 )
 def test_arrow_c_stream_test_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
     # "poison" the dunder method to make sure it actually got called above
-    monkeypatch.setattr("narwhals.series.Series.__arrow_c_stream__", lambda *_: 1 / 0)
+    monkeypatch.setattr("narwhals.series.Series.__arrow_c_stream__", _poison)
     s = nw.from_native(pl.Series([1, 2, 3]), series_only=True)
-    with pytest.raises(ZeroDivisionError, match="division by zero"):
+    with pytest.raises(RuntimeError, match="poisoned"):
         pa.chunked_array(s)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -214,7 +214,7 @@ def pyspark_session() -> SparkSession:  # pragma: no cover
         from pyspark.sql.connect.session import SparkSession as _SparkSession
     else:
         from pyspark.sql import SparkSession as _SparkSession
-    builder = cast("_SparkSession.Builder", _SparkSession.builder).appName("unit-tests")
+    builder = _SparkSession.builder.appName("unit-tests")
     builder = (
         builder.remote(f"sc://localhost:{os.environ.get('SPARK_PORT', '15002')}")
         if is_spark_connect


### PR DESCRIPTION
# Description

It's not much but it's a honest job. Spotted via `uvx pyrefly@1.3.0.dev4 check --min-severity=info .` resulting as warnings

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [x] 🐳 Other

