### PR TITLE
fix: use `dtype.categories` for `pl.Enum` in `get_categories`

### DIFF
--- a/src/narwhals/_polars/expr.py
+++ b/src/narwhals/_polars/expr.py
@@ -16,6 +16,7 @@ from narwhals._polars.utils import (
     extract_args_kwargs,
     extract_native,
     narwhals_to_native_dtype,
+    native_get_categories,
 )
 from narwhals._utils import NO_DEFAULT, Implementation, requires
 
@@ -506,11 +507,8 @@ class PolarsExprCatNamespace(
     PolarsExprNamespace, PolarsCatNamespace[PolarsExpr, pl.Expr]
 ):
     def get_categories(self) -> PolarsExpr:
-        # NOTE: Polars deprecated `cat.get_categories` in v1.44 and removed it
-        # in v2.0, so we use the workaround they suggest.
-        # See https://github.com/narwhals-dev/narwhals/issues/3895.
         return self.compliant._with_native(
-            self.native.unique(maintain_order=True).drop_nulls().cast(pl.String)
+            self.native.map_batches(native_get_categories, return_dtype=pl.String)
         )
 
 

--- a/src/narwhals/_polars/series.py
+++ b/src/narwhals/_polars/series.py
@@ -18,6 +18,7 @@ from narwhals._polars.utils import (
     extract_args_kwargs,
     extract_native,
     narwhals_to_native_dtype,
+    native_get_categories,
     native_to_narwhals_dtype,
 )
 from narwhals._utils import NO_DEFAULT, Implementation, requires
@@ -847,12 +848,7 @@ class PolarsSeriesCatNamespace(
     PolarsSeriesNamespace, PolarsCatNamespace[PolarsSeries, pl.Series]
 ):
     def get_categories(self) -> PolarsSeries:
-        # NOTE: Polars deprecated `cat.get_categories` in v1.44 and removed it
-        # in v2.0, so we use the workaround they suggest.
-        # See https://github.com/narwhals-dev/narwhals/issues/3895.
-        return self.compliant._with_native(
-            self.native.unique(maintain_order=True).drop_nulls().cast(pl.String)
-        )
+        return self.compliant._with_native(native_get_categories(self.native))
 
 
 class PolarsSeriesListNamespace(

--- a/src/narwhals/_polars/utils.py
+++ b/src/narwhals/_polars/utils.py
@@ -369,14 +369,10 @@ def native_get_categories(native: pl.Series) -> pl.Series:
     # See https://github.com/narwhals-dev/narwhals/issues/3895.
     #
     # For `Enum`, the declared categories are already unique, ordered, and
-    # null-free, so when every declared category is actually present in the
-    # data we can return `dtype.categories` directly instead of paying for
-    # `unique().drop_nulls().cast(String)`.
+    # null-free, so we can return `dtype.categories` directly.
     dtype = native.dtype
     if isinstance(dtype, pl.Enum):
-        categories = dtype.categories
-        if native.drop_nulls().n_unique() == len(categories):
-            return categories
+        return dtype.categories
     return native.unique(maintain_order=True).drop_nulls().cast(pl.String)
 
 

--- a/src/narwhals/_polars/utils.py
+++ b/src/narwhals/_polars/utils.py
@@ -363,6 +363,23 @@ class PolarsStringNamespace(PolarsAnyNamespace[CompliantT, NativeT_co]):
     pad_end: Method[CompliantT]
 
 
+def native_get_categories(native: pl.Series) -> pl.Series:
+    # NOTE: Polars deprecated `cat.get_categories` in v1.44 and removed it
+    # in v2.0, so we use the workaround they suggest.
+    # See https://github.com/narwhals-dev/narwhals/issues/3895.
+    #
+    # For `Enum`, the declared categories are already unique, ordered, and
+    # null-free, so when every declared category is actually present in the
+    # data we can return `dtype.categories` directly instead of paying for
+    # `unique().drop_nulls().cast(String)`.
+    dtype = native.dtype
+    if isinstance(dtype, pl.Enum):
+        categories = dtype.categories
+        if native.drop_nulls().n_unique() == len(categories):
+            return categories
+    return native.unique(maintain_order=True).drop_nulls().cast(pl.String)
+
+
 class PolarsCatNamespace(PolarsAnyNamespace[CompliantT, NativeT_co]):
     _accessor: ClassVar[Accessor] = "cat"
 

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -1315,6 +1315,26 @@ def test_get_categories_enum_polars_v1() -> None:
     assert result.to_list() == ["Panda", "Polar"]
 
 
+def test_get_categories_enum_all_present_polars_v1() -> None:
+    # When every declared `Enum` category is present in the data, Narwhals
+    # takes a fast path via `dtype.categories`, which preserves the *declared*
+    # category order rather than the order values first appear in the data.
+    pytest.importorskip("polars")
+    import polars as pl
+
+    df_native = pl.DataFrame(
+        {"a": ["Panda", "Polar"]}, schema={"a": pl.Enum(["Polar", "Panda"])}
+    )
+    df = nw_v1.from_native(df_native, eager_only=True)
+
+    result_series = df["a"].cat.get_categories()
+    assert result_series.dtype == nw_v1.String
+    assert result_series.to_list() == ["Polar", "Panda"]
+
+    result = df.select(nw_v1.col("a").cat.get_categories())
+    assert_equal_data(result, {"a": ["Polar", "Panda"]})
+
+
 def test_selectors_are_stable_v1(constructor_eager: ConstructorEager) -> None:
     # Selectors built from `narwhals.stable.v1.selectors` must behave like `v1`
     # expressions, not like main-namespace ones.

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -1306,31 +1306,21 @@ def test_get_categories_lazy_v1(constructor_eager: ConstructorEager) -> None:
 
 
 def test_get_categories_enum_polars_v1() -> None:
+    # `Enum.get_categories` always returns the *declared* categories, in
+    # declared order, regardless of which ones are actually present in the
+    # data (matching Polars' own `cat.get_categories` behavior for `Enum`).
     pytest.importorskip("polars")
     import polars as pl
 
     s_native = pl.Series("a", ["Panda", "Polar"], dtype=pl.Enum(["Polar", "Panda", "X"]))
     result = nw_v1.from_native(s_native, series_only=True).cat.get_categories()
     assert result.dtype == nw_v1.String
-    assert result.to_list() == ["Panda", "Polar"]
-
-
-def test_get_categories_enum_all_present_polars_v1() -> None:
-    # When every declared `Enum` category is present in the data, Narwhals
-    # takes a fast path via `dtype.categories`, which preserves the *declared*
-    # category order rather than the order values first appear in the data.
-    pytest.importorskip("polars")
-    import polars as pl
+    assert result.to_list() == ["Polar", "Panda", "X"]
 
     df_native = pl.DataFrame(
         {"a": ["Panda", "Polar"]}, schema={"a": pl.Enum(["Polar", "Panda"])}
     )
     df = nw_v1.from_native(df_native, eager_only=True)
-
-    result_series = df["a"].cat.get_categories()
-    assert result_series.dtype == nw_v1.String
-    assert result_series.to_list() == ["Polar", "Panda"]
-
     result = df.select(nw_v1.col("a").cat.get_categories())
     assert_equal_data(result, {"a": ["Polar", "Panda"]})
 

--- a/tests/v2_test.py
+++ b/tests/v2_test.py
@@ -657,6 +657,26 @@ def test_get_categories_enum_polars_v2() -> None:
     assert result.to_list() == ["Panda", "Polar"]
 
 
+def test_get_categories_enum_all_present_polars_v2() -> None:
+    # When every declared `Enum` category is present in the data, Narwhals
+    # takes a fast path via `dtype.categories`, which preserves the *declared*
+    # category order rather than the order values first appear in the data.
+    pytest.importorskip("polars")
+    import polars as pl
+
+    df_native = pl.DataFrame(
+        {"a": ["Panda", "Polar"]}, schema={"a": pl.Enum(["Polar", "Panda"])}
+    )
+    df = nw_v2.from_native(df_native, eager_only=True)
+
+    result_series = df["a"].cat.get_categories()
+    assert result_series.dtype == nw_v2.String
+    assert result_series.to_list() == ["Polar", "Panda"]
+
+    result = df.select(nw_v2.col("a").cat.get_categories())
+    assert_equal_data(result, {"a": ["Polar", "Panda"]})
+
+
 def test_selectors_are_stable_v2() -> None:
     # Selectors built from `narwhals.stable.v2.selectors` must behave like `v2`
     # expressions, not like main-namespace ones.

--- a/tests/v2_test.py
+++ b/tests/v2_test.py
@@ -648,31 +648,21 @@ def test_get_categories_lazy_v2(constructor_eager: ConstructorEager) -> None:
 
 
 def test_get_categories_enum_polars_v2() -> None:
+    # `Enum.get_categories` always returns the *declared* categories, in
+    # declared order, regardless of which ones are actually present in the
+    # data (matching Polars' own `cat.get_categories` behavior for `Enum`).
     pytest.importorskip("polars")
     import polars as pl
 
     s_native = pl.Series("a", ["Panda", "Polar"], dtype=pl.Enum(["Polar", "Panda", "X"]))
     result = nw_v2.from_native(s_native, series_only=True).cat.get_categories()
     assert result.dtype == nw_v2.String
-    assert result.to_list() == ["Panda", "Polar"]
-
-
-def test_get_categories_enum_all_present_polars_v2() -> None:
-    # When every declared `Enum` category is present in the data, Narwhals
-    # takes a fast path via `dtype.categories`, which preserves the *declared*
-    # category order rather than the order values first appear in the data.
-    pytest.importorskip("polars")
-    import polars as pl
+    assert result.to_list() == ["Polar", "Panda", "X"]
 
     df_native = pl.DataFrame(
         {"a": ["Panda", "Polar"]}, schema={"a": pl.Enum(["Polar", "Panda"])}
     )
     df = nw_v2.from_native(df_native, eager_only=True)
-
-    result_series = df["a"].cat.get_categories()
-    assert result_series.dtype == nw_v2.String
-    assert result_series.to_list() == ["Polar", "Panda"]
-
     result = df.select(nw_v2.col("a").cat.get_categories())
     assert_equal_data(result, {"a": ["Polar", "Panda"]})
 


### PR DESCRIPTION
closes #3923 

this also fixes the shiny downstream ci failure

<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
