### PR TITLE
fix: avoid name collision in `{max,min}_horizontal` for pandas-like

### DIFF
--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -262,7 +262,8 @@ class PandasLikeNamespace(
             return [
                 PandasLikeSeries(
                     self.concat(
-                        (s.to_frame() for s in series), how="horizontal"
+                        (s.alias(str(i)).to_frame() for i, s in enumerate(series)),
+                        how="horizontal",
                     )._native_frame.min(axis=1),
                     implementation=self._implementation,
                     version=self._version,
@@ -282,7 +283,8 @@ class PandasLikeNamespace(
             return [
                 PandasLikeSeries(
                     self.concat(
-                        (s.to_frame() for s in series), how="horizontal"
+                        (s.alias(str(i)).to_frame() for i, s in enumerate(series)),
+                        how="horizontal",
                     ).native.max(axis=1),
                     implementation=self._implementation,
                     version=self._version,

--- a/tests/expr_and_series/max_horizontal_test.py
+++ b/tests/expr_and_series/max_horizontal_test.py
@@ -23,3 +23,16 @@ def test_maxh_all(constructor: Constructor) -> None:
     result = df.select(nw.max_horizontal(nw.all()), c=nw.max_horizontal(nw.all()))
     expected = {"a": expected_values, "c": expected_values}
     assert_equal_data(result, expected)
+
+
+def test_maxh_duplicate_output_names(constructor: Constructor) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3934
+    df = nw.from_native(constructor(data))
+    exprs = [
+        nw.when(nw.col("a") > 1).then(nw.lit(1)),
+        nw.when(nw.col("b") > 1).then(nw.lit(2)),
+        nw.when(nw.col("z") > 1).then(nw.lit(3)),
+    ]
+    result = df.select(horizontal_max=nw.max_horizontal(*exprs))
+    expected = {"horizontal_max": [3, 1, 2, None]}
+    assert_equal_data(result, expected)

--- a/tests/expr_and_series/min_horizontal_test.py
+++ b/tests/expr_and_series/min_horizontal_test.py
@@ -23,3 +23,16 @@ def test_minh_all(constructor: Constructor) -> None:
     result = df.select(nw.min_horizontal(nw.all()), c=nw.min_horizontal(nw.all()))
     expected = {"a": expected_values, "c": expected_values}
     assert_equal_data(result, expected)
+
+
+def test_minh_duplicate_output_names(constructor: Constructor) -> None:
+    # https://github.com/narwhals-dev/narwhals/issues/3934
+    df = nw.from_native(constructor(data))
+    exprs = [
+        nw.when(nw.col("a") > 1).then(nw.lit(1)),
+        nw.when(nw.col("b") > 1).then(nw.lit(2)),
+        nw.when(nw.col("z") > 1).then(nw.lit(3)),
+    ]
+    result = df.select(horizontal_min=nw.min_horizontal(*exprs))
+    expected = {"horizontal_min": [2, 1, 2, None]}
+    assert_equal_data(result, expected)


### PR DESCRIPTION
closes #3934 

<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

<!--
## If you have comments or want to explain your changes, please do so in this section
-->

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Related issue #\<issue number\>
- Closes #\<issue number\>

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [ ] AI tools were used.

## Checklist

- [ ] Code follows style guide (ruff)
- [ ] Tests added
- [ ] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```
