### PR TITLE
fix(pyarrow): `strip_chars` with empty characters no longer strips whitespace

### DIFF
--- a/src/narwhals/_arrow/series_str.py
+++ b/src/narwhals/_arrow/series_str.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import string
 from typing import TYPE_CHECKING
 
 import pyarrow as pa
@@ -14,6 +13,7 @@ from narwhals._arrow.utils import (
     parse_time_format,
 )
 from narwhals._compliant.any_namespace import StringNamespace
+from narwhals._utils import parse_str_strip_chars
 
 if TYPE_CHECKING:
     from narwhals._arrow.series import ArrowSeries
@@ -44,7 +44,7 @@ class ArrowSeriesStringNamespace(ArrowSeriesNamespace, StringNamespace["ArrowSer
 
     def strip_chars(self, characters: str | None) -> ArrowSeries:
         return self.with_native(
-            pc.utf8_trim(self.native, characters or string.whitespace)
+            pc.utf8_trim(self.native, parse_str_strip_chars(characters))
         )
 
     def strip_chars_start(self, characters: str) -> ArrowSeries:

--- a/tests/expr_and_series/str/strip_chars_test.py
+++ b/tests/expr_and_series/str/strip_chars_test.py
@@ -13,7 +13,13 @@ directional_data = {"a": ["  foobar  ", "xyxbarxy", "\n\tbaz\n\t", "", None]}
 
 @pytest.mark.parametrize(
     ("characters", "expected"),
-    [(None, {"a": ["foobar", "bar", "baz"]}), ("foo", {"a": ["bar", "bar\n", " baz"]})],
+    [
+        (None, {"a": ["foobar", "bar", "baz"]}),
+        ("foo", {"a": ["bar", "bar\n", " baz"]}),
+        # An empty set of characters should strip nothing, see polars:
+        # `strip_chars("")` is a no-op, `strip_chars(None)` strips whitespace.
+        ("", {"a": ["foobar", "bar\n", " baz"]}),
+    ],
 )
 def test_str_strip_chars(
     constructor: Constructor,
@@ -31,7 +37,11 @@ def test_str_strip_chars(
 
 @pytest.mark.parametrize(
     ("characters", "expected"),
-    [(None, {"a": ["foobar", "bar", "baz"]}), ("foo", {"a": ["bar", "bar\n", " baz"]})],
+    [
+        (None, {"a": ["foobar", "bar", "baz"]}),
+        ("foo", {"a": ["bar", "bar\n", " baz"]}),
+        ("", {"a": ["foobar", "bar\n", " baz"]}),
+    ],
 )
 def test_str_strip_chars_series(
     constructor_eager: ConstructorEager, characters: str | None, expected: Any


### PR DESCRIPTION
# Description

`str.strip_chars("")` on the PyArrow backend stripped whitespace instead of doing nothing.

In Polars, `characters=""` means "strip nothing" and `characters=None` means "strip whitespace". pandas and dask follow the same split because they delegate to Python's `str.strip`. The PyArrow implementation used `characters or string.whitespace`, so the empty string fell through to the whitespace default.

I found this by running the same expression on every backend and diffing the results.

```python
import pyarrow as pa
import narwhals as nw

df = nw.from_native(pa.table({"a": ["foobar", "bar\n", " baz"]}))
df.select(nw.col("a").str.strip_chars(""))
# main:    {'a': ['foobar', 'bar', 'baz']}
# this PR: {'a': ['foobar', 'bar\n', ' baz']}
```

`pc.utf8_trim(arr, "")` is already a no-op, so the fix is just to stop substituting the default. The diff now uses the existing `parse_str_strip_chars` helper, which does the `None` check properly (the SQL backends already inline the same logic).

## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation
- [ ] Test
- [ ] Other

## Related issues

Searched issues and PRs for `strip_chars`, didn't find this reported.

## AI assistance

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

The work was done with opencode (open-source coding agent, GLM model). It ran the cross-backend comparison that found the divergence and helped prepare the fix and the tests. I checked the behaviour against Polars, pandas and PyArrow directly, and I can defend every line of the diff in review.

## Checklist

- [x] Code follows style guide (ruff)
- [x] Tests added
- [x] Documented the changes (bug fix to documented semantics, no doc change needed)
- [x] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

This is my first PR here. Screenshot of the checklist command passing locally on commit `d7e8f9d` (rendered from the captured terminal output of the run, full text below):

![pytest passing locally](https://raw.githubusercontent.com/ptimizeroracle/narwhals/assets/pytest_screenshot.png)

```bash
PYTEST_ADDOPTS="--numprocesses=logical" \
make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
```

```
TOTAL                                             28276     33   2864      0    99%

446 files skipped due to complete coverage.
Required test coverage of 80.0% reached. Total coverage: 99.89%
========== 14864 passed, 262 skipped, 884 xfailed in 98.66s (0:01:38) ==========
```

The new `("", {"a": ["foobar", "bar\n", " baz"]})` case fails on pyarrow on main and passes with this change. Every other constructor passes before and after.
