### PR TITLE
docs: mention narwhals-datafusion plugin in supported backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@
 Extremely lightweight and extensible compatibility layer between dataframe libraries!
 
 - **Full API support**: cuDF, Modin, pandas, Polars, PyArrow.
-- **Lazy-only support**: Dask, DuckDB, Ibis, PySpark, SQLFrame, and Daft via the
-  [narwhals-daft](https://github.com/narwhals-dev/narwhals-daft) plugin.
+- **Lazy-only support**: Dask, DuckDB, Ibis, PySpark, SQLFrame, Daft via the
+  [narwhals-daft](https://github.com/narwhals-dev/narwhals-daft) plugin, and Apache DataFusion via the
+  [narwhals-datafusion](https://github.com/s5dsn-eqee/narwhals-datafusion) plugin.
 
 Seamlessly support all, without depending on any!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,9 @@
 Extremely lightweight and extensible compatibility layer between dataframe libraries!
 
 - **Full API support**: cuDF, Modin, pandas, Polars, PyArrow.
-- **Lazy-only support**: Dask, DuckDB, Ibis, PySpark, SQLFrame, and Daft via the
-  [narwhals-daft](https://github.com/narwhals-dev/narwhals-daft) plugin.
+- **Lazy-only support**: Dask, DuckDB, Ibis, PySpark, SQLFrame, Daft via the
+  [narwhals-daft](https://github.com/narwhals-dev/narwhals-daft) plugin, and Apache DataFusion via the
+  [narwhals-datafusion](https://github.com/s5dsn-eqee/narwhals-datafusion) plugin.
 
 Seamlessly support all, without depending on any!
 


### PR DESCRIPTION
<!--
# Thanks for contributing a pull request!
## Please make sure you see our contribution guidelines: https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md
-->

# Description

Adds Apache DataFusion, available via the [narwhals-datafusion](https://github.com/s5dsn-eqee/narwhals-datafusion) plugin, to the lazy-only backends list in `README.md` and `docs/index.md`, next to narwhals-daft.

Following the discussion with @FBruzzesi in #3225, I had planned to open this docs PR after the datafusion-python 55 release. Since that release window can be quite long, and the plugin, its test suite and CI workflows are already stable, I decided to bring it in now rather than wait.

Plugin status:

- Published on PyPI: `pip install narwhals-datafusion`
- Registered via the `narwhals.plugins` entry point, built on the shared `narwhals._sql` layer
- Runs narwhals' own test suite in CI, plus a weekly compat workflow against the latest narwhals release

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [x] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other

## Related issues

- Closes #3225

## AI assistance

<!--
For transparency only.
By submitting this PR you accept full responsibility for every line of code,
regardless of how it was produced.
See [AI-assisted contributions](https://github.com/narwhals-dev/narwhals/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
-->

- [ ] No AI tools were used for this PR.
- [x] AI tools were used.

## Checklist

- [x] Code follows style guide (ruff)
- [ ] Tests added
- [x] Documented the changes
- [ ] If this is your first PR to narwhals, attach a screenshot of `pytest` passing locally (not CI):

    ```bash
    PYTEST_ADDOPTS="--numprocesses=logical" \
    make run-ci DEPS="--extra pandas --extra dask --group core-tests --group sklearn --group plugins" \
    CMD="pytest tests --cov=src --cov=tests --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe"
    ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)