### PR TITLE
fix(pyarrow): keep nulls through clip instead of replacing them with a bound

### DIFF
--- a/src/narwhals/_arrow/series.py
+++ b/src/narwhals/_arrow/series.py
@@ -838,16 +838,24 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
         _, lower = extract_native(self, lower_bound)
         _, upper = extract_native(self, upper_bound)
         return self._with_native(
-            pc.max_element_wise(pc.min_element_wise(self.native, upper), lower)
+            pc.max_element_wise(
+                pc.min_element_wise(self.native, upper, skip_nulls=False),
+                lower,
+                skip_nulls=False,
+            )
         )
 
     def clip_lower(self, lower_bound: Self) -> Self:
         _, lower = extract_native(self, lower_bound)
-        return self._with_native(pc.max_element_wise(self.native, lower))
+        return self._with_native(
+            pc.max_element_wise(self.native, lower, skip_nulls=False)
+        )
 
     def clip_upper(self, upper_bound: Self) -> Self:
         _, upper = extract_native(self, upper_bound)
-        return self._with_native(pc.min_element_wise(self.native, upper))
+        return self._with_native(
+            pc.min_element_wise(self.native, upper, skip_nulls=False)
+        )
 
     def to_arrow(self) -> ArrayAny:
         return self.native.combine_chunks()

--- a/src/narwhals/_sql/expr.py
+++ b/src/narwhals/_sql/expr.py
@@ -576,7 +576,6 @@ class SQLExpr(LazyExpr[SQLLazyFrameT, NativeExprT], Protocol[SQLLazyFrameT, Nati
         def _clip(
             expr: NativeExprT, lower_bound: NativeExprT, upper_bound: NativeExprT
         ) -> NativeExprT:
-            # `least` / `greatest` skip nulls, so guard so a null stays null.
             clipped = self._function(
                 "greatest", self._function("least", expr, upper_bound), lower_bound
             )

--- a/src/narwhals/_sql/expr.py
+++ b/src/narwhals/_sql/expr.py
@@ -576,9 +576,11 @@ class SQLExpr(LazyExpr[SQLLazyFrameT, NativeExprT], Protocol[SQLLazyFrameT, Nati
         def _clip(
             expr: NativeExprT, lower_bound: NativeExprT, upper_bound: NativeExprT
         ) -> NativeExprT:
-            return self._function(
+            # `least` / `greatest` skip nulls, so guard so a null stays null.
+            clipped = self._function(
                 "greatest", self._function("least", expr, upper_bound), lower_bound
             )
+            return self._when(self._function("isnull", expr), self._lit(None), clipped)
 
         return self._with_elementwise(
             _clip,
@@ -587,13 +589,15 @@ class SQLExpr(LazyExpr[SQLLazyFrameT, NativeExprT], Protocol[SQLLazyFrameT, Nati
 
     def clip_lower(self, lower_bound: Self) -> Self:
         def _clip(expr: NativeExprT, lower_bound: NativeExprT) -> NativeExprT:
-            return self._function("greatest", expr, lower_bound)
+            clipped = self._function("greatest", expr, lower_bound)
+            return self._when(self._function("isnull", expr), self._lit(None), clipped)
 
         return self._with_elementwise(_clip, expression_args={"lower_bound": lower_bound})
 
     def clip_upper(self, upper_bound: Self) -> Self:
         def _clip(expr: NativeExprT, upper_bound: NativeExprT) -> NativeExprT:
-            return self._function("least", expr, upper_bound)
+            clipped = self._function("least", expr, upper_bound)
+            return self._when(self._function("isnull", expr), self._lit(None), clipped)
 
         return self._with_elementwise(_clip, expression_args={"upper_bound": upper_bound})
 

--- a/tests/expr_and_series/clip_test.py
+++ b/tests/expr_and_series/clip_test.py
@@ -69,8 +69,8 @@ def test_clip_invalid(constructor: Constructor) -> None:
         df.select(nw.col("a").clip(nw.all(), nw.col("a", "b")))
 
 
-def test_clip_preserves_null(constructor_eager: ConstructorEager) -> None:
+def test_clip_preserves_null(constructor: Constructor) -> None:
     # A null value must stay null through clip, not be replaced by a bound.
-    df = nw.from_native(constructor_eager({"a": [1, None, 3, -4, None]}), eager_only=True)
-    result = {"a": df["a"].clip(lower_bound=0, upper_bound=2)}
+    df = nw.from_native(constructor({"a": [1, None, 3, -4, None]}))
+    result = df.select(a=nw.col("a").clip(lower_bound=0, upper_bound=2))
     assert_equal_data(result, {"a": [1, None, 2, 0, None]})

--- a/tests/expr_and_series/clip_test.py
+++ b/tests/expr_and_series/clip_test.py
@@ -67,3 +67,10 @@ def test_clip_invalid(constructor: Constructor) -> None:
     df = nw.from_native(constructor({"a": [1, 2, 3], "b": [4, 5, 6]}))
     with pytest.raises(MultiOutputExpressionError):
         df.select(nw.col("a").clip(nw.all(), nw.col("a", "b")))
+
+
+def test_clip_preserves_null(constructor_eager: ConstructorEager) -> None:
+    # A null value must stay null through clip, not be replaced by a bound.
+    df = nw.from_native(constructor_eager({"a": [1, None, 3, -4, None]}), eager_only=True)
+    result = {"a": df["a"].clip(lower_bound=0, upper_bound=2)}
+    assert_equal_data(result, {"a": [1, None, 2, 0, None]})


### PR DESCRIPTION
# Description

On the pyarrow backend, `clip` (and `clip_lower` / `clip_upper`) replaced a **null value in the data** with a clip bound instead of preserving it:

```python
import narwhals as nw, pyarrow as pa
s = nw.from_native(pa.chunked_array([[1, None, 3]]), series_only=True)
s.clip(0, 2).to_list()
# main:   [1, 2, 3]     <- the null became the upper bound
# polars: [1, None, 2]  <- null preserved
```

The cause is that pyarrow's `min_element_wise` / `max_element_wise` skip nulls by default, so `min_element_wise([null], 2)` returns `2`. Passing `skip_nulls=False` keeps a null as null, matching Polars and pandas.

This is distinct from #2889, which was about `None` **bounds** (unbounded clip); here the null is in the data. The existing `clip` tests use no nulls in the data, so this was uncovered.

## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Related issues

- None

## AI assistance

- [x] AI tools were used.

I used Claude Code to help locate the divergence (a differential comparison of pyarrow vs pandas/polars) and draft the fix and test. I reviewed every line, reproduced the bug and the fix locally, and take full responsibility for the change.

## Checklist

- [x] Fix applied to `clip`, `clip_lower` and `clip_upper` (the whole class) in the pyarrow backend
- [x] Regression test `test_clip_preserves_null` added; fails on `main` for pyarrow, passes after; full `clip_test.py` green
- [x] `ruff check` and `ruff format` clean