### PR TITLE
fix(typing): Stableify `concat` with the stable frame classes

### DIFF
--- a/src/narwhals/stable/v1/__init__.py
+++ b/src/narwhals/stable/v1/__init__.py
@@ -969,7 +969,8 @@ def concat(items: Iterable[FrameT], *, how: ConcatMethod = "vertical") -> FrameT
     Raises:
         TypeError: The items to concatenate should either all be eager, or all lazy
     """
-    return _stableify(nw_f.concat(items, how=how))
+    # Pyrefly needs this cast; concat and _stableify preserve the eager/lazy kind.
+    return cast("FrameT", _stableify(nw_f.concat(items, how=how)))  # type: ignore[redundant-cast]
 
 
 @deprecate_native_namespace(required=True)

--- a/src/narwhals/stable/v1/__init__.py
+++ b/src/narwhals/stable/v1/__init__.py
@@ -969,7 +969,10 @@ def concat(items: Iterable[FrameT], *, how: ConcatMethod = "vertical") -> FrameT
     Raises:
         TypeError: The items to concatenate should either all be eager, or all lazy
     """
-    # Pyrefly needs this cast; concat and _stableify preserve the eager/lazy kind.
+    # `pyrefly` rejects the union `_stableify` returns while `FrameT` is still
+    # unsolved; `mypy` solves per-constraint and calls the cast redundant, hence
+    # the ignore. CI cannot catch removal of either, because `pyrefly check` only
+    # covers `tests`. Verify with: pyrefly check src/narwhals/stable/v1/__init__.py
     return cast("FrameT", _stableify(nw_f.concat(items, how=how)))  # type: ignore[redundant-cast]
 
 

--- a/src/narwhals/stable/v1/__init__.py
+++ b/src/narwhals/stable/v1/__init__.py
@@ -25,7 +25,7 @@ from narwhals._utils import (
 from narwhals.dataframe import DataFrame as NwDataFrame, LazyFrame as NwLazyFrame
 from narwhals.exceptions import InvalidIntoExprError, NarwhalsUnstableWarning
 from narwhals.expr import Expr as NwExpr
-from narwhals.functions import _new_series_impl, concat, show_versions
+from narwhals.functions import _new_series_impl, show_versions
 from narwhals.schema import Schema as NwSchema
 from narwhals.series import Series as NwSeries
 from narwhals.stable.v1 import dependencies, dtypes, selectors
@@ -108,6 +108,7 @@ if TYPE_CHECKING:
     )
     from narwhals.dataframe import MultiColSelector, MultiIndexSelector
     from narwhals.typing import (
+        ConcatMethod,
         FileSource,
         IntoDType,
         IntoExpr,
@@ -123,6 +124,7 @@ if TYPE_CHECKING:
     T = TypeVar("T", default=Any)
     P = ParamSpec("P")
     R = TypeVar("R")
+    _FrameT = TypeVar("_FrameT", "DataFrame[Any]", "LazyFrame[Any]")
 
 
 # NOTE legit
@@ -946,6 +948,24 @@ class Then(nw_f.Then, Expr):
 
 def when(*predicates: IntoExpr | Iterable[IntoExpr]) -> When:
     return When.from_when(nw_f.when(*predicates))
+
+
+@overload
+def concat(
+    items: Iterable[DataFrame[Any]], *, how: ConcatMethod = "vertical"
+) -> DataFrame[Any]: ...
+
+
+@overload
+def concat(
+    items: Iterable[LazyFrame[Any]], *, how: ConcatMethod = "vertical"
+) -> LazyFrame[Any]: ...
+
+
+def concat(
+    items: Iterable[_FrameT], *, how: ConcatMethod = "vertical"
+) -> DataFrame[Any] | LazyFrame[Any]:
+    return _stableify(nw_f.concat(items, how=how))
 
 
 @deprecate_native_namespace(required=True)

--- a/src/narwhals/stable/v1/__init__.py
+++ b/src/narwhals/stable/v1/__init__.py
@@ -62,6 +62,7 @@ from narwhals.stable.v1.dtypes import (
 )
 from narwhals.stable.v1.typing import (
     DataFrameT,
+    FrameT,
     IntoDataFrameT,
     IntoFrame,
     IntoLazyFrameT,
@@ -124,7 +125,6 @@ if TYPE_CHECKING:
     T = TypeVar("T", default=Any)
     P = ParamSpec("P")
     R = TypeVar("R")
-    _FrameT = TypeVar("_FrameT", "DataFrame[Any]", "LazyFrame[Any]")
 
 
 # NOTE legit
@@ -950,21 +950,23 @@ def when(*predicates: IntoExpr | Iterable[IntoExpr]) -> When:
     return When.from_when(nw_f.when(*predicates))
 
 
-@overload
-def concat(
-    items: Iterable[DataFrame[Any]], *, how: ConcatMethod = "vertical"
-) -> DataFrame[Any]: ...
+def concat(items: Iterable[FrameT], *, how: ConcatMethod = "vertical") -> FrameT:
+    """Concatenate multiple DataFrames, LazyFrames into a single entity.
 
+    Arguments:
+        items: DataFrames, LazyFrames to concatenate.
+        how: concatenating strategy
 
-@overload
-def concat(
-    items: Iterable[LazyFrame[Any]], *, how: ConcatMethod = "vertical"
-) -> LazyFrame[Any]: ...
+            - vertical: Concatenate vertically. Column names must match.
+            - horizontal: Concatenate horizontally. If lengths don't match, then
+                missing rows are filled with null values. This is only supported
+                when all inputs are (eager) DataFrames.
+            - diagonal: Finds a union between the column schemas and fills missing column
+                values with null.
 
-
-def concat(
-    items: Iterable[_FrameT], *, how: ConcatMethod = "vertical"
-) -> DataFrame[Any] | LazyFrame[Any]:
+    Raises:
+        TypeError: The items to concatenate should either all be eager, or all lazy
+    """
     return _stableify(nw_f.concat(items, how=how))
 
 

--- a/src/narwhals/stable/v2/__init__.py
+++ b/src/narwhals/stable/v2/__init__.py
@@ -947,7 +947,8 @@ def concat(items: Iterable[FrameT], *, how: ConcatMethod = "vertical") -> FrameT
     Raises:
         TypeError: The items to concatenate should either all be eager, or all lazy
     """
-    return _stableify(nw_f.concat(items, how=how))
+    # Pyrefly needs this cast; concat and _stableify preserve the eager/lazy kind.
+    return cast("FrameT", _stableify(nw_f.concat(items, how=how)))  # type: ignore[redundant-cast]
 
 
 def new_series(

--- a/src/narwhals/stable/v2/__init__.py
+++ b/src/narwhals/stable/v2/__init__.py
@@ -61,7 +61,6 @@ from narwhals.series import Series as NwSeries
 from narwhals.stable.v2 import dependencies, dtypes, selectors
 from narwhals.stable.v2.typing import (
     DataFrameT,
-    Frame,
     FrameT,
     IntoDataFrameT,
     IntoFrame,
@@ -929,19 +928,7 @@ def when(*predicates: IntoExpr | Iterable[IntoExpr]) -> When:
     return When.from_when(nw_f.when(*predicates))
 
 
-@overload
-def concat(
-    items: Iterable[DataFrame[Any]], *, how: ConcatMethod = "vertical"
-) -> DataFrame[Any]: ...
-
-
-@overload
-def concat(
-    items: Iterable[LazyFrame[Any]], *, how: ConcatMethod = "vertical"
-) -> LazyFrame[Any]: ...
-
-
-def concat(items: Iterable[FrameT], *, how: ConcatMethod = "vertical") -> Frame:
+def concat(items: Iterable[FrameT], *, how: ConcatMethod = "vertical") -> FrameT:
     """Concatenate multiple DataFrames, LazyFrames into a single entity.
 
     Arguments:

--- a/src/narwhals/stable/v2/__init__.py
+++ b/src/narwhals/stable/v2/__init__.py
@@ -947,7 +947,10 @@ def concat(items: Iterable[FrameT], *, how: ConcatMethod = "vertical") -> FrameT
     Raises:
         TypeError: The items to concatenate should either all be eager, or all lazy
     """
-    # Pyrefly needs this cast; concat and _stableify preserve the eager/lazy kind.
+    # `pyrefly` rejects the union `_stableify` returns while `FrameT` is still
+    # unsolved; `mypy` solves per-constraint and calls the cast redundant, hence
+    # the ignore. CI cannot catch removal of either, because `pyrefly check` only
+    # covers `tests`. Verify with: `pyrefly check src/narwhals/stable/v2/__init__.py`
     return cast("FrameT", _stableify(nw_f.concat(items, how=how)))  # type: ignore[redundant-cast]
 
 

--- a/src/narwhals/stable/v2/__init__.py
+++ b/src/narwhals/stable/v2/__init__.py
@@ -55,12 +55,14 @@ from narwhals.dtypes import (
 )
 from narwhals.exceptions import NarwhalsUnstableWarning
 from narwhals.expr import Expr as NwExpr
-from narwhals.functions import _new_series_impl, concat, show_versions
+from narwhals.functions import _new_series_impl, show_versions
 from narwhals.schema import Schema as NwSchema
 from narwhals.series import Series as NwSeries
 from narwhals.stable.v2 import dependencies, dtypes, selectors
 from narwhals.stable.v2.typing import (
     DataFrameT,
+    Frame,
+    FrameT,
     IntoDataFrameT,
     IntoFrame,
     IntoLazyFrameT,
@@ -97,6 +99,7 @@ if TYPE_CHECKING:
     )
     from narwhals.dataframe import MultiColSelector, MultiIndexSelector
     from narwhals.typing import (
+        ConcatMethod,
         IntoDType,
         IntoExpr,
         IntoSchema,
@@ -924,6 +927,38 @@ def when(*predicates: IntoExpr | Iterable[IntoExpr]) -> When:
         A "When" object, which `.then` can be called on.
     """
     return When.from_when(nw_f.when(*predicates))
+
+
+@overload
+def concat(
+    items: Iterable[DataFrame[Any]], *, how: ConcatMethod = "vertical"
+) -> DataFrame[Any]: ...
+
+
+@overload
+def concat(
+    items: Iterable[LazyFrame[Any]], *, how: ConcatMethod = "vertical"
+) -> LazyFrame[Any]: ...
+
+
+def concat(items: Iterable[FrameT], *, how: ConcatMethod = "vertical") -> Frame:
+    """Concatenate multiple DataFrames, LazyFrames into a single entity.
+
+    Arguments:
+        items: DataFrames, LazyFrames to concatenate.
+        how: concatenating strategy
+
+            - vertical: Concatenate vertically. Column names must match.
+            - horizontal: Concatenate horizontally. If lengths don't match, then
+                missing rows are filled with null values. This is only supported
+                when all inputs are (eager) DataFrames.
+            - diagonal: Finds a union between the column schemas and fills missing column
+                values with null.
+
+    Raises:
+        TypeError: The items to concatenate should either all be eager, or all lazy
+    """
+    return _stableify(nw_f.concat(items, how=how))
 
 
 def new_series(

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 
     from narwhals._typing import EagerAllowed
     from narwhals.dtypes import DType
-    from narwhals.stable.v1.typing import IntoDataFrameT
+    from narwhals.stable.v1.typing import FrameT as StableFrameT, IntoDataFrameT
     from narwhals.typing import IntoDType, _1DArray, _2DArray
     from tests.utils import Constructor, ConstructorEager
 
@@ -228,9 +228,31 @@ def test_concat() -> None:
     result = nw_v1.concat([df, df], how="vertical")
     expected = {"a": [1, 2, 3, 1, 2, 3]}
     assert_equal_data(result, expected)
-    assert isinstance(result, nw_v1.DataFrame)
     if TYPE_CHECKING:
+        # Check the inferred return type before isinstance narrows it.
         assert_type(result, nw_v1.DataFrame[Any])
+    assert isinstance(result, nw_v1.DataFrame)
+
+    def identity(x: FrameT) -> FrameT:
+        return x
+
+    identity(nw_v1.concat([df], how="horizontal"))
+
+    def concat_generic(frame: StableFrameT) -> StableFrameT:
+        return nw_v1.concat([frame, frame])
+
+    def concat_sequence(frames: Sequence[StableFrameT]) -> StableFrameT:
+        return nw_v1.concat(frames)
+
+    assert_equal_data(concat_generic(df), expected)
+    assert_equal_data(concat_sequence([df, df]), expected)
+    lazy_result = concat_generic(df.lazy())
+    if TYPE_CHECKING:
+        assert_type(lazy_result, nw_v1.LazyFrame[Any])
+        assert_type(nw_v1.concat([df.lazy()]), nw_v1.LazyFrame[Any])
+    assert isinstance(lazy_result, nw_v1.LazyFrame)
+    assert_equal_data(lazy_result.collect(), expected)
+    assert_equal_data(concat_sequence([df.lazy(), df.lazy()]).collect(), expected)
 
 
 def test_to_dict() -> None:
@@ -1250,35 +1272,3 @@ def test_schema_from_generator() -> None:
     )
     assert schema == nw_v1.Schema({"a": nw_v1.Int64(), "b": nw_v1.String()})
     assert schema._version is Version.V1
-
-
-def test_concat_typing() -> None:
-    """`concat` in the stable API should be typed with the stable classes.
-
-    https://github.com/narwhals-dev/narwhals/issues/3897
-    """
-    pytest.importorskip("pandas")
-    import pandas as pd
-
-    df = nw_v1.from_native(pd.DataFrame({"a": [1, 2, 3]}), eager_only=True)
-    result = nw_v1.concat([df], how="horizontal")
-    assert isinstance(result, nw_v1.DataFrame)
-    if TYPE_CHECKING:
-        assert_type(result, nw_v1.DataFrame[Any])
-
-
-def test_concat_typevar() -> None:
-    """The literal reproduction from issue #3897.
-
-    A constrained TypeVar over stable `Series` / `DataFrame` must accept the
-    result of stable `concat`.
-    """
-    pytest.importorskip("pandas")
-    import pandas as pd
-
-    df = nw_v1.from_native(pd.DataFrame({"a": [1, 2, 3]}), eager_only=True)
-
-    def identity(x: FrameT) -> FrameT:
-        return x
-
-    identity(nw_v1.concat([df], how="horizontal"))

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -248,8 +248,12 @@ def test_concat() -> None:
     assert_equal_data(concat_sequence([df, df]), expected)
     lazy_result = concat_generic(df.lazy())
     if TYPE_CHECKING:
+        assert_type(concat_generic(df), nw_v1.DataFrame[Any])
         assert_type(lazy_result, nw_v1.LazyFrame[Any])
         assert_type(nw_v1.concat([df.lazy()]), nw_v1.LazyFrame[Any])
+        # Mixing eager and lazy must stay a type error. `warn_unused_ignores` (via
+        # `strict`) makes this self-verifying: the ignore goes unused if it regresses.
+        nw_v1.concat([df, df.lazy()])  # type: ignore[type-var]
     assert isinstance(lazy_result, nw_v1.LazyFrame)
     assert_equal_data(lazy_result.collect(), expected)
     assert_equal_data(concat_sequence([df.lazy(), df.lazy()]).collect(), expected)

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -44,6 +44,7 @@ from tests.utils import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
+    from typing import TypeVar
 
     from typing_extensions import assert_type
 
@@ -52,6 +53,8 @@ if TYPE_CHECKING:
     from narwhals.stable.v1.typing import IntoDataFrameT
     from narwhals.typing import IntoDType, _1DArray, _2DArray
     from tests.utils import Constructor, ConstructorEager
+
+    FrameT = TypeVar("FrameT", nw_v1.Series[Any], nw_v1.DataFrame[Any])
 
 
 def test_toplevel() -> None:
@@ -1247,3 +1250,35 @@ def test_schema_from_generator() -> None:
     )
     assert schema == nw_v1.Schema({"a": nw_v1.Int64(), "b": nw_v1.String()})
     assert schema._version is Version.V1
+
+
+def test_concat_typing() -> None:
+    """`concat` in the stable API should be typed with the stable classes.
+
+    https://github.com/narwhals-dev/narwhals/issues/3897
+    """
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df = nw_v1.from_native(pd.DataFrame({"a": [1, 2, 3]}), eager_only=True)
+    result = nw_v1.concat([df], how="horizontal")
+    assert isinstance(result, nw_v1.DataFrame)
+    if TYPE_CHECKING:
+        assert_type(result, nw_v1.DataFrame[Any])
+
+
+def test_concat_typevar() -> None:
+    """The literal reproduction from issue #3897.
+
+    A constrained TypeVar over stable `Series` / `DataFrame` must accept the
+    result of stable `concat`.
+    """
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df = nw_v1.from_native(pd.DataFrame({"a": [1, 2, 3]}), eager_only=True)
+
+    def identity(x: FrameT) -> FrameT:
+        return x
+
+    identity(nw_v1.concat([df], how="horizontal"))

--- a/tests/v2_test.py
+++ b/tests/v2_test.py
@@ -238,8 +238,12 @@ def test_concat() -> None:
     assert_equal_data(concat_sequence([df, df]), expected)
     lazy_result = concat_generic(df.lazy())
     if TYPE_CHECKING:
+        assert_type(concat_generic(df), nw_v2.DataFrame[Any])
         assert_type(lazy_result, nw_v2.LazyFrame[Any])
         assert_type(nw_v2.concat([df.lazy()]), nw_v2.LazyFrame[Any])
+        # Mixing eager and lazy must stay a type error. `warn_unused_ignores` (via
+        # `strict`) makes this self-verifying: the ignore goes unused if it regresses.
+        nw_v2.concat([df, df.lazy()])  # type: ignore[type-var]
     assert isinstance(lazy_result, nw_v2.LazyFrame)
     assert_equal_data(lazy_result.collect(), expected)
     assert_equal_data(concat_sequence([df.lazy(), df.lazy()]).collect(), expected)

--- a/tests/v2_test.py
+++ b/tests/v2_test.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from typing_extensions import assert_type
 
     from narwhals._typing import EagerAllowed
-    from narwhals.stable.v2.typing import IntoDataFrameT
+    from narwhals.stable.v2.typing import FrameT, IntoDataFrameT
     from narwhals.typing import IntoDType, _1DArray, _2DArray
 
 
@@ -586,3 +586,35 @@ def test_schema_from_generator() -> None:
     )
     assert schema == nw_v2.Schema({"a": nw_v2.Int64(), "b": nw_v2.String()})
     assert schema._version is Version.V2
+
+
+def test_concat_typing() -> None:
+    """`concat` in the stable API should be typed with the stable classes.
+
+    https://github.com/narwhals-dev/narwhals/issues/3897
+    """
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df = nw_v2.from_native(pd.DataFrame({"a": [1, 2, 3]}), eager_only=True)
+    result = nw_v2.concat([df], how="horizontal")
+    assert isinstance(result, nw_v2.DataFrame)
+    if TYPE_CHECKING:
+        assert_type(result, nw_v2.DataFrame[Any])
+
+
+def test_concat_typevar() -> None:
+    """The literal reproduction from issue #3897.
+
+    A constrained TypeVar over stable `Series` / `DataFrame` must accept the
+    result of stable `concat`.
+    """
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df = nw_v2.from_native(pd.DataFrame({"a": [1, 2, 3]}), eager_only=True)
+
+    def identity(x: FrameT) -> FrameT:
+        return x
+
+    identity(nw_v2.concat([df], how="horizontal"))

--- a/tests/v2_test.py
+++ b/tests/v2_test.py
@@ -26,12 +26,15 @@ from tests.utils import (
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import TypeVar
 
     from typing_extensions import assert_type
 
     from narwhals._typing import EagerAllowed
-    from narwhals.stable.v2.typing import FrameT, IntoDataFrameT
+    from narwhals.stable.v2.typing import FrameT as StableFrameT, IntoDataFrameT
     from narwhals.typing import IntoDType, _1DArray, _2DArray
+
+    FrameT = TypeVar("FrameT", nw_v2.Series[Any], nw_v2.DataFrame[Any])
 
 
 def test_toplevel() -> None:
@@ -215,9 +218,31 @@ def test_concat() -> None:
     result = nw_v2.concat([df, df], how="vertical")
     expected = {"a": [1, 2, 3, 1, 2, 3]}
     assert_equal_data(result, expected)
-    assert isinstance(result, nw_v2.DataFrame)
     if TYPE_CHECKING:
+        # Check the inferred return type before isinstance narrows it.
         assert_type(result, nw_v2.DataFrame[Any])
+    assert isinstance(result, nw_v2.DataFrame)
+
+    def identity(x: FrameT) -> FrameT:
+        return x
+
+    identity(nw_v2.concat([df], how="horizontal"))
+
+    def concat_generic(frame: StableFrameT) -> StableFrameT:
+        return nw_v2.concat([frame, frame])
+
+    def concat_sequence(frames: Sequence[StableFrameT]) -> StableFrameT:
+        return nw_v2.concat(frames)
+
+    assert_equal_data(concat_generic(df), expected)
+    assert_equal_data(concat_sequence([df, df]), expected)
+    lazy_result = concat_generic(df.lazy())
+    if TYPE_CHECKING:
+        assert_type(lazy_result, nw_v2.LazyFrame[Any])
+        assert_type(nw_v2.concat([df.lazy()]), nw_v2.LazyFrame[Any])
+    assert isinstance(lazy_result, nw_v2.LazyFrame)
+    assert_equal_data(lazy_result.collect(), expected)
+    assert_equal_data(concat_sequence([df.lazy(), df.lazy()]).collect(), expected)
 
 
 def test_to_dict_as_series() -> None:
@@ -586,35 +611,3 @@ def test_schema_from_generator() -> None:
     )
     assert schema == nw_v2.Schema({"a": nw_v2.Int64(), "b": nw_v2.String()})
     assert schema._version is Version.V2
-
-
-def test_concat_typing() -> None:
-    """`concat` in the stable API should be typed with the stable classes.
-
-    https://github.com/narwhals-dev/narwhals/issues/3897
-    """
-    pytest.importorskip("pandas")
-    import pandas as pd
-
-    df = nw_v2.from_native(pd.DataFrame({"a": [1, 2, 3]}), eager_only=True)
-    result = nw_v2.concat([df], how="horizontal")
-    assert isinstance(result, nw_v2.DataFrame)
-    if TYPE_CHECKING:
-        assert_type(result, nw_v2.DataFrame[Any])
-
-
-def test_concat_typevar() -> None:
-    """The literal reproduction from issue #3897.
-
-    A constrained TypeVar over stable `Series` / `DataFrame` must accept the
-    result of stable `concat`.
-    """
-    pytest.importorskip("pandas")
-    import pandas as pd
-
-    df = nw_v2.from_native(pd.DataFrame({"a": [1, 2, 3]}), eager_only=True)
-
-    def identity(x: FrameT) -> FrameT:
-        return x
-
-    identity(nw_v2.concat([df], how="horizontal"))


### PR DESCRIPTION
## Summary

`concat` in `narwhals.stable.v1` / `stable.v2` was re-exported from the main namespace, so type checkers saw its result as `narwhals.dataframe.DataFrame[Any]` instead of the stable classes. Passing the result to a function typed with the stable classes (e.g. through a constrained `TypeVar` over `nw.DataFrame` / `nw.Series`) was rejected by mypy and pyrefly, even though the runtime object is a stable instance.

## Root cause

Both stable namespaces imported and re-exported `narwhals.functions.concat` unchanged, leaving its annotations tied to the main namespace.

## Fix

- Define `concat` in both stable namespaces, wrapping the main implementation with `_stableify`.
- Use each namespace's existing `FrameT` in the signature `Iterable[FrameT] -> FrameT`, preserving generic callers without separate eager/lazy overloads.
- Include the concat docstring in both wrappers, keeping v2 consistent with the main namespace.

## Tests

- Consolidate regression checks into each namespace's existing `test_concat`.
- Check inferred return types before `isinstance` narrows them.
- Use the same `Series` / `DataFrame` constrained TypeVar in v1 and v2 for the issue's `identity(concat(...))` reproduction.
- Exercise generic `FrameT` and `Sequence[FrameT]` callers with both eager and lazy frames, checking types and data.

Local validation on `ed446cf`, after merging `main` at `6bb4f7c`:

- All `prek run --all-files` checks pass.
- mypy, pyright, and the default project-scoped pyrefly check report no errors (see the source-level follow-up below).
- `pytest tests/v1_test.py tests/v2_test.py tests/stable_api_test.py tests/namespace_test.py tests/frame/concat_test.py`: **458 passed, 16 skipped, 9 xfailed**.
- `pytest src --doctest-modules`: **484 passed**.
- Dynamic documentation generation and `zensical build --clean --strict` pass.
- Full suite with the Makefile's constructor list, slow tests, coverage, and four workers: **14,650 passed, 4 failed, 478 skipped, 864 xfailed**. The four failures are SQLFrame timezone assertions in this Windows environment. An independent, unmodified `main` checkout at `6bb4f7c` produces the same four failures and test counts. Both runs fall below the 100% coverage gate, with the same 79 uncovered statements and six partially covered branches.

Fixes #3897

## Source-level pyrefly follow-up

Commit `c8c5d2b` adds an explicit `cast` to each stable `concat` return. Both the underlying concatenation and `_stableify` preserve the eager/lazy kind represented by the constrained `FrameT`. Mypy already infers this relationship, so a per-line `redundant-cast` annotation handles that checker difference.

The default `pyrefly check` targets `tests`; it did not report the two `bad-return` errors found by directly checking the stable source files. After this fix, both concat errors are gone. Direct source checking still reports two pre-existing `DataFrame.to_dict` override errors, also present on unmodified `main`. The result is the same when targeting Python 3.12.

Mypy, pyright, default pyrefly, public type completeness, pre-commit checks, the 458 targeted tests, and 484 doctests pass. The full suite retains the same 14,650 passes and four baseline SQLFrame timezone failures described above.

## AI assistance

- [x] AI tools were used: Codex (GPT-6) assisted with implementation and validation.
