### PR TITLE
test: cover to_time custom formats, schema and invalid raises

### DIFF
--- a/tests/expr_and_series/str/to_time_test.py
+++ b/tests/expr_and_series/str/to_time_test.py
@@ -137,8 +137,7 @@ def test_to_time_custom_format(
     format: str,
     expected: str,
 ) -> None:
-    # `format` must be honoured (previously ignored on some paths) and the
-    # lazy schema must already report `Time`.
+    # The plugin ignored `format` entirely; the schema assertion guards that.
     requires_time_support(request, constructor)
     result = (
         nw.from_native(constructor(data)).lazy().select(b=nw.col("a").str.to_time(format))
@@ -161,7 +160,6 @@ def test_to_time_series_custom_format(
     format: str,
     expected: time,
 ) -> None:
-    # Series variant: `format` is honoured elementwise, nulls preserved.
     requires_time_support(request, constructor_eager)
     result = nw.from_native(constructor_eager(data), eager_only=True)["a"].str.to_time(
         format
@@ -176,9 +174,6 @@ def test_to_time_series_custom_format(
 def test_to_time_invalid_raises(
     constructor: Constructor, data: dict[str, list[str]], format: str | None
 ) -> None:
-    # Unparseable input raises (each backend with its own error type) instead
-    # of silently becoming null. Backends without `Time` support also raise,
-    # so no xfail is needed here (any exception counts).
     if constructor.__name__.startswith(("pandas", "modin")):
         if PANDAS_VERSION < (2, 2, 0):
             pytest.skip("pandas < 2.2.0 has no Time dtype")
@@ -186,8 +181,7 @@ def test_to_time_invalid_raises(
             pytest.skip("pandas requires pyarrow for the Time dtype")
     df = nw.from_native(constructor(data))
     expr = nw.col("a").str.to_time(format)
-    # Broad `Exception`: every backend raises, but each with its own error
-    # type. The pinned contract is only "raises rather than returning null".
+    # Broad `Exception`: error types differ per backend.
     if isinstance(df, nw.LazyFrame):
         with pytest.raises(Exception):  # noqa: B017, PT011
             df.select(expr).lazy().collect()

--- a/tests/expr_and_series/str/to_time_test.py
+++ b/tests/expr_and_series/str/to_time_test.py
@@ -12,6 +12,7 @@ from tests.utils import (
     PYARROW_VERSION,
     assert_equal_data,
     is_windows,
+    maybe_collect,
 )
 
 if TYPE_CHECKING:
@@ -202,9 +203,5 @@ def test_to_time_invalid_raises(
     df = nw.from_native(constructor(data))
     expr = nw.col("a").str.to_time(format)
     # Broad `Exception`: error types differ per backend.
-    if isinstance(df, nw.LazyFrame):
-        with pytest.raises(Exception):  # noqa: B017, PT011
-            df.select(expr).lazy().collect()
-    else:
-        with pytest.raises(Exception):  # noqa: B017, PT011
-            df.select(expr)
+    with pytest.raises(Exception):  # noqa: B017, PT011
+        maybe_collect(df.select(expr))

--- a/tests/expr_and_series/str/to_time_test.py
+++ b/tests/expr_and_series/str/to_time_test.py
@@ -6,7 +6,13 @@ from typing import TYPE_CHECKING
 import pytest
 
 import narwhals as nw
-from tests.utils import PANDAS_VERSION, POLARS_VERSION, PYARROW_VERSION, assert_equal_data
+from tests.utils import (
+    PANDAS_VERSION,
+    POLARS_VERSION,
+    PYARROW_VERSION,
+    assert_equal_data,
+    is_windows,
+)
 
 if TYPE_CHECKING:
     from tests.utils import Constructor, ConstructorEager
@@ -126,8 +132,8 @@ def test_to_time_series_infer_fmt(
 @pytest.mark.parametrize(
     ("data", "format", "expected"),
     [
-        ({"a": ["12-34"]}, "%H-%M", "12:34:00"),
-        ({"a": ["01:30 PM"]}, "%I:%M %p", "13:30:00"),
+        pytest.param({"a": ["12-34"]}, "%H-%M", "12:34:00", id="dash"),
+        pytest.param({"a": ["01:30 PM"]}, "%I:%M %p", "13:30:00", id="ampm"),
     ],
 )
 def test_to_time_custom_format(
@@ -139,6 +145,13 @@ def test_to_time_custom_format(
 ) -> None:
     # The plugin ignored `format` entirely; the schema assertion guards that.
     requires_time_support(request, constructor)
+    if (
+        "ampm" in request.node.callspec.id
+        and is_windows()
+        and "pyarrow_table" in str(constructor)
+    ):
+        # pyarrow 25 on Windows cannot parse `%p`.
+        request.applymarker(pytest.mark.xfail(reason="pyarrow %p on Windows"))
     result = (
         nw.from_native(constructor(data)).lazy().select(b=nw.col("a").str.to_time(format))
     )
@@ -149,8 +162,8 @@ def test_to_time_custom_format(
 @pytest.mark.parametrize(
     ("data", "format", "expected"),
     [
-        ({"a": ["12-34", None]}, "%H-%M", time(12, 34)),
-        ({"a": ["01:30 PM", None]}, "%I:%M %p", time(13, 30)),
+        pytest.param({"a": ["12-34", None]}, "%H-%M", time(12, 34), id="dash"),
+        pytest.param({"a": ["01:30 PM", None]}, "%I:%M %p", time(13, 30), id="ampm"),
     ],
 )
 def test_to_time_series_custom_format(
@@ -161,6 +174,13 @@ def test_to_time_series_custom_format(
     expected: time,
 ) -> None:
     requires_time_support(request, constructor_eager)
+    if (
+        "ampm" in request.node.callspec.id
+        and is_windows()
+        and "pyarrow_table" in str(constructor_eager)
+    ):
+        # pyarrow 25 on Windows cannot parse `%p`.
+        request.applymarker(pytest.mark.xfail(reason="pyarrow %p on Windows"))
     result = nw.from_native(constructor_eager(data), eager_only=True)["a"].str.to_time(
         format
     )

--- a/tests/expr_and_series/str/to_time_test.py
+++ b/tests/expr_and_series/str/to_time_test.py
@@ -147,11 +147,9 @@ def test_to_time_custom_format(
 
 
 @pytest.mark.parametrize(
-    ("data", "format"),
-    [({"a": ["12:34"]}, "%H:%M:%S"), ({"a": ["25:00:00"]}, None)],
+    ("data", "format"), [({"a": ["12:34"]}, "%H:%M:%S"), ({"a": ["25:00:00"]}, None)]
 )
 def test_to_time_invalid_raises(
-    request: pytest.FixtureRequest,
     constructor: Constructor,
     data: dict[str, list[str]],
     format: str | None,
@@ -166,9 +164,11 @@ def test_to_time_invalid_raises(
             pytest.skip("pandas requires pyarrow for the Time dtype")
     df = nw.from_native(constructor(data))
     expr = nw.col("a").str.to_time(format)
+    # Broad `Exception`: every backend raises, but each with its own error
+    # type. The pinned contract is only "raises rather than returning null".
     if isinstance(df, nw.LazyFrame):
-        with pytest.raises(Exception):  # noqa: BLE001, PT011
+        with pytest.raises(Exception):  # noqa: B017, PT011
             df.select(expr).lazy().collect()
     else:
-        with pytest.raises(Exception):  # noqa: BLE001, PT011
+        with pytest.raises(Exception):  # noqa: B017, PT011
             df.select(expr)

--- a/tests/expr_and_series/str/to_time_test.py
+++ b/tests/expr_and_series/str/to_time_test.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from datetime import time
 from typing import TYPE_CHECKING
 
 import pytest
 
 import narwhals as nw
-from tests.utils import PANDAS_VERSION, POLARS_VERSION, PYARROW_VERSION
+from tests.utils import PANDAS_VERSION, POLARS_VERSION, PYARROW_VERSION, assert_equal_data
 
 if TYPE_CHECKING:
     from tests.utils import Constructor, ConstructorEager
@@ -147,12 +148,33 @@ def test_to_time_custom_format(
 
 
 @pytest.mark.parametrize(
+    ("data", "format", "expected"),
+    [
+        ({"a": ["12-34", None]}, "%H-%M", time(12, 34)),
+        ({"a": ["01:30 PM", None]}, "%I:%M %p", time(13, 30)),
+    ],
+)
+def test_to_time_series_custom_format(
+    request: pytest.FixtureRequest,
+    constructor_eager: ConstructorEager,
+    data: dict[str, list[str]],
+    format: str,
+    expected: time,
+) -> None:
+    # Series variant: `format` is honoured elementwise, nulls preserved.
+    requires_time_support(request, constructor_eager)
+    result = nw.from_native(constructor_eager(data), eager_only=True)["a"].str.to_time(
+        format
+    )
+    assert isinstance(result.dtype, nw.Time)
+    assert_equal_data({"a": result}, {"a": [expected, None]})
+
+
+@pytest.mark.parametrize(
     ("data", "format"), [({"a": ["12:34"]}, "%H:%M:%S"), ({"a": ["25:00:00"]}, None)]
 )
 def test_to_time_invalid_raises(
-    constructor: Constructor,
-    data: dict[str, list[str]],
-    format: str | None,
+    constructor: Constructor, data: dict[str, list[str]], format: str | None
 ) -> None:
     # Unparseable input raises (each backend with its own error type) instead
     # of silently becoming null. Backends without `Time` support also raise,

--- a/tests/expr_and_series/str/to_time_test.py
+++ b/tests/expr_and_series/str/to_time_test.py
@@ -120,3 +120,55 @@ def test_to_time_series_infer_fmt(
     result = nw.from_native(constructor_eager(data), eager_only=True)["a"].str.to_time()
     assert str(result.item(0)) == expected
     assert isinstance(result.dtype, nw.Time)
+
+
+@pytest.mark.parametrize(
+    ("data", "format", "expected"),
+    [
+        ({"a": ["12-34"]}, "%H-%M", "12:34:00"),
+        ({"a": ["01:30 PM"]}, "%I:%M %p", "13:30:00"),
+    ],
+)
+def test_to_time_custom_format(
+    request: pytest.FixtureRequest,
+    constructor: Constructor,
+    data: dict[str, list[str]],
+    format: str,
+    expected: str,
+) -> None:
+    # `format` must be honoured (previously ignored on some paths) and the
+    # lazy schema must already report `Time`.
+    requires_time_support(request, constructor)
+    result = (
+        nw.from_native(constructor(data)).lazy().select(b=nw.col("a").str.to_time(format))
+    )
+    assert isinstance(result.collect_schema()["b"], nw.Time)
+    assert str(result.collect().item(row=0, column="b")) == expected
+
+
+@pytest.mark.parametrize(
+    ("data", "format"),
+    [({"a": ["12:34"]}, "%H:%M:%S"), ({"a": ["25:00:00"]}, None)],
+)
+def test_to_time_invalid_raises(
+    request: pytest.FixtureRequest,
+    constructor: Constructor,
+    data: dict[str, list[str]],
+    format: str | None,
+) -> None:
+    # Unparseable input raises (each backend with its own error type) instead
+    # of silently becoming null. Backends without `Time` support also raise,
+    # so no xfail is needed here (any exception counts).
+    if constructor.__name__.startswith(("pandas", "modin")):
+        if PANDAS_VERSION < (2, 2, 0):
+            pytest.skip("pandas < 2.2.0 has no Time dtype")
+        if PYARROW_VERSION == (0, 0, 0):
+            pytest.skip("pandas requires pyarrow for the Time dtype")
+    df = nw.from_native(constructor(data))
+    expr = nw.col("a").str.to_time(format)
+    if isinstance(df, nw.LazyFrame):
+        with pytest.raises(Exception):  # noqa: BLE001, PT011
+            df.select(expr).lazy().collect()
+    else:
+        with pytest.raises(Exception):  # noqa: BLE001, PT011
+            df.select(expr)


### PR DESCRIPTION
# Description

Non-default formats (`"12-34"` with `"%H-%M"`, `"01:30 PM"` with `"%I:%M %p"`), including a lazy `collect_schema() == Time` assertion (the plugin had no `Time` mapping, which the old tests never caught), plus unparseable inputs raising a generic `Exception` (backends without `Time` support also raise, so no xfail is needed there).

Follow-up adds the series variants of the custom-format cases with nulls preserved.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

None. Test-only follow-up from narwhals-daft differential testing.

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes (N/A, test-only, no behavior change)
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe"
    ```

Note: the full-suite command above was not run. Targeted run on the CI constructor set instead: `pytest tests/expr_and_series/str/to_time_test.py --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe` gives 66 passed, 5 xfailed. Also green with `--constructors=ibis` and `--constructors=dask`.
