### PR TITLE
ci: fix downstream pins for pointblank

### DIFF
--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -489,6 +489,12 @@ jobs:
           . .venv/bin/activate
           uv pip install . --group dev
           uv pip install pytest pytest-cov pytest-snapshot pandas polars "ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0" chatlas shiny
+          # Temporary pin to get CI green: sqlglot 30.18.0 refactored `DROP TABLE`
+          # to use a `tables` argument instead of `this` (tobymao/sqlglot#8229),
+          # which breaks ibis's in-memory table creation (it still builds
+          # `sge.Drop(this=...)`), causing "syntax error at end of input" from
+          # duckdb/sqlite in pointblank's test fixtures.
+          uv pip install "sqlglot<30.18.0"
       - name: install-narwhals-dev
         run: |
           cd pointblank

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -205,7 +205,7 @@ jobs:
           cd py-shiny
           uv pip uninstall narwhals
           uv pip install -e ./..
-     - name: show-deps
+      - name: show-deps
         env:
           UV_SYSTEM_PYTHON: "1"
         run: |

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -205,6 +205,9 @@ jobs:
           cd py-shiny
           uv pip uninstall narwhals
           uv pip install -e ./..
+          # Temporary pin to get CI green: py-shiny's test suite (test_serialize_dtype)
+          # doesn't yet account for a categorical-category-ordering change in pandas 3.0.
+          uv pip install "pandas<3"
       - name: show-deps
         env:
           UV_SYSTEM_PYTHON: "1"
@@ -485,10 +488,6 @@ jobs:
           uv venv -p ${{ matrix.python-version }}
           . .venv/bin/activate
           uv pip install . --group dev
-          # Temporary pin to get CI green: `mcp` 2.0.0 is a breaking release that the
-          # resolved `fastmcp` 2.x does not support (dropped `pydantic-settings`,
-          # renamed `McpError` -> `MCPError`).
-          uv pip install "mcp<2"
           uv pip install pytest pytest-cov pytest-snapshot pandas polars "ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0" chatlas shiny
       - name: install-narwhals-dev
         run: |

--- a/.github/workflows/downstream_tests.yml
+++ b/.github/workflows/downstream_tests.yml
@@ -205,10 +205,7 @@ jobs:
           cd py-shiny
           uv pip uninstall narwhals
           uv pip install -e ./..
-          # Temporary pin to get CI green: py-shiny's test suite (test_serialize_dtype)
-          # doesn't yet account for a categorical-category-ordering change in pandas 3.0.
-          uv pip install "pandas<3"
-      - name: show-deps
+     - name: show-deps
         env:
           UV_SYSTEM_PYTHON: "1"
         run: |


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
