### PR TITLE
test: cover `corr` and `cov` constant, stability and group_by cases

### DIFF
--- a/tests/expr_and_series/corr_test.py
+++ b/tests/expr_and_series/corr_test.py
@@ -160,6 +160,13 @@ def test_corr_series_foreign_index() -> None:
     assert_equal_data(result, expected)
 
 
+def test_corr_constant_column(constructor: Constructor) -> None:
+    # A constant column has no variance, so correlation is undefined.
+    df = nw.from_native(constructor({"a": [1.0, 1.0, 1.0], "b": [1.0, 2.0, 3.0]}))
+    result = df.select(nw.corr("a", "b").alias("c"))
+    assert_equal_data(result, {"c": [None]})
+
+
 def test_corr_pairwise_nulls(
     constructor: Constructor, request: pytest.FixtureRequest
 ) -> None:

--- a/tests/expr_and_series/corr_test.py
+++ b/tests/expr_and_series/corr_test.py
@@ -143,7 +143,6 @@ def test_corr_over(constructor: Constructor) -> None:
 
 
 def test_corr_over_single_row_group(constructor: Constructor) -> None:
-    # A group with a single row has undefined correlation there.
     if not any(x in str(constructor) for x in ("duckdb", "pyspark", "sqlframe")):
         pytest.skip()
     if "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3):

--- a/tests/expr_and_series/corr_test.py
+++ b/tests/expr_and_series/corr_test.py
@@ -142,6 +142,19 @@ def test_corr_over(constructor: Constructor) -> None:
     assert_equal_data(result, expected)
 
 
+def test_corr_over_single_row_group(constructor: Constructor) -> None:
+    # A group with a single row has undefined correlation there.
+    if not any(x in str(constructor) for x in ("duckdb", "pyspark", "sqlframe")):
+        pytest.skip()
+    if "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3):
+        pytest.skip()
+    df = nw.from_native(
+        constructor({"i": [0, 1, 2], "g": [1, 1, 2], "a": [1, 3, 2], "b": [1, 2, 1]})
+    )
+    result = df.with_columns(corr=nw.corr("a", "b").over("g")).sort("i").select("corr")
+    assert_equal_data(result, {"corr": [1.0, 1.0, None]})
+
+
 def test_corr_series_foreign_index() -> None:
     # https://github.com/narwhals-dev/narwhals/issues/3864
     # A `Series` with an index unrelated to `df`'s own must be aligned

--- a/tests/expr_and_series/cov_test.py
+++ b/tests/expr_and_series/cov_test.py
@@ -119,8 +119,7 @@ def test_cov_series_foreign_index() -> None:
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_cov_single_pair_ddof1(constructor: Constructor) -> None:
-    # A single valid pair leaves no degrees of freedom with `ddof=1`.
-    # Degenerate-slice `RuntimeWarning`s (e.g. from dask/numpy) are expected.
+    # No degrees of freedom left; dask/numpy warn on the degenerate slice.
     df = nw.from_native(constructor({"a": [1.0], "b": [2.0]}))
     result = df.select(nw.cov("a", "b", ddof=1).alias("cov"))
     assert_equal_data(result, {"cov": [None]})

--- a/tests/expr_and_series/cov_test.py
+++ b/tests/expr_and_series/cov_test.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import pytest
 
 import narwhals as nw
-from tests.utils import DUCKDB_VERSION, Constructor, ConstructorEager, assert_equal_data
+from tests.utils import (
+    DUCKDB_VERSION,
+    POLARS_VERSION,
+    Constructor,
+    ConstructorEager,
+    assert_equal_data,
+)
 
 data = {"a": [1, 3, 3], "b": [1, 2, 3], "c": [1, None, 1]}
 
@@ -157,8 +163,13 @@ def test_cov_series(constructor_eager: ConstructorEager) -> None:
     assert_equal_data(result, expected)
 
 
-def test_cov_numerical_stability(constructor: Constructor) -> None:
-    # Large offsets stress single-pass variance implementations.
+def test_cov_numerical_stability(
+    constructor: Constructor, request: pytest.FixtureRequest
+) -> None:
+    # Large offsets stress single-pass variance implementations. Old polars
+    # computes this the single-pass way and gets `0.0`/`NaN`.
+    if "polars" in str(constructor) and POLARS_VERSION < (1, 11, 0):
+        request.applymarker(pytest.mark.xfail(reason="single-pass variance"))
     df = nw.from_native(
         constructor({"a": [1e9 + 1, 1e9 + 2, 1e9 + 3], "b": [1e9 + 2, 1e9 + 4, 1e9 + 7]})
     )

--- a/tests/expr_and_series/cov_test.py
+++ b/tests/expr_and_series/cov_test.py
@@ -132,3 +132,21 @@ def test_cov_series(constructor_eager: ConstructorEager) -> None:
         "a_c_sample": [0.0],
     }
     assert_equal_data(result, expected)
+
+
+def test_cov_numerical_stability(constructor: Constructor) -> None:
+    # Large offsets stress single-pass variance implementations.
+    df = nw.from_native(
+        constructor({"a": [1e9 + 1, 1e9 + 2, 1e9 + 3], "b": [1e9 + 2, 1e9 + 4, 1e9 + 7]})
+    )
+    result = df.select(nw.cov("a", "b").round(2), nw.corr("a", "b").round(2).alias("corr"))
+    assert_equal_data(result, {"a": [2.5], "corr": [0.99]})
+
+
+@pytest.mark.filterwarnings("ignore:Found complex group-by:UserWarning")
+def test_cov_group_by(constructor: Constructor, request: pytest.FixtureRequest) -> None:
+    if "pyarrow_table" in str(constructor):
+        request.applymarker(pytest.mark.xfail(reason="non-elementary agg"))
+    df = nw.from_native(constructor({"g": [1, 1, 2], "a": [1.0, 2.0, 3.0], "b": [1.0, 2.0, 3.0]}))
+    result = df.group_by("g").agg(nw.cov("a", "b").alias("cov")).sort("g")
+    assert_equal_data(result, {"g": [1, 2], "cov": [0.5, None]})

--- a/tests/expr_and_series/cov_test.py
+++ b/tests/expr_and_series/cov_test.py
@@ -145,7 +145,7 @@ def test_cov_numerical_stability(constructor: Constructor) -> None:
 
 @pytest.mark.filterwarnings("ignore:Found complex group-by:UserWarning")
 def test_cov_group_by(constructor: Constructor, request: pytest.FixtureRequest) -> None:
-    if "pyarrow_table" in str(constructor):
+    if "pyarrow_table" in str(constructor) or "dask" in str(constructor):
         request.applymarker(pytest.mark.xfail(reason="non-elementary agg"))
     df = nw.from_native(constructor({"g": [1, 1, 2], "a": [1.0, 2.0, 3.0], "b": [1.0, 2.0, 3.0]}))
     result = df.group_by("g").agg(nw.cov("a", "b").alias("cov")).sort("g")

--- a/tests/expr_and_series/cov_test.py
+++ b/tests/expr_and_series/cov_test.py
@@ -139,7 +139,9 @@ def test_cov_numerical_stability(constructor: Constructor) -> None:
     df = nw.from_native(
         constructor({"a": [1e9 + 1, 1e9 + 2, 1e9 + 3], "b": [1e9 + 2, 1e9 + 4, 1e9 + 7]})
     )
-    result = df.select(nw.cov("a", "b").round(2), nw.corr("a", "b").round(2).alias("corr"))
+    result = df.select(
+        nw.cov("a", "b").round(2), nw.corr("a", "b").round(2).alias("corr")
+    )
     assert_equal_data(result, {"a": [2.5], "corr": [0.99]})
 
 
@@ -147,6 +149,8 @@ def test_cov_numerical_stability(constructor: Constructor) -> None:
 def test_cov_group_by(constructor: Constructor, request: pytest.FixtureRequest) -> None:
     if "pyarrow_table" in str(constructor) or "dask" in str(constructor):
         request.applymarker(pytest.mark.xfail(reason="non-elementary agg"))
-    df = nw.from_native(constructor({"g": [1, 1, 2], "a": [1.0, 2.0, 3.0], "b": [1.0, 2.0, 3.0]}))
+    df = nw.from_native(
+        constructor({"g": [1, 1, 2], "a": [1.0, 2.0, 3.0], "b": [1.0, 2.0, 3.0]})
+    )
     result = df.group_by("g").agg(nw.cov("a", "b").alias("cov")).sort("g")
     assert_equal_data(result, {"g": [1, 2], "cov": [0.5, None]})

--- a/tests/expr_and_series/cov_test.py
+++ b/tests/expr_and_series/cov_test.py
@@ -117,6 +117,30 @@ def test_cov_series_foreign_index() -> None:
     assert_equal_data(result, expected)
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_cov_single_pair_ddof1(constructor: Constructor) -> None:
+    # A single valid pair leaves no degrees of freedom with `ddof=1`.
+    # Degenerate-slice `RuntimeWarning`s (e.g. from dask/numpy) are expected.
+    df = nw.from_native(constructor({"a": [1.0], "b": [2.0]}))
+    result = df.select(nw.cov("a", "b", ddof=1).alias("cov"))
+    assert_equal_data(result, {"cov": [None]})
+
+
+def test_cov_over_single_row_group(constructor: Constructor) -> None:
+    # Window function on a group with a single row yields null there.
+    if not any(x in str(constructor) for x in ("duckdb", "pyspark", "sqlframe")):
+        pytest.skip()
+    if "duckdb" in str(constructor) and DUCKDB_VERSION < (1, 3):
+        pytest.skip()
+    df = nw.from_native(
+        constructor(
+            {"i": [0, 1, 2], "g": [1, 1, 2], "a": [1.0, 3.0, 2.0], "b": [1.0, 2.0, 1.0]}
+        )
+    )
+    result = df.with_columns(sample=nw.cov("a", "b").over("g")).sort("i").select("sample")
+    assert_equal_data(result, {"sample": [1.0, 1.0, None]})
+
+
 def test_cov_series(constructor_eager: ConstructorEager) -> None:
     df = nw.from_native(constructor_eager(data), eager_only=True)
     result = df.select(


### PR DESCRIPTION
# Description

Constant-column correlation is null/NaN, a large-offset stability case (`cov` to 2.5 and `corr` to 0.99 after `round(2)`), and `group_by(...).agg(cov)` (xfailed for `pyarrow_table`/`dask` as a non-elementary aggregation; the pandas complex-group-by `UserWarning` is filtered).

Now covered: single-pair `ddof=1` covariance is pinned to null, and single-row groups in `over` windows are pinned to null for both `corr` and `cov` (following the existing duckdb/spark-only skip pattern, since other backends lack windowed `corr` and `cov`).

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [x] ✅ Test
- [ ] 🐳 Other

## Related issues

None. Test-only follow-up from narwhals-daft differential testing.

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes (N/A, test-only, no behavior change)
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```

Note: the full-suite command above was not run. Targeted run on the CI constructor set instead: `pytest tests/expr_and_series/corr_test.py tests/expr_and_series/cov_test.py --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe` gives 156 passed, 14 skipped, 1 xfailed. Also green with `--constructors=ibis` and `--constructors=dask`.
