### PR TITLE
fix: inplace deprecation warning from pandas in `hist`

### DIFF
--- a/src/narwhals/_pandas_like/series.py
+++ b/src/narwhals/_pandas_like/series.py
@@ -1325,7 +1325,12 @@ class _PandasHist(EagerSeriesHist["pd.Series[Any]", "list[float]"]):
         count = categories.value_counts(dropna=True, sort=False).reindex(
             categories.cat.categories, fill_value=0
         )
-        count.reset_index(drop=True, inplace=True)  # noqa: PD002
+        impl = self._series._implementation
+        if impl.is_pandas() and impl._backend_version() < (3, 0):  # pragma: no cover
+            # NOTE: Keep `inplace=True` to avoid making a redundant copy.
+            count.reset_index(drop=True, inplace=True)  # noqa: PD002
+        else:
+            count = count.reset_index(drop=True)
         if self._breakpoint:
             return {"breakpoint": bins[1:], "count": count}
         return {"count": count}


### PR DESCRIPTION
# Description

Hit in nightly CI. `_PandasHist._calculate_hist` was the last ungated `inplace=True` call site. pandas nightly raises `Pandas4Warning` for `Series.reset_index(inplace=...)` per PDEP-8.

Gate it behind `pandas < 3.0` like the other call sites, falling back to the copying form elsewhere.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other
