### PR TITLE
fix: align pandas-like and Dask `concat_str` boolean rendering

### DIFF
--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -370,10 +370,17 @@ class PandasLikeNamespace(
         self, *exprs: PandasLikeExpr, separator: str, ignore_nulls: bool
     ) -> PandasLikeExpr:
         string = self._version.dtypes.String()
+        boolean = self._version.dtypes.Boolean()
 
         def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
             expr_results = [s for _expr in exprs for s in _expr(df)]
-            series = [s.cast(string) for s in expr_results]
+            # Polars renders booleans lowercase, pandas `astype(str)` does not.
+            series = [
+                s.cast(string).str.to_lowercase()
+                if s.dtype == boolean
+                else s.cast(string)
+                for s in expr_results
+            ]
             null_mask = [s.is_null() for s in expr_results]
 
             if not ignore_nulls:

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -72,6 +72,24 @@ def test_concat_str_with_lit(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
+def test_concat_str_single_expr(constructor: Constructor) -> None:
+    # A single expression is passed through (null preserved).
+    df = nw.from_native(constructor({"b": ["a", None]}))
+    result = df.select(nw.concat_str(["b"], separator=", ").alias("out"))
+    assert_equal_data(result, {"out": ["a", None]})
+
+
+def test_concat_str_null_literal(constructor: Constructor) -> None:
+    # A null literal poisons the row when `ignore_nulls=False` (default).
+    df = nw.from_native(constructor({"b": ["a", None]}))
+    result = df.select(
+        nw.concat_str(["b", nw.lit(None, dtype=nw.String())], separator=", ").alias(
+            "out"
+        )
+    )
+    assert_equal_data(result, {"out": [None, None]})
+
+
 @pytest.mark.parametrize(
     ("input_schema", "input_values", "expected_function"),
     [

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -83,9 +83,7 @@ def test_concat_str_null_literal(constructor: Constructor) -> None:
     # A null literal poisons the row when `ignore_nulls=False` (default).
     df = nw.from_native(constructor({"b": ["a", None]}))
     result = df.select(
-        nw.concat_str(["b", nw.lit(None, dtype=nw.String())], separator=", ").alias(
-            "out"
-        )
+        nw.concat_str(["b", nw.lit(None, dtype=nw.String())], separator=", ").alias("out")
     )
     assert_equal_data(result, {"out": [None, None]})
 

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -104,6 +104,11 @@ def test_concat_str_edge(
         or any(x in str(constructor) for x in ("modin", "dask"))
     ):
         request.applymarker(pytest.mark.xfail(reason="object-dtype bools"))
+    # Old pandas renders a null literal as the string `"None"`.
+    if "null_literal" in request.node.callspec.id and (
+        "pandas_constructor" in str(constructor) and PANDAS_VERSION < (3,)
+    ):
+        request.applymarker(pytest.mark.xfail(reason="old pandas null literal"))
     df = nw.from_native(constructor(data))
     result = df.select(nw.concat_str(columns, separator=" ").alias("out"))
     assert_equal_data(result, expected)
@@ -118,6 +123,8 @@ def test_concat_str_all_null_ignore_nulls(
         pytest.skip(reason="ibis cannot create all-null column")
     if "pyarrow_table" in str(constructor):
         request.applymarker(pytest.mark.xfail(reason="pyarrow drops all-null rows"))
+    if "pandas_constructor" in str(constructor) and PANDAS_VERSION < (3,):
+        request.applymarker(pytest.mark.xfail(reason="old pandas all-null concat"))
     df = nw.from_native(constructor({"b": [None, None], "c": [None, None]}))
     df = df.with_columns(nw.col("b").cast(nw.String()), nw.col("c").cast(nw.String()))
     result = df.select(

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -5,7 +5,13 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import narwhals as nw
-from tests.utils import PANDAS_VERSION, POLARS_VERSION, Constructor, assert_equal_data
+from tests.utils import (
+    PANDAS_VERSION,
+    POLARS_VERSION,
+    Constructor,
+    assert_equal_data,
+    uses_pyarrow_backend,
+)
 
 pytest.importorskip("pyarrow")
 
@@ -97,11 +103,13 @@ def test_concat_str_edge(
     columns: list[str | nw.Expr],
     expected: dict[str, list[str | None]],
 ) -> None:
-    # Plain pandas (and dask/modin) infer `object` dtype for mixed bool/null
-    # columns, where bools are indistinguishable from `"True"` strings.
+    # Plain pandas (and dask, and non-pyarrow modin) infer `object` dtype for
+    # mixed bool/null columns, where bools are indistinguishable from `"True"`
+    # strings. Pyarrow-backed frames keep a boolean dtype and render lowercase.
     if "bool" in request.node.callspec.id and (
         "pandas_constructor" in str(constructor)
-        or any(x in str(constructor) for x in ("modin", "dask"))
+        or "dask" in str(constructor)
+        or ("modin" in str(constructor) and not uses_pyarrow_backend(constructor))
     ):
         request.applymarker(pytest.mark.xfail(reason="object-dtype bools"))
     # Old pandas renders a null literal as the string `"None"`.

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -72,24 +72,24 @@ def test_concat_str_with_lit(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
-concat_str_cases = [
-    pytest.param({"b": ["a", None]}, ["b"], {"out": ["a", None]}, id="single"),
-    pytest.param(
-        {"b": ["a", None]},
-        ["b", nw.lit(None, dtype=nw.String())],
-        {"out": [None, None]},
-        id="null_literal",
-    ),
-    pytest.param(
-        {"bo": [True, None], "b": ["x", "y"]},
-        ["bo", "b"],
-        {"out": ["true x", None]},
-        id="bool",
-    ),
-]
-
-
-@pytest.mark.parametrize(("data", "columns", "expected"), concat_str_cases)
+@pytest.mark.parametrize(
+    ("data", "columns", "expected"),
+    [
+        pytest.param({"b": ["a", None]}, ["b"], {"out": ["a", None]}, id="single"),
+        pytest.param(
+            {"b": ["a", None]},
+            ["b", nw.lit(None, dtype=nw.String())],
+            {"out": [None, None]},
+            id="null_literal",
+        ),
+        pytest.param(
+            {"bo": [True, None], "b": ["x", "y"]},
+            ["bo", "b"],
+            {"out": ["true x", None]},
+            id="bool",
+        ),
+    ],
+)
 def test_concat_str_edge(
     constructor: Constructor,
     request: pytest.FixtureRequest,

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -88,6 +88,38 @@ def test_concat_str_null_literal(constructor: Constructor) -> None:
     assert_equal_data(result, {"out": [None, None]})
 
 
+def test_concat_str_all_null_ignore_nulls(
+    constructor: Constructor, request: pytest.FixtureRequest
+) -> None:
+    # A row of only nulls concatenates to `""` with `ignore_nulls=True`.
+    # The pyarrow kernel returns no rows at all for all-null `skip` inputs.
+    if "ibis" in str(constructor):
+        pytest.skip(reason="ibis cannot create all-null column")
+    if "pyarrow_table" in str(constructor):
+        request.applymarker(pytest.mark.xfail(reason="pyarrow drops all-null rows"))
+    df = nw.from_native(constructor({"b": [None, None], "c": [None, None]}))
+    df = df.with_columns(nw.col("b").cast(nw.String()), nw.col("c").cast(nw.String()))
+    result = df.select(
+        nw.concat_str(["b", "c"], separator=", ", ignore_nulls=True).alias("out")
+    )
+    assert_equal_data(result, {"out": ["", ""]})
+
+
+def test_concat_str_bool(
+    constructor: Constructor, request: pytest.FixtureRequest
+) -> None:
+    # Booleans render lowercase, matching polars. Plain pandas (and modin and
+    # dask) infer `object` dtype for `[True, None]`, where bools are
+    # indistinguishable from the strings `"True"`/`"False"`.
+    if "pandas_constructor" in str(constructor) or any(
+        x in str(constructor) for x in ("modin", "dask")
+    ):
+        request.applymarker(pytest.mark.xfail(reason="object-dtype bools"))
+    df = nw.from_native(constructor({"bo": [True, None], "b": ["x", "y"]}))
+    result = df.select(nw.concat_str(["bo", "b"], separator=" ").alias("out"))
+    assert_equal_data(result, {"out": ["true x", None]})
+
+
 @pytest.mark.parametrize(
     ("input_schema", "input_values", "expected_function"),
     [

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -112,11 +112,12 @@ def test_concat_str_edge(
         or ("modin" in str(constructor) and not uses_pyarrow_backend(constructor))
     ):
         request.applymarker(pytest.mark.xfail(reason="object-dtype bools"))
-    # Old pandas renders a null literal as the string `"None"`.
+    # Old pandas renders a null literal as the string `"None"`, as does modin.
     if "null_literal" in request.node.callspec.id and (
-        "pandas_constructor" in str(constructor) and PANDAS_VERSION < (3,)
+        ("pandas_constructor" in str(constructor) and PANDAS_VERSION < (3,))
+        or "modin" in str(constructor)
     ):
-        request.applymarker(pytest.mark.xfail(reason="old pandas null literal"))
+        request.applymarker(pytest.mark.xfail(reason="null literal as string"))
     df = nw.from_native(constructor(data))
     result = df.select(nw.concat_str(columns, separator=" ").alias("out"))
     assert_equal_data(result, expected)

--- a/tests/expr_and_series/concat_str_test.py
+++ b/tests/expr_and_series/concat_str_test.py
@@ -72,20 +72,41 @@ def test_concat_str_with_lit(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
-def test_concat_str_single_expr(constructor: Constructor) -> None:
-    # A single expression is passed through (null preserved).
-    df = nw.from_native(constructor({"b": ["a", None]}))
-    result = df.select(nw.concat_str(["b"], separator=", ").alias("out"))
-    assert_equal_data(result, {"out": ["a", None]})
+concat_str_cases = [
+    pytest.param({"b": ["a", None]}, ["b"], {"out": ["a", None]}, id="single"),
+    pytest.param(
+        {"b": ["a", None]},
+        ["b", nw.lit(None, dtype=nw.String())],
+        {"out": [None, None]},
+        id="null_literal",
+    ),
+    pytest.param(
+        {"bo": [True, None], "b": ["x", "y"]},
+        ["bo", "b"],
+        {"out": ["true x", None]},
+        id="bool",
+    ),
+]
 
 
-def test_concat_str_null_literal(constructor: Constructor) -> None:
-    # A null literal poisons the row when `ignore_nulls=False` (default).
-    df = nw.from_native(constructor({"b": ["a", None]}))
-    result = df.select(
-        nw.concat_str(["b", nw.lit(None, dtype=nw.String())], separator=", ").alias("out")
-    )
-    assert_equal_data(result, {"out": [None, None]})
+@pytest.mark.parametrize(("data", "columns", "expected"), concat_str_cases)
+def test_concat_str_edge(
+    constructor: Constructor,
+    request: pytest.FixtureRequest,
+    data: dict[str, list[bool | str | None]],
+    columns: list[str | nw.Expr],
+    expected: dict[str, list[str | None]],
+) -> None:
+    # Plain pandas (and dask/modin) infer `object` dtype for mixed bool/null
+    # columns, where bools are indistinguishable from `"True"` strings.
+    if "bool" in request.node.callspec.id and (
+        "pandas_constructor" in str(constructor)
+        or any(x in str(constructor) for x in ("modin", "dask"))
+    ):
+        request.applymarker(pytest.mark.xfail(reason="object-dtype bools"))
+    df = nw.from_native(constructor(data))
+    result = df.select(nw.concat_str(columns, separator=" ").alias("out"))
+    assert_equal_data(result, expected)
 
 
 def test_concat_str_all_null_ignore_nulls(
@@ -103,21 +124,6 @@ def test_concat_str_all_null_ignore_nulls(
         nw.concat_str(["b", "c"], separator=", ", ignore_nulls=True).alias("out")
     )
     assert_equal_data(result, {"out": ["", ""]})
-
-
-def test_concat_str_bool(
-    constructor: Constructor, request: pytest.FixtureRequest
-) -> None:
-    # Booleans render lowercase, matching polars. Plain pandas (and modin and
-    # dask) infer `object` dtype for `[True, None]`, where bools are
-    # indistinguishable from the strings `"True"`/`"False"`.
-    if "pandas_constructor" in str(constructor) or any(
-        x in str(constructor) for x in ("modin", "dask")
-    ):
-        request.applymarker(pytest.mark.xfail(reason="object-dtype bools"))
-    df = nw.from_native(constructor({"bo": [True, None], "b": ["x", "y"]}))
-    result = df.select(nw.concat_str(["bo", "b"], separator=" ").alias("out"))
-    assert_equal_data(result, {"out": ["true x", None]})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Cover single-expression passthrough (null preserved), null literals under the default `ignore_nulls=False`, and all-null input with `ignore_nulls=True`.

This PR also proposes lowercase boolean rendering in `concat_str` for pandas-like and Dask backends, matching Polars while leaving actual strings unchanged. Tests cover nullable booleans, both null-handling modes, and multiple Dask partitions.

**Still to discuss:** should Narwhals support concatenating booleans with strings and standardize the result, or leave support and rendering to each backend? The boolean implementation and tests here represent a proposal, not an established API guarantee. Mixed object-dtype boolean cases remain `xfail`d.

Rebased onto `main`, retaining the upstream fixes from #3939 and #3941 and removing obsolete pandas/PyArrow null-related `xfail`s. Added regression coverage for literal and aggregation broadcasting. Dask retains its existing string representation and pre-cast null masks to avoid an empty Arrow-string metadata failure on pandas 2.0.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

Follow-up from narwhals-daft differential testing and the review of this PR.

Related: #3939 and #3941. The Dask trailing-separator and `mean_horizontal` fixes from #3967 and #3968 are already included through the rebase.

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

Delta was used for implementation, regression tests, and review.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes (boolean-concatenation semantics remain under discussion)
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

```bash
CI=true GITHUB_ACTIONS=true PYTEST_XDIST_AUTO_NUM_WORKERS=8 \
make test-full-coverage
```