### PR TITLE
test: cover list.contains numeric coercion and all-null inner

### DIFF
--- a/tests/expr_and_series/list/contains_test.py
+++ b/tests/expr_and_series/list/contains_test.py
@@ -7,7 +7,7 @@ import pytest
 
 import narwhals as nw
 from narwhals.exceptions import InvalidOperationError
-from tests.utils import assert_equal_data
+from tests.utils import POLARS_VERSION, assert_equal_data
 
 if TYPE_CHECKING:
     from tests.utils import Constructor, ConstructorEager
@@ -96,7 +96,9 @@ def test_contains_numeric_coercion_expr(
 def test_contains_none_item_expr(
     request: pytest.FixtureRequest, constructor: Constructor
 ) -> None:
-    # SQL backends return null for every row instead.
+    # SQL backends return null for every row instead. Old polars does too.
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 24, 0):
+        request.applymarker(pytest.mark.xfail(reason="old polars null item"))
     if any(
         backend in str(constructor)
         for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
@@ -132,6 +134,13 @@ def test_contains_invalid_item_raises(
     item: bool | str | datetime,
 ) -> None:
     # Mismatched items raise, matching polars; SQL backends coerce instead.
+    # Old polars coerces precision-mismatched datetimes instead of raising.
+    if (
+        "datetime_precision" in request.node.callspec.id
+        and "polars" in str(constructor)
+        and POLARS_VERSION < (1, 28, 0)
+    ):
+        request.applymarker(pytest.mark.xfail(reason="old polars precision"))
     if any(
         backend in str(constructor)
         for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")

--- a/tests/expr_and_series/list/contains_test.py
+++ b/tests/expr_and_series/list/contains_test.py
@@ -41,39 +41,39 @@ def test_contains_series(
     assert_equal_data({"a": result}, expected)
 
 
-coercion_cases = [
-    pytest.param(
-        {"a": [[2, 2, 3, None, None], None, [], [None], [1], [0, -1]]},
-        nw.Int64(),
-        2.0,
-        [True, None, False, False, False, False],
-        id="float_matches_int",
-    ),
-    pytest.param(
-        {"a": [[2, 2, 3, None, None], None, [], [None], [1], [0, -1]]},
-        nw.Int64(),
-        1.5,
-        [False, None, False, False, False, False],
-        id="non_integer",
-    ),
-    pytest.param(
-        {"a": [[2, 2, 3, None, None], None, [], [None], [1], [0, -1]]},
-        nw.Int8(),
-        300,
-        [False, None, False, False, False, False],
-        id="overflow",
-    ),
-    pytest.param(
-        {"a": [[1.0, 2.0], [3.0], None, []]},
-        nw.Float64(),
-        1,
-        [True, False, None, False],
-        id="int_matches_float",
-    ),
-]
-
-
-@pytest.mark.parametrize(("data", "inner", "item", "expected"), coercion_cases)
+@pytest.mark.parametrize(
+    ("data", "inner", "item", "expected"),
+    [
+        pytest.param(
+            {"a": [[2, 2, 3, None, None], None, [], [None], [1], [0, -1]]},
+            nw.Int64(),
+            2.0,
+            [True, None, False, False, False, False],
+            id="float_matches_int",
+        ),
+        pytest.param(
+            {"a": [[2, 2, 3, None, None], None, [], [None], [1], [0, -1]]},
+            nw.Int64(),
+            1.5,
+            [False, None, False, False, False, False],
+            id="non_integer",
+        ),
+        pytest.param(
+            {"a": [[2, 2, 3, None, None], None, [], [None], [1], [0, -1]]},
+            nw.Int8(),
+            300,
+            [False, None, False, False, False, False],
+            id="overflow",
+        ),
+        pytest.param(
+            {"a": [[1.0, 2.0], [3.0], None, []]},
+            nw.Float64(),
+            1,
+            [True, False, None, False],
+            id="int_matches_float",
+        ),
+    ],
+)
 def test_contains_numeric_coercion_expr(
     request: pytest.FixtureRequest,
     constructor: Constructor,
@@ -112,19 +112,19 @@ def test_contains_none_item_expr(
     assert_equal_data(result, {"a": [True, False, None, False]})
 
 
-invalid_item_cases = [
-    pytest.param({"a": [[2, 3], [1], None]}, nw.Int64(), True, id="bool_item"),
-    pytest.param({"a": [[2, 3], [1], None]}, nw.Int64(), "2", id="str_item"),
-    pytest.param(
-        {"a": [[datetime(2020, 1, 1, 1, 2, 3)], [], None]},
-        nw.Datetime("ns"),
-        datetime(2020, 1, 1, 1, 2, 3),
-        id="datetime_precision",
-    ),
-]
-
-
-@pytest.mark.parametrize(("data", "inner", "item"), invalid_item_cases)
+@pytest.mark.parametrize(
+    ("data", "inner", "item"),
+    [
+        pytest.param({"a": [[2, 3], [1], None]}, nw.Int64(), True, id="bool_item"),
+        pytest.param({"a": [[2, 3], [1], None]}, nw.Int64(), "2", id="str_item"),
+        pytest.param(
+            {"a": [[datetime(2020, 1, 1, 1, 2, 3)], [], None]},
+            nw.Datetime("ns"),
+            datetime(2020, 1, 1, 1, 2, 3),
+            id="datetime_precision",
+        ),
+    ],
+)
 def test_contains_invalid_item_raises(
     request: pytest.FixtureRequest,
     constructor: Constructor,

--- a/tests/expr_and_series/list/contains_test.py
+++ b/tests/expr_and_series/list/contains_test.py
@@ -10,6 +10,7 @@ from narwhals.exceptions import InvalidOperationError
 from tests.utils import POLARS_VERSION, assert_equal_data
 
 if TYPE_CHECKING:
+    from narwhals.typing import IntoDType
     from tests.utils import Constructor, ConstructorEager
 
 data = {"a": [[2, 2, 3, None, None], None, []]}
@@ -78,7 +79,7 @@ def test_contains_numeric_coercion_expr(
     request: pytest.FixtureRequest,
     constructor: Constructor,
     data: dict[str, list[list[int | float | None] | None]],
-    inner: nw.DType,
+    inner: IntoDType,
     item: float,
     expected: list[bool | None],
 ) -> None:
@@ -123,7 +124,7 @@ def test_contains_invalid_item_raises(
     request: pytest.FixtureRequest,
     constructor: Constructor,
     data: dict[str, list[list[int | str | datetime] | None]],
-    inner: nw.DType,
+    inner: IntoDType,
     *,
     item: bool | str | datetime,
 ) -> None:

--- a/tests/expr_and_series/list/contains_test.py
+++ b/tests/expr_and_series/list/contains_test.py
@@ -83,6 +83,14 @@ def test_contains_numeric_coercion_expr(
     item: float,
     expected: list[bool | None],
 ) -> None:
+    # Polars 2.0 requires an explicit cast rather than lossily coercing to `Float64`.
+    # `overflow` compares two integer types, so it still resolves.
+    if (
+        "polars" in str(constructor)
+        and POLARS_VERSION >= (2,)
+        and "overflow" not in request.node.callspec.id
+    ):
+        request.applymarker(pytest.mark.xfail(reason="polars 2.0 needs a cast"))
     if any(backend in str(constructor) for backend in UNSUPPORTED_BACKENDS):
         request.applymarker(pytest.mark.xfail(reason="`list.contains` unsupported"))
     result = nw.from_native(constructor(data)).select(

--- a/tests/expr_and_series/list/contains_test.py
+++ b/tests/expr_and_series/list/contains_test.py
@@ -51,19 +51,19 @@ def test_contains_numeric_coercion_expr(
     ):
         request.applymarker(pytest.mark.xfail)
     data_num = {"a": [[2, 2, 3, None, None], None, [], [None], [1], [0, -1]]}
-    cases: list[tuple[nw.DType, object, list[bool | None]]] = [
+    cases: list[tuple[nw.DType, int | float, list[bool | None]]] = [
         (nw.Int64(), 2.0, [True, None, False, False, False, False]),
         (nw.Int64(), 1.5, [False, None, False, False, False, False]),
         (nw.Int8(), 300, [False, None, False, False, False, False]),
     ]
     for inner, item, expected_num in cases:
         result = nw.from_native(constructor(data_num)).select(
-            nw.col("a").cast(nw.List(inner)).list.contains(item)  # type: ignore[arg-type]
+            nw.col("a").cast(nw.List(inner)).list.contains(item)
         )
         assert_equal_data(result, {"a": expected_num})
-    result = nw.from_native(
-        constructor({"a": [[1.0, 2.0], [3.0], None, []]})
-    ).select(nw.col("a").cast(nw.List(nw.Float64())).list.contains(1))
+    result = nw.from_native(constructor({"a": [[1.0, 2.0], [3.0], None, []]})).select(
+        nw.col("a").cast(nw.List(nw.Float64())).list.contains(1)
+    )
     assert_equal_data(result, {"a": [True, False, None, False]})
 
 

--- a/tests/expr_and_series/list/contains_test.py
+++ b/tests/expr_and_series/list/contains_test.py
@@ -37,3 +37,48 @@ def test_contains_series(
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df["a"].cast(nw.List(nw.Int32())).list.contains(2)
     assert_equal_data({"a": result}, expected)
+
+
+def test_contains_numeric_coercion_expr(
+    request: pytest.FixtureRequest, constructor: Constructor
+) -> None:
+    # Different numeric widths/families coerce without matching spuriously:
+    # `2.0` matches ints, `1.5` does not, `300` overflows `Int8`, and `1`
+    # matches a `Float64` list.
+    if any(
+        backend in str(constructor)
+        for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
+    ):
+        request.applymarker(pytest.mark.xfail)
+    data_num = {"a": [[2, 2, 3, None, None], None, [], [None], [1], [0, -1]]}
+    cases: list[tuple[nw.DType, object, list[bool | None]]] = [
+        (nw.Int64(), 2.0, [True, None, False, False, False, False]),
+        (nw.Int64(), 1.5, [False, None, False, False, False, False]),
+        (nw.Int8(), 300, [False, None, False, False, False, False]),
+    ]
+    for inner, item, expected_num in cases:
+        result = nw.from_native(constructor(data_num)).select(
+            nw.col("a").cast(nw.List(inner)).list.contains(item)  # type: ignore[arg-type]
+        )
+        assert_equal_data(result, {"a": expected_num})
+    result = nw.from_native(
+        constructor({"a": [[1.0, 2.0], [3.0], None, []]})
+    ).select(nw.col("a").cast(nw.List(nw.Float64())).list.contains(1))
+    assert_equal_data(result, {"a": [True, False, None, False]})
+
+
+def test_contains_all_null_inner_expr(
+    request: pytest.FixtureRequest, constructor: Constructor
+) -> None:
+    # A list of only nulls contains nothing.
+    if "ibis" in str(constructor):
+        pytest.skip(reason="ibis cannot create all-null column")
+    if any(
+        backend in str(constructor)
+        for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
+    ):
+        request.applymarker(pytest.mark.xfail)
+    result = nw.from_native(constructor({"a": [[None, None]]})).select(
+        nw.col("a").cast(nw.List(nw.Int64())).list.contains(1)
+    )
+    assert_equal_data(result, {"a": [False]})

--- a/tests/expr_and_series/list/contains_test.py
+++ b/tests/expr_and_series/list/contains_test.py
@@ -15,12 +15,15 @@ if TYPE_CHECKING:
 data = {"a": [[2, 2, 3, None, None], None, []]}
 expected = {"a": [True, None, False]}
 
+UNSUPPORTED_EAGER_BACKENDS = ("cudf", "modin", "pandas", "pyarrow")
+"""Eager backends where `list.contains` is not implemented."""
+
+UNSUPPORTED_BACKENDS = ("dask", *UNSUPPORTED_EAGER_BACKENDS)
+"""Backends where `list.contains` is not implemented."""
+
 
 def test_contains_expr(request: pytest.FixtureRequest, constructor: Constructor) -> None:
-    if any(
-        backend in str(constructor)
-        for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
-    ):
+    if any(backend in str(constructor) for backend in UNSUPPORTED_BACKENDS):
         request.applymarker(pytest.mark.xfail)
     result = nw.from_native(constructor(data)).select(
         nw.col("a").cast(nw.List(nw.Int32())).list.contains(2)
@@ -31,10 +34,7 @@ def test_contains_expr(request: pytest.FixtureRequest, constructor: Constructor)
 def test_contains_series(
     request: pytest.FixtureRequest, constructor_eager: ConstructorEager
 ) -> None:
-    if any(
-        backend in str(constructor_eager)
-        for backend in ("modin", "cudf", "pyarrow", "pandas")
-    ):
+    if any(backend in str(constructor_eager) for backend in UNSUPPORTED_EAGER_BACKENDS):
         request.applymarker(pytest.mark.xfail)
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df["a"].cast(nw.List(nw.Int32())).list.contains(2)
@@ -82,11 +82,8 @@ def test_contains_numeric_coercion_expr(
     item: float,
     expected: list[bool | None],
 ) -> None:
-    if any(
-        backend in str(constructor)
-        for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
-    ):
-        request.applymarker(pytest.mark.xfail)
+    if any(backend in str(constructor) for backend in UNSUPPORTED_BACKENDS):
+        request.applymarker(pytest.mark.xfail(reason="`list.contains` unsupported"))
     result = nw.from_native(constructor(data)).select(
         nw.col("a").cast(nw.List(inner)).list.contains(item)
     )
@@ -99,11 +96,8 @@ def test_contains_none_item_expr(
     # SQL backends return null for every row instead. Old polars does too.
     if "polars" in str(constructor) and POLARS_VERSION < (1, 24, 0):
         request.applymarker(pytest.mark.xfail(reason="old polars null item"))
-    if any(
-        backend in str(constructor)
-        for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
-    ):
-        request.applymarker(pytest.mark.xfail)
+    if any(backend in str(constructor) for backend in UNSUPPORTED_BACKENDS):
+        request.applymarker(pytest.mark.xfail(reason="`list.contains` unsupported"))
     if any(x in str(constructor) for x in ("duckdb", "sqlframe", "ibis", "pyspark")):
         request.applymarker(pytest.mark.xfail(reason="null item returns null"))
     result = nw.from_native(constructor({"a": [[2, None], [1], None, []]})).select(
@@ -141,11 +135,8 @@ def test_contains_invalid_item_raises(
         and POLARS_VERSION < (1, 28, 0)
     ):
         request.applymarker(pytest.mark.xfail(reason="old polars precision"))
-    if any(
-        backend in str(constructor)
-        for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
-    ):
-        request.applymarker(pytest.mark.xfail)
+    if any(backend in str(constructor) for backend in UNSUPPORTED_BACKENDS):
+        request.applymarker(pytest.mark.xfail(reason="`list.contains` unsupported"))
     if any(x in str(constructor) for x in ("duckdb", "sqlframe", "ibis", "pyspark")):
         request.applymarker(pytest.mark.xfail(reason="mismatched item coerced"))
     df = nw.from_native(constructor(data))
@@ -163,11 +154,8 @@ def test_contains_all_null_inner_expr(
 ) -> None:
     if "ibis" in str(constructor):
         pytest.skip(reason="ibis cannot create all-null column")
-    if any(
-        backend in str(constructor)
-        for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
-    ):
-        request.applymarker(pytest.mark.xfail)
+    if any(backend in str(constructor) for backend in UNSUPPORTED_BACKENDS):
+        request.applymarker(pytest.mark.xfail(reason="`list.contains` unsupported"))
     result = nw.from_native(constructor({"a": [[None, None]]})).select(
         nw.col("a").cast(nw.List(nw.Int64())).list.contains(1)
     )

--- a/tests/expr_and_series/list/contains_test.py
+++ b/tests/expr_and_series/list/contains_test.py
@@ -41,39 +41,62 @@ def test_contains_series(
     assert_equal_data({"a": result}, expected)
 
 
+coercion_cases = [
+    pytest.param(
+        {"a": [[2, 2, 3, None, None], None, [], [None], [1], [0, -1]]},
+        nw.Int64(),
+        2.0,
+        [True, None, False, False, False, False],
+        id="float_matches_int",
+    ),
+    pytest.param(
+        {"a": [[2, 2, 3, None, None], None, [], [None], [1], [0, -1]]},
+        nw.Int64(),
+        1.5,
+        [False, None, False, False, False, False],
+        id="non_integer",
+    ),
+    pytest.param(
+        {"a": [[2, 2, 3, None, None], None, [], [None], [1], [0, -1]]},
+        nw.Int8(),
+        300,
+        [False, None, False, False, False, False],
+        id="overflow",
+    ),
+    pytest.param(
+        {"a": [[1.0, 2.0], [3.0], None, []]},
+        nw.Float64(),
+        1,
+        [True, False, None, False],
+        id="int_matches_float",
+    ),
+]
+
+
+@pytest.mark.parametrize(("data", "inner", "item", "expected"), coercion_cases)
 def test_contains_numeric_coercion_expr(
-    request: pytest.FixtureRequest, constructor: Constructor
+    request: pytest.FixtureRequest,
+    constructor: Constructor,
+    data: dict[str, list[list[int | float | None] | None]],
+    inner: nw.DType,
+    item: float,
+    expected: list[bool | None],
 ) -> None:
-    # Different numeric widths/families coerce without matching spuriously:
-    # `2.0` matches ints, `1.5` does not, `300` overflows `Int8`, and `1`
-    # matches a `Float64` list.
     if any(
         backend in str(constructor)
         for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
     ):
         request.applymarker(pytest.mark.xfail)
-    data_num = {"a": [[2, 2, 3, None, None], None, [], [None], [1], [0, -1]]}
-    cases: list[tuple[nw.DType, int | float, list[bool | None]]] = [
-        (nw.Int64(), 2.0, [True, None, False, False, False, False]),
-        (nw.Int64(), 1.5, [False, None, False, False, False, False]),
-        (nw.Int8(), 300, [False, None, False, False, False, False]),
-    ]
-    for inner, item, expected_num in cases:
-        result = nw.from_native(constructor(data_num)).select(
-            nw.col("a").cast(nw.List(inner)).list.contains(item)
-        )
-        assert_equal_data(result, {"a": expected_num})
-    result = nw.from_native(constructor({"a": [[1.0, 2.0], [3.0], None, []]})).select(
-        nw.col("a").cast(nw.List(nw.Float64())).list.contains(1)
+    result = nw.from_native(constructor(data)).select(
+        nw.col("a").cast(nw.List(inner)).list.contains(item)
     )
-    assert_equal_data(result, {"a": [True, False, None, False]})
+    assert_equal_data(result, {"a": expected})
 
 
 def test_contains_none_item_expr(
     request: pytest.FixtureRequest, constructor: Constructor
 ) -> None:
-    # `None` matches lists holding null, misses other lists, and preserves a
-    # null list, matching polars. SQL backends return null for every row.
+    # SQL backends return null for every row instead.
     if any(
         backend in str(constructor)
         for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
@@ -87,12 +110,28 @@ def test_contains_none_item_expr(
     assert_equal_data(result, {"a": [True, False, None, False]})
 
 
-@pytest.mark.parametrize("item", [True, "2"])
-def test_contains_mismatched_type_raises(
-    request: pytest.FixtureRequest, constructor: Constructor, *, item: bool | str
+invalid_item_cases = [
+    pytest.param({"a": [[2, 3], [1], None]}, nw.Int64(), True, id="bool_item"),
+    pytest.param({"a": [[2, 3], [1], None]}, nw.Int64(), "2", id="str_item"),
+    pytest.param(
+        {"a": [[datetime(2020, 1, 1, 1, 2, 3)], [], None]},
+        nw.Datetime("ns"),
+        datetime(2020, 1, 1, 1, 2, 3),
+        id="datetime_precision",
+    ),
+]
+
+
+@pytest.mark.parametrize(("data", "inner", "item"), invalid_item_cases)
+def test_contains_invalid_item_raises(
+    request: pytest.FixtureRequest,
+    constructor: Constructor,
+    data: dict[str, list[list[int | str | datetime] | None]],
+    inner: nw.DType,
+    *,
+    item: bool | str | datetime,
 ) -> None:
-    # A bool or str item on an int list raises, matching polars. SQL backends
-    # coerce and return a boolean instead.
+    # Mismatched items raise, matching polars; SQL backends coerce instead.
     if any(
         backend in str(constructor)
         for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
@@ -100,34 +139,8 @@ def test_contains_mismatched_type_raises(
         request.applymarker(pytest.mark.xfail)
     if any(x in str(constructor) for x in ("duckdb", "sqlframe", "ibis", "pyspark")):
         request.applymarker(pytest.mark.xfail(reason="mismatched item coerced"))
-    df = nw.from_native(constructor({"a": [[2, 3], [1], None]}))
-    expr = nw.col("a").cast(nw.List(nw.Int64())).list.contains(item)
-    if isinstance(df, nw.LazyFrame):
-        with pytest.raises(InvalidOperationError):
-            df.select(expr).lazy().collect()
-    else:
-        with pytest.raises(InvalidOperationError):
-            df.select(expr)
-
-
-def test_contains_datetime_precision_mismatch_raises(
-    request: pytest.FixtureRequest, constructor: Constructor
-) -> None:
-    # A `Datetime` item of a different precision than the list raises,
-    # matching polars. SQL backends coerce and return a boolean instead.
-    if any(
-        backend in str(constructor)
-        for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
-    ):
-        request.applymarker(pytest.mark.xfail)
-    if any(x in str(constructor) for x in ("duckdb", "sqlframe", "ibis", "pyspark")):
-        request.applymarker(pytest.mark.xfail(reason="precision coerced"))
-    df = nw.from_native(constructor({"a": [[datetime(2020, 1, 1, 1, 2, 3)], [], None]}))
-    expr = (
-        nw.col("a")
-        .cast(nw.List(nw.Datetime("ns")))
-        .list.contains(datetime(2020, 1, 1, 1, 2, 3))
-    )
+    df = nw.from_native(constructor(data))
+    expr = nw.col("a").cast(nw.List(inner)).list.contains(item)
     if isinstance(df, nw.LazyFrame):
         with pytest.raises(InvalidOperationError):
             df.select(expr).lazy().collect()
@@ -139,7 +152,6 @@ def test_contains_datetime_precision_mismatch_raises(
 def test_contains_all_null_inner_expr(
     request: pytest.FixtureRequest, constructor: Constructor
 ) -> None:
-    # A list of only nulls contains nothing.
     if "ibis" in str(constructor):
         pytest.skip(reason="ibis cannot create all-null column")
     if any(

--- a/tests/expr_and_series/list/contains_test.py
+++ b/tests/expr_and_series/list/contains_test.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 import pytest
 
 import narwhals as nw
+from narwhals.exceptions import InvalidOperationError
 from tests.utils import assert_equal_data
 
 if TYPE_CHECKING:
@@ -65,6 +67,73 @@ def test_contains_numeric_coercion_expr(
         nw.col("a").cast(nw.List(nw.Float64())).list.contains(1)
     )
     assert_equal_data(result, {"a": [True, False, None, False]})
+
+
+def test_contains_none_item_expr(
+    request: pytest.FixtureRequest, constructor: Constructor
+) -> None:
+    # `None` matches lists holding null, misses other lists, and preserves a
+    # null list, matching polars. SQL backends return null for every row.
+    if any(
+        backend in str(constructor)
+        for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
+    ):
+        request.applymarker(pytest.mark.xfail)
+    if any(x in str(constructor) for x in ("duckdb", "sqlframe", "ibis", "pyspark")):
+        request.applymarker(pytest.mark.xfail(reason="null item returns null"))
+    result = nw.from_native(constructor({"a": [[2, None], [1], None, []]})).select(
+        nw.col("a").cast(nw.List(nw.Int64())).list.contains(None)
+    )
+    assert_equal_data(result, {"a": [True, False, None, False]})
+
+
+@pytest.mark.parametrize("item", [True, "2"])
+def test_contains_mismatched_type_raises(
+    request: pytest.FixtureRequest, constructor: Constructor, *, item: bool | str
+) -> None:
+    # A bool or str item on an int list raises, matching polars. SQL backends
+    # coerce and return a boolean instead.
+    if any(
+        backend in str(constructor)
+        for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
+    ):
+        request.applymarker(pytest.mark.xfail)
+    if any(x in str(constructor) for x in ("duckdb", "sqlframe", "ibis", "pyspark")):
+        request.applymarker(pytest.mark.xfail(reason="mismatched item coerced"))
+    df = nw.from_native(constructor({"a": [[2, 3], [1], None]}))
+    expr = nw.col("a").cast(nw.List(nw.Int64())).list.contains(item)
+    if isinstance(df, nw.LazyFrame):
+        with pytest.raises(InvalidOperationError):
+            df.select(expr).lazy().collect()
+    else:
+        with pytest.raises(InvalidOperationError):
+            df.select(expr)
+
+
+def test_contains_datetime_precision_mismatch_raises(
+    request: pytest.FixtureRequest, constructor: Constructor
+) -> None:
+    # A `Datetime` item of a different precision than the list raises,
+    # matching polars. SQL backends coerce and return a boolean instead.
+    if any(
+        backend in str(constructor)
+        for backend in ("dask", "modin", "cudf", "pyarrow", "pandas")
+    ):
+        request.applymarker(pytest.mark.xfail)
+    if any(x in str(constructor) for x in ("duckdb", "sqlframe", "ibis", "pyspark")):
+        request.applymarker(pytest.mark.xfail(reason="precision coerced"))
+    df = nw.from_native(constructor({"a": [[datetime(2020, 1, 1, 1, 2, 3)], [], None]}))
+    expr = (
+        nw.col("a")
+        .cast(nw.List(nw.Datetime("ns")))
+        .list.contains(datetime(2020, 1, 1, 1, 2, 3))
+    )
+    if isinstance(df, nw.LazyFrame):
+        with pytest.raises(InvalidOperationError):
+            df.select(expr).lazy().collect()
+    else:
+        with pytest.raises(InvalidOperationError):
+            df.select(expr)
 
 
 def test_contains_all_null_inner_expr(


### PR DESCRIPTION
# Description

Numeric width and family coercion (`2.0` matches ints, `1.5` does not, `300` overflows `Int8`, `1` matches a `Float64` list) and an all-null inner list containing nothing. Same xfail pattern as the existing tests for `dask`/`modin`/`cudf`/`pyarrow`/`pandas`; ibis is skipped for the all-null fixture because it cannot construct one.

Now covered, pinned to polars: a `None` item matches null-holding lists (SQL backends return null everywhere instead, hence `xfail`), mismatched bool or str items on int lists raise (SQL backends coerce instead, hence `xfail`), and precision-mismatched datetime items raise (SQL backends coerce instead, hence `xfail`).

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

None. Test-only follow-up from narwhals-daft differential testing.

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes (N/A, test-only, no behavior change)
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```

Note: the full-suite command above was not run. Targeted run on the CI constructor set instead: `pytest tests/expr_and_series/list/contains_test.py --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe` gives 13 passed, 16 xfailed. Also green with `--constructors=ibis` and `--constructors=dask`.
