### PR TITLE
fix(pyarrow): `shift` preserves length when `n` exceeds the series length

### DIFF
--- a/src/narwhals/_arrow/series.py
+++ b/src/narwhals/_arrow/series.py
@@ -374,10 +374,15 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
         return self._with_native(self.native.drop_null())
 
     def shift(self, n: int) -> Self:
+        # Cap the number of null padding values at the length of the series:
+        # shifting by more than the length must still return a series of the
+        # same length (all null), and must not desync the array lengths that
+        # rolling windows rely on.
+        length = len(self.native)
         if n > 0:
-            arrays = [nulls_like(n, self), *self.native[:-n].chunks]
+            arrays = [nulls_like(min(n, length), self), *self.native[:-n].chunks]
         elif n < 0:
-            arrays = [*self.native[-n:].chunks, nulls_like(-n, self)]
+            arrays = [*self.native[-n:].chunks, nulls_like(min(-n, length), self)]
         else:
             return self._with_native(self.native)
         return self._with_native(pa.concat_arrays(arrays))

--- a/src/narwhals/_arrow/series.py
+++ b/src/narwhals/_arrow/series.py
@@ -374,17 +374,22 @@ class ArrowSeries(EagerSeries["ChunkedArrayAny"]):
         return self._with_native(self.native.drop_null())
 
     def shift(self, n: int) -> Self:
+        if n == 0:
+            return self._with_native(self.native)
+        length = len(self.native)
         # Cap the number of null padding values at the length of the series:
-        # shifting by more than the length must still return a series of the
+        # shifting by at least the length must still return a series of the
         # same length (all null), and must not desync the array lengths that
         # rolling windows rely on.
-        length = len(self.native)
+        null_array = nulls_like(min(abs(n), length), self)
+        if abs(n) >= length:
+            # Every value is shifted out, so the result is all null; return it
+            # directly and skip the slice and concat.
+            return self._with_native(null_array)
         if n > 0:
-            arrays = [nulls_like(min(n, length), self), *self.native[:-n].chunks]
-        elif n < 0:
-            arrays = [*self.native[-n:].chunks, nulls_like(min(-n, length), self)]
+            arrays = [null_array, *self.native[:-n].chunks]
         else:
-            return self._with_native(self.native)
+            arrays = [*self.native[-n:].chunks, null_array]
         return self._with_native(pa.concat_arrays(arrays))
 
     def std(self, *, ddof: int, _return_py_scalar: bool = True) -> float:

--- a/tests/expr_and_series/rolling_sum_test.py
+++ b/tests/expr_and_series/rolling_sum_test.py
@@ -298,3 +298,12 @@ def test_rolling_sum_hypothesis(center: bool, values: list[float]) -> None:  # n
     )
     expected_dict = nw.from_native(expected, eager_only=True).to_dict(as_series=False)
     assert_equal_data(result, expected_dict)
+
+
+def test_rolling_sum_window_longer_than_series(
+    constructor_eager: ConstructorEager,
+) -> None:
+    # A window larger than the series must yield nulls, not crash.
+    df = nw.from_native(constructor_eager({"a": [1]}), eager_only=True)
+    result = {"a": df["a"].rolling_sum(window_size=2)}
+    assert_equal_data(result, {"a": [None]})

--- a/tests/expr_and_series/shift_test.py
+++ b/tests/expr_and_series/shift_test.py
@@ -131,3 +131,13 @@ def test_shift_series_invalid_params(
     df = nw.from_native(constructor_eager(data), eager_only=True)
     with context:
         df["a"].shift(n)
+
+
+def test_shift_longer_than_series(constructor_eager: ConstructorEager) -> None:
+    # Shifting by more than the length must return an all-null series of the
+    # same length, not grow or shrink it.
+    df = nw.from_native(constructor_eager({"a": [1, 2]}), eager_only=True)
+    assert_equal_data(df.select(nw.col("a").shift(3)), {"a": [None, None]})
+    assert_equal_data(df.select(nw.col("a").shift(-3)), {"a": [None, None]})
+    assert_equal_data({"a": df["a"].shift(3)}, {"a": [None, None]})
+    assert_equal_data({"a": df["a"].shift(-3)}, {"a": [None, None]})


### PR DESCRIPTION
# Description

`ArrowSeries.shift(n)` padded the result with `n` nulls without capping `n` at the series length, so shifting by more than the length grew the series instead of returning an all-null series of the same length. For example, `shift(3)` on a two-row pyarrow series returned three rows.

The same series is used by the rolling functions — `rolling_sum`, `rolling_mean`, `rolling_var` and `rolling_std` all shift by `window_size` internally — so a window larger than the series desynced the chunk lengths and raised `ArrowInvalid: Array arguments must all be the same length` instead of returning nulls:

```python
import narwhals as nw
import pyarrow as pa

s = nw.from_native(pa.chunked_array([[1]]), series_only=True)

s.rolling_sum(window_size=2)   # main: ArrowInvalid  ->  this PR: [None]
s.shift(3).to_list()           # main: [None, None, None]  ->  this PR: [None]
```

polars and pandas both return an all-null series of the original length here, so this brings the pyarrow backend in line with them.

The fix caps the null padding at the series length (`min(n, length)`), which keeps the existing behaviour for every in-range shift untouched. Added a regression test for `shift` beyond the length across the eager backends, and one for `rolling_sum` with a window longer than the series.

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Found while testing the pyarrow backend; no existing issue.

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [ ] Documented the changes (no public API change; behaviour now matches polars/pandas)
