### PR TITLE
fix: preserve nulls when casting to `String` on pandas pre v3.0.0

### DIFF
--- a/src/narwhals/_pandas_like/namespace.py
+++ b/src/narwhals/_pandas_like/namespace.py
@@ -375,8 +375,11 @@ class PandasLikeNamespace(
 
         def func(df: PandasLikeDataFrame) -> list[PandasLikeSeries]:
             expr_results = [s for _expr in exprs for s in _expr(df)]
-            series = [s.cast(string) for s in expr_results]
             null_mask = [s.is_null() for s in expr_results]
+            # NOTE: The masks below decide what a null row becomes, so blank the nulls
+            # out first: before pandas 3 a string column is `object`, where adding
+            # `None` raises instead of propagating.
+            series = [s.cast(string).fill_null("", None, None) for s in expr_results]
 
             if not ignore_nulls:
                 null_mask_result = reduce(operator.or_, null_mask)
@@ -387,9 +390,7 @@ class PandasLikeNamespace(
                 # NOTE: Trying to help `mypy` later
                 # error: Cannot determine type of "values"  [has-type]
                 values: list[PandasLikeSeries]
-                init_value, *values = (
-                    s.zip_with(~nm, "") for s, nm in zip(series, null_mask, strict=True)
-                )
+                init_value, *values = series
                 sep_array = init_value._with_native(
                     init_value.__native_namespace__().Series(
                         separator,

--- a/src/narwhals/_pandas_like/series.py
+++ b/src/narwhals/_pandas_like/series.py
@@ -12,6 +12,7 @@ from narwhals._pandas_like.series_str import PandasLikeSeriesStringNamespace
 from narwhals._pandas_like.series_struct import PandasLikeSeriesStructNamespace
 from narwhals._pandas_like.utils import (
     NUMPY_VERSION,
+    PANDAS_VERSION,
     align_and_extract_native,
     binary_string_sum_fallback,
     broadcast_series_to_index,
@@ -325,11 +326,15 @@ class PandasLikeSeries(EagerSeries[Any]):
             version=self._version,
         )
         result = self.native.astype(pd_dtype)
-        if pd_dtype is str and result.dtype == object:
+        if (
+            pd_dtype is str
+            and PANDAS_VERSION < (3,)
+            and (null_mask := self.native.isna()).any()
+        ):
             # NOTE: Before pandas 3, `astype(str)` renders nulls as `'None'` / `'nan'`
             # instead of keeping them null. Newer versions cast to a string dtype which
             # preserves them, so there's nothing to restore.
-            result = result.where(self.native.notna(), None)
+            result = result.where(~null_mask, None)
         return self._with_native(result, preserve_broadcast=True)
 
     def item(self, index: int | None = None) -> Any:

--- a/src/narwhals/_pandas_like/series.py
+++ b/src/narwhals/_pandas_like/series.py
@@ -324,7 +324,13 @@ class PandasLikeSeries(EagerSeries[Any]):
             implementation=self._implementation,
             version=self._version,
         )
-        return self._with_native(self.native.astype(pd_dtype), preserve_broadcast=True)
+        result = self.native.astype(pd_dtype)
+        if pd_dtype is str and result.dtype == object:
+            # NOTE: Before pandas 3, `astype(str)` renders nulls as `'None'` / `'nan'`
+            # instead of keeping them null. Newer versions cast to a string dtype which
+            # preserves them, so there's nothing to restore.
+            result = result.where(self.native.notna(), None)
+        return self._with_native(result, preserve_broadcast=True)
 
     def item(self, index: int | None = None) -> Any:
         # cuDF doesn't have Series.item().

--- a/tests/expr_and_series/cast_test.py
+++ b/tests/expr_and_series/cast_test.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, time, timedelta, timezone
-from typing import TYPE_CHECKING
+from datetime import date, datetime, time, timedelta, timezone
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -200,6 +200,36 @@ def test_cast_string() -> None:
     s = s.cast(nw.String)
     result = nw.to_native(s)
     assert str(result.dtype) in {"string", "object", "dtype('O')"}
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param(["x", None], id="string"),
+        pytest.param([1, None], id="int"),
+        pytest.param([1.5, None], id="float"),
+        pytest.param([True, None], id="bool"),
+        pytest.param([datetime(2020, 1, 1), None], id="datetime"),
+        pytest.param([date(2020, 1, 1), None], id="date"),
+    ],
+)
+def test_cast_string_keeps_nulls(constructor: Constructor, values: list[Any]) -> None:
+    # Asserting on nullness rather than on the rendering: backends disagree on how
+    # they format a bool or a float, but not on whether the result is null.
+    df = nw.from_native(constructor({"a": values}))
+    result = df.select(nw.col("a").cast(nw.String()).is_null().alias("n"))
+    assert_equal_data(result, {"n": [False, True]})
+
+
+def test_cast_string_null_literal(constructor: Constructor) -> None:
+    df = nw.from_native(constructor({"a": [1, 2]}))
+    result = df.with_columns(b=nw.lit(None, dtype=nw.String()))
+    assert_equal_data(result, {"a": [1, 2], "b": [None, None]})
+
+
+def test_cast_string_keeps_nulls_series(constructor_eager: ConstructorEager) -> None:
+    s = nw.from_native(constructor_eager({"a": ["x", None]}), eager_only=True)["a"]
+    assert s.cast(nw.String()).is_null().to_list() == [False, True]
 
 
 def test_cast_raises_for_unknown_dtype(
@@ -451,4 +481,7 @@ def test_cast_object_pandas() -> None:
 
     s = nw.from_native(pd.DataFrame({"a": [2, 3, None]}, dtype=object))["a"]
     assert s[0] == 2
-    assert s.cast(nw.String)[0] == "2"
+    result = s.cast(nw.String)
+    assert result[0] == "2"
+    # Before pandas 3, `astype(str)` rendered this as the string `"None"`.
+    assert result.is_null().to_list() == [False, False, True]


### PR DESCRIPTION
# Description

Before pandas 3, `nw.String()` maps to builtin `str` and `astype(str)` renders nulls as the strings 'None' / 'nan' / 'NaT', so a null survived a cast as data. `PandasLikeSeries.cast` now restores the null mask when the result comes back as object, keying off the result dtype rather than a version check so modin and cudf are covered too.

`concat_str` needs a matching `fill_null("")`: with the nulls genuinely null, adding them raises `TypeError`.

Spotted while reviewing #3916 

@MarcoGorelli this would be a breaking change?!

## What type of PR is this? (check all applicable)

- [ ] 💾 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Optimization
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🐳 Other
