### PR TITLE
test: cover to_datetime date-only, all-null and trailing cases

### DIFF
--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -275,24 +275,45 @@ def test_to_datetime_all_null_offset_format(constructor: Constructor) -> None:
 
 
 @pytest.mark.parametrize(
-    ("format", "time_unit"),
-    [("%Y-%m-%dT%H:%M:%S%.3f", "ms"), ("%Y-%m-%dT%H:%M:%S%.f", "us")],
+    ("format", "time_unit", "value", "expected"),
+    [
+        (
+            "%Y-%m-%dT%H:%M:%S%.3f",
+            "ms",
+            "2020-01-01T12:34:56.123",
+            datetime(2020, 1, 1, 12, 34, 56, 123000),
+        ),
+        (
+            "%Y-%m-%dT%H:%M:%S%.f",
+            "us",
+            "2020-01-01T12:34:56.123",
+            datetime(2020, 1, 1, 12, 34, 56, 123000),
+        ),
+        (
+            "%Y-%m-%dT%H:%M:%S%.9f",
+            "ns",
+            "2020-01-01T12:34:56.123456789",
+            datetime(2020, 1, 1, 12, 34, 56, 123456),
+        ),
+    ],
 )
 def test_to_datetime_fractional_seconds(
     constructor: Constructor,
     request: pytest.FixtureRequest,
     format: str,
     time_unit: TimeUnit,
+    value: str,
+    expected: datetime,
 ) -> None:
     # Fractional-second formats determine the resulting `Datetime` precision,
     # matching polars. No other backend parses them.
     if "polars" not in str(constructor):
         request.applymarker(pytest.mark.xfail(reason="fractional format unsupported"))
-    result = nw.from_native(constructor({"a": ["2020-01-01T12:34:56.123"]})).select(
+    result = nw.from_native(constructor({"a": [value]})).select(
         b=nw.col("a").str.to_datetime(format)
     )
     assert result.collect_schema()["b"] == nw.Datetime(time_unit)
-    assert_equal_data(result, {"b": [datetime(2020, 1, 1, 12, 34, 56, 123000)]})
+    assert_equal_data(result, {"b": [expected]})
 
 
 @pytest.mark.parametrize("format", ["%Y-%m-%dT%H:%M:%S", None])

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -247,6 +247,45 @@ def test_to_datetime_tz_aware(
         assert_equal_data(result, expected)
 
 
+def test_to_datetime_date_only_format(constructor: Constructor) -> None:
+    # Explicit date-only format parses to midnight. Previously only datetime
+    # formats were exercised, so backends that cannot parse dates went unnoticed.
+    from datetime import datetime
+
+    result = (
+        nw.from_native(constructor({"a": ["2020-01-01", None]}))
+        .lazy()
+        .select(b=nw.col("a").str.to_datetime(format="%Y-%m-%d"))
+    )
+    assert isinstance(result.collect_schema()["b"], nw.Datetime)
+    assert_equal_data(result, {"b": [datetime(2020, 1, 1), None]})
+
+
+def test_to_datetime_all_null_offset_format(constructor: Constructor) -> None:
+    # Explicit (offset) format on an all-null column yields all nulls instead
+    # of panicking on the missing non-null sample.
+    if "ibis" in str(constructor):
+        pytest.skip(reason="ibis cannot create all-null column")
+    df = nw.from_native(constructor({"a": [None, None]}))
+    df = df.with_columns(nw.col("a").cast(nw.String()))
+    result = df.select(nw.col("a").str.to_datetime(format="%Y-%m-%dT%H:%M:%S%z"))
+    assert isinstance(result.collect_schema()["a"], nw.Datetime)
+    assert_equal_data(result, {"a": [None, None]})
+
+
+def test_to_datetime_trailing_input_raises(constructor: Constructor) -> None:
+    # Trailing characters after an explicit format raise on all backends
+    # (each with its own error type), rather than parsing the prefix.
+    df = nw.from_native(constructor({"a": ["2020-01-01T12:34:56.789"]}))
+    expr = nw.col("a").str.to_datetime(format="%Y-%m-%dT%H:%M:%S")
+    if isinstance(df, nw.LazyFrame):
+        with pytest.raises(Exception):  # noqa: BLE001, PT011
+            df.select(expr).lazy().collect()
+    else:
+        with pytest.raises(Exception):  # noqa: BLE001, PT011
+            df.select(expr)
+
+
 @pytest.mark.skipif(PANDAS_VERSION < (2, 2, 0), reason="too old for pyarrow types")
 def test_to_datetime_pd_preserves_pyarrow_backend_dtype() -> None:
     # Remark that pandas doesn't have a numpy-nullable datetime dtype, so

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -335,8 +335,18 @@ def test_to_datetime_fractional_seconds(
     ids=["unparseable_explicit", "unparseable_infer", "trailing"],
 )
 def test_to_datetime_invalid_raises(
-    constructor: Constructor, data: dict[str, list[str]], format: str | None
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    data: dict[str, list[str]],
+    format: str | None,
 ) -> None:
+    # Old numpy-backed pandas ignores trailing input rather than rejecting it.
+    if (
+        "trailing" in request.node.callspec.id
+        and "pandas_constructor" in str(constructor)
+        and PANDAS_VERSION < (2,)
+    ):
+        pytest.skip(reason="old pandas ignores trailing input")
     df = nw.from_native(constructor(data))
     expr = nw.col("a").str.to_datetime(format)
     # Broad `Exception`: error types differ per backend.

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -316,31 +316,21 @@ def test_to_datetime_fractional_seconds(
     assert_equal_data(result, {"b": [expected]})
 
 
-@pytest.mark.parametrize("format", ["%Y-%m-%dT%H:%M:%S", None])
-def test_to_datetime_unparseable_raises(
-    constructor: Constructor, format: str | None
+@pytest.mark.parametrize(
+    ("data", "format"),
+    [
+        ({"a": ["abc"]}, "%Y-%m-%dT%H:%M:%S"),
+        ({"a": ["abc"]}, None),
+        ({"a": ["2020-01-01T12:34:56.789"]}, "%Y-%m-%dT%H:%M:%S"),
+    ],
+    ids=["unparseable_explicit", "unparseable_infer", "trailing"],
+)
+def test_to_datetime_invalid_raises(
+    constructor: Constructor, data: dict[str, list[str]], format: str | None
 ) -> None:
-    # Unparseable input raises on every backend (each with its own error type)
-    # instead of silently becoming null.
-    df = nw.from_native(constructor({"a": ["abc"]}))
+    df = nw.from_native(constructor(data))
     expr = nw.col("a").str.to_datetime(format)
-    # Broad `Exception`: every backend raises, but each with its own error
-    # type. The pinned contract is only "raises rather than returning null".
-    if isinstance(df, nw.LazyFrame):
-        with pytest.raises(Exception):  # noqa: B017, PT011
-            df.select(expr).lazy().collect()
-    else:
-        with pytest.raises(Exception):  # noqa: B017, PT011
-            df.select(expr)
-
-
-def test_to_datetime_trailing_input_raises(constructor: Constructor) -> None:
-    # Trailing characters after an explicit format raise on all backends
-    # (each with its own error type), rather than parsing the prefix.
-    df = nw.from_native(constructor({"a": ["2020-01-01T12:34:56.789"]}))
-    expr = nw.col("a").str.to_datetime(format="%Y-%m-%dT%H:%M:%S")
-    # Broad `Exception`: every backend raises, but each with its own error
-    # type. The pinned contract is only "raises rather than prefix-parses".
+    # Broad `Exception`: error types differ per backend.
     if isinstance(df, nw.LazyFrame):
         with pytest.raises(Exception):  # noqa: B017, PT011
             df.select(expr).lazy().collect()

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -15,6 +15,7 @@ from tests.utils import (
     assert_equal_data,
     is_pyarrow_windows_no_tzdata,
     is_windows,
+    maybe_collect,
 )
 
 if TYPE_CHECKING:
@@ -348,12 +349,8 @@ def test_to_datetime_invalid_raises(
     df = nw.from_native(constructor(data))
     expr = nw.col("a").str.to_datetime(format)
     # Broad `Exception`: error types differ per backend.
-    if isinstance(df, nw.LazyFrame):
-        with pytest.raises(Exception):  # noqa: B017, PT011
-            df.select(expr).lazy().collect()
-    else:
-        with pytest.raises(Exception):  # noqa: B017, PT011
-            df.select(expr)
+    with pytest.raises(Exception):  # noqa: B017, PT011
+        maybe_collect(df.select(expr))
 
 
 @pytest.mark.skipif(PANDAS_VERSION < (2, 2, 0), reason="too old for pyarrow types")

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -18,6 +18,7 @@ from tests.utils import (
 )
 
 if TYPE_CHECKING:
+    from narwhals.typing import TimeUnit
     from tests.utils import Constructor, ConstructorEager
 
 data = {"a": ["2020-01-01T12:34:56"]}
@@ -271,6 +272,45 @@ def test_to_datetime_all_null_offset_format(constructor: Constructor) -> None:
     result = df.select(nw.col("a").str.to_datetime(format="%Y-%m-%dT%H:%M:%S%z"))
     assert isinstance(result.collect_schema()["a"], nw.Datetime)
     assert_equal_data(result, {"a": [None, None]})
+
+
+@pytest.mark.parametrize(
+    ("format", "time_unit"),
+    [("%Y-%m-%dT%H:%M:%S%.3f", "ms"), ("%Y-%m-%dT%H:%M:%S%.f", "us")],
+)
+def test_to_datetime_fractional_seconds(
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    format: str,
+    time_unit: TimeUnit,
+) -> None:
+    # Fractional-second formats determine the resulting `Datetime` precision,
+    # matching polars. No other backend parses them.
+    if "polars" not in str(constructor):
+        request.applymarker(pytest.mark.xfail(reason="fractional format unsupported"))
+    result = nw.from_native(constructor({"a": ["2020-01-01T12:34:56.123"]})).select(
+        b=nw.col("a").str.to_datetime(format)
+    )
+    assert result.collect_schema()["b"] == nw.Datetime(time_unit)
+    assert_equal_data(result, {"b": [datetime(2020, 1, 1, 12, 34, 56, 123000)]})
+
+
+@pytest.mark.parametrize("format", ["%Y-%m-%dT%H:%M:%S", None])
+def test_to_datetime_unparseable_raises(
+    constructor: Constructor, format: str | None
+) -> None:
+    # Unparseable input raises on every backend (each with its own error type)
+    # instead of silently becoming null.
+    df = nw.from_native(constructor({"a": ["abc"]}))
+    expr = nw.col("a").str.to_datetime(format)
+    # Broad `Exception`: every backend raises, but each with its own error
+    # type. The pinned contract is only "raises rather than returning null".
+    if isinstance(df, nw.LazyFrame):
+        with pytest.raises(Exception):  # noqa: B017, PT011
+            df.select(expr).lazy().collect()
+    else:
+        with pytest.raises(Exception):  # noqa: B017, PT011
+            df.select(expr)
 
 
 def test_to_datetime_trailing_input_raises(constructor: Constructor) -> None:

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -260,15 +260,15 @@ def test_to_datetime_date_only_format(constructor: Constructor) -> None:
     assert_equal_data(result, {"b": [datetime(2020, 1, 1), None]})
 
 
-def test_to_datetime_all_null_offset_format(
-    constructor: Constructor, request: pytest.FixtureRequest
-) -> None:
+def test_to_datetime_all_null_offset_format(constructor: Constructor) -> None:
     # Explicit (offset) format on an all-null column yields all nulls instead
     # of panicking on the missing non-null sample.
     if "ibis" in str(constructor):
         pytest.skip(reason="ibis cannot create all-null column")
-    if "pandas_constructor" in str(constructor) and PANDAS_VERSION < (3,):
-        request.applymarker(pytest.mark.xfail(reason="old pandas parses None"))
+    # Pandas < 3 handles this differently per dtype backend: numpy-backed parses
+    # `None`, while the nullable and pyarrow ones raise on the literal "None".
+    if "pandas" in str(constructor) and PANDAS_VERSION < (3,):
+        pytest.skip(reason="old pandas all-null offset parsing")
     df = nw.from_native(constructor({"a": [None, None]}))
     df = df.with_columns(nw.col("a").cast(nw.String()))
     result = df.select(nw.col("a").str.to_datetime(format="%Y-%m-%dT%H:%M:%S%z"))
@@ -330,7 +330,7 @@ def test_to_datetime_fractional_seconds(
         ({"a": ["abc"]}, None),
         ({"a": ["2020-01-01T12:34:56.789"]}, "%Y-%m-%dT%H:%M:%S"),
     ],
-    ids=["unparseable_explicit", "unparseable_infer", "trailing"],
+    ids=["unparsable_explicit", "unparsable_infer", "trailing"],
 )
 def test_to_datetime_invalid_raises(
     constructor: Constructor,

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -251,8 +251,6 @@ def test_to_datetime_tz_aware(
 def test_to_datetime_date_only_format(constructor: Constructor) -> None:
     # Explicit date-only format parses to midnight. Previously only datetime
     # formats were exercised, so backends that cannot parse dates went unnoticed.
-    from datetime import datetime
-
     result = (
         nw.from_native(constructor({"a": ["2020-01-01", None]}))
         .lazy()

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -262,11 +262,15 @@ def test_to_datetime_date_only_format(constructor: Constructor) -> None:
     assert_equal_data(result, {"b": [datetime(2020, 1, 1), None]})
 
 
-def test_to_datetime_all_null_offset_format(constructor: Constructor) -> None:
+def test_to_datetime_all_null_offset_format(
+    constructor: Constructor, request: pytest.FixtureRequest
+) -> None:
     # Explicit (offset) format on an all-null column yields all nulls instead
     # of panicking on the missing non-null sample.
     if "ibis" in str(constructor):
         pytest.skip(reason="ibis cannot create all-null column")
+    if "pandas_constructor" in str(constructor) and PANDAS_VERSION < (3,):
+        request.applymarker(pytest.mark.xfail(reason="old pandas parses None"))
     df = nw.from_native(constructor({"a": [None, None]}))
     df = df.with_columns(nw.col("a").cast(nw.String()))
     result = df.select(nw.col("a").str.to_datetime(format="%Y-%m-%dT%H:%M:%S%z"))
@@ -285,7 +289,7 @@ def test_to_datetime_all_null_offset_format(constructor: Constructor) -> None:
         ),
         (
             "%Y-%m-%dT%H:%M:%S%.f",
-            "us",
+            None,
             "2020-01-01T12:34:56.123",
             datetime(2020, 1, 1, 12, 34, 56, 123000),
         ),
@@ -301,18 +305,23 @@ def test_to_datetime_fractional_seconds(
     constructor: Constructor,
     request: pytest.FixtureRequest,
     format: str,
-    time_unit: TimeUnit,
+    time_unit: TimeUnit | None,
     value: str,
     expected: datetime,
 ) -> None:
     # Fractional-second formats determine the resulting `Datetime` precision,
-    # matching polars. No other backend parses them.
+    # matching polars. No other backend parses them. `%.f` parses on every
+    # supported polars, but its unit varies by version, so only its values
+    # are pinned.
     if "polars" not in str(constructor):
         request.applymarker(pytest.mark.xfail(reason="fractional format unsupported"))
     result = nw.from_native(constructor({"a": [value]})).select(
         b=nw.col("a").str.to_datetime(format)
     )
-    assert result.collect_schema()["b"] == nw.Datetime(time_unit)
+    if time_unit is None:
+        assert isinstance(result.collect_schema()["b"], nw.Datetime)
+    else:
+        assert result.collect_schema()["b"] == nw.Datetime(time_unit)
     assert_equal_data(result, {"b": [expected]})
 
 

--- a/tests/expr_and_series/str/to_datetime_test.py
+++ b/tests/expr_and_series/str/to_datetime_test.py
@@ -278,11 +278,13 @@ def test_to_datetime_trailing_input_raises(constructor: Constructor) -> None:
     # (each with its own error type), rather than parsing the prefix.
     df = nw.from_native(constructor({"a": ["2020-01-01T12:34:56.789"]}))
     expr = nw.col("a").str.to_datetime(format="%Y-%m-%dT%H:%M:%S")
+    # Broad `Exception`: every backend raises, but each with its own error
+    # type. The pinned contract is only "raises rather than prefix-parses".
     if isinstance(df, nw.LazyFrame):
-        with pytest.raises(Exception):  # noqa: BLE001, PT011
+        with pytest.raises(Exception):  # noqa: B017, PT011
             df.select(expr).lazy().collect()
     else:
-        with pytest.raises(Exception):  # noqa: BLE001, PT011
+        with pytest.raises(Exception):  # noqa: B017, PT011
             df.select(expr)
 
 


### PR DESCRIPTION
# Description

Explicit `"%Y-%m-%d"` parses to midnight (with a `Datetime` schema assertion); an explicit offset format on an all-null column yields all nulls (values only, since time units and time zones differ by backend; ibis is skipped because it cannot construct an all-null column); trailing input with an explicit format raises on all backends, asserted with a generic `Exception` plus a `B017, PT011` noqa and justification comment (each backend has its own error type, so the pinned contract is only "raises rather than prefix-parses").

Now covered: fractional-second formats pin polars dtypes (millis and micros variants) with `xfail` for every other backend, and unparseable input (explicit or inferred format) is pinned to raising via generic `Exception`. Strict cross-backend error-type and time-unit assertions remain open.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

None. Test-only follow-up from narwhals-daft differential testing.

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes (N/A, test-only, no behavior change)
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```

Note: the full-suite command above was not run. Targeted run on the CI constructor set instead: `pytest tests/expr_and_series/str/to_datetime_test.py --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe` gives 97 passed, 8 xfailed. Also green with `--constructors=ibis` and `--constructors=dask`.
